### PR TITLE
ctl: show https_redirect configuration option in query_application()

### DIFF
--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -899,6 +899,7 @@ pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>
               let mut header = Vec::new();
               header.push(cell!("id"));
               header.push(cell!("sticky_session"));
+              header.push(cell!("https_redirect"));
               for ref key in data.keys() {
                 header.push(cell!(&key));
               }
@@ -973,6 +974,7 @@ pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>
                 let mut row = Vec::new();
                 row.push(cell!(key.configuration.clone().map(|conf| conf.app_id).unwrap_or(String::from(""))));
                 row.push(cell!(key.configuration.clone().map(|conf| conf.sticky_session).unwrap_or(false)));
+                row.push(cell!(key.configuration.clone().map(|conf| conf.https_redirect).unwrap_or(false)));
 
                 for val in values.iter() {
                   if keys.contains(val) {


### PR DESCRIPTION
I didn't know much about the `ctl` when I added that option :)