### PR TITLE
Fix a panic when parsing cookies

### DIFF
--- a/lib/src/parser/http11.rs
+++ b/lib/src/parser/http11.rs
@@ -243,13 +243,13 @@ pub struct CookieValue<'a> {
   name: &'a [u8],
   value: &'a [u8],
   semicolon: Option<&'a [u8]>,
-  spaces: Option<&'a [u8]>
+  spaces: &'a [u8]
 }
 
 impl<'a> CookieValue<'a> {
   pub fn get_full_length(&self) -> usize {
     let semicolon = if self.semicolon.is_some() { 1 } else { 0 };
-    let space = self.spaces.map(|sp| sp.len()).unwrap_or(0);
+    let space = self.spaces.len();
 
     self.name.len() + self.value.len() + semicolon + space + 1 // +1 is for =
   }
@@ -265,7 +265,7 @@ named!(pub single_request_cookie<CookieValue>,
     name: take_until_and_consume!("=") >>
     value: take_while!(is_cookie_value_char) >>
     semicolon: opt!(complete!(tag!(";"))) >>
-    spaces: opt!(complete!(take_while!(is_space))) >>
+    spaces: complete!(take_while!(is_space)) >>
     (CookieValue {
       name: name,
       value: value,
@@ -645,7 +645,7 @@ impl<'a> Header<'a> {
                 // if sozublanceid is the last element, we want to delete the "; " chars from
                 // the before last cookie
                 if (current_cookie + 1) == sozu_balance_position {
-                  let spaces = cookie.spaces.map(|s| s.len()).unwrap_or(0);
+                  let spaces = cookie.spaces.len();
                   // This one is obvious but I prefer to name the value
                   let semicolon = 1;
                   moves.push(BufferMove::Advance(cookie_length - spaces - semicolon));
@@ -3075,22 +3075,22 @@ mod tests {
     assert_eq!(some_cookies[0].name, b"FOO");
     assert_eq!(some_cookies[0].value, b"BAR");
     assert_eq!(some_cookies[0].semicolon.is_some(), true);
-    assert_eq!(some_cookies[0].spaces.unwrap().len(), 0);
+    assert_eq!(some_cookies[0].spaces.len(), 0);
 
     assert_eq!(some_cookies[1].name, b"BAR");
     assert_eq!(some_cookies[1].value, b"FOO");
     assert_eq!(some_cookies[1].semicolon.is_some(), true);
-    assert_eq!(some_cookies[1].spaces.unwrap().len(), 1);
+    assert_eq!(some_cookies[1].spaces.len(), 1);
 
     assert_eq!(some_cookies[2].name, b"SOZUBALANCEID");
     assert_eq!(some_cookies[2].value, b"0");
     assert_eq!(some_cookies[2].semicolon.is_some(), true);
-    assert_eq!(some_cookies[2].spaces.unwrap().len(), 3);
+    assert_eq!(some_cookies[2].spaces.len(), 3);
 
     assert_eq!(some_cookies[3].name, b"SOZU");
     assert_eq!(some_cookies[3].value, b"SOZU");
     assert_eq!(some_cookies[3].semicolon.is_some(), false);
-    assert_eq!(some_cookies[3].spaces.unwrap().len(), 0);
+    assert_eq!(some_cookies[3].spaces.len(), 0);
   }
 
   #[test]

--- a/lib/src/parser/http11.rs
+++ b/lib/src/parser/http11.rs
@@ -637,11 +637,14 @@ impl<'a> Header<'a> {
           match iter.next() {
             Some(cookie) => {
               if &cookie.name[..] == b"SOZUBALANCEID" {
-                moves.push(BufferMove::Delete(cookie.get_full_length()));
+                // if the cookie is the last one, we left the "; " from the previous cookie, so we
+                // have to delete it too
+                let full_delete = if sozu_balance_is_last { 2 } else { 0 } + cookie.get_full_length();
+                moves.push(BufferMove::Delete(full_delete));
               } else if sozu_balance_is_last {
                 // if sozublanceid is the last element, we want to delete the "; " chars from
                 // the before last cookie
-                let next = current_cookie + 1;
+                let next = current_cookie;
                 let cookie_length = cookie.get_full_length();
                 if next == sozu_balance_position {
                   moves.push(BufferMove::Advance(cookie_length - 2));


### PR DESCRIPTION
A panic could occur when parsing cookies if the `SOZUBALANCEID=X` was found at the end of the cookie chain. Some bytes would not be deleted from the request, leading 2 chars (`=X`) not consumed.

Those commits fix that and try to be a bit more smarter about bytes consumption