### PR TITLE
Logs: avoid extra tab

### DIFF
--- a/lib/src/network/protocol/http.rs
+++ b/lib/src/network/protocol/http.rs
@@ -327,13 +327,13 @@ impl<Front:SocketHandler> Http<Front> {
     let status_line  = self.get_response_status().map(|line| format!("{} {}", line.status, line.reason)).unwrap_or(String::from("-"));
 
     if front_keep_alive && back_keep_alive {
-      info!("{}\t {} -> {}\t{} {} {}\t| keep alive front/back", self.log_ctx,
+      info!("{}{} -> {}\t{} {} {}\t| keep alive front/back", self.log_ctx,
         client, backend, status_line, host, request_line);
     } else if front_keep_alive && !back_keep_alive {
-      info!("{}\t {} -> {}\t{} {} {}\t| keep alive front", self.log_ctx,
+      info!("{}{} -> {}\t{} {} {}\t| keep alive front", self.log_ctx,
         client, backend, status_line, host, request_line);
     } else {
-      info!("{}\t {} -> {}\t{} {} {}\t| no keep alive", self.log_ctx,
+      info!("{}{} -> {}\t{} {} {}\t| no keep alive", self.log_ctx,
         client, backend, status_line, host, request_line);
     }
   }


### PR DESCRIPTION
`self.log_ctx` already ends with a tab