### PR TITLE
Configurable worker channel buffer size

### DIFF
--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -65,7 +65,9 @@ fn main() {
                                     .arg(Arg::with_name("id").long("id")
                                          .takes_value(true).required(true).help("worker identifier"))
                                     .arg(Arg::with_name("fd").long("fd")
-                                         .takes_value(true).required(true).help("IPC file descriptor")))
+                                         .takes_value(true).required(true).help("IPC file descriptor"))
+                                    .arg(Arg::with_name("channel-buffer-size").long("channel-buffer-size")
+                                         .takes_value(true).required(false).help("Worker's channel buffer size")))
                         .get_matches();
 
   if let Some(matches) = matches.subcommand_matches("worker") {
@@ -73,8 +75,11 @@ fn main() {
       .parse::<i32>().expect("the file descriptor must be a number");
     let id  = matches.value_of("id").expect("needs a worker id");
     let tag = matches.value_of("tag").expect("needs a configuration tag");
+    let buffer_size = matches.value_of("channel-buffer-size")
+      .and_then(|size| size.parse::<usize>().ok())
+      .unwrap_or(10000);
 
-    begin_worker_process(fd, id, tag, builder);
+    begin_worker_process(fd, id, tag, buffer_size, builder);
     return;
   }
 

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -69,11 +69,11 @@ fn generate_channels() -> io::Result<(Channel<ProxyOrder,ServerMessage>, Channel
   Ok((command_channel, proxy_channel))
 }
 
-pub fn begin_worker_process(fd: i32, id: &str, tag: &str, mut builder: LogBuilder) {
+pub fn begin_worker_process(fd: i32, id: &str, tag: &str, channel_buffer_size: usize, mut builder: LogBuilder) {
   let mut command: Channel<ServerMessage,ProxyConfig> = Channel::new(
     unsafe { UnixStream::from_raw_fd(fd) },
-    10000,
-    20000
+    channel_buffer_size,
+    channel_buffer_size * 2
   );
 
   command.set_nonblocking(false);

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -120,10 +120,13 @@ pub fn start_worker_process(config: &ProxyConfig, tag: &str, id: &str) -> (pid_t
   new_cl_flags.remove(FD_CLOEXEC);
   fcntl(client.as_raw_fd(), FcntlArg::F_SETFD(new_cl_flags));
 
+  let channel_buffer_size = config.channel_buffer_size.unwrap_or(10000);
+  let channel_max_buffer_size = channel_buffer_size * 2;
+
   let mut command: Channel<ProxyConfig,ServerMessage> = Channel::new(
     server,
-    10000,
-    20000
+    channel_buffer_size,
+    channel_max_buffer_size
   );
   command.set_nonblocking(false);
 

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -19,6 +19,7 @@ pub struct ProxyConfig {
   pub port:                      u16,
   pub max_connections:           usize,
   pub buffer_size:               usize,
+  pub channel_buffer_size:       Option<usize>,
   pub answer_404:                Option<String>,
   pub answer_503:                Option<String>,
   pub cipher_list:               Option<String>,

--- a/lib/src/channel.rs
+++ b/lib/src/channel.rs
@@ -277,7 +277,7 @@ impl<Tx: Debug+Serialize, Rx: Debug+Deserialize> Channel<Tx,Rx> {
 
     if msg_len > self.back_buf.available_space() {
       if msg_len - self.back_buf.available_space() + self.back_buf.capacity() > self.max_buffer_size {
-        error!("message is too large to write to back buffer");
+        error!("message is too large to write to back buffer. Consider increasing proxy channel buffer size, current value is {}", self.back_buf.capacity());
         return false;
       }
 
@@ -302,7 +302,7 @@ impl<Tx: Debug+Serialize, Rx: Debug+Deserialize> Channel<Tx,Rx> {
 
     if msg_len > self.back_buf.available_space() {
       if msg_len - self.back_buf.available_space() + self.back_buf.capacity() > self.max_buffer_size {
-        error!("message is too large to write to back buffer");
+        error!("message is too large to write to back buffer. Consider increasing proxy channel buffer size, current value is {}", self.back_buf.capacity());
         return false;
       }
 


### PR DESCRIPTION
This fixes #114 

It adds a new option `channel_buffer_size` in the `ProxyConfig` struct.
The value will default to `10000` if not specified, max will be `value * 2`.

The command line argument to start a worker could be improved, like the option's name in the `config.toml` file.