### PR TITLE
Build: add 2 features flag to enable DEBUG and TRACE logs

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -42,6 +42,8 @@ procinfo = "^0.4.1"
 
 [features]
 unstable = []
+logs-debug = ["sozu-lib/logs-debug", "sozu-command-lib/logs-debug"]
+logs-trace = ["sozu-lib/logs-trace", "sozu-command-lib/logs-trace"]
 
 [badges]
 travis-ci = { repository = "sozu-proxy/sozu" }

--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -33,6 +33,8 @@ serde_derive = "^1.0.2"
 
 [features]
 unstable = []
+logs-debug = []
+logs-trace = []
 
 [badges]
 travis-ci = { repository = "sozu-proxy/sozu" }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -51,6 +51,8 @@ features = ["v4"]
 default  = []
 splice   = []
 unstable = []
+logs-debug = []
+logs-trace = []
 
 [badges]
 travis-ci = { repository = "sozu-proxy/sozu" }

--- a/lib/src/logging.rs
+++ b/lib/src/logging.rs
@@ -470,12 +470,12 @@ macro_rules! info {
 #[macro_export]
 macro_rules! debug {
     ($format:expr, $($arg:tt)*) => {
-        #[cfg(debug_assertions)]
+        #[cfg(any(debug_assertions, feature = "logs-debug", feature = "logs-trace"))]
         log!($crate::logging::LogLevel::Debug, concat!("{}\t", $format),
           "DEBUG", {module_path!()}, $($arg)*);
     };
     ($format:expr) => {
-        #[cfg(debug_assertions)]
+        #[cfg(any(debug_assertions, feature = "logs-debug", feature = "logs-trace"))]
         log!($crate::logging::LogLevel::Debug, concat!("{}\t", $format),
           "DEBUG", {module_path!()});
     }
@@ -484,12 +484,12 @@ macro_rules! debug {
 #[macro_export]
 macro_rules! trace {
     ($format:expr, $($arg:tt)*) => (
-        #[cfg(debug_assertions)]
+        #[cfg(any(debug_assertions, feature = "logs-trace"))]
         log!($crate::logging::LogLevel::Trace, concat!("{}\t", $format),
           "TRACE", module_path!(), $($arg)*);
     );
     ($format:expr) => (
-        #[cfg(debug_assertions)]
+        #[cfg(any(debug_assertions, feature = "logs-trace"))]
         log!($crate::logging::LogLevel::Trace, concat!("{}\t", $format),
           "TRACE", module_path!());
     )


### PR DESCRIPTION
The debug! macro checks both flags because if we want to enable the
TRACE logs, there is also some chances we want to add the DEBUG log

We may need this on testing platforms where we want to build in release but still want to have verbose logs to debug stuff.

I'm not very familiar with cargo features, so let me know what you think about this PR