### PR TITLE
Socket transfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,7 @@ dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pem 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -575,7 +575,7 @@ impl CommandServer {
     self.proxies.remove(&token);
 
     let id = self.next_id;
-    if let Ok(mut worker) = start_worker(id, &self.config, &self.state) {
+    if let Ok(mut worker) = start_worker(id, &self.config, &self.state, None) {
       info!("created new worker: {}", id);
       self.next_id += 1;
       let worker_token = self.token_count + 1;

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -19,6 +19,7 @@ use sozu_command::channel::Channel;
 use sozu_command::state::ConfigState;
 use sozu_command::data::{ConfigMessage,ConfigMessageAnswer,ConfigMessageStatus,RunState};
 use sozu_command::messages::{OrderMessage,OrderMessageAnswer,OrderMessageStatus};
+use sozu_command::scm_socket::ScmSocket;
 
 pub mod orders;
 pub mod client;
@@ -53,10 +54,12 @@ pub struct Worker {
   pub pid:           pid_t,
   pub run_state:     RunState,
   pub queue:         VecDeque<OrderMessage>,
+  pub scm:           ScmSocket,
 }
 
 impl Worker {
-  pub fn new(id: u32, pid: pid_t, channel: Channel<OrderMessage,OrderMessageAnswer>, _: &Config) -> Worker {
+  pub fn new(id: u32, pid: pid_t, channel: Channel<OrderMessage,OrderMessageAnswer>, scm: ScmSocket, _: &Config)
+    -> Worker {
     Worker {
       id:         id,
       channel:    channel,
@@ -64,6 +67,7 @@ impl Worker {
       pid:        pid,
       run_state:  RunState::Running,
       queue:      VecDeque::new(),
+      scm:        scm,
     }
   }
 

--- a/bin/src/command/orders.rs
+++ b/bin/src/command/orders.rs
@@ -16,6 +16,7 @@ use nom::{HexDisplay,IResult,Offset};
 
 use sozu_command::buffer::Buffer;
 use sozu_command::channel::Channel;
+use sozu_command::scm_socket::ScmSocket;
 use sozu_command::messages::{Order,OrderMessage,Query};
 use sozu_command::data::{AnswerData,ConfigCommand,ConfigMessage,ConfigMessageAnswer,ConfigMessageStatus,RunState,WorkerInfo};
 
@@ -501,6 +502,7 @@ impl CommandServer {
               pid:        serialized.pid,
               run_state:  serialized.run_state.clone(),
               queue:      serialized.queue.clone().into(),
+              scm:        ScmSocket::new(serialized.scm),
             }
           )
         )

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -55,6 +55,8 @@ fn main() {
                                          .takes_value(true).required(true).help("worker identifier"))
                                     .arg(Arg::with_name("fd").long("fd")
                                          .takes_value(true).required(true).help("IPC file descriptor"))
+                                    .arg(Arg::with_name("scm").long("scm")
+                                         .takes_value(true).required(true).help("IPC SCM_RIGHTS file descriptor"))
                                     .arg(Arg::with_name("configuration-state-fd").long("configuration-state-fd")
                                          .takes_value(true).required(true).help("configuration data file descriptor"))
                                     .arg(Arg::with_name("channel-buffer-size").long("channel-buffer-size")
@@ -72,6 +74,8 @@ fn main() {
   if let Some(matches) = matches.subcommand_matches("worker") {
     let fd  = matches.value_of("fd").expect("needs a file descriptor")
       .parse::<i32>().expect("the file descriptor must be a number");
+    let scm  = matches.value_of("scm").expect("needs a file descriptor")
+      .parse::<i32>().expect("the SCM_RIGHTS file descriptor must be a number");
     let configuration_state_fd  = matches.value_of("configuration-state-fd")
       .expect("needs a configuration state file descriptor")
       .parse::<i32>().expect("the file descriptor must be a number");
@@ -81,7 +85,7 @@ fn main() {
       .and_then(|size| size.parse::<usize>().ok())
       .unwrap_or(1_000_000);
 
-    begin_worker_process(fd, configuration_state_fd, id, buffer_size);
+    begin_worker_process(fd, scm, configuration_state_fd, id, buffer_size);
     return;
   }
 

--- a/bin/src/upgrade.rs
+++ b/bin/src/upgrade.rs
@@ -29,6 +29,7 @@ pub struct SerializedWorker {
   pub run_state:  RunState,
   pub token:      Option<usize>,
   pub queue:      Vec<OrderMessage>,
+  pub scm:        i32,
 }
 
 impl SerializedWorker {
@@ -40,6 +41,7 @@ impl SerializedWorker {
       run_state:  proxy.run_state.clone(),
       token:      proxy.token.clone().map(|Token(t)| t),
       queue:      proxy.queue.clone().into(),
+      scm:        proxy.scm.raw_fd(),
     }
   }
 }

--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -24,6 +24,7 @@ include = [
 hex = "^0.2"
 log = "^0.3"
 pem = "^0.4"
+nix = "^0.8"
 mio = "^0.6"
 mio-uds = "^0.6"
 pool = "^0.1"

--- a/command/assets/upgrade_worker.json
+++ b/command/assets/upgrade_worker.json
@@ -1,0 +1,6 @@
+{
+  "id": "ID_TEST",
+  "version": 0,
+  "type": "UPGRADE_WORKER",
+  "data": 0
+}

--- a/command/src/lib.rs
+++ b/command/src/lib.rs
@@ -4,6 +4,7 @@
 extern crate hex;
 extern crate mio;
 extern crate pem;
+extern crate nix;
 extern crate toml;
 extern crate pool;
 extern crate sha2;
@@ -18,3 +19,4 @@ pub mod state;
 pub mod messages;
 pub mod channel;
 pub mod buffer;
+pub mod scm_socket;

--- a/command/src/messages.rs
+++ b/command/src/messages.rs
@@ -133,6 +133,8 @@ pub enum Order {
     Status,
     Metrics,
     Logging(String),
+
+    ReturnListenSockets,
 }
 
 
@@ -404,6 +406,7 @@ impl Order {
       Order::Status               => [Topic::HttpProxyConfig, Topic::HttpsProxyConfig, Topic::TcpProxyConfig].iter().cloned().collect(),
       Order::Metrics              => HashSet::new(),
       Order::Logging(_)           => [Topic::HttpsProxyConfig, Topic::HttpProxyConfig, Topic::TcpProxyConfig].iter().cloned().collect(),
+      Order::ReturnListenSockets  => HashSet::new(),
     }
   }
 }

--- a/command/src/scm_socket.rs
+++ b/command/src/scm_socket.rs
@@ -1,0 +1,151 @@
+use nix::sys::socket;
+use nix::sys::uio;
+use nix::Error;
+use nix::Result as NixResult;
+use std::iter::repeat;
+use std::str::from_utf8;
+use std::os::unix::io::RawFd;
+use serde_json;
+
+pub const MAX_FDS_OUT: usize = 200;
+pub const MAX_BYTES_OUT: usize = 4096;
+
+#[derive(Clone,Debug,Serialize,Deserialize)]
+pub struct ScmSocket {
+  pub fd: RawFd,
+}
+
+impl ScmSocket {
+  pub fn new(fd: RawFd) -> ScmSocket {
+    ScmSocket {
+      fd
+    }
+  }
+
+  pub fn raw_fd(&self) -> i32 {
+    self.fd
+  }
+
+  pub fn send_listeners(&self, listeners: Listeners) -> NixResult<()> {
+    let listeners_count = ListenersCount {
+      http: listeners.http.is_some(),
+      tls:  listeners.tls.is_some(),
+      tcp:  listeners.tcp.len() as u32,
+    };
+
+    let message = serde_json::to_string(&listeners_count).map(|s| s.into_bytes()).unwrap_or(vec!());
+
+    let mut v: Vec<RawFd> = Vec::new();
+    if let Some(fd) = listeners.http {
+      v.push(fd);
+    }
+    if let Some(fd) = listeners.tls {
+      v.push(fd);
+    }
+
+    v.extend_from_slice(&listeners.tcp);
+
+    self.send_msg(&message, &v)
+  }
+
+  pub fn receive_listeners(&self) -> Listeners {
+    let mut buf = Vec::with_capacity(MAX_BYTES_OUT);
+    buf.extend(repeat(0).take(MAX_BYTES_OUT));
+
+    let mut received_fds: [RawFd; MAX_FDS_OUT] = [0; MAX_FDS_OUT];
+    let default = Listeners {
+      http: None,
+      tls:  None,
+      tcp:  Vec::new()
+    };
+
+    match self.rcv_msg(&mut buf, &mut received_fds) {
+      Err(e) => {
+        error!("could not receive listeners: {:?}", e);
+        default
+      },
+      Ok((sz, fds_len)) => {
+        match from_utf8(&buf[..sz]) {
+          Ok(s) => match serde_json::from_str::<ListenersCount>(s) {
+            Err(e) => {
+              error!("could not parse listeners list: {:?}", e);
+              default
+            },
+            Ok(listeners_count) => {
+              let mut index = 0;
+              let http = if listeners_count.http {
+                index = 1;
+                Some(received_fds[0])
+              } else {
+                None
+              };
+
+              let tls = if listeners_count.tls {
+                let fd = received_fds[index];
+                index += 1;
+                Some(fd)
+              } else {
+                None
+              };
+
+              let mut tcp = Vec::new();
+              tcp.extend_from_slice(&received_fds[index..fds_len]);
+
+              Listeners { http, tls, tcp }
+            }
+          }
+          Err(e) => {
+            error!("could not parse listeners list: {:?}", e);
+            default
+          }
+        }
+      }
+    }
+  }
+
+  pub fn send_msg(&self, bytes: &[u8], fds: &[RawFd]) -> NixResult<()> {
+    let iov = [uio::IoVec::from_slice(bytes)];
+    if fds.len() > 0 {
+      let cmsgs = [socket::ControlMessage::ScmRights(fds)];
+      socket::sendmsg(self.fd, &iov, &cmsgs, socket::MSG_DONTWAIT, None)?;
+    } else {
+      socket::sendmsg(self.fd, &iov, &[], socket::MSG_DONTWAIT, None)?;
+    };
+    Ok(())
+  }
+
+  pub fn rcv_msg(&self, buffer: &mut [u8], mut fds: &mut [RawFd]) -> NixResult<(usize, usize)> {
+    let mut cmsg = socket::CmsgSpace::<[RawFd; MAX_FDS_OUT]>::new();
+    let iov = [uio::IoVec::from_mut_slice(buffer)];
+
+    let msg = socket::recvmsg(self.fd, &iov[..], Some(&mut cmsg), socket::MSG_DONTWAIT)?;
+
+    let mut fd_count = 0;
+    let received_fds = msg.cmsgs()
+      .flat_map(|cmsg|
+                match cmsg {
+                  socket::ControlMessage::ScmRights(s) => s,
+                  _ => &[]
+                }.iter()
+               );
+    for (fd, place) in received_fds.zip(fds.iter_mut()) {
+      fd_count += 1;
+      *place = *fd;
+    }
+    Ok((msg.bytes, fd_count))
+  }
+}
+
+#[derive(Clone,Debug,Serialize,Deserialize)]
+pub struct Listeners {
+  pub http: Option<RawFd>,
+  pub tls:  Option<RawFd>,
+  pub tcp:  Vec<RawFd>,
+}
+
+#[derive(Clone,Debug,Serialize,Deserialize)]
+pub struct ListenersCount {
+  pub http: bool,
+  pub tls:  bool,
+  pub tcp:  u32,
+}

--- a/ctl/src/cli.rs
+++ b/ctl/src/cli.rs
@@ -16,7 +16,10 @@ pub enum SubCmd {
     hard: bool
   },
   #[structopt(name = "upgrade", about = "upgrade the proxy")]
-  Upgrade,
+  Upgrade {
+    #[structopt(short = "w", long = "worker", help = "Upgrade the worker with this id")]
+    worker: Option<u32>,
+  },
   #[structopt(name = "status", about = "gets information on the running workers")]
   Status {
     #[structopt(short = "j", long = "json", help = "Print the command result in JSON format")]

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -18,10 +18,10 @@ use sozu_command::channel::Channel;
 use sozu_command::data::{ConfigMessage,ConfigMessageAnswer};
 
 use command::{add_application,remove_application,dump_state,load_state,
-  save_state,soft_stop,hard_stop,upgrade,status,metrics,
+  save_state, soft_stop, hard_stop, upgrade_master, status,metrics,
   remove_backend, add_backend, remove_http_frontend, add_http_frontend,
   remove_tcp_frontend, add_tcp_frontend, add_certificate, remove_certificate,
-  query_application, logging_filter};
+  query_application, logging_filter, upgrade_worker};
 
 use cli::*;
 
@@ -42,7 +42,8 @@ fn main() {
         soft_stop(channel);
       }
     },
-    SubCmd::Upgrade => upgrade(channel, &config.command_socket_path()),
+    SubCmd::Upgrade { worker: None } => upgrade_master(channel, &config.command_socket_path()),
+    SubCmd::Upgrade { worker: Some(id) } => upgrade_worker(channel, timeout, id),
     SubCmd::Status{ json } => status(channel, json),
     SubCmd::Metrics{ json } => metrics(channel, json),
     SubCmd::Logging{ level } => logging_filter(channel, timeout, &level),

--- a/lib/src/network/http.rs
+++ b/lib/src/network/http.rs
@@ -312,8 +312,7 @@ impl ServerConfiguration {
     let front = config.front;
 
     let listener = tcp_listener.or_else(|| server_bind(&config.front).map_err(|e| {
-      let formatted_err = format!("could not create listener {:?}: {:?}", front, e);
-      error!("{}", formatted_err);
+      error!("could not create listener {:?}: {:?}", front, e);
     }).ok());
 
     if let Some(ref sock) = listener {

--- a/lib/src/network/http.rs
+++ b/lib/src/network/http.rs
@@ -295,7 +295,7 @@ pub struct DefaultAnswers {
 pub type Hostname = String;
 
 pub struct ServerConfiguration {
-  pub listener:        Option<TcpListener>,
+  listener:        Option<TcpListener>,
   address:         SocketAddr,
   instances:       BackendMap,
   fronts:          HashMap<Hostname, Vec<HttpFront>>,
@@ -333,16 +333,20 @@ impl ServerConfiguration {
     };
 
     ServerConfiguration {
-      listener:      listener,
-      address:       config.front,
-      applications:  HashMap::new(),
-      instances:     BackendMap::new(),
-      fronts:        HashMap::new(),
-      pool:          pool,
-      answers:       default,
-      config:        config,
+      listener:       listener,
+      address:        config.front,
+      applications:   HashMap::new(),
+      instances:      BackendMap::new(),
+      fronts:         HashMap::new(),
+      pool:           pool,
+      answers:        default,
+      config:         config,
     }
 
+  }
+
+  pub fn give_back_listener(&mut self) -> Option<TcpListener> {
+    self.listener.take()
   }
 
   pub fn add_application(&mut self, application: Application, event_loop: &mut Poll) {

--- a/lib/src/network/http.rs
+++ b/lib/src/network/http.rs
@@ -295,7 +295,7 @@ pub struct DefaultAnswers {
 pub type Hostname = String;
 
 pub struct ServerConfiguration {
-  listener:        Option<TcpListener>,
+  pub listener:        Option<TcpListener>,
   address:         SocketAddr,
   instances:       BackendMap,
   fronts:          HashMap<Hostname, Vec<HttpFront>>,

--- a/lib/src/network/http.rs
+++ b/lib/src/network/http.rs
@@ -1081,7 +1081,7 @@ mod tests {
     let front: SocketAddr = FromStr::from_str("127.0.0.1:1030").expect("could not parse address");
     let listener = net::TcpListener::bind(&front).expect("should bind TCP socket");
     let server_config = ServerConfiguration {
-      listener:  listener,
+      listener:  Some(listener),
       address:   front,
       applications: HashMap::new(),
       instances: BackendMap::new(),

--- a/lib/src/network/http.rs
+++ b/lib/src/network/http.rs
@@ -295,7 +295,7 @@ pub struct DefaultAnswers {
 pub type Hostname = String;
 
 pub struct ServerConfiguration {
-  listener:        TcpListener,
+  listener:        Option<TcpListener>,
   address:         SocketAddr,
   instances:       BackendMap,
   fronts:          HashMap<Hostname, Vec<HttpFront>>,
@@ -307,53 +307,43 @@ pub struct ServerConfiguration {
 
 impl ServerConfiguration {
   pub fn new(config: HttpProxyConfiguration, event_loop: &mut Poll, start_at:usize,
-    pool: Rc<RefCell<Pool<BufferQueue>>>, tcp_listener: Option<TcpListener>) -> io::Result<ServerConfiguration> {
+    pool: Rc<RefCell<Pool<BufferQueue>>>, tcp_listener: Option<TcpListener>) -> ServerConfiguration {
 
     let front = config.front;
 
-    let listener = if let Some(listener) = tcp_listener {
-      Ok(listener)
-    } else {
-      server_bind(&config.front)
+    let listener = tcp_listener.or_else(|| server_bind(&config.front).map_err(|e| {
+      let formatted_err = format!("could not create listener {:?}: {:?}", front, e);
+      error!("{}", formatted_err);
+    }).ok());
+
+    if let Some(ref sock) = listener {
+      event_loop.register(sock, Token(start_at), Ready::readable(), PollOpt::edge());
+    }
+
+    let default = DefaultAnswers {
+      NotFound: Vec::from(if config.answer_404.len() > 0 {
+                  config.answer_404.as_bytes()
+                } else {
+                  &b"HTTP/1.1 404 Not Found\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"[..]
+                }),
+      ServiceUnavailable: Vec::from(if config.answer_503.len() > 0 {
+                  config.answer_503.as_bytes()
+                } else {
+                  &b"HTTP/1.1 503 your application is in deployment\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"[..]
+                }),
     };
 
-    match listener {
-      Ok(sock) => {
-        event_loop.register(&sock, Token(start_at), Ready::readable(), PollOpt::edge());
-
-        let default = DefaultAnswers {
-          NotFound: Vec::from(if config.answer_404.len() > 0 {
-              config.answer_404.as_bytes()
-            } else {
-              &b"HTTP/1.1 404 Not Found\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"[..]
-            }),
-          ServiceUnavailable: Vec::from(if config.answer_503.len() > 0 {
-              config.answer_503.as_bytes()
-            } else {
-              &b"HTTP/1.1 503 your application is in deployment\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"[..]
-            }),
-        };
-
-        Ok(ServerConfiguration {
-          listener:      sock,
-          address:       config.front,
-          applications:  HashMap::new(),
-          instances:     BackendMap::new(),
-          fronts:        HashMap::new(),
-          pool:          pool,
-          answers:       default,
-          config:        config,
-        })
-      },
-      Err(e) => {
-        let formatted_err = format!("could not create listener {:?}: {:?}", front, e);
-        error!("{}", formatted_err);
-        //FIXME: return an error if listener creation failed
-        //channel.write_message(&OrderMessageAnswer{id: String::from("listener_failed"), status: OrderMessageStatus::Error(formatted_err)});
-        //channel.run();
-        Err(e)
-      }
+    ServerConfiguration {
+      listener:      listener,
+      address:       config.front,
+      applications:  HashMap::new(),
+      instances:     BackendMap::new(),
+      fronts:        HashMap::new(),
+      pool:          pool,
+      answers:       default,
+      config:        config,
     }
+
   }
 
   pub fn add_application(&mut self, application: Application, event_loop: &mut Poll) {
@@ -699,14 +689,18 @@ impl ProxyConfiguration<Client> for ServerConfiguration {
         info!("{} processing soft shutdown", message.id);
         //FIXME: handle shutdown
         //event_loop.shutdown();
-        event_loop.deregister(&self.listener);
+        if let Some(ref sock) = self.listener {
+          event_loop.deregister(sock);
+        }
         OrderMessageAnswer{ id: message.id, status: OrderMessageStatus::Processing, data: None }
       },
       Order::HardStop => {
         info!("{} hard shutdown", message.id);
         //FIXME: handle shutdown
         //event_loop.shutdown();
-        event_loop.deregister(&self.listener);
+        if let Some(ref sock) = self.listener {
+          event_loop.deregister(sock);
+        }
         OrderMessageAnswer{ id: message.id, status: OrderMessageStatus::Ok, data: None }
       },
       Order::Status => {
@@ -729,24 +723,29 @@ impl ProxyConfiguration<Client> for ServerConfiguration {
   }
 
   fn accept(&mut self, token: ListenToken) -> Result<(Client, bool), AcceptError> {
-    self.listener.accept().map_err(|e| {
-      match e.kind() {
-        ErrorKind::WouldBlock => AcceptError::WouldBlock,
-        other => {
-          error!("accept() IO error: {:?}", e);
-          AcceptError::IoError
+    if let Some(ref sock) = self.listener {
+      sock.accept().map_err(|e| {
+        match e.kind() {
+          ErrorKind::WouldBlock => AcceptError::WouldBlock,
+          other => {
+            error!("accept() IO error: {:?}", e);
+            AcceptError::IoError
+          }
         }
-      }
-    }).and_then(|(frontend_sock, _)| {
-      frontend_sock.set_nodelay(true);
-      if let Some(mut c) = Client::new(frontend_sock, Rc::downgrade(&self.pool), self.config.public_address) {
-        c.readiness().front_interest.insert(Ready::readable());
-        c.readiness().back_interest.remove(Ready::readable() | Ready::writable());
-        Ok((c, false))
-      } else {
-        Err(AcceptError::TooManyClients)
-      }
-    })
+      }).and_then(|(frontend_sock, _)| {
+        frontend_sock.set_nodelay(true);
+        if let Some(mut c) = Client::new(frontend_sock, Rc::downgrade(&self.pool), self.config.public_address) {
+          c.readiness().front_interest.insert(Ready::readable());
+          c.readiness().back_interest.remove(Ready::readable() | Ready::writable());
+          Ok((c, false))
+        } else {
+          Err(AcceptError::TooManyClients)
+        }
+      })
+    } else {
+      error!("cannot accept connections, no listening socket available");
+      Err(AcceptError::IoError)
+    }
   }
 
   fn close_backend(&mut self, app_id: String, addr: &SocketAddr) {
@@ -798,7 +797,7 @@ impl InitialServerConfiguration {
         event_loop.register(&sock, Token(start_at), Ready::readable(), PollOpt::edge());
 
         Ok(ServerConfiguration {
-          listener:      sock,
+          listener:      Some(sock),
           address:       self.config.front,
           applications:  self.applications,
           instances:     self.instances,
@@ -829,16 +828,15 @@ pub fn start(config: HttpProxyConfiguration, channel: ProxyChannel, max_buffers:
     Pool::with_capacity(2*max_buffers, 0, || BufferQueue::with_capacity(buffer_size))
   ));
   // start at max_listeners + 1 because token(0) is the channel, and token(1) is the timer
-  if let Ok(configuration) = ServerConfiguration::new(config, &mut event_loop, 1 + max_listeners, pool, None) {
-    let session    = Session::new(max_listeners, max_buffers, 0, configuration, &mut event_loop);
-    let (scm_server, scm_client) = UnixStream::pair().unwrap();
-    let mut server = Server::new(event_loop, channel, ScmSocket::new(scm_server.as_raw_fd()),
-      Some(session), None, None, None);
+  let configuration = ServerConfiguration::new(config, &mut event_loop, 1 + max_listeners, pool, None);
+  let session       = Session::new(max_listeners, max_buffers, 0, configuration, &mut event_loop);
+  let (scm_server, scm_client) = UnixStream::pair().unwrap();
+  let mut server    = Server::new(event_loop, channel, ScmSocket::new(scm_server.as_raw_fd()),
+    Some(session), None, None, None);
 
-    info!("starting event loop");
-    server.run();
-    info!("ending event loop");
-  }
+  info!("starting event loop");
+  server.run();
+  info!("ending event loop");
 }
 
 #[cfg(test)]

--- a/lib/src/network/proxy.rs
+++ b/lib/src/network/proxy.rs
@@ -91,8 +91,8 @@ impl Server {
     });
 
     let tcp_session = config.tcp.map(|conf| {
-      let configuration = tcp::ServerConfiguration::new(conf.max_listeners, 12297829382473034410, pool.clone(),
-        listeners.tcp.drain(..).map(|fd| unsafe { TcpListener::from_raw_fd(fd) }).collect());
+      let configuration = tcp::ServerConfiguration::new(conf.max_listeners, 12297829382473034410,  &mut event_loop, pool.clone(),
+        listeners.tcp.drain(..).map(|(app_id, fd)| (app_id, unsafe { TcpListener::from_raw_fd(fd) })).collect());
       Session::new(conf.max_listeners, max_buffers, 12297829382473034410, configuration, &mut event_loop)
     });
 

--- a/lib/src/network/proxy.rs
+++ b/lib/src/network/proxy.rs
@@ -75,12 +75,12 @@ impl Server {
 
     let max_connections = config.max_connections;
     let max_buffers     = config.max_buffers;
-    let http_session = config.http.and_then(|conf| conf.to_http()).and_then(|http_conf| {
+    let http_session = config.http.and_then(|conf| conf.to_http()).map(|http_conf| {
       let max_listeners = 1;
-      http::ServerConfiguration::new(http_conf, &mut event_loop, 1 + max_listeners, pool.clone(),
-        listeners.http.map(|fd| unsafe { TcpListener::from_raw_fd(fd) })).map(|configuration| {
-        Session::new(1, max_connections, 0, configuration, &mut event_loop)
-      }).ok()
+      let configuration = http::ServerConfiguration::new(http_conf, &mut event_loop, 1 + max_listeners, pool.clone(),
+        listeners.http.map(|fd| unsafe { TcpListener::from_raw_fd(fd) }));
+
+      Session::new(1, max_connections, 0, configuration, &mut event_loop)
     });
 
     let https_session = config.https.and_then(|conf| conf.to_tls()).and_then(|https_conf| {

--- a/lib/src/network/session.rs
+++ b/lib/src/network/session.rs
@@ -273,7 +273,9 @@ pub struct Session<ServerConfiguration,Client> {
 }
 
 impl<ServerConfiguration:ProxyConfiguration<Client>,Client:ProxyClient> Session<ServerConfiguration,Client> {
-  pub fn new(max_listeners: usize, max_connections: usize, base_token: usize, configuration: ServerConfiguration, poll: &mut Poll) -> Self {
+  pub fn new(max_listeners: usize, max_connections: usize, base_token: usize, configuration: ServerConfiguration,
+    accept_ready: HashSet<ListenToken>, poll: &mut Poll) -> Self {
+
     let clients = Slab::with_capacity(max_connections);
     let backend = Slab::with_capacity(max_connections);
     Session {
@@ -283,7 +285,7 @@ impl<ServerConfiguration:ProxyConfiguration<Client>,Client:ProxyClient> Session<
       max_listeners:   max_listeners,
       max_connections: max_connections,
       shutting_down:   None,
-      accept_ready:    HashSet::new(),
+      accept_ready:    accept_ready,
       can_accept:      true,
       base_token:      base_token,
     }

--- a/lib/src/network/session.rs
+++ b/lib/src/network/session.rs
@@ -261,7 +261,7 @@ pub trait ProxyConfiguration<Client> {
 }
 
 pub struct Session<ServerConfiguration,Client> {
-  configuration:   ServerConfiguration,
+  pub configuration:   ServerConfiguration,
   clients:         Slab<Client,FrontToken>,
   backend:         Slab<FrontToken,BackToken>,
   max_listeners:   usize,

--- a/lib/src/network/tls.rs
+++ b/lib/src/network/tls.rs
@@ -553,6 +553,10 @@ impl ServerConfiguration {
     }
   }
 
+  pub fn give_back_listener(&mut self) -> Option<TcpListener> {
+    self.listener.take()
+  }
+
   pub fn add_application(&mut self, application: Application, event_loop: &mut Poll) {
     self.applications.insert(application.app_id.clone(), application);
   }


### PR DESCRIPTION
This adds a much awaited feature in sozu: transfering listener sockets between master and worker.
Before this PR, here is how an upgrade worked:
- we start a new worker, it starts listening
- we tell the old worker to soft stop:
  - it will try to accept as many connections as possible to clear the accept queue
  - then it will close the listen queue
  - then it handles current connections until they all end
Unfortunately, there's a small race condition between accepting in a loop and closing the listener socket, that means some new connections might be lost.

With this PR, we tell the old worker to send the listener sockets (with SCM_RIGHTS feature in unix sockets) to the master, then the master starts a new worker and sends it the listener sockets. That way, the accept queue is kept from one process to the next.
During the transfer, we might put those new connections on hold until the new worker has started, but at least we should not lose connections.

The current version of the code is not really clean:
- ~~lots of println everywhere~~
- ~~only the HTTP listener is transferred (and not in the cleanest way, since we do not deregister the socket)~~
- ~~when initializing with existing listening sockets, we should mark them as readable right away (I'm worried about issues with events and epoll)~~
- #332: there's a new option the `upgrade` command line flag to specify a worker, so we can test this easily, but the new `UpgradeWorker` message is not yet used in the full upgrade (we'll start using it once it's stable)
- #333: the unix socket used to transfer listener sockets is sometimes in blocking mode, sometimes not, this should be fixed properly
- the handling of the `UpgradeWorker` is really not well done:
  - #333: there's lots of code blocking on sockets
  - #334: we don't handle the response from the worker to the `SoftStop` (we should store a state for that)
  - #335: we should send messages correctly to the client, like `Processing` messages when we receive the listeners, when the old worker started the soft stop, when the new worker is starting, when the new worker is started, and the ok message when the old worker has stopped)

Since, for personal reasons, I might not be very available in the following weeks, I propose the merge of the PR more or less in this state (depending on whether I can fix it up in the next days), then we'll fix it and test it incrementally.