### PR TITLE
Change Cargo include statement in lib

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,10 +13,10 @@ categories = ["network-programming"]
 include = [
   "README.md",
   "Cargo.toml",
-  "src/*.rs",
-  "examples/main.rs",
-  "examples/minimal.rs",
-  "assets/*"
+  "/src",
+  "/examples/main.rs",
+  "/examples/minimal.rs",
+  "/assets"
 ]
 
 [dependencies]


### PR DESCRIPTION
Try to fix #197.
Change the include configuration based on the modification in rust-lang/cargo#4268

Hope I've not missed something from the issue.