### PR TITLE
Add options to configure timeout of sozuctl commands

### DIFF
--- a/bin/config.toml
+++ b/bin/config.toml
@@ -12,6 +12,7 @@ handle_process_affinity = false
 max_connections = 500
 max_buffers = 500
 buffer_size = 16384
+#ctl_commands_timeout = 1000
 
 [metrics]
 address = "127.0.0.1"

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -405,7 +405,8 @@ pub struct FileConfig {
   pub https:                   Option<ProxyConfig>,
   pub tcp:                     Option<TcpProxyConfig>,
   pub applications:            Option<HashMap<String, FileAppConfig>>,
-  pub handle_process_affinity: Option<bool>
+  pub handle_process_affinity: Option<bool>,
+  pub ctl_commands_timeout:    Option<u64>
 }
 
 
@@ -456,6 +457,7 @@ impl FileConfig {
       tcp: self.tcp,
       applications: applications,
       handle_process_affinity: self.handle_process_affinity.unwrap_or(false),
+      ctl_commands_timeout: self.ctl_commands_timeout.unwrap_or(1_000)
     }
   }
 }
@@ -480,6 +482,7 @@ pub struct Config {
   pub tcp:                     Option<TcpProxyConfig>,
   pub applications:            HashMap<String, AppConfig>,
   pub handle_process_affinity: bool,
+  pub ctl_commands_timeout:    u64,
 }
 
 impl Config {
@@ -619,6 +622,7 @@ mod tests {
       https: Some(https),
       tcp:   None,
       applications: None,
+      ctl_commands_timeout: None
     };
 
     println!("config: {:?}", to_string(&config));

--- a/ctl/src/cli.rs
+++ b/ctl/src/cli.rs
@@ -2,7 +2,7 @@
 pub struct App {
   #[structopt(short="c", long = "config", help = "Sets a custom config file")]
   pub config: String,
-  #[structopt(short="t", long = "timeout", help = "Sets a custom timeout for commands (in milliseconds)")]
+  #[structopt(short="t", long = "timeout", help = "Sets a custom timeout for commands (in milliseconds). 0 disables the timeout")]
   pub timeout: Option<u64>,
   #[structopt(subcommand)]
   pub cmd: SubCmd,

--- a/ctl/src/cli.rs
+++ b/ctl/src/cli.rs
@@ -2,6 +2,8 @@
 pub struct App {
   #[structopt(short="c", long = "config", help = "Sets a custom config file")]
   pub config: String,
+  #[structopt(short="t", long = "timeout", help = "Sets a custom timeout for commands (in milliseconds)")]
+  pub timeout: Option<u64>,
   #[structopt(subcommand)]
   pub cmd: SubCmd,
 }

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -16,7 +16,6 @@ use prettytable::Table;
 use prettytable::row::Row;
 use super::create_channel;
 
-const DEFAULT_TIMEOUT: u64 = 1000;
 
 fn generate_id() -> String {
   let s: String = thread_rng().gen_ascii_chars().take(6).collect();
@@ -47,7 +46,7 @@ macro_rules! command_timeout {
   )
 }
 
-pub fn save_state(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, path: String) {
+pub fn save_state(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, path: String) {
   let id = generate_id();
   channel.write_message(&ConfigMessage::new(
     id.clone(),
@@ -55,7 +54,7 @@ pub fn save_state(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, path:
     None,
   ));
 
-  command_timeout!(DEFAULT_TIMEOUT, {
+  command_timeout!(timeout, {
     match channel.read_message() {
       None          => {
         println!("the proxy didn't answer");
@@ -85,7 +84,7 @@ pub fn save_state(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, path:
   });
 }
 
-pub fn load_state(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, path: String) {
+pub fn load_state(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, path: String) {
   let id = generate_id();
   channel.write_message(&ConfigMessage::new(
     id.clone(),
@@ -93,7 +92,7 @@ pub fn load_state(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, path:
     None,
   ));
 
-  command_timeout!(DEFAULT_TIMEOUT, {
+  command_timeout!(timeout, {
     match channel.read_message() {
       None          => {
         println!("the proxy didn't answer");
@@ -123,7 +122,7 @@ pub fn load_state(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, path:
   });
 }
 
-pub fn dump_state(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>) {
+pub fn dump_state(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64) {
   let id = generate_id();
   channel.write_message(&ConfigMessage::new(
     id.clone(),
@@ -131,7 +130,7 @@ pub fn dump_state(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>) {
     None,
   ));
 
-  command_timeout!(DEFAULT_TIMEOUT, {
+  command_timeout!(timeout, {
     match channel.read_message() {
       None          => {
         println!("the proxy didn't answer");
@@ -201,7 +200,7 @@ pub fn soft_stop(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>) {
   }
 }
 
-pub fn hard_stop(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>) {
+pub fn hard_stop(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64) {
   println!("shutting down proxy");
   let id = generate_id();
   channel.write_message(&ConfigMessage::new(
@@ -211,7 +210,7 @@ pub fn hard_stop(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>) {
     None,
   ));
 
-  command_timeout!(DEFAULT_TIMEOUT,
+  command_timeout!(timeout,
     loop {
       match channel.read_message() {
         None          => println!("the proxy didn't answer"),
@@ -702,26 +701,26 @@ pub fn metrics(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>) {
   }
 }
 
-pub fn add_application(channel: Channel<ConfigMessage,ConfigMessageAnswer>, app_id: &str, sticky_session: bool, https_redirect: bool) {
-  order_command(channel, Order::AddApplication(Application {
+pub fn add_application(channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, app_id: &str, sticky_session: bool, https_redirect: bool) {
+  order_command(channel, timeout, Order::AddApplication(Application {
     app_id:         String::from(app_id),
     sticky_session: sticky_session,
     https_redirect: https_redirect
   }));
 }
 
-pub fn remove_application(channel: Channel<ConfigMessage,ConfigMessageAnswer>, app_id: &str) {
-  order_command(channel, Order::RemoveApplication(String::from(app_id)));
+pub fn remove_application(channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, app_id: &str) {
+  order_command(channel, timeout, Order::RemoveApplication(String::from(app_id)));
 }
 
-pub fn add_http_frontend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, app_id: &str, hostname: &str, path_begin: &str, certificate: Option<String>) {
+pub fn add_http_frontend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, app_id: &str, hostname: &str, path_begin: &str, certificate: Option<String>) {
   if let Some(certificate_path) = certificate {
     match Config::load_file_bytes(&certificate_path) {
       Ok(data) => {
         match calculate_fingerprint(&data) {
           None              => println!("could not calculate fingerprint for certificate"),
           Some(fingerprint) => {
-            order_command(channel, Order::AddHttpsFront(HttpsFront {
+            order_command(channel, timeout, Order::AddHttpsFront(HttpsFront {
               app_id: String::from(app_id),
               hostname: String::from(hostname),
               path_begin: String::from(path_begin),
@@ -733,7 +732,7 @@ pub fn add_http_frontend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, ap
       Err(e) => println!("could not load file: {:?}", e)
     }
   } else {
-    order_command(channel, Order::AddHttpFront(HttpFront {
+    order_command(channel, timeout, Order::AddHttpFront(HttpFront {
       app_id: String::from(app_id),
       hostname: String::from(hostname),
       path_begin: String::from(path_begin),
@@ -741,14 +740,14 @@ pub fn add_http_frontend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, ap
   }
 }
 
-pub fn remove_http_frontend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, app_id: &str, hostname: &str, path_begin: &str, certificate: Option<String>) {
+pub fn remove_http_frontend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, app_id: &str, hostname: &str, path_begin: &str, certificate: Option<String>) {
   if let Some(certificate_path) = certificate {
     match Config::load_file_bytes(&certificate_path) {
       Ok(data) => {
         match calculate_fingerprint(&data) {
           None              => println!("could not calculate fingerprint for certificate"),
           Some(fingerprint) => {
-            order_command(channel, Order::RemoveHttpsFront(HttpsFront {
+            order_command(channel, timeout, Order::RemoveHttpsFront(HttpsFront {
               app_id: String::from(app_id),
               hostname: String::from(hostname),
               path_begin: String::from(path_begin),
@@ -760,7 +759,7 @@ pub fn remove_http_frontend(channel: Channel<ConfigMessage,ConfigMessageAnswer>,
       Err(e) => println!("could not load file: {:?}", e)
     }
   } else {
-    order_command(channel, Order::RemoveHttpFront(HttpFront {
+    order_command(channel, timeout, Order::RemoveHttpFront(HttpFront {
       app_id: String::from(app_id),
       hostname: String::from(hostname),
       path_begin: String::from(path_begin),
@@ -769,8 +768,8 @@ pub fn remove_http_frontend(channel: Channel<ConfigMessage,ConfigMessageAnswer>,
 }
 
 
-pub fn add_backend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, app_id: &str, instance_id: &str, ip: &str, port: u16) {
-  order_command(channel, Order::AddInstance(Instance {
+pub fn add_backend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, app_id: &str, instance_id: &str, ip: &str, port: u16) {
+  order_command(channel, timeout, Order::AddInstance(Instance {
       app_id: String::from(app_id),
       instance_id: String::from(instance_id),
       ip_address: String::from(ip),
@@ -778,8 +777,8 @@ pub fn add_backend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, app_id: 
     }));
 }
 
-pub fn remove_backend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, app_id: &str, instance_id: &str, ip: &str, port: u16) {
-    order_command(channel, Order::RemoveInstance(Instance {
+pub fn remove_backend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, app_id: &str, instance_id: &str, ip: &str, port: u16) {
+    order_command(channel, timeout, Order::RemoveInstance(Instance {
       app_id: String::from(app_id),
       instance_id: String::from(instance_id),
       ip_address: String::from(ip),
@@ -787,7 +786,7 @@ pub fn remove_backend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, app_i
     }));
 }
 
-pub fn add_certificate(channel: Channel<ConfigMessage,ConfigMessageAnswer>, certificate_path: &str, certificate_chain_path: &str, key_path: &str) {
+pub fn add_certificate(channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, certificate_path: &str, certificate_chain_path: &str, key_path: &str) {
   match Config::load_file(certificate_path) {
     Err(e) => println!("could not load certificate: {:?}", e),
     Ok(certificate) => {
@@ -797,7 +796,7 @@ pub fn add_certificate(channel: Channel<ConfigMessage,ConfigMessageAnswer>, cert
           match Config::load_file(key_path) {
             Err(e) => println!("could not load key: {:?}", e),
             Ok(key) => {
-              order_command(channel, Order::AddCertificate(CertificateAndKey {
+              order_command(channel, timeout, Order::AddCertificate(CertificateAndKey {
                 certificate: certificate,
                 certificate_chain: certificate_chain,
                 key: key
@@ -811,11 +810,11 @@ pub fn add_certificate(channel: Channel<ConfigMessage,ConfigMessageAnswer>, cert
   }
 }
 
-pub fn remove_certificate(channel: Channel<ConfigMessage,ConfigMessageAnswer>, certificate_path: &str) {
+pub fn remove_certificate(channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, certificate_path: &str) {
   match Config::load_file_bytes(certificate_path) {
     Ok(data) => {
       match calculate_fingerprint(&data) {
-        Some(fingerprint) => order_command(channel, Order::RemoveCertificate(CertFingerprint(fingerprint))),
+        Some(fingerprint) => order_command(channel, timeout, Order::RemoveCertificate(CertFingerprint(fingerprint))),
         None              => println!("could not calculate finrprint for certificate")
       }
     },
@@ -823,16 +822,16 @@ pub fn remove_certificate(channel: Channel<ConfigMessage,ConfigMessageAnswer>, c
   }
 }
 
-pub fn add_tcp_frontend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, app_id: &str, ip_address: &str, port: u16) {
-  order_command(channel, Order::AddTcpFront(TcpFront {
+pub fn add_tcp_frontend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, app_id: &str, ip_address: &str, port: u16) {
+  order_command(channel, timeout, Order::AddTcpFront(TcpFront {
     app_id: String::from(app_id),
     ip_address: String::from(ip_address),
     port: port
   }));
 }
 
-pub fn remove_tcp_frontend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, app_id: &str, ip_address: &str, port: u16) {
-  order_command(channel, Order::RemoveTcpFront(TcpFront {
+pub fn remove_tcp_frontend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, app_id: &str, ip_address: &str, port: u16) {
+  order_command(channel, timeout, Order::RemoveTcpFront(TcpFront {
     app_id: String::from(app_id),
     ip_address: String::from(ip_address),
     port: port
@@ -1073,11 +1072,11 @@ pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>
   }
 }
 
-pub fn logging_filter(channel: Channel<ConfigMessage,ConfigMessageAnswer>, filter: &str) {
-  order_command(channel, Order::Logging(String::from(filter)));
+pub fn logging_filter(channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, filter: &str) {
+  order_command(channel, timeout, Order::Logging(String::from(filter)));
 }
 
-fn order_command(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, order: Order) {
+fn order_command(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, order: Order) {
   let id = generate_id();
   channel.write_message(&ConfigMessage::new(
     id.clone(),
@@ -1085,7 +1084,7 @@ fn order_command(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, order:
     None,
   ));
 
-  command_timeout!(DEFAULT_TIMEOUT, {
+  command_timeout!(timeout, {
     match channel.read_message() {
       None          => println!("the proxy didn't answer"),
       Some(message) => {

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -33,15 +33,19 @@ fn generate_tagged_id(tag: &str) -> String {
 // to do with the message received.
 macro_rules! command_timeout {
   ($duration: expr, $block: expr) => (
-    let (send, recv) = mpsc::channel();
-
-    thread::spawn(move || {
+    if $duration == 0 {
       $block
-      send.send(()).unwrap();
-    });
+    } else {
+      let (send, recv) = mpsc::channel();
 
-    if recv.recv_timeout(Duration::from_millis($duration)).is_err() {
-      eprintln!("Command timeout. The proxy didn't send answer");
+      thread::spawn(move || {
+        $block
+        send.send(()).unwrap();
+      });
+
+      if recv.recv_timeout(Duration::from_millis($duration)).is_err() {
+        eprintln!("Command timeout. The proxy didn't send answer");
+      }
     }
   )
 }

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -29,11 +29,12 @@ fn main() {
 
   let config  = Config::load_from_path(config_file.as_str()).expect("could not parse configuration file");
   let channel = create_channel(&config.command_socket_path()).expect("could not connect to the command unix socket");
+  let timeout: u64 = matches.timeout.unwrap_or(config.ctl_commands_timeout);
 
   match matches.cmd {
     SubCmd::Shutdown{ hard } => {
       if hard {
-        hard_stop(channel);
+        hard_stop(channel, timeout);
       } else {
         soft_stop(channel);
       }
@@ -41,46 +42,46 @@ fn main() {
     SubCmd::Upgrade => upgrade(channel, &config.command_socket_path()),
     SubCmd::Status => status(channel),
     SubCmd::Metrics => metrics(channel),
-    SubCmd::Logging{ level } => logging_filter(channel, &level),
+    SubCmd::Logging{ level } => logging_filter(channel, timeout, &level),
     SubCmd::State{ cmd } => {
       match cmd {
-        StateCmd::Save{ file } => save_state(channel, file),
-        StateCmd::Load{ file } => load_state(channel, file),
-        StateCmd::Dump => dump_state(channel),
+        StateCmd::Save{ file } => save_state(channel, timeout, file),
+        StateCmd::Load{ file } => load_state(channel, timeout, file),
+        StateCmd::Dump => dump_state(channel, timeout),
       }
     },
     SubCmd::Application{ cmd } => {
       match cmd {
-        ApplicationCmd::Add{ id, sticky_session, https_redirect } => add_application(channel, &id, sticky_session, https_redirect),
-        ApplicationCmd::Remove{ id } => remove_application(channel, &id),
+        ApplicationCmd::Add{ id, sticky_session, https_redirect } => add_application(channel, timeout, &id, sticky_session, https_redirect),
+        ApplicationCmd::Remove{ id } => remove_application(channel, timeout, &id),
       }
     },
     SubCmd::Backend{ cmd } => {
       match cmd {
-        BackendCmd::Add{ id, instance_id, ip, port } => add_backend(channel, &id, &instance_id, &ip, port),
-        BackendCmd::Remove{ id, instance_id, ip, port } => remove_backend(channel, &id, &instance_id, &ip, port),
+        BackendCmd::Add{ id, instance_id, ip, port } => add_backend(channel, timeout, &id, &instance_id, &ip, port),
+        BackendCmd::Remove{ id, instance_id, ip, port } => remove_backend(channel, timeout, &id, &instance_id, &ip, port),
       }
     },
     SubCmd::Frontend{ cmd } => {
       match cmd {
         FrontendCmd::Http{ cmd } => match cmd {
           HttpFrontendCmd::Add{ id, hostname, path_begin, path_to_certificate } =>
-            add_http_frontend(channel, &id, &hostname, &path_begin.unwrap_or("".to_string()), path_to_certificate),
+            add_http_frontend(channel, timeout, &id, &hostname, &path_begin.unwrap_or("".to_string()), path_to_certificate),
           HttpFrontendCmd::Remove{ id, hostname, path_begin, path_to_certificate } =>
-            remove_http_frontend(channel, &id, &hostname, &path_begin.unwrap_or("".to_string()), path_to_certificate),
+            remove_http_frontend(channel, timeout, &id, &hostname, &path_begin.unwrap_or("".to_string()), path_to_certificate),
         },
         FrontendCmd::Tcp { cmd } => match cmd {
           TcpFrontendCmd::Add{ id, ip_address, port } =>
-            add_tcp_frontend(channel, &id, &ip_address, port),
+            add_tcp_frontend(channel, timeout, &id, &ip_address, port),
           TcpFrontendCmd::Remove{ id, ip_address, port } =>
-            remove_tcp_frontend(channel, &id, &ip_address, port),
+            remove_tcp_frontend(channel, timeout, &id, &ip_address, port),
         }
       }
     },
     SubCmd::Certificate{ cmd } => {
       match cmd {
-        CertificateCmd::Add{ certificate, chain, key } => add_certificate(channel, &certificate, &chain, key.unwrap_or("missing key path".to_string()).as_str()),
-        CertificateCmd::Remove{ certificate } => remove_certificate(channel, &certificate),
+        CertificateCmd::Add{ certificate, chain, key } => add_certificate(channel, timeout, &certificate, &chain, key.unwrap_or("missing key path".to_string()).as_str()),
+        CertificateCmd::Remove{ certificate } => remove_certificate(channel, timeout, &certificate),
       }
     },
     SubCmd::Query{ cmd } => {


### PR DESCRIPTION
Default timeout was hard coded and of 1 second (1_000 ms).

This PR adds a cli flag (-t, --timeout) and a Config (`ctl_commands_timeout`) option to configure the timeout, or disable it (if the configured timeout is 0). If none of the options are set, it defaults to a 1_000 ms timeout, as before.

The timeout is passed to all functions needing a timeout. Let me know if you're good with the fact to add a new argument at each function needing the timeout or if you think of a better way to do this (because we also pass the `channel` on each function, maybe we could have a struct with the configuration ?)