### PR TITLE
http and tls proxies: make front and back timeout configurable

### DIFF
--- a/bin/config.toml
+++ b/bin/config.toml
@@ -20,6 +20,8 @@ port = 8080
 buffer_size = 16384
 #answer_404 = "./404.html"
 #answer_503 = "./503.html"
+#front_timeout = 5000
+#back_timeout = 5000
 
 [https]
 address = "127.0.0.1"
@@ -35,6 +37,8 @@ default_app_id = "MyApp"
 
 #answer_404 = "../lib/assets/404.html"
 #answer_503 = "../lib/assets/503.html"
+#front_timeout = 5000
+#back_timeout = 5000
 
 [applications]
 

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -29,6 +29,8 @@ pub struct ProxyConfig {
   pub default_certificate_chain: Option<String>,
   pub default_key:               Option<String>,
   pub tls_versions:              Option<Vec<String>>,
+  pub back_timeout:              Option<u64>,
+  pub front_timeout:             Option<u64>,
 }
 
 impl ProxyConfig {
@@ -66,6 +68,14 @@ impl ProxyConfig {
         .and_then(|mut file| file.read_to_string(&mut answer_503).ok()).is_some() {
         configuration.answer_503 = answer_503;
       }
+
+      if let Some(back_timeout) = self.back_timeout {
+        configuration.back_timeout = back_timeout;
+      }
+      if let Some(front_timeout) = self.front_timeout {
+        configuration.front_timeout = front_timeout;
+      }
+
       configuration
     })
   }
@@ -167,8 +177,14 @@ impl ProxyConfig {
         configuration.default_key = Some(default_key);
       }
 
-      configuration
+      if let Some(back_timeout) = self.back_timeout {
+        configuration.back_timeout = back_timeout;
+      }
+      if let Some(front_timeout) = self.front_timeout {
+        configuration.front_timeout = front_timeout;
+      }
 
+      configuration
     })
   }
 }
@@ -367,6 +383,8 @@ mod tests {
       buffer_size: 16384,
       answer_404: Some(String::from("404.html")),
       answer_503: None,
+      front_timeout: None,
+      back_timeout: None,
       public_address: None,
       tls_versions: None,
       cipher_list: None,
@@ -384,6 +402,8 @@ mod tests {
       buffer_size: 16384,
       answer_404: Some(String::from("404.html")),
       answer_503: None,
+      front_timeout: None,
+      back_timeout: None,
       public_address: None,
       tls_versions: None,
       cipher_list: None,

--- a/lib/src/network/http.rs
+++ b/lib/src/network/http.rs
@@ -338,9 +338,8 @@ impl ServerConfiguration {
           pool:          Rc::new(RefCell::new(
                            Pool::with_capacity(2*config.max_connections, 0, || BufferQueue::with_capacity(config.buffer_size))
           )),
-          //FIXME: make the timeout values configurable
-          front_timeout: 5000,
-          back_timeout:  5000,
+          front_timeout: config.front_timeout,
+          back_timeout:  config.back_timeout,
           answers:       default,
           config:        config,
         })

--- a/lib/src/network/tls.rs
+++ b/lib/src/network/tls.rs
@@ -399,8 +399,8 @@ impl ServerConfiguration {
           pool:            Rc::new(RefCell::new(
                              Pool::with_capacity(2*config.max_connections, 0, || BufferQueue::with_capacity(config.buffer_size))
           )),
-          front_timeout:   50000,
-          back_timeout:    50000,
+          front_timeout:   config.front_timeout,
+          back_timeout:    config.back_timeout,
           answers:         default,
           base_token:      base_token,
           config:          config,


### PR DESCRIPTION
I'm not really sure how to test this though. I tried a simple program which only listens for TCP connections without doing anything with it. The timeout should have been triggered, I guess. But maybe I failed to understand what it really is. There doesn't seem to be any traffic from `tcpdump`'s point of view between sozu and the test server.

Maybe this should go in an issue, if this behavior is not expected

```
use std::net::{TcpListener, TcpStream};

fn main(){
    let listener = TcpListener::bind("127.0.0.1:1026").unwrap();

    std::thread::sleep(std::time::Duration::new(100, 0));
}
```