### PR TITLE
Don't pass hardcoded sticky session value

### DIFF
--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -263,7 +263,7 @@ impl HttpAppConfig {
 
     v.push(Order::AddApplication(Application {
       app_id: self.app_id.clone(),
-      sticky_session: false,
+      sticky_session: self.sticky_session.clone(),
     }));
 
     //create the front both for HTTP and HTTPS if possible


### PR DESCRIPTION
Fixes #302

It's still hardcoded  in `TcpAppConfig::generate_orders` but I guess sticky sessions don't apply for TCP