### PR TITLE
Add metrics tracking for the monitoring

### DIFF
--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -401,6 +401,7 @@ impl CommandServer {
                   ));
 
                 } else {
+                  incr_resp_client_cmd!();
                   self.clients[conn_token].queue.push_front(msg);
                 }
               }
@@ -416,6 +417,7 @@ impl CommandServer {
             self.clients[conn_token].channel.readable();
             loop {
               if let Some(message) = self.clients[conn_token].channel.read_message() {
+                incr_client_cmd!();
                 self.handle_client_message(conn_token, &message);
               } else {
                 break;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -150,6 +150,7 @@
 //! }
 //! ```
 //!
+#![feature(exclusive_range_pattern)]
 #![cfg_attr(feature = "unstable", feature(test))]
 #[cfg(all(feature = "unstable", test))]
 extern crate test;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -150,7 +150,6 @@
 //! }
 //! ```
 //!
-#![feature(exclusive_range_pattern)]
 #![cfg_attr(feature = "unstable", feature(test))]
 #[cfg(all(feature = "unstable", test))]
 extern crate test;

--- a/lib/src/network/metrics.rs
+++ b/lib/src/network/metrics.rs
@@ -329,3 +329,23 @@ macro_rules! time_end (
   }
 );
 
+///Client-side request errors caused by:
+/// 
+/// * Client terminates before sending request
+/// * Read error from client
+/// * Client timeout
+/// * Client terminated connection
+#[macro_export]
+macro_rules! incr_ereq (
+  () => (incr!("ereq");)
+);
+
+#[macro_export]
+macro_rules! incr_client_cmd (
+  () => (incr!("client_cmd");)
+);
+
+#[macro_export]
+macro_rules! incr_resp_client_cmd (
+  () => (incr!("incr_resp_client_cmd");)
+);

--- a/lib/src/network/protocol/http.rs
+++ b/lib/src/network/protocol/http.rs
@@ -8,7 +8,7 @@ use pool::{Pool,Checkout,Reset};
 use time::{Duration, precise_time_s, precise_time_ns};
 use uuid::Uuid;
 use parser::http11::{HttpState,parse_request_until_stop, parse_response_until_stop,
-  BufferMove, RequestState, ResponseState, Chunk, Continue};
+  BufferMove, RequestState, ResponseState, Chunk, Continue, RStatusLine};
 use network::{ClientResult,Protocol};
 use network::buffer_queue::BufferQueue;
 use network::session::Readiness;
@@ -246,6 +246,16 @@ impl<Front:SocketHandler> Http<Front> {
     ClientResult::CloseBoth
   }
 
+  /// Retrieve the response status from the http response state 
+  pub fn get_response_status(&mut self) -> Option<RStatusLine> {
+    if let Some(state) = self.state.as_ref() {
+      state.get_status_line()
+    }
+    else {
+      None
+    }
+  }
+
   // Read content from the client
   pub fn readable(&mut self) -> ClientResult {
     if self.status == ClientStatus::DefaultAnswer {
@@ -264,6 +274,7 @@ impl<Front:SocketHandler> Http<Front> {
         error!("{}\t[{:?}] front buffer full, no backend, closing the connection", self.log_ctx, self.token);
         self.readiness.front_interest = UnixReady::from(Ready::empty());
         self.readiness.back_interest  = UnixReady::from(Ready::empty());
+        incr_ereq!();
         return ClientResult::CloseClient;
       } else {
         self.readiness.front_interest.remove(Ready::readable());
@@ -278,6 +289,7 @@ impl<Front:SocketHandler> Http<Front> {
     if sz > 0 {
       self.front_buf.buffer.fill(sz);
       self.front_buf.sliced_input(sz);
+      count!("bytes_in", sz as i64);
 
       if self.front_buf.start_parsing_position > self.front_buf.parsed_position {
         let to_consume = min(self.front_buf.input_data_size(),
@@ -295,6 +307,7 @@ impl<Front:SocketHandler> Http<Front> {
     match res {
       SocketResult::Error => {
         error!("{}\t[{:?}] front socket error, closing the connection", self.log_ctx, self.token);
+        incr_ereq!();
         self.readiness.reset();
         return ClientResult::CloseClient;
       },
@@ -390,7 +403,6 @@ impl<Front:SocketHandler> Http<Front> {
   pub fn writable(&mut self) -> ClientResult {
 
     assert!(self.front_buf.empty(), "investigating single buffer usage: the front->back buffer should not be used while parsing and forwarding the response");
-
     let output_size = self.back_buf.output_data_size();
     if self.status == ClientStatus::DefaultAnswer {
       if self.back_buf.output_data_size() == 0 {
@@ -414,12 +426,14 @@ impl<Front:SocketHandler> Http<Front> {
       if self.back_buf.buffer.available_data() == 0 {
         self.readiness.reset();
         error!("{}\t[{:?}] cannot write, back buffer was empty", self.log_ctx, self.token);
+        incr_ereq!();
         return ClientResult::CloseClient;
       }
 
       if res == SocketResult::Error {
         self.readiness.reset();
         error!("{}\t[{:?}] error writing to front socket, closing", self.log_ctx, self.token);
+        incr_ereq!();
         return ClientResult::CloseClient;
       } else {
         return ClientResult::Continue;
@@ -446,6 +460,7 @@ impl<Front:SocketHandler> Http<Front> {
       self.back_buf.consume_output_data(current_sz);
       self.back_buf_position += current_sz;
       sz += current_sz;
+      count!("bytes_out", current_sz as i64);
     }
 
     if let Some((front,back)) = self.tokens() {
@@ -455,6 +470,7 @@ impl<Front:SocketHandler> Http<Front> {
     match res {
       SocketResult::Error => {
         error!("{}\t[{:?}] error writing to front socket, closing", self.log_ctx, self.token);
+        incr_ereq!();
         self.readiness.reset();
         return ClientResult::CloseClient;
       },
@@ -481,35 +497,40 @@ impl<Front:SocketHandler> Http<Front> {
       return ClientResult::Continue;
     }
 
+    
+
     match unwrap_msg!(self.state.as_ref()).response {
       // FIXME: should only restart parsing if we are using keepalive
-      Some(ResponseState::Response(_,_))                            |
-      Some(ResponseState::ResponseWithBody(_,_,_))                  |
-      Some(ResponseState::ResponseWithBodyChunks(_,_,Chunk::Ended)) => {
+      Some(ResponseState::Response(_, _))                            |
+      Some(ResponseState::ResponseWithBody(_, _, _))                  |
+      Some(ResponseState::ResponseWithBodyChunks(_, _, Chunk::Ended)) => {
         let front_keep_alive = self.state.as_ref().map(|st| st.request.as_ref().map(|r| r.should_keep_alive()).unwrap_or(false)).unwrap_or(false);
         let back_keep_alive  = self.state.as_ref().map(|st| st.response.as_ref().map(|r| r.should_keep_alive()).unwrap_or(false)).unwrap_or(false);
+
+        save_http_status_metric(self.get_response_status());
 
         //FIXME: we could get smarter about this
         // with no keepalive on backend, we could open a new backend ConnectionError
         // with no keepalive on front but keepalive on backend, we could have
         // a pool of connections
-        if front_keep_alive && back_keep_alive {
+        if front_keep_alive && back_keep_alive {  
           self.reset();
           self.readiness.front_interest = UnixReady::from(Ready::readable()) | UnixReady::hup() | UnixReady::error();
           self.readiness.back_interest  = UnixReady::from(Ready::writable()) | UnixReady::hup() | UnixReady::error();
-
           info!("{}\t[{:?}] request ended successfully, keep alive for front and back", self.log_ctx, self.token);
           ClientResult::Continue
           //FIXME: issues reusing the backend socket
           //self.readiness.back_interest  = UnixReady::hup() | UnixReady::error();
           //ClientResult::CloseBackend
-        } else if front_keep_alive && !back_keep_alive {
+        } 
+        else if front_keep_alive && !back_keep_alive {
           self.reset();
           self.readiness.front_interest = UnixReady::from(Ready::readable()) | UnixReady::hup() | UnixReady::error();
           self.readiness.back_interest  = UnixReady::hup() | UnixReady::error();
           info!("{}\t[{:?}] request ended successfully, keepalive for front", self.log_ctx, self.token);
           ClientResult::CloseBackend
-        } else {
+        } 
+        else {
           info!("{}\t[{:?}] request ended successfully, closing front and back connections", self.log_ctx, self.token);
           self.readiness.reset();
           ClientResult::CloseBoth
@@ -535,7 +556,7 @@ impl<Front:SocketHandler> Http<Front> {
   }
 
   // Forward content to application
-  pub fn back_writable(&mut self) -> ClientResult {
+  pub fn back_writable(&mut self) -> ClientResult {    
     if self.status == ClientStatus::DefaultAnswer {
       error!("{}\tsending default answer, should not write to back", self.log_ctx);
       self.readiness.back_interest.remove(Ready::writable());
@@ -712,6 +733,7 @@ impl<Front:SocketHandler> Http<Front> {
       },
       Some(ResponseState::ResponseWithBodyChunks(_,_,Chunk::Error)) => {
         error!("{}\tback read should have stopped on chunk error", self.log_ctx);
+        incr_ereq!();
         self.readiness.reset();
         (ProtocolResult::Continue, ClientResult::CloseClient)
       },
@@ -767,10 +789,23 @@ impl<Front:SocketHandler> Http<Front> {
   }
 }
 
+/// Save the backend http response status code metric
+fn save_http_status_metric(rs_status_line : Option<RStatusLine>) {
+  if let Some(rs_status_line) = rs_status_line {
+    match rs_status_line.status {
+      100..199 => { incr!("hrsp_1xx"); },
+      200..299 => { incr!("hrsp_2xx"); }, 
+      300..399 => { incr!("hrsp_3xx"); }, 
+      400..499 => { incr!("hrsp_4xx"); }, 
+      500..599 => { incr!("hrsp_5xx"); }, 
+      _ => { incr!("hrsp_other"); }, // http responses with other codes (protocol error)
+    }
+  }
+}
+
 
 #[allow(non_snake_case)]
 pub struct DefaultAnswers {
   pub NotFound:           Vec<u8>,
   pub ServiceUnavailable: Vec<u8>
 }
-


### PR DESCRIPTION
Addresses #96.

Implementation of metrics inspired by  [haproxy](https://gist.github.com/alq666/20a464665a1086de0c9ddf1754a9b7fb) metrics :

* Frontend metrics: client connections and requests
* Backend: availability and health of backend servers
* Health metrics: State of your sozu proxy

 I want to use this metrics to make benchmarks too.

Still a WIP.