### PR TITLE
Add an option to automatically redirect traffic to HTTPS

### DIFF
--- a/command/assets/add_application.json
+++ b/command/assets/add_application.json
@@ -6,7 +6,8 @@
     "type": "ADD_APPLICATION",
     "data": {
       "app_id": "xxx",
-      "sticky_session": true
+      "sticky_session": true,
+      "https_redirect": true
     }
   }
 }

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -184,6 +184,7 @@ pub struct FileAppConfig {
   pub certificate_chain: Option<String>,
   pub backends:          Vec<String>,
   pub sticky_session:    Option<bool>,
+  pub https_redirect:    Option<bool>,
 }
 
 impl FileAppConfig {
@@ -210,6 +211,7 @@ impl FileAppConfig {
 
       let path_begin     = self.path_begin.unwrap_or(String::new());
       let sticky_session = self.sticky_session.unwrap_or(false);
+      let https_redirect = self.https_redirect.unwrap_or(false);
 
       let key_opt         = self.key.as_ref().and_then(|path| Config::load_file(&path).ok());
       let certificate_opt = self.certificate.as_ref().and_then(|path| Config::load_file(&path).ok());
@@ -239,7 +241,7 @@ impl FileAppConfig {
         certificate_chain: chain_opt,
         backends:          self.backends,
         sticky_session:    sticky_session,
-
+        https_redirect:    https_redirect,
       }))
     }
   }
@@ -255,6 +257,7 @@ pub struct HttpAppConfig {
   pub certificate_chain: Option<Vec<String>>,
   pub backends:          Vec<String>,
   pub sticky_session:    bool,
+  pub https_redirect:    bool,
 }
 
 impl HttpAppConfig {
@@ -264,6 +267,7 @@ impl HttpAppConfig {
     v.push(Order::AddApplication(Application {
       app_id: self.app_id.clone(),
       sticky_session: self.sticky_session.clone(),
+      https_redirect: self.https_redirect.clone(),
     }));
 
     //create the front both for HTTP and HTTPS if possible
@@ -334,6 +338,7 @@ impl TcpAppConfig {
     v.push(Order::AddApplication(Application {
       app_id: self.app_id.clone(),
       sticky_session: false,
+      https_redirect: false,
     }));
 
     v.push(Order::AddTcpFront(TcpFront {

--- a/command/src/data.rs
+++ b/command/src/data.rs
@@ -380,6 +380,7 @@ mod tests {
       data:     ConfigCommand::ProxyConfiguration(Order::AddApplication(Application {
                   app_id: String::from("xxx"),
                   sticky_session: true,
+                  https_redirect: true
       })),
       proxy_id: None
     });

--- a/command/src/messages.rs
+++ b/command/src/messages.rs
@@ -188,6 +188,7 @@ impl<'de> serde::Deserialize<'de> for CertFingerprint {
 pub struct Application {
     pub app_id:         String,
     pub sticky_session: bool,
+    pub https_redirect: bool,
 }
 
 #[derive(Debug,Clone,PartialEq,Eq,Hash, Serialize, Deserialize)]
@@ -231,6 +232,7 @@ pub struct Instance {
 pub struct HttpProxyConfiguration {
     pub front:           SocketAddr,
     pub public_address:  Option<IpAddr>,
+    pub answer_301:      String,
     pub answer_404:      String,
     pub answer_503:      String,
 }
@@ -240,6 +242,7 @@ impl Default for HttpProxyConfiguration {
     HttpProxyConfiguration {
       front:           "127.0.0.1:8080".parse().expect("could not parse address"),
       public_address:  None,
+      answer_301:      String::from("HTTP/1.1 301 Moved Permanently\r\nContent-Length: 0\r\nLocation: {}\r\n\r\n"),
       answer_404:      String::from("HTTP/1.1 404 Not Found\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"),
       answer_503:      String::from("HTTP/1.1 503 your application is in deployment\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"),
     }
@@ -250,6 +253,7 @@ impl Default for HttpProxyConfiguration {
 pub struct HttpsProxyConfiguration {
     pub front:                     SocketAddr,
     pub public_address:            Option<IpAddr>,
+    pub answer_301:                String,
     pub answer_404:                String,
     pub answer_503:                String,
     pub versions:                  Vec<String>,
@@ -266,6 +270,7 @@ impl Default for HttpsProxyConfiguration {
     HttpsProxyConfiguration {
       front:           "127.0.0.1:8443".parse().expect("could not parse address"),
       public_address:  None,
+      answer_301:      String::from("HTTP/1.1 301 Moved Permanently\r\nContent-Length: 0\r\nLocation: {}\r\n\r\n"),
       answer_404:      String::from("HTTP/1.1 404 Not Found\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"),
       answer_503:      String::from("HTTP/1.1 503 your application is in deployment\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"),
       cipher_list:     String::from(

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -367,21 +367,21 @@ mod tests {
     state.handle_order(&Order::AddInstance(Instance { app_id: String::from("app_1"), instance_id: String::from("app_1-0"), ip_address: String::from("127.0.0.1"), port: 1026 }));
     state.handle_order(&Order::AddInstance(Instance { app_id: String::from("app_1"), instance_id: String::from("app_1-1"), ip_address: String::from("127.0.0.2"), port: 1027 }));
     state.handle_order(&Order::AddInstance(Instance { app_id: String::from("app_2"), instance_id: String::from("app_2-0"), ip_address: String::from("192.167.1.2"), port: 1026 }));
-    state.handle_order(&Order::AddApplication(Application { app_id: String::from("app_2"), sticky_session: true }));
+    state.handle_order(&Order::AddApplication(Application { app_id: String::from("app_2"), sticky_session: true, https_redirect: true }));
 
     let mut state2:ConfigState = Default::default();
     state2.handle_order(&Order::AddHttpFront(HttpFront { app_id: String::from("app_1"), hostname: String::from("lolcatho.st:8080"), path_begin: String::from("/") }));
     state2.handle_order(&Order::AddInstance(Instance { app_id: String::from("app_1"), instance_id: String::from("app_1-0"), ip_address: String::from("127.0.0.1"), port: 1026 }));
     state2.handle_order(&Order::AddInstance(Instance { app_id: String::from("app_1"), instance_id: String::from("app_1-1"), ip_address: String::from("127.0.0.2"), port: 1027 }));
     state2.handle_order(&Order::AddInstance(Instance { app_id: String::from("app_1"), instance_id: String::from("app_1-2"), ip_address: String::from("127.0.0.2"), port: 1028 }));
-    state2.handle_order(&Order::AddApplication(Application { app_id: String::from("app_3"), sticky_session: false }));
+    state2.handle_order(&Order::AddApplication(Application { app_id: String::from("app_3"), sticky_session: false, https_redirect: false }));
 
    let e = vec!(
      Order::RemoveHttpFront(HttpFront { app_id: String::from("app_2"), hostname: String::from("test.local"), path_begin: String::from("/abc") }),
      Order::RemoveInstance(Instance { app_id: String::from("app_2"), instance_id: String::from("app_2-0"), ip_address: String::from("192.167.1.2"), port: 1026 }),
      Order::AddInstance(Instance { app_id: String::from("app_1"), instance_id: String::from("app_1-2"), ip_address: String::from("127.0.0.2"), port: 1028 }),
      Order::RemoveApplication(String::from("app_2")),
-     Order::AddApplication(Application { app_id: String::from("app_3"), sticky_session: false }),
+     Order::AddApplication(Application { app_id: String::from("app_3"), sticky_session: false, https_redirect: false }),
    );
    let expected_diff:HashSet<&Order> = HashSet::from_iter(e.iter());
 

--- a/ctl/src/cli.rs
+++ b/ctl/src/cli.rs
@@ -85,6 +85,8 @@ pub enum ApplicationCmd {
     id: String,
     #[structopt(short = "s", long = "sticky-session")]
     sticky_session: bool,
+    #[structopt(short = "h", long = "https-redirect")]
+    https_redirect: bool
   },
 }
 

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -702,10 +702,11 @@ pub fn metrics(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>) {
   }
 }
 
-pub fn add_application(channel: Channel<ConfigMessage,ConfigMessageAnswer>, app_id: &str, sticky_session: bool) {
+pub fn add_application(channel: Channel<ConfigMessage,ConfigMessageAnswer>, app_id: &str, sticky_session: bool, https_redirect: bool) {
   order_command(channel, Order::AddApplication(Application {
     app_id:         String::from(app_id),
     sticky_session: sticky_session,
+    https_redirect: https_redirect
   }));
 }
 

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -51,7 +51,7 @@ fn main() {
     },
     SubCmd::Application{ cmd } => {
       match cmd {
-        ApplicationCmd::Add{ id, sticky_session } => add_application(channel, &id, sticky_session),
+        ApplicationCmd::Add{ id, sticky_session, https_redirect } => add_application(channel, &id, sticky_session, https_redirect),
         ApplicationCmd::Remove{ id } => remove_application(channel, &id),
       }
     },

--- a/lib/src/network/mod.rs
+++ b/lib/src/network/mod.rs
@@ -128,7 +128,8 @@ pub enum ConnectionError {
   NoRequestLineGiven,
   HostNotFound,
   NoBackendAvailable,
-  ToBeDefined
+  ToBeDefined,
+  HttpsRedirect
 }
 
 #[derive(Debug,PartialEq,Eq)]

--- a/lib/src/network/protocol/http.rs
+++ b/lib/src/network/protocol/http.rs
@@ -39,6 +39,7 @@ pub enum ClientStatus {
 
 #[derive(Debug,Clone,Copy,PartialEq)]
 pub enum DefaultAnswerStatus {
+  Answer301,
   Answer404,
   Answer503,
 }
@@ -348,6 +349,7 @@ impl<Front:SocketHandler> Http<Front> {
 
     let status_line = match self.status {
       ClientStatus::Normal => "-",
+      ClientStatus::DefaultAnswer(DefaultAnswerStatus::Answer301) => "301 Moved Permanently",
       ClientStatus::DefaultAnswer(DefaultAnswerStatus::Answer404) => "404 Not Found",
       ClientStatus::DefaultAnswer(DefaultAnswerStatus::Answer503) => "503 Service Unavailable",
     };

--- a/lib/src/network/session.rs
+++ b/lib/src/network/session.rs
@@ -421,7 +421,7 @@ impl<ServerConfiguration:ProxyConfiguration<Client>,Client:ProxyClient> Session<
           return;
         }
       },
-      Err(ConnectionError::HostNotFound) | Err(ConnectionError::NoBackendAvailable) => {
+      Err(ConnectionError::HostNotFound) | Err(ConnectionError::NoBackendAvailable) | Err(ConnectionError::HttpsRedirect) => {
         self.clients[token].readiness().front_interest = UnixReady::from(Ready::writable()) | UnixReady::hup() | UnixReady::error();
         self.clients[token].readiness().back_interest  = UnixReady::hup() | UnixReady::error();
       },


### PR DESCRIPTION
The option is named `https_redirect`. I'm open to change the name.

I handled the redirection in `ServerConfiguration::connect_to_backend()`. It returns a `Err(ConnectionError::HttpsRedirect)`, which I don't really like because that's not an error per say. If you have a better idea, let me know :)

Part of #219 