### PR TITLE
workers: return Result type for the start_worker_process and friends functions

### DIFF
--- a/bin/src/command/orders.rs
+++ b/bin/src/command/orders.rs
@@ -104,7 +104,7 @@ impl CommandServer {
         info!("received LaunchWorker with tag \"{}\"", tag);
 
         let id = self.next_id + 1;
-        if let Some(mut worker) = start_worker(id, &self.config) {
+        if let Ok(mut worker) = start_worker(id, &self.config) {
           self.conns[token].write_message(&ConfigMessageAnswer::new(
             message.id.clone(),
             ConfigMessageStatus::Processing,

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -98,9 +98,14 @@ fn main() {
     let metrics_guard = ProxyMetrics::run();
 
     if check_process_limits(&config) {
-      let workers: Vec<Worker> = start_workers(&config);
-      info!("created workers: {:?}", workers);
-      command::start(config, workers);
+      match start_workers(&config) {
+        Ok(workers) => {
+          info!("created workers: {:?}", workers);
+
+          command::start(config, workers);
+        },
+        Err(e) => error!("Error while creating workers: {}", e)
+      }
     }
 
     info!("master process stopped");


### PR DESCRIPTION
This allows methods to return a status for the process creation instead of failing and only report the error without appropriate error handling.

The only question I have is: for the `start_wokers` method, would it be better to return a `Result<Vec<Worker>>` or a `Vec<Result<Worker>>` ? 