### PR TITLE
Unify command handler signatures for Channel

### DIFF
--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -235,7 +235,7 @@ pub fn hard_stop(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>) {
   );
 }
 
-pub fn upgrade(channel: &mut Channel<ConfigMessage,ConfigMessageAnswer>) {
+pub fn upgrade(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>) {
   let id = generate_tagged_id("LIST-WORKERS");
   channel.write_message(&ConfigMessage::new(
     id.clone(),
@@ -505,7 +505,7 @@ pub fn status(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>) {
   }
 }
 
-pub fn metrics(channel: &mut Channel<ConfigMessage,ConfigMessageAnswer>) {
+pub fn metrics(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>) {
   let id = generate_id();
   //println!("will send message for metrics with id {}", id);
   channel.write_message(&ConfigMessage::new(

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -41,9 +41,9 @@ fn main() {
         soft_stop(channel);
       }
     },
-    SubCmd::Upgrade => upgrade(&mut channel),
+    SubCmd::Upgrade => upgrade(channel),
     SubCmd::Status => status(channel),
-    SubCmd::Metrics => metrics(&mut channel),
+    SubCmd::Metrics => metrics(channel),
     SubCmd::Logging{ level } => logging_filter(channel, &level),
     SubCmd::State{ cmd } => {
       match cmd {


### PR DESCRIPTION
All of the other sozuctl commands take ownership of the the Channel object. Update upgrade & metrics commands to follow the same style.