### PR TITLE
Fix the build of http11 benchmark

### DIFF
--- a/lib/src/parser/http11.rs
+++ b/lib/src/parser/http11.rs
@@ -3188,7 +3188,6 @@ mod tests {
 mod bench {
   use super::*;
   use test::Bencher;
-  use network::buffer::Buffer;
   use network::buffer_queue::BufferQueue;
   use std::io::Write;
   use nom::HexDisplay;


### PR DESCRIPTION
The `network::buffer::Buffer` is no longer needed in the http11 bench `mod`.