### PR TITLE
worker channel: pass channel buffer size to worker spawn command

### DIFF
--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -153,6 +153,8 @@ pub fn start_worker_process(config: &ProxyConfig, tag: &str, id: &str) -> (pid_t
         .arg(tag)
         .arg("--id")
         .arg(id)
+        .arg("--channel-buffer-size")
+        .arg(channel_buffer_size.to_string())
         .exec();
 
       unreachable!();


### PR DESCRIPTION
This was forgotten from the previous PR (#115)