### PR TITLE
Fronts: convert hostname to ascii before adding or removing a front

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,7 @@ version = "0.4.0"
 dependencies = [
  "hdrsample 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -37,6 +37,7 @@ pool = "^0.1"
 openssl = {version="^0.9.5", features= ["v102"]}
 hdrsample = "^6.0"
 sozu-command-lib = { version = "^0.4", path = "../command" }
+idna = "^0.1"
 
 [dev-dependencies]
 tiny_http = "^0.4"

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -169,6 +169,7 @@ extern crate slab;
 extern crate mio_uds;
 extern crate hdrsample;
 extern crate sozu_command_lib as sozu_command;
+extern crate idna;
 
 #[macro_use] pub mod util;
 #[macro_use] pub mod logging;


### PR DESCRIPTION
Related to #250 

It converts hostnames to ascii format using the idna crate so we can support utf-8 domain names 