### PR TITLE
Session::handle_remaining_readiness: avoid infinite loop

### DIFF
--- a/lib/src/network/session.rs
+++ b/lib/src/network/session.rs
@@ -604,6 +604,9 @@ impl<ServerConfiguration:ProxyConfiguration<Client>,Client:ProxyClient> Session<
               break;
             }
           }
+        } else {
+          // we don't have any more elements to loop over
+          break;
         }
       }
     }


### PR DESCRIPTION
An infinite looping can occur if the `accept()` call errors with a WouldBlock
error, removing entries from the accept_ready HashMap resulting in a None
when we iterate through the HashMap.

This can easily be reproduced with a `max_connections = 1` in the configuration and do more than 1 connections at the same time.

I'm not sure why the socket would block though