### PR TITLE
Move package specific defaults to a build script. #199

### DIFF
--- a/bin/build.rs
+++ b/bin/build.rs
@@ -1,0 +1,10 @@
+use std::env;
+
+fn main(){
+    // Export defaults as compile time environment variables.
+    // These variables are to be set by package managers in their build script.
+    // `export SOZU_CONFIG=<default configuration file> && cargo build`.
+    if let Ok(config) = env::var("SOZU_CONFIG") {
+        println!("cargo:rustc-env={}={}", "SOZU_CONFIG", config);
+    }
+}

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -47,7 +47,7 @@ fn main() {
                                         .value_name("FILE")
                                         .help("Sets a custom config file")
                                         .takes_value(true)
-                                        .required(true)))
+                                        .required(option_env!("SOZU_CONFIG").is_none())))
                         .subcommand(SubCommand::with_name("worker")
                                     .about("start a worker (internal command, should not be used directly)")
                                     .arg(Arg::with_name("id").long("id")
@@ -88,8 +88,11 @@ fn main() {
   }
 
   let submatches = matches.subcommand_matches("start").expect("unknown subcommand");
-  let config_file = submatches.value_of("config").expect("required config file");
-
+  let config_file = match submatches.value_of("config"){
+                      Some(config_file) => config_file,
+                      None => option_env!("SOZU_CONFIG").expect("could not find `SOZU_CONFIG` env var at build"),
+                    };
+                    
   if let Ok(config) = Config::load_from_path(config_file) {
     //FIXME: should have an id for the master too
     logging::setup("MASTER".to_string(), &config.log_level, &config.log_target);

--- a/ctl/build.rs
+++ b/ctl/build.rs
@@ -1,0 +1,12 @@
+use std::env;
+
+// Configuration defaults.
+
+fn main(){
+    // Export defaults as compile time environment variables.
+    // These variables are to be set by package managers in their build script.
+    // `export SOZU_CONFIG=<default configuration file> && cargo build`.
+    if let Ok(config) = env::var("SOZU_CONFIG") {
+        println!("cargo:rustc-env={}={}", "SOZU_CONFIG", config);
+    }
+}

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
                             .value_name("FILE")
                             .help("Sets a custom config file")
                             .takes_value(true)
-                            .required(true))
+                            .required(option_env!("SOZU_CONFIG").is_none()))
                         .subcommand(SubCommand::with_name("shutdown")
                                     .about("shuts down the proxy")
                                     .arg(Arg::with_name("hard").long("hard")
@@ -182,8 +182,11 @@ fn main() {
                                                       .takes_value(true)
                                                       .required(true))))
                         .get_matches();
-
-  let config_file = matches.value_of("config").expect("required config file");
+ 
+  let config_file = match matches.value_of("config"){
+                      Some(config_file) => config_file,
+                      None => option_env!("SOZU_CONFIG").expect("could not find `SOZU_CONFIG` env var at build"),
+                    };
 
   let config = Config::load_from_path(config_file).expect("could not parse configuration file");
   let stream = UnixStream::connect(&config.command_socket).expect("could not connect to the command unix socket");


### PR DESCRIPTION
This only implements the default for the config file. I am not quite sure how to go about the `command_socket` as it seems to be coupled with the config file. It is fairly straight forward for `sozuctl` but   `sozu` uses the `command_socket` along with the config to start the Command server [here](https://github.com/sozu-proxy/sozu/blob/master/bin/src/command/mod.rs#L522-L565). It also seems that we are passing in the config file just to get `command_socket` in `sozuctl`?

Hope everything else is fine with this though. 