### PR TITLE
Sticky session

### DIFF
--- a/bin/config.toml
+++ b/bin/config.toml
@@ -47,4 +47,5 @@ key = "../lib/assets/key.pem" # optional
 certificate_chain = "../lib/assets/certificate_chain.pem" # optional
 frontends = ["HTTP", "HTTPS"] # list of proxy tags
 backends  = [ "127.0.0.1:1026" ] # list of IP/port
+#sticky_session = true
 

--- a/command/assets/add_http_front.json
+++ b/command/assets/add_http_front.json
@@ -7,7 +7,8 @@
     "data": {
       "app_id": "xxx",
       "hostname": "yyy",
-      "path_begin": "xxx"
+      "path_begin": "xxx",
+      "sticky_session": false
     }
   }
 }

--- a/command/assets/add_https_front.json
+++ b/command/assets/add_https_front.json
@@ -8,7 +8,8 @@
       "app_id": "xxx",
       "hostname": "yyy",
       "path_begin": "xxx",
-      "fingerprint": "ab2618b674e15243fd02a5618c66509e4840ba60e7d64cebec84cdbfeceee0c5"
+      "fingerprint": "ab2618b674e15243fd02a5618c66509e4840ba60e7d64cebec84cdbfeceee0c5",
+      "sticky_session": false
     }
   }
 }

--- a/command/assets/remove_http_front.json
+++ b/command/assets/remove_http_front.json
@@ -7,7 +7,8 @@
     "data": {
       "app_id": "xxx",
       "hostname": "yyy",
-      "path_begin": "xxx"
+      "path_begin": "xxx",
+      "sticky_session": false
     }
   }
 }

--- a/command/assets/remove_https_front.json
+++ b/command/assets/remove_https_front.json
@@ -8,7 +8,8 @@
       "app_id": "xxx",
       "hostname": "yyy",
       "path_begin": "xxx",
-      "fingerprint": "ab2618b674e15243fd02a5618c66509e4840ba60e7d64cebec84cdbfeceee0c5"
+      "fingerprint": "ab2618b674e15243fd02a5618c66509e4840ba60e7d64cebec84cdbfeceee0c5",
+      "sticky_session": false
     }
   }
 }

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -186,6 +186,7 @@ pub struct AppConfig {
   pub key:               Option<String>,
   pub certificate_chain: Option<String>,
   pub backends:          Vec<String>,
+  pub sticky_session:    Option<bool>,
 }
 
 #[derive(Debug,Clone,PartialEq,Eq,Serialize,Deserialize)]
@@ -236,9 +237,10 @@ impl Config {
 
       //create the front both for HTTP and HTTPS if possible
       let order = Order::AddHttpFront(HttpFront {
-        app_id:     id.to_string(),
-        hostname:   app.hostname.clone(),
-        path_begin: path_begin.clone(),
+        app_id:         id.to_string(),
+        hostname:       app.hostname.clone(),
+        path_begin:     path_begin.clone(),
+        sticky_session: app.sticky_session.unwrap_or(false),
       });
       v.push(ConfigMessage {
         id:       format!("CONFIG-{}", count),
@@ -284,10 +286,11 @@ impl Config {
         });
         count += 1;
         let front_order = Order::AddHttpsFront(HttpsFront {
-          app_id:      id.to_string(),
-          hostname:    app.hostname.clone(),
-          path_begin:  path_begin,
-          fingerprint: fingerprint,
+          app_id:         id.to_string(),
+          hostname:       app.hostname.clone(),
+          path_begin:     path_begin,
+          fingerprint:    fingerprint,
+          sticky_session: app.sticky_session.unwrap_or(false),
         });
         v.push(ConfigMessage {
           id:       format!("CONFIG-{}", count),

--- a/command/src/data.rs
+++ b/command/src/data.rs
@@ -290,13 +290,14 @@ mod tests {
 
   #[test]
   fn config_message_test() {
-    let raw_json = r#"{ "id": "ID_TEST", "version": 0, "type": "PROXY", "data":{"type": "ADD_HTTP_FRONT", "data": {"app_id": "xxx", "hostname": "yyy", "path_begin": "xxx"}} }"#;
+    let raw_json = r#"{ "id": "ID_TEST", "version": 0, "type": "PROXY", "data":{"type": "ADD_HTTP_FRONT", "data": {"app_id": "xxx", "hostname": "yyy", "path_begin": "xxx", "sticky_session": false}} }"#;
     let message: ConfigMessage = serde_json::from_str(raw_json).unwrap();
     println!("{:?}", message);
     assert_eq!(message.data, ConfigCommand::ProxyConfiguration(Order::AddHttpFront(HttpFront{
       app_id: String::from("xxx"),
       hostname: String::from("yyy"),
       path_begin: String::from("xxx"),
+      sticky_session: false,
     })));
   }
 
@@ -341,6 +342,7 @@ mod tests {
                   app_id: String::from("xxx"),
                   hostname: String::from("yyy"),
                   path_begin: String::from("xxx"),
+                  sticky_session: false
       })),
       proxy_id: None
     });
@@ -352,6 +354,7 @@ mod tests {
                   app_id: String::from("xxx"),
                   hostname: String::from("yyy"),
                   path_begin: String::from("xxx"),
+                  sticky_session: false
       })),
       proxy_id: None
     });
@@ -363,7 +366,8 @@ mod tests {
                   app_id: String::from("xxx"),
                   hostname: String::from("yyy"),
                   path_begin: String::from("xxx"),
-                  fingerprint: CertFingerprint(FromHex::from_hex("ab2618b674e15243fd02a5618c66509e4840ba60e7d64cebec84cdbfeceee0c5").unwrap())
+                  fingerprint: CertFingerprint(FromHex::from_hex("ab2618b674e15243fd02a5618c66509e4840ba60e7d64cebec84cdbfeceee0c5").unwrap()),
+                  sticky_session: false
       })),
       proxy_id: None
     });
@@ -375,7 +379,8 @@ mod tests {
                   app_id: String::from("xxx"),
                   hostname: String::from("yyy"),
                   path_begin: String::from("xxx"),
-                  fingerprint: CertFingerprint(FromHex::from_hex("ab2618b674e15243fd02a5618c66509e4840ba60e7d64cebec84cdbfeceee0c5").unwrap())
+                  fingerprint: CertFingerprint(FromHex::from_hex("ab2618b674e15243fd02a5618c66509e4840ba60e7d64cebec84cdbfeceee0c5").unwrap()),
+                  sticky_session: false
       })),
       proxy_id: None
     });

--- a/command/src/messages.rs
+++ b/command/src/messages.rs
@@ -132,9 +132,10 @@ impl<'de> serde::Deserialize<'de> for CertFingerprint {
 
 #[derive(Debug,Clone,PartialEq,Eq,Hash, Serialize, Deserialize)]
 pub struct HttpFront {
-    pub app_id:     String,
-    pub hostname:   String,
-    pub path_begin: String,
+    pub app_id:         String,
+    pub hostname:       String,
+    pub path_begin:     String,
+    pub sticky_session: bool,
 }
 
 #[derive(Debug,Clone,PartialEq,Eq,Hash, Serialize, Deserialize)]
@@ -146,10 +147,11 @@ pub struct CertificateAndKey {
 
 #[derive(Debug,Clone,PartialEq,Eq,Hash, Serialize, Deserialize)]
 pub struct HttpsFront {
-    pub app_id:       String,
-    pub hostname:     String,
-    pub path_begin:   String,
-    pub fingerprint:  CertFingerprint,
+    pub app_id:         String,
+    pub hostname:       String,
+    pub path_begin:     String,
+    pub fingerprint:    CertFingerprint,
+    pub sticky_session: bool,
 }
 
 #[derive(Debug,Clone,PartialEq,Eq,Hash, Serialize, Deserialize)]
@@ -288,25 +290,27 @@ mod tests {
 
   #[test]
   fn add_acl_test() {
-    let raw_json = r#"{"type": "ADD_HTTP_FRONT", "data": {"app_id": "xxx", "hostname": "yyy", "path_begin": "xxx", "port": 4242}}"#;
+    let raw_json = r#"{"type": "ADD_HTTP_FRONT", "data": {"app_id": "xxx", "hostname": "yyy", "path_begin": "xxx", "port": 4242, "sticky_session": false}}"#;
     let command: Order = serde_json::from_str(raw_json).expect("could not parse json");
     println!("{:?}", command);
     assert!(command == Order::AddHttpFront(HttpFront{
       app_id: String::from("xxx"),
       hostname: String::from("yyy"),
       path_begin: String::from("xxx"),
+      sticky_session: false,
     }));
   }
 
   #[test]
   fn remove_acl_test() {
-    let raw_json = r#"{"type": "REMOVE_HTTP_FRONT", "data": {"app_id": "xxx", "hostname": "yyy", "path_begin": "xxx", "port": 4242}}"#;
+    let raw_json = r#"{"type": "REMOVE_HTTP_FRONT", "data": {"app_id": "xxx", "hostname": "yyy", "path_begin": "xxx", "port": 4242, "sticky_session": false}}"#;
     let command: Order = serde_json::from_str(raw_json).expect("could not parse json");
     println!("{:?}", command);
     assert!(command == Order::RemoveHttpFront(HttpFront{
       app_id: String::from("xxx"),
       hostname: String::from("yyy"),
       path_begin: String::from("xxx"),
+      sticky_session: false,
     }));
   }
 
@@ -337,25 +341,27 @@ mod tests {
 
   #[test]
   fn http_front_crash_test() {
-    let raw_json = r#"{"type": "ADD_HTTP_FRONT", "data": {"app_id": "aa", "hostname": "cltdl.fr", "path_begin": ""}}"#;
+    let raw_json = r#"{"type": "ADD_HTTP_FRONT", "data": {"app_id": "aa", "hostname": "cltdl.fr", "path_begin": "", "sticky_session": false}}"#;
     let command: Order = serde_json::from_str(raw_json).expect("could not parse json");
     println!("{:?}", command);
     assert!(command == Order::AddHttpFront(HttpFront{
       app_id: String::from("aa"),
       hostname: String::from("cltdl.fr"),
       path_begin: String::from(""),
+      sticky_session: false,
     }));
   }
 
   #[test]
   fn http_front_crash_test2() {
-    let raw_json = r#"{"app_id": "aa", "hostname": "cltdl.fr", "path_begin": ""}"#;
+    let raw_json = r#"{"app_id": "aa", "hostname": "cltdl.fr", "path_begin": "", "sticky_session": false}"#;
     let front: HttpFront = serde_json::from_str(raw_json).expect("could not parse json");
     println!("{:?}",front);
     assert!(front == HttpFront{
       app_id: String::from("aa"),
       hostname: String::from("cltdl.fr"),
       path_begin: String::from(""),
+      sticky_session: false,
     });
   }
 }

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -467,7 +467,7 @@ pub fn metrics(channel: &mut Channel<ConfigMessage,ConfigMessageAnswer>) {
 }
 
 
-pub fn add_frontend(channel: &mut Channel<ConfigMessage,ConfigMessageAnswer>, app_id: &str, hostname: &str, path_begin: &str, certificate: Option<&str>) {
+pub fn add_frontend(channel: &mut Channel<ConfigMessage,ConfigMessageAnswer>, app_id: &str, hostname: &str, path_begin: &str, certificate: Option<&str>, sticky_session: bool) {
   if let Some(certificate_path) = certificate {
     match Config::load_file_bytes(certificate_path) {
       Ok(data) => {
@@ -478,7 +478,8 @@ pub fn add_frontend(channel: &mut Channel<ConfigMessage,ConfigMessageAnswer>, ap
               app_id: String::from(app_id),
               hostname: String::from(hostname),
               path_begin: String::from(path_begin),
-              fingerprint: CertFingerprint(fingerprint)
+              fingerprint: CertFingerprint(fingerprint),
+              sticky_session: sticky_session
             }));
           },
         }
@@ -489,12 +490,13 @@ pub fn add_frontend(channel: &mut Channel<ConfigMessage,ConfigMessageAnswer>, ap
     order_command(channel, Order::AddHttpFront(HttpFront {
       app_id: String::from(app_id),
       hostname: String::from(hostname),
-      path_begin: String::from(path_begin)
+      path_begin: String::from(path_begin),
+      sticky_session: sticky_session
     }));
   }
 }
 
-pub fn remove_frontend(channel: &mut Channel<ConfigMessage,ConfigMessageAnswer>, app_id: &str, hostname: &str, path_begin: &str, certificate: Option<&str>) {
+pub fn remove_frontend(channel: &mut Channel<ConfigMessage,ConfigMessageAnswer>, app_id: &str, hostname: &str, path_begin: &str, certificate: Option<&str>, sticky_session: bool) {
   if let Some(certificate_path) = certificate {
     match Config::load_file_bytes(certificate_path) {
       Ok(data) => {
@@ -505,7 +507,8 @@ pub fn remove_frontend(channel: &mut Channel<ConfigMessage,ConfigMessageAnswer>,
               app_id: String::from(app_id),
               hostname: String::from(hostname),
               path_begin: String::from(path_begin),
-              fingerprint: CertFingerprint(fingerprint)
+              fingerprint: CertFingerprint(fingerprint),
+              sticky_session: sticky_session
             }));
           },
         }
@@ -516,7 +519,8 @@ pub fn remove_frontend(channel: &mut Channel<ConfigMessage,ConfigMessageAnswer>,
     order_command(channel, Order::RemoveHttpFront(HttpFront {
       app_id: String::from(app_id),
       hostname: String::from(hostname),
-      path_begin: String::from(path_begin)
+      path_begin: String::from(path_begin),
+      sticky_session: sticky_session
     }));
   }
 }

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -19,6 +19,8 @@ use sozu_command::data::{ConfigMessage,ConfigMessageAnswer};
 use command::{dump_state,load_state,save_state,soft_stop,hard_stop,upgrade,status,metrics,
   remove_backend, add_backend, remove_frontend, add_frontend, add_certificate, remove_certificate};
 
+use std::str::FromStr;
+
 fn main() {
   let matches = App::new("sozuctl")
                         .version(crate_version!())
@@ -120,6 +122,11 @@ fn main() {
                                                       .long("certificate")
                                                       .value_name("path to a certificate file")
                                                       .takes_value(true)
+                                                      .required(false))
+                                                  .arg(Arg::with_name("sticky_session")
+                                                      .long("sticky session")
+                                                      .value_name("the frontend should do sticky session")
+                                                      .takes_value(true)
                                                       .required(false)))
                                                 .subcommand(SubCommand::with_name("remove")
                                                   .arg(Arg::with_name("id")
@@ -142,6 +149,11 @@ fn main() {
                                                   .arg(Arg::with_name("certificate")
                                                       .long("certificate")
                                                       .value_name("path to a certificate file")
+                                                      .takes_value(true)
+                                                      .required(false))
+                                                  .arg(Arg::with_name("sticky_session")
+                                                      .long("sticky session")
+                                                      .value_name("the frontend should do sticky session")
                                                       .takes_value(true)
                                                       .required(false))))
                         .subcommand(SubCommand::with_name("certificate")
@@ -232,18 +244,20 @@ fn main() {
     ("frontend", Some(sub)) => {
       match sub.subcommand() {
         ("remove", Some(frontend_sub)) => {
-          let id          = frontend_sub.value_of("id").expect("missing id");
-          let hostname    = frontend_sub.value_of("hostname").expect("missing frontend hostname");
-          let path_begin  = frontend_sub.value_of("path_begin").unwrap_or("");
-          let certificate = frontend_sub.value_of("certificate");
-          remove_frontend(&mut channel, id, hostname, path_begin, certificate);
+          let id              = frontend_sub.value_of("id").expect("missing id");
+          let hostname        = frontend_sub.value_of("hostname").expect("missing frontend hostname");
+          let path_begin      = frontend_sub.value_of("path_begin").unwrap_or("");
+          let certificate     = frontend_sub.value_of("certificate");
+          let sticky_session  = frontend_sub.value_of("sticky_session").and_then(|b| bool::from_str(b).ok()).unwrap_or(false);
+          remove_frontend(&mut channel, id, hostname, path_begin, certificate, sticky_session);
         },
         ("add", Some(frontend_sub)) => {
-          let id          = frontend_sub.value_of("id").expect("missing id");
-          let hostname    = frontend_sub.value_of("hostname").expect("missing frontend hostname");
-          let path_begin  = frontend_sub.value_of("path_begin").unwrap_or("");
-          let certificate = frontend_sub.value_of("certificate");
-          add_frontend(&mut channel, id, hostname, path_begin, certificate);
+          let id              = frontend_sub.value_of("id").expect("missing id");
+          let hostname        = frontend_sub.value_of("hostname").expect("missing frontend hostname");
+          let path_begin      = frontend_sub.value_of("path_begin").unwrap_or("");
+          let certificate     = frontend_sub.value_of("certificate");
+          let sticky_session  = frontend_sub.value_of("sticky_session").and_then(|b| bool::from_str(b).ok()).unwrap_or(false);
+          add_frontend(&mut channel, id, hostname, path_begin, certificate, sticky_session);
         }
         _ => println!("unknown backend management command")
       }

--- a/lib/examples/main.rs
+++ b/lib/examples/main.rs
@@ -43,7 +43,7 @@ fn main() {
     network::http::start(config, channel);
   });
 
-  let http_front = messages::HttpFront { app_id: String::from("app_1"), hostname: String::from("lolcatho.st"), path_begin: String::from("/") };
+  let http_front = messages::HttpFront { app_id: String::from("app_1"), hostname: String::from("lolcatho.st"), path_begin: String::from("/"), sticky_session: false };
   let http_instance = messages::Instance { app_id: String::from("app_1"), ip_address: String::from("127.0.0.1"), port: 1026 };
   command.write_message(&messages::OrderMessage { id: String::from("ID_ABCD"), order: messages::Order::AddHttpFront(http_front) });
   command.write_message(&messages::OrderMessage { id: String::from("ID_EFGH"), order: messages::Order::AddInstance(http_instance) });
@@ -97,7 +97,8 @@ fn main() {
     app_id:      String::from("app_1"),
     hostname:    String::from("lolcatho.st"),
     path_begin:  String::from("/"),
-    fingerprint: messages::CertFingerprint(hex::FromHex::from_hex("AB2618B674E15243FD02A5618C66509E4840BA60E7D64CEBEC84CDBFECEEE0C5").unwrap())
+    fingerprint: messages::CertFingerprint(hex::FromHex::from_hex("AB2618B674E15243FD02A5618C66509E4840BA60E7D64CEBEC84CDBFECEEE0C5").unwrap()),
+    sticky_session: false
   };
   command2.write_message(&messages::OrderMessage { id: String::from("ID_IJKL2"), order: messages::Order::AddHttpsFront(tls_front) });
   let tls_instance = messages::Instance { app_id: String::from("app_1"), ip_address: String::from("127.0.0.1"), port: 1026 };
@@ -119,7 +120,8 @@ fn main() {
     app_id:      String::from("app_2"),
     hostname:    String::from("test.local"),
     path_begin:  String::from("/"),
-    fingerprint: messages::CertFingerprint(hex::FromHex::from_hex("7E8EBF9AD0645AB755A2E51EB3734B91D4ACACEF1F28AD9D96D9385487FAE6E6").unwrap())
+    fingerprint: messages::CertFingerprint(hex::FromHex::from_hex("7E8EBF9AD0645AB755A2E51EB3734B91D4ACACEF1F28AD9D96D9385487FAE6E6").unwrap()),
+    sticky_session: false
   };
   command2.write_message(&messages::OrderMessage { id: String::from("ID_QRST2"), order: messages::Order::AddHttpsFront(tls_front2) });
   let tls_instance2 = messages::Instance { app_id: String::from("app_2"), ip_address: String::from("127.0.0.1"), port: 1026 };

--- a/lib/examples/minimal.rs
+++ b/lib/examples/minimal.rs
@@ -37,7 +37,8 @@ fn main() {
   let http_front = messages::HttpFront {
     app_id:     String::from("test"),
     hostname:   String::from("example.com"),
-    path_begin: String::from("/")
+    path_begin: String::from("/"),
+    sticky_session: false
   };
   let http_instance = messages::Instance {
     app_id:     String::from("test"),

--- a/lib/src/network/http.rs
+++ b/lib/src/network/http.rs
@@ -21,7 +21,7 @@ use sozu_command::messages::{self,Order,HttpFront,HttpProxyConfiguration,OrderMe
 
 use network::{Backend,ClientResult,ConnectionError,RequiredEvents,Protocol};
 use network::buffer_queue::BufferQueue;
-use network::protocol::{ProtocolResult,TlsHandshake,Http,Pipe};
+use network::protocol::{ProtocolResult,StickySession,TlsHandshake,Http,Pipe};
 use network::proxy::{Server,ProxyChannel};
 use network::session::{BackendConnectAction,BackendConnectionStatus,ProxyClient,ProxyConfiguration,Readiness,ListenToken,FrontToken,BackToken,AcceptError,Session};
 use network::socket::{SocketHandler,SocketResult,server_bind};
@@ -52,6 +52,7 @@ pub struct Client {
   back_connected: BackendConnectionStatus,
   protocol:       Option<State>,
   pool:           Weak<RefCell<Pool<BufferQueue>>>,
+  sticky_session: bool,
 }
 
 impl Client {
@@ -77,6 +78,7 @@ impl Client {
         protocol:       Some(State::Http(http)),
         frontend:       sock,
         pool:           pool,
+        sticky_session: false
       };
 
     client
@@ -446,7 +448,7 @@ impl ServerConfiguration {
     }
   }
 
-  pub fn backend_from_app_id(&mut self, client: &mut Client, app_id: &str) -> Result<TcpStream,ConnectionError> {
+  pub fn backend_from_app_id(&mut self, client: &mut Client, app_id: &str, front_should_stick: bool) -> Result<TcpStream,ConnectionError> {
     // FIXME: the app id clone here is probably very inefficient
     //if let Some(app_id) = self.frontend_from_request(host, uri).map(|ref front| front.http.app_id.clone()) {
     client.http().map(|h| h.app_id = Some(String::from(app_id)));
@@ -483,6 +485,9 @@ impl ServerConfiguration {
           if conn.is_ok() {
             client.back_connected = BackendConnectionStatus::Connecting;
             client.instance = Some(b.clone());
+            if front_should_stick {
+              client.http().map(|mut http| http.sticky_session = Some(StickySession::new(backend.id.clone())));
+            }
           }
 
           conn
@@ -496,6 +501,36 @@ impl ServerConfiguration {
     } else {
       Err(ConnectionError::NoBackendAvailable)
     }
+  }
+
+  pub fn backend_from_sticky_session(&mut self, client: &mut Client, app_id: &str, sticky_session: u32) -> Option<Result<TcpStream,ConnectionError>> {
+    let max_failures_per_backend = 10;
+    if let Some(ref mut app_instances) = self.instances.get_mut(app_id) {
+      let mut sticky_backend: Option<&mut Rc<RefCell<Backend>>> = app_instances.iter_mut().find(|b| {
+        let backend = &*b.borrow();
+        backend.id == sticky_session && backend.can_open(max_failures_per_backend)
+      });
+
+      if let Some(b) = sticky_backend {
+        //FIXME: hardcoded for now, these should come from configuration
+        let ref mut backend = *b.borrow_mut();
+        let conn = backend.try_connect(max_failures_per_backend);
+        info!("{}\tConnecting {} -> {:?} using session {}", client.http().map(|h| h.log_ctx.clone()).unwrap_or("".to_string()), app_id, (backend.address, backend.active_connections, backend.failures), sticky_session);
+        if backend.failures >= max_failures_per_backend {
+          error!("{}\tbackend {:?} connections failed {} times, disabling it", client.http().map(|h| h.log_ctx.clone()).unwrap_or("".to_string()), (backend.address, backend.active_connections), backend.failures);
+        }
+        if conn.is_ok() {
+          client.back_connected = BackendConnectionStatus::Connecting;
+          client.instance = Some(b.clone());
+          client.http().map(|mut http| http.sticky_session = Some(StickySession::new(backend.id.clone())));
+        }
+
+        return Some(conn);
+      }
+    }
+
+    debug!("Couldn't find a backend corresponding to sticky_session {} for app {}", sticky_session, app_id);
+    None
   }
 }
 
@@ -524,9 +559,11 @@ impl ProxyConfiguration<Client> for ServerConfiguration {
       return Err(ConnectionError::ToBeDefined);
     };
 
+    let sticky_session = client.http().unwrap().state.as_ref().unwrap().get_request_sticky_session();
+
     //FIXME: too many unwraps here
     let rl     = try!(client.http().unwrap().state.as_ref().unwrap().get_request_line().ok_or(ConnectionError::NoRequestLineGiven));
-    if let Some(app_id) = self.frontend_from_request(&host, &rl.uri).map(|ref front| front.app_id.clone()) {
+    if let Some((app_id, front_should_stick)) = self.frontend_from_request(&host, &rl.uri).map(|ref front| { (front.app_id.clone(), front.sticky_session.clone()) }) {
       if (client.http().map(|h| h.app_id.as_ref()).unwrap_or(None) == Some(&app_id)) && client.back_connected == BackendConnectionStatus::Connected {
         //matched on keepalive
         return Ok(BackendConnectAction::Reuse);
@@ -553,7 +590,17 @@ impl ProxyConfiguration<Client> for ServerConfiguration {
         sock.shutdown(Shutdown::Both);
       }
 
-      let conn   = self.backend_from_app_id(client, &app_id);
+      let conn = match (front_should_stick, sticky_session) {
+        (true, Some(session)) => {
+          if let Some(conn) = self.backend_from_sticky_session(client, &app_id, session) {
+            conn
+          } else {
+            self.backend_from_app_id(client, &app_id, front_should_stick)
+          }
+        },
+        (_, _) => self.backend_from_app_id(client, &app_id, front_should_stick)
+      };
+
       match conn {
         Ok(socket) => {
           socket.set_nodelay(true);

--- a/lib/src/network/http.rs
+++ b/lib/src/network/http.rs
@@ -749,7 +749,7 @@ mod tests {
       start(config, channel);
     });
 
-    let front = HttpFront { app_id: String::from("app_1"), hostname: String::from("localhost"), path_begin: String::from("/") };
+    let front = HttpFront { app_id: String::from("app_1"), hostname: String::from("localhost"), path_begin: String::from("/"), sticky_session: false };
     command.write_message(&OrderMessage { id: String::from("ID_ABCD"), order: Order::AddHttpFront(front) });
     let instance = Instance { app_id: String::from("app_1"), ip_address: String::from("127.0.0.1"), port: 1025 };
     command.write_message(&OrderMessage { id: String::from("ID_EFGH"), order: Order::AddInstance(instance) });
@@ -803,7 +803,7 @@ mod tests {
       start(config, channel);
     });
 
-    let front = HttpFront { app_id: String::from("app_1"), hostname: String::from("localhost"), path_begin: String::from("/") };
+    let front = HttpFront { app_id: String::from("app_1"), hostname: String::from("localhost"), path_begin: String::from("/"), sticky_session: false };
     command.write_message(&OrderMessage { id: String::from("ID_ABCD"), order: Order::AddHttpFront(front) });
     let instance = Instance { app_id: String::from("app_1"), ip_address: String::from("127.0.0.1"), port: 1028 };
     command.write_message(&OrderMessage { id: String::from("ID_EFGH"), order: Order::AddInstance(instance) });
@@ -897,12 +897,12 @@ mod tests {
 
     let mut fronts = HashMap::new();
     fronts.insert("lolcatho.st".to_owned(), vec![
-      HttpFront { app_id: app_id1, hostname: "lolcatho.st".to_owned(), path_begin: uri1 },
-      HttpFront { app_id: app_id2, hostname: "lolcatho.st".to_owned(), path_begin: uri2 },
-      HttpFront { app_id: app_id3, hostname: "lolcatho.st".to_owned(), path_begin: uri3 }
+      HttpFront { app_id: app_id1, hostname: "lolcatho.st".to_owned(), path_begin: uri1, sticky_session: false },
+      HttpFront { app_id: app_id2, hostname: "lolcatho.st".to_owned(), path_begin: uri2, sticky_session: false },
+      HttpFront { app_id: app_id3, hostname: "lolcatho.st".to_owned(), path_begin: uri3, sticky_session: false }
     ]);
     fronts.insert("other.domain".to_owned(), vec![
-      HttpFront { app_id: "app_1".to_owned(), hostname: "other.domain".to_owned(), path_begin: "/test".to_owned() },
+      HttpFront { app_id: "app_1".to_owned(), hostname: "other.domain".to_owned(), path_begin: "/test".to_owned(), sticky_session: false },
     ]);
 
     let front: SocketAddr = FromStr::from_str("127.0.0.1:1030").expect("could not parse address");

--- a/lib/src/network/http.rs
+++ b/lib/src/network/http.rs
@@ -382,14 +382,15 @@ impl ServerConfiguration {
 
   pub fn add_instance(&mut self, app_id: &str, instance_address: &SocketAddr, event_loop: &mut Poll) {
     if let Some(addrs) = self.instances.get_mut(app_id) {
-      let backend = Rc::new(RefCell::new(Backend::new(*instance_address)));
+      let id = addrs.last().map(|b| (*b.borrow_mut()).id ).unwrap_or(0) + 1;
+      let backend = Rc::new(RefCell::new(Backend::new(*instance_address, id)));
       if !addrs.contains(&backend) {
         addrs.push(backend);
       }
     }
 
     if self.instances.get(app_id).is_none() {
-      let backend = Backend::new(*instance_address);
+      let backend = Backend::new(*instance_address, 0);
       self.instances.insert(String::from(app_id), vec![Rc::new(RefCell::new(backend))]);
     }
   }

--- a/lib/src/network/mod.rs
+++ b/lib/src/network/mod.rs
@@ -142,6 +142,7 @@ pub enum BackendStatus {
 
 #[derive(Debug,PartialEq,Eq)]
 pub struct Backend {
+  pub id:                 u32,
   pub address:            SocketAddr,
   pub status:             BackendStatus,
   pub active_connections: usize,
@@ -149,8 +150,9 @@ pub struct Backend {
 }
 
 impl Backend {
-  pub fn new(addr: SocketAddr) -> Backend {
+  pub fn new(addr: SocketAddr, id: u32) -> Backend {
     Backend {
+      id:                 id,
       address:            addr,
       status:             BackendStatus::Normal,
       active_connections: 0,

--- a/lib/src/network/protocol/mod.rs
+++ b/lib/src/network/protocol/mod.rs
@@ -4,7 +4,7 @@ pub mod tls;
 
 pub use self::tls::TlsHandshake;
 pub use self::pipe::Pipe;
-pub use self::http::Http;
+pub use self::http::{Http,StickySession};
 
 #[derive(Debug,Clone,Copy,PartialEq)]
 pub enum ProtocolResult {

--- a/lib/src/network/tls.rs
+++ b/lib/src/network/tls.rs
@@ -682,14 +682,15 @@ impl ServerConfiguration {
 
   pub fn add_instance(&mut self, app_id: &str, instance_address: &SocketAddr, event_loop: &mut Poll) {
     if let Some(addrs) = self.instances.get_mut(app_id) {
-      let backend = Rc::new(RefCell::new(Backend::new(*instance_address)));
+      let id = addrs.last().map(|b| (*b.borrow_mut()).id ).unwrap_or(0) + 1;
+      let backend = Rc::new(RefCell::new(Backend::new(*instance_address, id)));
       if !addrs.contains(&backend) {
         addrs.push(backend);
       }
     }
 
     if self.instances.get(app_id).is_none() {
-      let backend = Backend::new(*instance_address);
+      let backend = Backend::new(*instance_address, 0);
       self.instances.insert(String::from(app_id), vec![Rc::new(RefCell::new(backend))]);
     }
   }

--- a/lib/src/network/tls.rs
+++ b/lib/src/network/tls.rs
@@ -42,7 +42,7 @@ use network::session::{BackendConnectAction,BackendConnectionStatus,ProxyClient,
 use network::http::{self,DefaultAnswers};
 use network::socket::{SocketHandler,SocketResult,server_bind};
 use network::trie::*;
-use network::protocol::{ProtocolResult,TlsHandshake,Http,Pipe};
+use network::protocol::{ProtocolResult,TlsHandshake,Http,Pipe,StickySession};
 use util::UnwrapLog;
 
 
@@ -56,6 +56,7 @@ pub struct TlsApp {
   pub hostname:         String,
   pub path_begin:       String,
   pub cert_fingerprint: CertFingerprint,
+  pub sticky_session:   bool,
 }
 
 pub enum State {
@@ -75,6 +76,7 @@ pub struct TlsClient {
   public_address: Option<IpAddr>,
   ssl:            Option<Ssl>,
   pool:           Weak<RefCell<Pool<BufferQueue>>>,
+  sticky_session: bool,
 }
 
 impl TlsClient {
@@ -94,6 +96,7 @@ impl TlsClient {
       public_address: public_address,
       ssl:            None,
       pool:           pool,
+      sticky_session: false,
     }
   }
 
@@ -373,6 +376,7 @@ impl ServerConfiguration {
       hostname:         config.default_name.clone().unwrap_or(String::new()),
       path_begin:       String::new(),
       cert_fingerprint: fingerprint,
+      sticky_session:   false,
     };
     fronts.insert(config.default_name.clone().unwrap_or(String::from("")), vec![app]);
 
@@ -542,6 +546,7 @@ impl ServerConfiguration {
       hostname:         tls_front.hostname.clone(),
       path_begin:       tls_front.path_begin.clone(),
       cert_fingerprint: tls_front.fingerprint.clone(),
+      sticky_session:   tls_front.sticky_session.clone(),
     };
 
     if let Some(fronts) = self.fronts.get_mut(&tls_front.hostname) {
@@ -741,7 +746,7 @@ impl ServerConfiguration {
     }
   }
 
-  pub fn backend_from_request(&mut self, client: &mut TlsClient, host: &str, uri: &str) -> Result<TcpStream,ConnectionError> {
+  pub fn backend_from_request(&mut self, client: &mut TlsClient, host: &str, uri: &str, front_should_stick: bool) -> Result<TcpStream,ConnectionError> {
     trace!("looking for backend for host: {}", host);
     let real_host = if let Some(h) = host.split(":").next() {
       h
@@ -785,6 +790,9 @@ impl ServerConfiguration {
            if conn.is_ok() {
              client.back_connected = BackendConnectionStatus::Connecting;
              client.instance = Some(b.clone());
+              if front_should_stick {
+                client.http().map(|mut http| http.sticky_session = Some(StickySession::new(backend.id.clone())));
+              }
            }
 
             conn
@@ -801,6 +809,36 @@ impl ServerConfiguration {
     } else {
       Err(ConnectionError::HostNotFound)
     }
+  }
+
+  pub fn backend_from_sticky_session(&mut self, client: &mut TlsClient, app_id: &str, sticky_session: u32) -> Option<Result<TcpStream,ConnectionError>> {
+    let max_failures_per_backend = 10;
+    if let Some(ref mut app_instances) = self.instances.get_mut(app_id) {
+      let mut sticky_backend: Option<&mut Rc<RefCell<Backend>>> = app_instances.iter_mut().find(|b| {
+        let backend = &*b.borrow();
+        backend.id == sticky_session && backend.can_open(max_failures_per_backend)
+      });
+
+      if let Some(b) = sticky_backend {
+        //FIXME: hardcoded for now, these should come from configuration
+        let ref mut backend = *b.borrow_mut();
+        let conn = backend.try_connect(max_failures_per_backend);
+        info!("{}\tConnecting {} -> {:?} using session {}", client.http().map(|h| h.log_ctx.clone()).unwrap_or("".to_string()), app_id, (backend.address, backend.active_connections, backend.failures), sticky_session);
+        if backend.failures >= max_failures_per_backend {
+          error!("{}\tbackend {:?} connections failed {} times, disabling it", client.http().map(|h| h.log_ctx.clone()).unwrap_or("".to_string()), (backend.address, backend.active_connections), backend.failures);
+        }
+        if conn.is_ok() {
+          client.back_connected = BackendConnectionStatus::Connecting;
+          client.instance = Some(b.clone());
+          client.http().map(|mut http| http.sticky_session = Some(StickySession::new(backend.id.clone())));
+        }
+
+        return Some(conn);
+      }
+    }
+
+    debug!("Couldn't find a backend corresponding to sticky_session {} for app {}", sticky_session, app_id);
+    None
   }
 }
 
@@ -862,74 +900,88 @@ impl ProxyConfiguration<TlsClient> for ServerConfiguration {
     };
 
     let rl:RRequestLine = try!(unwrap_msg!(client.http()).state().get_request_line().ok_or(ConnectionError::NoRequestLineGiven));
-    if let Some(app_id) = self.frontend_from_request(&host, &rl.uri).map(|ref front| front.app_id.clone()) {
+    if let Some((app_id, front_should_stick)) = self.frontend_from_request(&host, &rl.uri).map(|ref front| (front.app_id.clone(), front.sticky_session.clone())) {
       if (client.http().map(|h| h.app_id.as_ref()).unwrap_or(None) == Some(&app_id)) && client.back_connected == BackendConnectionStatus::Connected {
         //matched on keepalive
         return Ok(BackendConnectAction::Reuse);
       }
-    }
 
-    // circuit breaker
-    if client.back_connected == BackendConnectionStatus::Connecting {
-      client.instance.as_ref().map(|instance| {
-        let ref mut backend = *instance.borrow_mut();
-        backend.failures += 1;
-        backend.dec_connections();
-      });
-    }
-    info!("instances: {:?}", self.instances);
-
-    let reused = client.http().map(|http| http.app_id.is_some()).unwrap_or(false);
-    //deregister back socket if it is the wrong one or if it was not connecting
-    if reused || client.back_connected == BackendConnectionStatus::Connecting {
-      client.instance = None;
-      client.back_connected = BackendConnectionStatus::NotConnected;
-      client.readiness().back_interest  = UnixReady::from(Ready::empty());
-      client.readiness().back_readiness = UnixReady::from(Ready::empty());
-      client.back_socket().as_ref().map(|sock| {
-        event_loop.deregister(*sock);
-        sock.shutdown(Shutdown::Both);
-      });
-    }
-
-    let conn   = try!(unwrap_msg!(client.http()).state().get_front_keep_alive().ok_or(ConnectionError::ToBeDefined));
-    let conn   = self.backend_from_request(client, &host, &rl.uri);
-
-    match conn {
-      Ok(socket) => {
-        let req_state = unwrap_msg!(client.http()).state().request.clone();
-        let req_header_end = unwrap_msg!(client.http()).state().req_header_end;
-        let res_header_end = unwrap_msg!(client.http()).state().res_header_end;
-        let added_req_header = unwrap_msg!(client.http()).state().added_req_header.clone();
-        let added_res_header = unwrap_msg!(client.http()).state().added_res_header.clone();
-        // FIXME: is this still needed?
-        unwrap_msg!(client.http()).set_state(HttpState {
-          req_header_end: req_header_end,
-          res_header_end: res_header_end,
-          request:  req_state,
-          response: Some(ResponseState::Initial),
-          added_req_header: added_req_header,
-          added_res_header: added_res_header,
+      // circuit breaker
+      if client.back_connected == BackendConnectionStatus::Connecting {
+        client.instance.as_ref().map(|instance| {
+          let ref mut backend = *instance.borrow_mut();
+          backend.failures += 1;
+          backend.dec_connections();
         });
+      }
+      info!("instances: {:?}", self.instances);
 
-        client.set_back_socket(socket);
-        if reused {
-          Ok(BackendConnectAction::Replace)
-        } else {
-          Ok(BackendConnectAction::New)
-        }
-      },
-      Err(ConnectionError::NoBackendAvailable) => {
-        unwrap_msg!(client.http()).set_answer(&self.answers.ServiceUnavailable);
-        client.readiness().front_interest = UnixReady::from(Ready::writable()) | UnixReady::hup() | UnixReady::error();
-        Err(ConnectionError::NoBackendAvailable)
-      },
-      Err(ConnectionError::HostNotFound) => {
-        unwrap_msg!(client.http()).set_answer(&self.answers.NotFound);
-        client.readiness().front_interest = UnixReady::from(Ready::writable()) | UnixReady::hup() | UnixReady::error();
-        Err(ConnectionError::HostNotFound)
-      },
-      e => panic!(e)
+      let reused = client.http().map(|http| http.app_id.is_some()).unwrap_or(false);
+      //deregister back socket if it is the wrong one or if it was not connecting
+      if reused || client.back_connected == BackendConnectionStatus::Connecting {
+        client.instance = None;
+        client.back_connected = BackendConnectionStatus::NotConnected;
+        client.readiness().back_interest  = UnixReady::from(Ready::empty());
+        client.readiness().back_readiness = UnixReady::from(Ready::empty());
+        client.back_socket().as_ref().map(|sock| {
+          event_loop.deregister(*sock);
+          sock.shutdown(Shutdown::Both);
+        });
+      }
+
+      let conn   = try!(unwrap_msg!(client.http()).state().get_front_keep_alive().ok_or(ConnectionError::ToBeDefined));
+      let sticky_session = client.http().unwrap().state.as_ref().unwrap().get_request_sticky_session();
+      let conn = match (front_should_stick, sticky_session) {
+        (true, Some(session)) => {
+          if let Some(conn) = self.backend_from_sticky_session(client, &app_id, session) {
+            conn
+          } else {
+            self.backend_from_request(client, &host, &rl.uri, front_should_stick)
+          }
+        },
+        (_, _) => self.backend_from_request(client, &host, &rl.uri, front_should_stick)
+      };
+
+      match conn {
+        Ok(socket) => {
+          let req_state = unwrap_msg!(client.http()).state().request.clone();
+          let req_header_end = unwrap_msg!(client.http()).state().req_header_end;
+          let res_header_end = unwrap_msg!(client.http()).state().res_header_end;
+          let added_req_header = unwrap_msg!(client.http()).state().added_req_header.clone();
+          let added_res_header = unwrap_msg!(client.http()).state().added_res_header.clone();
+          // FIXME: is this still needed?
+          unwrap_msg!(client.http()).set_state(HttpState {
+            req_header_end: req_header_end,
+            res_header_end: res_header_end,
+            request:  req_state,
+            response: Some(ResponseState::Initial),
+            added_req_header: added_req_header,
+            added_res_header: added_res_header,
+          });
+
+          client.set_back_socket(socket);
+          if reused {
+            Ok(BackendConnectAction::Replace)
+          } else {
+            Ok(BackendConnectAction::New)
+          }
+        },
+        Err(ConnectionError::NoBackendAvailable) => {
+          unwrap_msg!(client.http()).set_answer(&self.answers.ServiceUnavailable);
+          client.readiness().front_interest = UnixReady::from(Ready::writable()) | UnixReady::hup() | UnixReady::error();
+          Err(ConnectionError::NoBackendAvailable)
+        },
+        Err(ConnectionError::HostNotFound) => {
+          unwrap_msg!(client.http()).set_answer(&self.answers.NotFound);
+          client.readiness().front_interest = UnixReady::from(Ready::writable()) | UnixReady::hup() | UnixReady::error();
+          Err(ConnectionError::HostNotFound)
+        },
+        e => panic!(e)
+      }
+    } else {
+      unwrap_msg!(client.http()).set_answer(&self.answers.NotFound);
+      client.readiness().front_interest = UnixReady::from(Ready::writable()) | UnixReady::hup() | UnixReady::error();
+      Err(ConnectionError::HostNotFound)
     }
   }
 
@@ -1174,21 +1226,25 @@ mod tests {
     fronts.insert("lolcatho.st".to_owned(), vec![
       TlsApp {
         app_id: app_id1, hostname: "lolcatho.st".to_owned(), path_begin: uri1,
-        cert_fingerprint: CertFingerprint(vec!())
+        cert_fingerprint: CertFingerprint(vec!()),
+        sticky_session: false
       },
       TlsApp {
         app_id: app_id2, hostname: "lolcatho.st".to_owned(), path_begin: uri2,
-        cert_fingerprint: CertFingerprint(vec!())
+        cert_fingerprint: CertFingerprint(vec!()),
+        sticky_session: false
       },
       TlsApp {
         app_id: app_id3, hostname: "lolcatho.st".to_owned(), path_begin: uri3,
-        cert_fingerprint: CertFingerprint(vec!())
+        cert_fingerprint: CertFingerprint(vec!()),
+        sticky_session: false
       }
     ]);
     fronts.insert("other.domain".to_owned(), vec![
       TlsApp {
         app_id: "app_1".to_owned(), hostname: "other.domain".to_owned(), path_begin: "/test".to_owned(),
-        cert_fingerprint: CertFingerprint(vec!())
+        cert_fingerprint: CertFingerprint(vec!()),
+        sticky_session: false
       },
     ]);
 

--- a/lib/src/parser/http11.rs
+++ b/lib/src/parser/http11.rs
@@ -2868,6 +2868,7 @@ mod tests {
               upgrade:     Some("WebSocket".to_string()),
               continues:   Continue::None,
               to_delete:   HashSet::new(),
+              sticky_session: None
             },
             String::from("localhost:8888"),
           )),

--- a/lib/src/parser/http11.rs
+++ b/lib/src/parser/http11.rs
@@ -568,6 +568,9 @@ impl<'a> Header<'a> {
         Some(tokens) => ! tokens.iter().any(|value| &value.to_ascii_lowercase()[..] == b"upgrade"),
         None         => true
       }
+    } else if &lowercase[..] == b"set-cookie" {
+      let look_for = b"SOZUBALANCEID=";
+      &self.value[0..look_for.len()] == look_for
     } else {
       &lowercase[..] == b"connection" && &self.value.to_ascii_lowercase()[..] != b"upgrade" ||
       &lowercase[..] == b"forwarded"         ||

--- a/lib/src/parser/http11.rs
+++ b/lib/src/parser/http11.rs
@@ -7,7 +7,7 @@ use network::buffer_queue::BufferQueue;
 use nom::{HexDisplay,IResult,Offset};
 use nom::IResult::*;
 
-use nom::{digit,is_alphanumeric};
+use nom::{digit,is_alphanumeric,is_space};
 
 use url::Url;
 
@@ -196,7 +196,7 @@ named!(pub message_header<Header>,
        chain!(
          name: token ~
          tag!(":")   ~
-         opt!(sp)    ~
+         opt!(take_while!(is_space))    ~
          value: take_while!(is_header_value_char) ~ // ToDo handle folding?
          crlf, || {
            Header {


### PR DESCRIPTION
This is a WIP pull request to support sticky sessions ( see #94 )

Right now, the sticky session cookie is hardcoded everywhere, I plan to make it configurable.
In this initial pull request, there is:
- partial support for parsing cookies (the parser take_while(is_alphanumeric) and it's not great). Also, I don't handle yet cookies larger than the input buffer (if I understood correctly)
- check if clients has a sticky session cookie and store it in the Connection
- remove Set-Cookie header from backend with the value of the sticky session cookie name
- untested "connect to backend if sticky session cookie matches a backend"

It still misses:
- Set the sticky cookie if not yet set
- Store the backend related to the cookie
- maybe other things