### PR TITLE
Change logging level at runtime

### DIFF
--- a/bin/src/command/orders.rs
+++ b/bin/src/command/orders.rs
@@ -358,6 +358,17 @@ impl CommandServer {
       info!("proxyconfig client order {:?}", order);
     }
 
+    if let &Order::Logging(ref logging_filter) = &order {
+      info!("Changing master log level to {}", logging_filter);
+      ::sozu::logging::LOGGER.with(|l| {
+        let directives = ::sozu::logging::parse_logging_spec(&logging_filter);
+        l.borrow_mut().set_directives(directives);
+      });
+      // also change / set the content of RUST_LOG so future workers / main thread
+      // will have the new logging filter value
+      ::std::env::set_var("RUST_LOG", logging_filter);
+    }
+
     self.state.handle_order(&order);
 
     if order == Order::SoftStop {

--- a/command/src/messages.rs
+++ b/command/src/messages.rs
@@ -89,6 +89,7 @@ pub enum Order {
 
     Status,
     Metrics,
+    Logging(String),
 }
 
 
@@ -309,6 +310,7 @@ impl Order {
       Order::HardStop             => [Topic::HttpProxyConfig, Topic::HttpsProxyConfig, Topic::TcpProxyConfig].iter().cloned().collect(),
       Order::Status               => [Topic::HttpProxyConfig, Topic::HttpsProxyConfig, Topic::TcpProxyConfig].iter().cloned().collect(),
       Order::Metrics              => HashSet::new(),
+      Order::Logging(_)           => [Topic::HttpsProxyConfig, Topic::HttpProxyConfig, Topic::TcpProxyConfig].iter().cloned().collect(),
     }
   }
 }

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -115,7 +115,9 @@ impl ConfigState {
         if let Some(instance_list) = self.instances.get_mut(&instance.app_id) {
           instance_list.retain(|el| el.ip_address != instance.ip_address || el.port != instance.port);
         }
-      }
+      },
+      // This is to avoid the error message
+      &Order::Logging(_) => {},
       o => {
         error!("state cannot handle order message: {:#?}", o);
       }

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -597,6 +597,9 @@ pub fn query_application(channel: &mut Channel<ConfigMessage,ConfigMessageAnswer
   }
 }
 
+pub fn logging_filter(channel: &mut Channel<ConfigMessage,ConfigMessageAnswer>, filter: &str) {
+  order_command(channel, Order::Logging(String::from(filter)));
+}
 
 fn order_command(channel: &mut Channel<ConfigMessage,ConfigMessageAnswer>, order: Order) {
   let id = generate_id();

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -13,7 +13,8 @@ use sozu_command::channel::Channel;
 use sozu_command::data::{ConfigMessage,ConfigMessageAnswer};
 
 use command::{add_application,remove_application,dump_state,load_state,save_state,soft_stop,hard_stop,upgrade,status,metrics,
-  remove_backend, add_backend, remove_frontend, add_frontend, add_certificate, remove_certificate, query_application};
+  remove_backend, add_backend, remove_frontend, add_frontend, add_certificate, remove_certificate, query_application,
+  logging_filter};
 
 use std::str::FromStr;
 
@@ -197,6 +198,14 @@ fn main() {
                                                       .value_name("application identifier")
                                                       .takes_value(true)
                                                       .required(false))))
+                        .subcommand(SubCommand::with_name("logging")
+                                                .about("change logging level")
+                                                .arg(Arg::with_name("level")
+                                                  .short("l")
+                                                  .long("level")
+                                                  .value_name("logging level")
+                                                  .takes_value(true)
+                                                  .required(true)))
                         .get_matches();
  
   let config_file = match matches.value_of("config"){
@@ -316,6 +325,10 @@ fn main() {
         },
         _ => println!("unknown query command")
       }
+    },
+    ("logging", Some(sub)) => {
+      let level = sub.value_of("level").expect("missing logging level");
+      logging_filter(&mut channel, level);
     },
     _                => println!("unknown subcommand")
   }

--- a/lib/src/network/http.rs
+++ b/lib/src/network/http.rs
@@ -649,6 +649,14 @@ impl ProxyConfiguration<Client> for ServerConfiguration {
         info!("{} status", message.id);
         OrderMessageAnswer{ id: message.id, status: OrderMessageStatus::Ok, data: None }
       },
+      Order::Logging(logging_filter) => {
+        info!("{} changing logging filter to {}", message.id, logging_filter);
+        ::logging::LOGGER.with(|l| {
+          let directives = ::logging::parse_logging_spec(&logging_filter);
+          l.borrow_mut().set_directives(directives);
+        });
+        OrderMessageAnswer{ id: message.id, status: OrderMessageStatus::Ok, data: None }
+      },
       command => {
         debug!("{} unsupported message, ignoring: {:?}", message.id, command);
         OrderMessageAnswer{ id: message.id, status: OrderMessageStatus::Error(String::from("unsupported message")), data: None }

--- a/lib/src/network/tcp.rs
+++ b/lib/src/network/tcp.rs
@@ -520,6 +520,14 @@ impl ProxyConfiguration<Client> for ServerConfiguration {
         info!("{} status", message.id);
         OrderMessageAnswer{ id: message.id, status: OrderMessageStatus::Ok, data: None}
       },
+      Order::Logging(logging_filter) => {
+        info!("{} changing logging filter to {}", message.id, logging_filter);
+        ::logging::LOGGER.with(|l| {
+          let directives = ::logging::parse_logging_spec(&logging_filter);
+          l.borrow_mut().set_directives(directives);
+        });
+        OrderMessageAnswer{ id: message.id, status: OrderMessageStatus::Ok, data: None }
+      },
       _ => {
         error!("unsupported message, ignoring");
         OrderMessageAnswer{ id: message.id, status: OrderMessageStatus::Error(String::from("unsupported message")), data: None}

--- a/lib/src/network/tls.rs
+++ b/lib/src/network/tls.rs
@@ -1019,6 +1019,14 @@ impl ProxyConfiguration<TlsClient> for ServerConfiguration {
         info!("{} status", message.id);
         OrderMessageAnswer{ id: message.id, status: OrderMessageStatus::Ok, data: None }
       },
+      Order::Logging(logging_filter) => {
+        info!("{} changing logging filter to {}", message.id, logging_filter);
+        ::logging::LOGGER.with(|l| {
+          let directives = ::logging::parse_logging_spec(&logging_filter);
+          l.borrow_mut().set_directives(directives);
+        });
+        OrderMessageAnswer{ id: message.id, status: OrderMessageStatus::Ok, data: None }
+      },
       command => {
         error!("{} unsupported message, ignoring {:?}", message.id, command);
         OrderMessageAnswer{ id: message.id, status: OrderMessageStatus::Error(String::from("unsupported message")), data: None }


### PR DESCRIPTION
This allows to change the logging level of the workers and main threads through a proxy configuration message.

The `RUST_LOG` environment variable is also set / updated to the new logging level so new workers / main thread (after an upgrade, for example) keep the same configuration.

The `sozuctl` command is `sozuctl -c config.toml logging --level <new level>`. It can be changed 

Fixes #249 