### PR TITLE
Make `[metrics]` optional in config file

### DIFF
--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -96,8 +96,11 @@ fn main() {
     logging::setup("MASTER".to_string(), &config.log_level, &config.log_target);
     info!("starting up");
 
-    metrics_set_up!(&config.metrics.address[..], config.metrics.port);
-    gauge!("sozu.TEST", 42);
+    if let Some(ref metrics) = config.metrics.as_ref() {
+      metrics_set_up!(&metrics.address[..], metrics.port);
+      gauge!("sozu.TEST", 42);
+    }
+
 
     if check_process_limits(config.clone()) {
       match start_workers(&config) {

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -73,9 +73,10 @@ pub fn begin_worker_process(fd: i32, id: &str, channel_buffer_size: usize) {
   command.set_nonblocking(true);
   let command: Channel<OrderMessageAnswer,OrderMessage> = command.into();
 
-
-  metrics_set_up!(&proxy_config.metrics.address[..], proxy_config.metrics.port);
-  gauge!("sozu.TEST", 42);
+  if let Some(ref metrics) = proxy_config.metrics.as_ref() {
+    metrics_set_up!(&metrics.address[..], metrics.port);
+    gauge!("sozu.TEST", 42);
+  }
 
   let mut event_loop  = Poll::new().expect("could not create event loop");
 

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -199,7 +199,7 @@ pub struct Config {
   pub log_level:               Option<String>,
   pub log_target:              Option<String>,
   pub worker_count:            Option<u16>,
-  pub metrics:                 MetricsConfig,
+  pub metrics:                 Option<MetricsConfig>,
   pub http:                    Option<ProxyConfig>,
   pub https:                   Option<ProxyConfig>,
   pub applications:            HashMap<String, AppConfig>,
@@ -398,10 +398,10 @@ mod tests {
       max_command_buffer_size: None,
       log_level:  None,
       log_target: None,
-      metrics: MetricsConfig {
+      metrics: Some(MetricsConfig {
         address: String::from("192.168.59.103"),
         port:    8125,
-      },
+      }),
       http:  Some(http),
       https: Some(https),
       applications: HashMap::new(),


### PR DESCRIPTION
Only start the metrics pipeline if `[metrics]` is present
Fixes #200 

I've not tested it yet, I've opened the PR mainly for discussion