### PR TITLE
Logger: use RUST_LOG environment variable if it exists or fallback to config file

### DIFF
--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -19,6 +19,7 @@ mod worker;
 
 use std::net::{UdpSocket,ToSocketAddrs};
 use std::collections::HashMap;
+use std::env;
 use sozu::network::metrics::{METRICS,ProxyMetrics};
 use sozu_command::config::Config;
 use log::{LogRecord,LogLevelFilter,LogLevel};
@@ -87,9 +88,11 @@ fn main() {
   let config_file = submatches.value_of("config").expect("required config file");
 
   if let Ok(config) = Config::load_from_path(config_file) {
-    if let Ok(log_level) = ::std::env::var("RUST_LOG") {
+    if let Ok(log_level) = env::var("RUST_LOG") {
       builder.parse(&log_level);
     } else if let Some(ref log_level) = config.log_level {
+      // We set the env variable so every worker can access it
+      env::set_var("RUST_LOG", log_level);
       builder.parse(&log_level);
     }
 

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -87,8 +87,10 @@ fn main() {
   let config_file = submatches.value_of("config").expect("required config file");
 
   if let Ok(config) = Config::load_from_path(config_file) {
-    if let Some(ref log_level) = config.log_level {
-     builder.parse(&log_level);
+    if let Ok(log_level) = ::std::env::var("RUST_LOG") {
+      builder.parse(&log_level);
+    } else if let Some(ref log_level) = config.log_level {
+      builder.parse(&log_level);
     }
 
     builder.init().unwrap();

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -81,8 +81,10 @@ pub fn begin_worker_process(fd: i32, id: &str, tag: &str, channel_buffer_size: u
   let proxy_config = command.read_message().expect("worker could not read configuration from socket");
   println!("got message: {:?}", proxy_config);
 
-  //FIXME: hardcoded log level
-  builder.parse("info");
+  if let Ok(log_level) = ::std::env::var("RUST_LOG"){
+    builder.parse(&log_level);
+  }
+
   builder.init().unwrap();
 
   command.set_nonblocking(true);


### PR DESCRIPTION
Also, pass the log configuration to workers