### PR TITLE
HTTP1.1 Parser: allow any character but CR and LF for the status line

### DIFF
--- a/lib/src/parser/http11.rs
+++ b/lib/src/parser/http11.rs
@@ -27,8 +27,7 @@ fn is_token_char(i: u8) -> bool {
 named!(pub token, take_while!(is_token_char));
 
 fn is_status_token_char(i: u8) -> bool {
-  is_alphanumeric(i) ||
-  b"!#$%&'*+-.^_`|~ \t".contains(&i)
+  i >= 32 && i != 127
 }
 
 named!(pub status_token, take_while!(is_status_token_char));


### PR DESCRIPTION
From https://tools.ietf.org/html/rfc2616#section-6.1 it seems
that any character can be used but CR and LF characters

The spec also indicate that clients should be nice with the status
line: https://tools.ietf.org/html/rfc2616#section-19.3

This fixes some response parsing errors