### PR TITLE
Http::new: explicitely set the protocol through arguments

### DIFF
--- a/lib/src/network/http.rs
+++ b/lib/src/network/http.rs
@@ -61,7 +61,8 @@ impl Client {
     let protocol = if let Some(pool) = pool.upgrade() {
       let mut p = pool.borrow_mut();
       if let (Some(front_buf), Some(back_buf)) = (p.checkout(), p.checkout()) {
-        Some(Http::new(unwrap_msg!(sock.try_clone()), front_buf, back_buf, public_address).expect("should create a HTTP state"))
+        Some(Http::new(unwrap_msg!(sock.try_clone()), front_buf, back_buf, public_address,
+          Protocol::HTTP).expect("should create a HTTP state"))
       } else { None }
     } else { None };
 

--- a/lib/src/network/protocol/http.rs
+++ b/lib/src/network/protocol/http.rs
@@ -63,7 +63,8 @@ pub struct Http<Front:SocketHandler> {
 }
 
 impl<Front:SocketHandler> Http<Front> {
-  pub fn new(sock: Front, front_buf: Checkout<BufferQueue>, back_buf: Checkout<BufferQueue>, public_address: Option<IpAddr>) -> Option<Http<Front>> {
+  pub fn new(sock: Front, front_buf: Checkout<BufferQueue>, back_buf: Checkout<BufferQueue>, public_address: Option<IpAddr>,
+             protocol: Protocol) -> Option<Http<Front>> {
     let request_id = Uuid::new_v4().hyphenated().to_string();
     let log_ctx    = format!("{}\tunknown\t", &request_id);
     let mut client = Http {
@@ -88,7 +89,7 @@ impl<Front:SocketHandler> Http<Front> {
       log_ctx:            log_ctx,
       public_address:     public_address,
       sticky_session:     None,
-      protocol:           Protocol::HTTP,
+      protocol:           protocol,
     };
     let req_header = client.added_request_header(public_address);
     let res_header = client.added_response_header();

--- a/lib/src/network/tls.rs
+++ b/lib/src/network/tls.rs
@@ -127,8 +127,7 @@ impl TlsClient {
 
         if let (Some(front_buf), Some(back_buf)) = (p.checkout(), p.checkout()) {
           let mut http = Http::new(unwrap_msg!(handshake.stream), front_buf,
-            back_buf, self.public_address.clone()).unwrap();
-          http.protocol = Protocol::HTTPS;
+            back_buf, self.public_address.clone(), Protocol::HTTPS).unwrap();
 
           http.readiness = handshake.readiness;
           http.readiness.front_interest = UnixReady::from(Ready::readable()) | UnixReady::hup() | UnixReady::error();


### PR DESCRIPTION
In case of a TLS connection, the Http::protocol is set *after*
the X-Forwarded-* headers are generated, which makes the backend
receive `X-Forwarded-Proto: http` instead of `https`. This can lead to infinite redirection loops