### PR TITLE
ctl: add an option to query an application using its domain name

### DIFF
--- a/bin/src/command/orders.rs
+++ b/bin/src/command/orders.rs
@@ -333,8 +333,8 @@ impl CommandServer {
 
   pub fn query(&mut self, token: FrontToken, message_id: &str, query: Query) {
     let message_type = match &query {
-      &Query::Application(ref app_id) => MessageType::QueryApplication(app_id.clone()),
-      &Query::ApplicationsHashes      => MessageType::QueryApplicationsHashes,
+      &Query::ApplicationsHashes          => MessageType::QueryApplicationsHashes,
+      &Query::Applications(ref query_type) => MessageType::QueryApplications(query_type.clone()),
     };
 
     self.order_state.insert_task(message_id, message_type, Some(token));

--- a/bin/src/command/orders.rs
+++ b/bin/src/command/orders.rs
@@ -333,8 +333,8 @@ impl CommandServer {
 
   pub fn query(&mut self, token: FrontToken, message_id: &str, query: Query) {
     let message_type = match &query {
-      &Query::Applications            => MessageType::QueryApplications,
       &Query::Application(ref app_id) => MessageType::QueryApplication(app_id.clone()),
+      &Query::ApplicationsHashes      => MessageType::QueryApplicationsHashes,
     };
 
     self.order_state.insert_task(message_id, message_type, Some(token));

--- a/bin/src/command/state.rs
+++ b/bin/src/command/state.rs
@@ -90,7 +90,7 @@ pub enum MessageType {
   LoadState,
   WorkerOrder,
   Metrics,
-  QueryApplications,
+  QueryApplicationsHashes,
   QueryApplication(String),
   Stop,
 }
@@ -136,7 +136,7 @@ impl Task {
         data.insert(String::from("master"), master_metrics);
         Some(AnswerData::Metrics(data))
       },
-      MessageType::QueryApplications => {
+      MessageType::QueryApplicationsHashes => {
         let mut data: BTreeMap<String, QueryAnswer> = self.data.into_iter().filter_map(|(tag, query)| {
           if let OrderMessageAnswerData::Query(data) = query {
             Some((tag, data))
@@ -145,7 +145,7 @@ impl Task {
           }
         }).collect();
 
-        data.insert(String::from("master"), QueryAnswer::Applications(master_state.hash_state()));
+        data.insert(String::from("master"), QueryAnswer::ApplicationsHashes(master_state.hash_state()));
 
         Some(AnswerData::Query(data))
       },

--- a/command/src/messages.rs
+++ b/command/src/messages.rs
@@ -304,7 +304,7 @@ pub enum Query {
   Application(String),
   //Certificate(CertFingerprint),
   //Certificates,
-  Applications,
+  ApplicationsHashes,
 }
 
 #[derive(Debug,Clone,PartialEq,Eq,Hash, Serialize, Deserialize)]
@@ -314,7 +314,7 @@ pub enum QueryAnswer {
   //Certificate(QueryAnswerCertificate),
   //Certificates(Vec<CertFingerprint>),
   /// application id, hash of application information
-  Applications(BTreeMap<String, u64>),
+  ApplicationsHashes(BTreeMap<String, u64>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/command/src/messages.rs
+++ b/command/src/messages.rs
@@ -299,9 +299,22 @@ impl Default for HttpsProxyConfiguration {
 }
 
 #[derive(Debug,Clone,PartialEq,Eq,Hash, Serialize, Deserialize)]
+pub struct QueryApplicationDomain {
+  pub hostname: String,
+  pub path_begin: Option<String>
+}
+
+#[derive(Debug,Clone,PartialEq,Eq,Hash, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum QueryApplicationType {
+  AppId(String),
+  Domain(QueryApplicationDomain)
+}
+
+#[derive(Debug,Clone,PartialEq,Eq,Hash, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Query {
-  Application(String),
+  Applications(QueryApplicationType),
   //Certificate(CertFingerprint),
   //Certificates,
   ApplicationsHashes,
@@ -310,7 +323,7 @@ pub enum Query {
 #[derive(Debug,Clone,PartialEq,Eq,Hash, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum QueryAnswer {
-  Application(QueryAnswerApplication),
+  Applications(Vec<QueryAnswerApplication>),
   //Certificate(QueryAnswerCertificate),
   //Certificates(Vec<CertFingerprint>),
   /// application id, hash of application information
@@ -324,6 +337,18 @@ pub struct QueryAnswerApplication {
   pub https_frontends: Vec<HttpsFront>,
   pub tcp_frontends:   Vec<TcpFront>,
   pub backends:        Vec<Instance>,
+}
+
+impl Default for QueryAnswerApplication {
+  fn default() -> QueryAnswerApplication {
+    QueryAnswerApplication {
+      configuration: None,
+      http_frontends: vec!(),
+      https_frontends: vec!(),
+      tcp_frontends: vec!(),
+      backends: vec!()
+    }
+  }
 }
 
 impl Order {

--- a/ctl/src/cli.rs
+++ b/ctl/src/cli.rs
@@ -201,6 +201,8 @@ pub enum QueryCmd {
   #[structopt(name = "applications")]
   Applications {
     #[structopt(short = "i", long="id", help="application identifier")]
-    id: Option<String>
+    id: Option<String>,
+    #[structopt(short = "d", long="domain", help="application domain name")]
+    domain: Option<String>
   }
 }

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -842,7 +842,7 @@ pub fn remove_tcp_frontend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, 
 pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, application_id: Option<String>) {
   let command = match application_id {
     Some(ref app_id) => ConfigCommand::Query(Query::Application(app_id.to_string())),
-    None         => ConfigCommand::Query(Query::Applications),
+    None         => ConfigCommand::Query(Query::ApplicationsHashes),
   };
 
   let id = generate_id();
@@ -1035,7 +1035,7 @@ pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>
 
               for ref metrics in data.values() {
                 //let m: u8 = metrics;
-                if let &QueryAnswer::Applications(ref apps) = *metrics {
+                if let &QueryAnswer::ApplicationsHashes(ref apps) = *metrics {
                   for (ref key, ref value) in apps.iter() {
                     (*(query_data.entry(key.clone()).or_insert(Vec::new()))).push(value.clone());
                   }

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -903,6 +903,7 @@ pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>
 
               let mut frontend_table = Table::new();
               let mut header = Vec::new();
+              header.push(cell!("id"));
               header.push(cell!("hostname"));
               header.push(cell!("path begin"));
               for ref key in data.keys() {
@@ -912,6 +913,7 @@ pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>
 
               let mut https_frontend_table = Table::new();
               let mut header = Vec::new();
+              header.push(cell!("id"));
               header.push(cell!("hostname"));
               header.push(cell!("path begin"));
               header.push(cell!("fingerprint"));
@@ -986,6 +988,7 @@ pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>
 
               for (ref key, ref values) in frontend_data.iter() {
                 let mut row = Vec::new();
+                row.push(cell!(key.app_id));
                 row.push(cell!(key.hostname));
                 row.push(cell!(key.path_begin));
 
@@ -1006,6 +1009,7 @@ pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>
 
               for (ref key, ref values) in https_frontend_data.iter() {
                 let mut row = Vec::new();
+                row.push(cell!(key.app_id));
                 row.push(cell!(key.hostname));
                 row.push(cell!(key.path_begin));
                 row.push(cell!(format!("{}", key.fingerprint)));

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -3,7 +3,7 @@ use sozu_command::channel::Channel;
 use sozu_command::certificate::{calculate_fingerprint,split_certificate_chain};
 use sozu_command::data::{AnswerData,ConfigCommand,ConfigMessage,ConfigMessageAnswer,ConfigMessageStatus,RunState};
 use sozu_command::messages::{Application, Order, Instance, HttpFront, HttpsFront, TcpFront,
-  CertificateAndKey, CertFingerprint, Query, QueryAnswer};
+  CertificateAndKey, CertFingerprint, Query, QueryAnswer, QueryApplicationType, QueryApplicationDomain};
 
 use std::collections::{HashMap,HashSet};
 use std::process::exit;
@@ -839,10 +839,30 @@ pub fn remove_tcp_frontend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, 
   }));
 }
 
-pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, application_id: Option<String>) {
-  let command = match application_id {
-    Some(ref app_id) => ConfigCommand::Query(Query::Application(app_id.to_string())),
-    None         => ConfigCommand::Query(Query::ApplicationsHashes),
+pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, application_id: Option<String>, domain: Option<String>) {
+  if application_id.is_some() && domain.is_some() {
+    println!("Error: Either request an application ID or a domain name");
+    return;
+  }
+
+  let command = if let Some(ref app_id) = application_id {
+    ConfigCommand::Query(Query::Applications(QueryApplicationType::AppId(app_id.to_string())))
+  } else if let Some(ref domain) = domain {
+    let splitted: Vec<String> = domain.splitn(2, "/").map(|elem| elem.to_string()).collect();
+
+    if splitted.len() == 0 {
+      println!("Domain can't be empty");
+      return;
+    }
+
+    let query_domain = QueryApplicationDomain {
+      hostname: splitted.get(0).expect("Domain can't be empty").clone(),
+      path_begin: splitted.get(1).cloned().map(|path| format!("/{}", path)) // We add the / again because of the splitn removing it
+    };
+
+    ConfigCommand::Query(Query::Applications(QueryApplicationType::Domain(query_domain)))
+  } else {
+    ConfigCommand::Query(Query::ApplicationsHashes)
   };
 
   let id = generate_id();
@@ -869,12 +889,13 @@ pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>
           println!("could not query proxy state: {}", message.message);
         },
         ConfigMessageStatus::Ok => {
-          if let Some(app_id) = application_id {
+          if let Some(needle) = application_id.or(domain) {
             println!("Proxy config answer:\n{}\n{:#?}", message.message, message.data);
             if let Some(AnswerData::Query(data)) = message.data {
               let mut application_table = Table::new();
               let mut header = Vec::new();
-              header.push(cell!("key"));
+              header.push(cell!("id"));
+              header.push(cell!("sticky_session"));
               for ref key in data.keys() {
                 header.push(cell!(&key));
               }
@@ -918,39 +939,42 @@ pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>
 
               for (ref key, ref metrics) in data.iter() {
                 //let m: u8 = metrics;
-                if let &QueryAnswer::Application(ref app) = *metrics {
-                  let mut entry = application_data.entry(String::from("sticky session")).or_insert(Vec::new());
-                  if let Some(ref conf) = app.configuration {
-                    entry.push(format!("{}", conf.sticky_session));
-                  } else {
-                    entry.push(String::from(""));
-                  }
-
-                  for frontend in app.http_frontends.iter() {
-                    let mut entry = frontend_data.entry(frontend).or_insert(Vec::new());
+                if let &QueryAnswer::Applications(ref apps) = *metrics {
+                  for app in apps.iter() {
+                    let mut entry = application_data.entry(app).or_insert(Vec::new());
                     entry.push(key.clone());
-                  }
 
-                  for frontend in app.https_frontends.iter() {
-                    let mut entry = https_frontend_data.entry(frontend).or_insert(Vec::new());
-                    entry.push(key.clone());
-                  }
+                    for frontend in app.http_frontends.iter() {
+                      let mut entry = frontend_data.entry(frontend).or_insert(Vec::new());
+                      entry.push(key.clone());
+                    }
 
-                  for backend in app.backends.iter() {
-                    let mut entry = backend_data.entry(backend).or_insert(Vec::new());
-                    entry.push(key.clone());
+                    for frontend in app.https_frontends.iter() {
+                      let mut entry = https_frontend_data.entry(frontend).or_insert(Vec::new());
+                      entry.push(key.clone());
+                    }
+
+                    for backend in app.backends.iter() {
+                      let mut entry = backend_data.entry(backend).or_insert(Vec::new());
+                      entry.push(key.clone());
+                    }
                   }
                 }
               }
 
-              println!("Application level configuration for {}:\n", app_id);
+              println!("Application level configuration for {}:\n", needle);
 
               for (ref key, ref values) in application_data.iter() {
                 let mut row = Vec::new();
-                row.push(cell!(key));
+                row.push(cell!(key.configuration.clone().map(|conf| conf.app_id).unwrap_or(String::from(""))));
+                row.push(cell!(key.configuration.clone().map(|conf| conf.sticky_session).unwrap_or(false)));
 
                 for val in values.iter() {
-                  row.push(cell!(format!("{}", val)));
+                  if keys.contains(val) {
+                    row.push(cell!(String::from("X")));
+                  } else {
+                    row.push(cell!(String::from("")));
+                  }
                 }
 
                 application_table.add_row(Row::new(row));
@@ -958,7 +982,7 @@ pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>
 
               application_table.printstd();
 
-              println!("\nHTTP frontends configuration for {}:\n", app_id);
+              println!("\nHTTP frontends configuration for {}:\n", needle);
 
               for (ref key, ref values) in frontend_data.iter() {
                 let mut row = Vec::new();
@@ -978,7 +1002,7 @@ pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>
 
               frontend_table.printstd();
 
-              println!("\nHTTPS frontends configuration for {}:\n", app_id);
+              println!("\nHTTPS frontends configuration for {}:\n", needle);
 
               for (ref key, ref values) in https_frontend_data.iter() {
                 let mut row = Vec::new();
@@ -999,7 +1023,7 @@ pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>
 
               https_frontend_table.printstd();
 
-              println!("\nbackends configuration for {}:\n", app_id);
+              println!("\nbackends configuration for {}:\n", needle);
 
               for (ref key, ref values) in backend_data.iter() {
                 let mut row = Vec::new();

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -85,7 +85,7 @@ fn main() {
     },
     SubCmd::Query{ cmd } => {
       match cmd {
-        QueryCmd::Applications{ id } => query_application(channel, id),
+        QueryCmd::Applications{ id, domain } => query_application(channel, id, domain),
       }
     },
   }

--- a/lib/src/network/proxy.rs
+++ b/lib/src/network/proxy.rs
@@ -326,12 +326,12 @@ impl Server {
 
     if let Order::Query(ref query) = message.order {
       match query {
-        &Query::Applications => {
+        &Query::ApplicationsHashes => {
           self.queue.push_back(OrderMessageAnswer {
             id:     message.id.clone(),
             status: OrderMessageStatus::Ok,
             data:   Some(OrderMessageAnswerData::Query(
-              QueryAnswer::Applications(self.config_state.hash_state())
+              QueryAnswer::ApplicationsHashes(self.config_state.hash_state())
             ))
           });
         },


### PR DESCRIPTION
I was not sure how to implement this at first, so I went ahead and tried :)

It adds a `sozuctl -c conf query applications --domain domain.tld/path_begin` option to query applications by their domain name.

I'm open to suggestions on how to improve !