### PR TITLE
README.md: fix path to launch sozu

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To start the reverse proxy:
 
 ```
 cd bin;
-./target/debug/sozu start -c config.toml
+../target/debug/sozu start -c config.toml
 ```
 
 You can edit the reverse proxy's configuration with the `config.toml` file. You can declare


### PR DESCRIPTION
Sozu binary is stored at the root directory of the project,
under the `./target/debug/` folder, not in the `./bin/target/debug/` folder
anymore