### PR TITLE
ctl: Add a --json flag to some commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,7 @@ dependencies = [
  "prettytable-rs 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sozu-command-lib 0.4.0",
  "structopt 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,8 @@ version = "0.4.0"
 dependencies = [
  "prettytable-rs 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sozu-command-lib 0.4.0",
  "structopt 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt-derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ctl/Cargo.toml
+++ b/ctl/Cargo.toml
@@ -21,6 +21,7 @@ structopt = "0.1.0"
 structopt-derive = "0.1.0"
 serde = "1.0"
 serde_json = "1.0"
+serde_derive = "1.0"
 
 [features]
 unstable = []

--- a/ctl/Cargo.toml
+++ b/ctl/Cargo.toml
@@ -19,6 +19,8 @@ prettytable-rs = "^0.6"
 sozu-command-lib = { version = "^0.4", path = "../command" }
 structopt = "0.1.0"
 structopt-derive = "0.1.0"
+serde = "1.0"
+serde_json = "1.0"
 
 [features]
 unstable = []

--- a/ctl/src/cli.rs
+++ b/ctl/src/cli.rs
@@ -18,7 +18,10 @@ pub enum SubCmd {
   #[structopt(name = "upgrade", about = "upgrade the proxy")]
   Upgrade,
   #[structopt(name = "status", about = "gets information on the running workers")]
-  Status,
+  Status {
+    #[structopt(short = "j", long = "json", help = "Print the command result in JSON format")]
+    json: bool
+  },
   #[structopt(name = "metrics", about = "gets statistics on the master and its workers")]
   Metrics {
     #[structopt(short = "j", long = "json", help = "Print the command result in JSON format")]

--- a/ctl/src/cli.rs
+++ b/ctl/src/cli.rs
@@ -71,7 +71,10 @@ pub enum StateCmd {
     file: String,
   },
   #[structopt(name = "dump")]
-  Dump,
+  Dump {
+    #[structopt(short = "j", long = "json", help = "Print the command result in JSON format")]
+    json: bool
+  },
 }
 
 #[derive(StructOpt, PartialEq, Debug)]

--- a/ctl/src/cli.rs
+++ b/ctl/src/cli.rs
@@ -20,7 +20,10 @@ pub enum SubCmd {
   #[structopt(name = "status", about = "gets information on the running workers")]
   Status,
   #[structopt(name = "metrics", about = "gets statistics on the master and its workers")]
-  Metrics,
+  Metrics {
+    #[structopt(short = "j", long = "json", help = "Print the command result in JSON format")]
+    json: bool
+  },
   #[structopt(name = "logging", about = "change logging level")]
   Logging {
     #[structopt(short = "l", long = "level", help = "change logging level")]

--- a/ctl/src/cli.rs
+++ b/ctl/src/cli.rs
@@ -53,6 +53,8 @@ pub enum SubCmd {
   },
   #[structopt(name = "query", about = "configuration state verification")]
   Query {
+    #[structopt(short = "j", long = "json", help = "Print the command result in JSON format")]
+    json: bool,
     #[structopt(subcommand)]
     cmd: QueryCmd,
   }

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -542,7 +542,7 @@ pub fn status(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>) {
   }
 }
 
-pub fn metrics(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>) {
+pub fn metrics(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, json: bool) {
   let id = generate_id();
   //println!("will send message for metrics with id {}", id);
   channel.write_message(&ConfigMessage::new(
@@ -561,13 +561,22 @@ pub fn metrics(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>) {
             println!("Proxy is processing: {}", message.message);
           },
           ConfigMessageStatus::Error => {
-            println!("could not stop the proxy: {}", message.message);
+            if json {
+              print_json_response(&message.message);
+            } else {
+              println!("could not stop the proxy: {}", message.message);
+            }
           },
           ConfigMessageStatus::Ok => {
             if &id == &message.id {
               //println!("Sozu metrics:\n{}\n{:#?}", message.message, message.data);
 
               if let Some(AnswerData::Metrics(mut data)) = message.data {
+                if json {
+                  print_json_response(&data);
+                  return;
+                }
+
                 if let Some(master) = data.remove("master") {
                   let mut master_table = Table::new();
                   master_table.add_row(row![String::from("key"), String::from("value")]);

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -906,7 +906,6 @@ pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>
         },
         ConfigMessageStatus::Ok => {
           if let Some(needle) = application_id.or(domain) {
-            println!("Proxy config answer:\n{}\n{:#?}", message.message, message.data);
             if let Some(AnswerData::Query(data)) = message.data {
               if json {
                 print_json_response(&data);

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -851,7 +851,7 @@ pub fn remove_tcp_frontend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, 
   }));
 }
 
-pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, application_id: Option<String>, domain: Option<String>) {
+pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, json: bool, application_id: Option<String>, domain: Option<String>) {
   if application_id.is_some() && domain.is_some() {
     println!("Error: Either request an application ID or a domain name");
     return;
@@ -898,12 +898,21 @@ pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>
           // until an error or ok message was sent
         },
         ConfigMessageStatus::Error => {
-          println!("could not query proxy state: {}", message.message);
+          if json {
+            print_json_response(&message.message);
+          } else {
+            println!("could not query proxy state: {}", message.message);
+          }
         },
         ConfigMessageStatus::Ok => {
           if let Some(needle) = application_id.or(domain) {
             println!("Proxy config answer:\n{}\n{:#?}", message.message, message.data);
             if let Some(AnswerData::Query(data)) = message.data {
+              if json {
+                print_json_response(&data);
+                return;
+              }
+
               let mut application_table = Table::new();
               let mut header = Vec::new();
               header.push(cell!("id"));

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -86,9 +86,9 @@ fn main() {
         CertificateCmd::Remove{ certificate } => remove_certificate(channel, timeout, &certificate),
       }
     },
-    SubCmd::Query{ cmd } => {
+    SubCmd::Query{ cmd, json } => {
       match cmd {
-        QueryCmd::Applications{ id, domain } => query_application(channel, id, domain),
+        QueryCmd::Applications{ id, domain } => query_application(channel, json, id, domain),
       }
     },
   }

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -5,6 +5,7 @@ extern crate structopt;
 #[macro_use] extern crate structopt_derive;
 extern crate serde;
 extern crate serde_json;
+#[macro_use] extern crate serde_derive;
 
 mod command;
 mod cli;
@@ -42,7 +43,7 @@ fn main() {
       }
     },
     SubCmd::Upgrade => upgrade(channel, &config.command_socket_path()),
-    SubCmd::Status => status(channel),
+    SubCmd::Status{ json } => status(channel, json),
     SubCmd::Metrics{ json } => metrics(channel, json),
     SubCmd::Logging{ level } => logging_filter(channel, timeout, &level),
     SubCmd::State{ cmd } => {

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
     },
     SubCmd::Upgrade => upgrade(channel, &config.command_socket_path()),
     SubCmd::Status => status(channel),
-    SubCmd::Metrics => metrics(channel),
+    SubCmd::Metrics{ json } => metrics(channel, json),
     SubCmd::Logging{ level } => logging_filter(channel, timeout, &level),
     SubCmd::State{ cmd } => {
       match cmd {

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -3,6 +3,8 @@ extern crate rand;
 extern crate sozu_command_lib as sozu_command;
 extern crate structopt;
 #[macro_use] extern crate structopt_derive;
+extern crate serde;
+extern crate serde_json;
 
 mod command;
 mod cli;
@@ -47,7 +49,7 @@ fn main() {
       match cmd {
         StateCmd::Save{ file } => save_state(channel, timeout, file),
         StateCmd::Load{ file } => load_state(channel, timeout, file),
-        StateCmd::Dump => dump_state(channel, timeout),
+        StateCmd::Dump{ json } => dump_state(channel, timeout, json),
       }
     },
     SubCmd::Application{ cmd } => {


### PR DESCRIPTION
Part of #281 

This adds a `--json` flag to the `state dump`, `metrics`, `query` and `status` commands.