### PR TITLE
Set process affinity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,14 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "num_cpus"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "openssl"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +441,7 @@ dependencies = [
  "mio-uds 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -665,6 +674,7 @@ dependencies = [
 "checksum num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "ef1a4bf6f9174aa5783a9b4cc892cacd11aebad6c69ad027a0b65c6ca5f8aa37"
 "checksum num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d1891bd7b936f12349b7d1403761c8a0b85a18b148e9da4429d5d102c1a41e"
 "checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
+"checksum num_cpus 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a18c392466409c50b87369414a2680c93e739aedeb498eb2bff7d7eb569744e2"
 "checksum openssl 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)" = "241bcf67b1bb8d19da97360a925730bdf5b6176d434ab8ded55b4ca632346e3a"
 "checksum openssl-sys 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e5e0fd64cb2fa018ed2e7b2c8d9649114fe5da957c9a67432957f01e5dcc82e9"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -32,7 +32,8 @@ rand = "^0.3.14"
 sozu-lib = { version = "^0.1", path = "../lib" }
 sozu-command-lib = { version = "^0.1", path = "../command" }
 
-#[target.'cfg(target_os="linux")'.dependencies]
+[target.'cfg(target_os="linux")'.dependencies]
+num_cpus = "^1.3.0"
 #procinfo = { git = "https://github.com/BlackYoup/procinfo-rs", branch = "limits" }
 
 [features]

--- a/bin/config.toml
+++ b/bin/config.toml
@@ -8,6 +8,7 @@ log_target     = "stdout"
 #log_target     = "tcp://127.0.0.1:9876"
 command_buffer_size = 16384
 worker_count = 2
+handle_process_affinity = false
 
 [metrics]
 address = "192.168.59.103"

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -203,6 +203,7 @@ pub struct Config {
   pub http:                    Option<ProxyConfig>,
   pub https:                   Option<ProxyConfig>,
   pub applications:            HashMap<String, AppConfig>,
+  pub handle_process_affinity: Option<bool>
 }
 
 impl Config {
@@ -398,6 +399,7 @@ mod tests {
       command_socket: String::from("./command_folder/sock"),
       saved_state: None,
       worker_count: Some(2),
+      handle_process_affinity: None,
       channel_buffer_size: Some(10000),
       command_buffer_size: None,
       max_command_buffer_size: None,


### PR DESCRIPTION
This sets process affinity. The logic is quite simple, bind each worker process (including the master process) to a CPU core by looping over the workers. There might be multiple workers bound to the same core if there are more workers than cores.

The code will only execute for linux because we don't use the `pthread` API (which is POSIX compliant).

Also, do we want to make it configurable ? Like only allowing the configured cores to be used (haproxy has such option for example)

Add a flag to disable / enable the feature ?

Fixes #33 