### PR TITLE
Don't panic if there is an error during events polling

### DIFF
--- a/lib/src/network/proxy.rs
+++ b/lib/src/network/proxy.rs
@@ -156,8 +156,21 @@ impl Server {
     //FIXME: make those parameters configurable?
     let mut events = Events::with_capacity(1024);
     let poll_timeout = Some(Duration::from_millis(1000));
+    let max_poll_errors = 10000;
+    let mut current_poll_errors = 0;
     loop {
-      self.poll.poll(&mut events, poll_timeout).expect("should be able to poll for events");
+      if current_poll_errors == max_poll_errors {
+        error!("Something is going very wrong. Last {} poll() calls failed, crashing..", current_poll_errors);
+        panic!(format!("poll() calls failed {} times in a row", current_poll_errors));
+      }
+
+      if let Err(error) = self.poll.poll(&mut events, poll_timeout) {
+        error!("Error while polling events: {:?}", error);
+        current_poll_errors += 1;
+        continue;
+      } else {
+        current_poll_errors = 0;
+      }
 
       for event in events.iter() {
         if event.token() == Token(0) {


### PR DESCRIPTION
If you want to strace sozu for example, the poll system call
will be interrupted when the process is attached, making sozu crash.

It's also the case for gdb as soon as you want to resume execution
after putting a breakpoint.

We ignore the error and retry the call.