### PR TITLE
orders: don't execute code inside a macro only compiled in debug mode

### DIFF
--- a/bin/src/command/orders.rs
+++ b/bin/src/command/orders.rs
@@ -484,9 +484,11 @@ impl CommandServer {
     let workers: HashMap<Token, Worker> = workers.iter().filter_map(|serialized| {
       let stream = unsafe { UnixStream::from_raw_fd(serialized.fd) };
       if let Some(token) = serialized.token {
-        debug!("registering: {:?}", poll.register(&stream, Token(token),
+        let _register = poll.register(&stream, Token(token),
           Ready::readable() | Ready::writable() | UnixReady::error() | UnixReady::hup(),
-          PollOpt::edge()));
+          PollOpt::edge());
+        debug!("registering: {:?}", _register);
+
         let mut channel = Channel::new(stream, buffer_size, buffer_size * 2);
         channel.readiness.insert(Ready::writable());
         Some(


### PR DESCRIPTION
The `poll.register()` function will never be called (or even compiled) in
release mode because the debug! macro expands to nothing on release
mode

It adds a `warning: unused variable: register` when compiled in release mode. Would it be good practice to rename the variable `_register` as suggested by the compiler?

This fixes the `sozuctl upgrade` command hanging at the end of the process