### PR TITLE
Move cookie parsing to its own parser file

### DIFF
--- a/lib/src/parser/cookies.rs
+++ b/lib/src/parser/cookies.rs
@@ -1,0 +1,83 @@
+use nom::{IResult, is_space};
+
+#[derive(Debug)]
+pub struct CookieValue<'a> {
+  pub name: &'a [u8],
+  pub value: &'a [u8],
+  pub semicolon: Option<&'a [u8]>,
+  pub spaces: &'a [u8]
+}
+
+impl<'a> CookieValue<'a> {
+  pub fn get_full_length(&self) -> usize {
+    let semicolon = if self.semicolon.is_some() { 1 } else { 0 };
+    let space = self.spaces.len();
+
+    self.name.len() + self.value.len() + semicolon + space + 1 // +1 is for =
+  }
+}
+
+pub fn is_cookie_value_char(chr: u8) -> bool {
+  // chars: (space) , ;
+  chr != 32 && chr != 44 && chr != 59
+}
+
+named!(pub single_request_cookie<CookieValue>,
+  do_parse!(
+    name: take_until_and_consume!("=") >>
+    value: take_while!(is_cookie_value_char) >>
+    semicolon: opt!(complete!(tag!(";"))) >>
+    spaces: complete!(take_while!(is_space)) >>
+    (CookieValue {
+      name: name,
+      value: value,
+      semicolon: semicolon,
+      spaces: spaces
+    })
+  )
+);
+
+pub fn parse_request_cookies(input: &[u8]) -> Option<Vec<CookieValue>> {
+  let res: IResult<&[u8], Vec<CookieValue>> = many0!(input, single_request_cookie);
+
+  if let IResult::Done(_, o) = res {
+    Some(o)
+  } else {
+    None
+  }
+}
+
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn header_cookies_request_cookies() {
+    let none_cookies = parse_request_cookies(b"FOOBAR").unwrap();
+    let some_cookies = parse_request_cookies(b"FOO=BAR;BAR=FOO; SOZUBALANCEID=0;   SOZU=SOZU").unwrap();
+
+    assert_eq!(none_cookies.len(), 0);
+    assert_eq!(some_cookies.len(), 4);
+
+    assert_eq!(some_cookies[0].name, b"FOO");
+    assert_eq!(some_cookies[0].value, b"BAR");
+    assert_eq!(some_cookies[0].semicolon.is_some(), true);
+    assert_eq!(some_cookies[0].spaces.len(), 0);
+
+    assert_eq!(some_cookies[1].name, b"BAR");
+    assert_eq!(some_cookies[1].value, b"FOO");
+    assert_eq!(some_cookies[1].semicolon.is_some(), true);
+    assert_eq!(some_cookies[1].spaces.len(), 1);
+
+    assert_eq!(some_cookies[2].name, b"SOZUBALANCEID");
+    assert_eq!(some_cookies[2].value, b"0");
+    assert_eq!(some_cookies[2].semicolon.is_some(), true);
+    assert_eq!(some_cookies[2].spaces.len(), 3);
+
+    assert_eq!(some_cookies[3].name, b"SOZU");
+    assert_eq!(some_cookies[3].value, b"SOZU");
+    assert_eq!(some_cookies[3].semicolon.is_some(), false);
+    assert_eq!(some_cookies[3].spaces.len(), 0);
+  }
+}

--- a/lib/src/parser/cookies.rs
+++ b/lib/src/parser/cookies.rs
@@ -1,14 +1,14 @@
 use nom::{IResult, is_space};
 
 #[derive(Debug)]
-pub struct CookieValue<'a> {
+pub struct RequestCookie<'a> {
   pub name: &'a [u8],
   pub value: &'a [u8],
   pub semicolon: Option<&'a [u8]>,
   pub spaces: &'a [u8]
 }
 
-impl<'a> CookieValue<'a> {
+impl<'a> RequestCookie<'a> {
   pub fn get_full_length(&self) -> usize {
     let semicolon = if self.semicolon.is_some() { 1 } else { 0 };
     let space = self.spaces.len();
@@ -22,13 +22,13 @@ pub fn is_cookie_value_char(chr: u8) -> bool {
   chr != 32 && chr != 44 && chr != 59
 }
 
-named!(pub single_request_cookie<CookieValue>,
+named!(pub single_request_cookie<RequestCookie>,
   do_parse!(
     name: take_until_and_consume!("=") >>
     value: take_while!(is_cookie_value_char) >>
     semicolon: opt!(complete!(tag!(";"))) >>
     spaces: complete!(take_while!(is_space)) >>
-    (CookieValue {
+    (RequestCookie {
       name: name,
       value: value,
       semicolon: semicolon,
@@ -37,8 +37,8 @@ named!(pub single_request_cookie<CookieValue>,
   )
 );
 
-pub fn parse_request_cookies(input: &[u8]) -> Option<Vec<CookieValue>> {
-  let res: IResult<&[u8], Vec<CookieValue>> = many0!(input, single_request_cookie);
+pub fn parse_request_cookies(input: &[u8]) -> Option<Vec<RequestCookie>> {
+  let res: IResult<&[u8], Vec<RequestCookie>> = many0!(input, single_request_cookie);
 
   if let IResult::Done(_, o) = res {
     Some(o)

--- a/lib/src/parser/http11.rs
+++ b/lib/src/parser/http11.rs
@@ -4,7 +4,7 @@
 use sozu_command::buffer::Buffer;
 use network::buffer_queue::BufferQueue;
 use network::protocol::StickySession;
-use parser::cookies::{CookieValue, parse_request_cookies};
+use parser::cookies::{RequestCookie, parse_request_cookies};
 
 use nom::{HexDisplay,IResult,Offset};
 use nom::IResult::*;
@@ -640,7 +640,7 @@ pub enum HeaderValue<'a> {
   //FIXME: are the references in Connection still valid after we delete that part of the headers?
   Connection(Vec<&'a [u8]>),
   Upgrade(&'a[u8]),
-  Cookie(Vec<CookieValue<'a>>),
+  Cookie(Vec<RequestCookie<'a>>),
   Other(&'a[u8],&'a[u8]),
   Forwarded,
   ExpectContinue,

--- a/lib/src/parser/http11.rs
+++ b/lib/src/parser/http11.rs
@@ -243,13 +243,13 @@ pub struct CookieValue<'a> {
   name: &'a [u8],
   value: &'a [u8],
   semicolon: Option<&'a [u8]>,
-  spaces: Option<&'a [u8]>
+  spaces: &'a [u8]
 }
 
 impl<'a> CookieValue<'a> {
   pub fn get_full_length(&self) -> usize {
     let semicolon = if self.semicolon.is_some() { 1 } else { 0 };
-    let space = self.spaces.map(|sp| sp.len()).unwrap_or(0);
+    let space = self.spaces.len();
 
     self.name.len() + self.value.len() + semicolon + space + 1 // +1 is for =
   }
@@ -265,7 +265,7 @@ named!(pub single_request_cookie<CookieValue>,
     name: take_until_and_consume!("=") >>
     value: take_while!(is_cookie_value_char) >>
     semicolon: opt!(complete!(tag!(";"))) >>
-    spaces: opt!(complete!(take_while!(is_space))) >>
+    spaces: complete!(take_while!(is_space)) >>
     (CookieValue {
       name: name,
       value: value,
@@ -645,7 +645,7 @@ impl<'a> Header<'a> {
                 // if sozublanceid is the last element, we want to delete the "; " chars from
                 // the before last cookie
                 if (current_cookie + 1) == sozu_balance_position {
-                  let spaces = cookie.spaces.map(|s| s.len()).unwrap_or(0);
+                  let spaces = cookie.spaces.len();
                   // This one is obvious but I prefer to name the value
                   let semicolon = 1;
                   moves.push(BufferMove::Advance(cookie_length - spaces - semicolon));
@@ -3075,22 +3075,22 @@ mod tests {
     assert_eq!(some_cookies[0].name, b"FOO");
     assert_eq!(some_cookies[0].value, b"BAR");
     assert_eq!(some_cookies[0].semicolon.is_some(), true);
-    assert_eq!(some_cookies[0].spaces.unwrap().len(), 0);
+    assert_eq!(some_cookies[0].spaces.len(), 0);
 
     assert_eq!(some_cookies[1].name, b"BAR");
     assert_eq!(some_cookies[1].value, b"FOO");
     assert_eq!(some_cookies[1].semicolon.is_some(), true);
-    assert_eq!(some_cookies[1].spaces.unwrap().len(), 1);
+    assert_eq!(some_cookies[1].spaces.len(), 1);
 
     assert_eq!(some_cookies[2].name, b"SOZUBALANCEID");
     assert_eq!(some_cookies[2].value, b"0");
     assert_eq!(some_cookies[2].semicolon.is_some(), true);
-    assert_eq!(some_cookies[2].spaces.unwrap().len(), 3);
+    assert_eq!(some_cookies[2].spaces.len(), 3);
 
     assert_eq!(some_cookies[3].name, b"SOZU");
     assert_eq!(some_cookies[3].value, b"SOZU");
     assert_eq!(some_cookies[3].semicolon.is_some(), false);
-    assert_eq!(some_cookies[3].spaces.unwrap().len(), 0);
+    assert_eq!(some_cookies[3].spaces.len(), 0);
   }
 
   #[test]

--- a/lib/src/parser/http11.rs
+++ b/lib/src/parser/http11.rs
@@ -637,11 +637,14 @@ impl<'a> Header<'a> {
           match iter.next() {
             Some(cookie) => {
               if &cookie.name[..] == b"SOZUBALANCEID" {
-                moves.push(BufferMove::Delete(cookie.get_full_length()));
+                // if the cookie is the last one, we left the "; " from the previous cookie, so we
+                // have to delete it too
+                let full_delete = if sozu_balance_is_last { 2 } else { 0 } + cookie.get_full_length();
+                moves.push(BufferMove::Delete(full_delete));
               } else if sozu_balance_is_last {
                 // if sozublanceid is the last element, we want to delete the "; " chars from
                 // the before last cookie
-                let next = current_cookie + 1;
+                let next = current_cookie;
                 let cookie_length = cookie.get_full_length();
                 if next == sozu_balance_position {
                   moves.push(BufferMove::Advance(cookie_length - 2));

--- a/lib/src/parser/mod.rs
+++ b/lib/src/parser/mod.rs
@@ -1,1 +1,2 @@
 pub mod http11;
+pub mod cookies;


### PR DESCRIPTION
This pull request depends on #233 

It moves cookie parsing code to its own parser file, which should help for better readability and tests