### PR TITLE
Fix "Error loading shared library libgcc_s.so.1"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache --virtual .build-dependencies \
   cargo \
   g++ \
   gcc \
+  libgcc \
   musl-dev \
   rust
 RUN apk add --no-cache openssl-dev llvm-libunwind pkgconfig


### PR DESCRIPTION
I got `Error loading shared library libgcc_s.so.1: No such file or directory` while trying to start Sozu from the Docker image, fixed it by installing `libgcc`.