### PR TITLE
Fix dockerfile to build with openssl 0.9.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache --virtual .build-dependencies \
   gcc \
   musl-dev \
   rust
-RUN apk add --no-cache openssl-dev llvm-libunwind
+RUN apk add --no-cache openssl-dev llvm-libunwind pkgconfig
 WORKDIR /source/ctl
 RUN cargo build --release
 WORKDIR /source/bin


### PR DESCRIPTION
Previous error was :
```
error: failed to run custom build command for `openssl-sys v0.9.17`
process didn't exit successfully: `/sources/sozu/target/debug/build/openssl-sys-beef38e1672c1154/build-script-build` (exit code: 101)
--- stdout
cargo:rerun-if-env-changed=OPENSSL_LIB_DIR
cargo:rerun-if-env-changed=OPENSSL_INCLUDE_DIR
cargo:rerun-if-env-changed=OPENSSL_DIR
run pkg_config fail: "Failed to run `\"pkg-config\" \"--libs\" \"--cflags\" \"openssl\"`: No such file or directory (os error 2)"

--- stderr
thread 'main' panicked at '

Could not find directory of OpenSSL installation, and this `-sys` crate cannot
proceed without this knowledge. If OpenSSL is installed and this crate had
trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
compilation process.

If you're in a situation where you think the directory *should* be found
automatically, please open a bug at https://github.com/sfackler/rust-openssl
and include information about your system as well as this message.

    $HOST = x86_64-unknown-linux-gnu
    $TARGET = x86_64-unknown-linux-gnu
    openssl-sys = 0.9.17

It looks like you're compiling on Linux and also targeting Linux. Currently this
requires the `pkg-config` utility to find OpenSSL but unfortunately `pkg-config`
could not be found. If you have OpenSSL installed you can likely fix this by
installing `pkg-config`.
```

So I add pkgconfig to Dockerfile, and no more error.