### PR TITLE
Client: fix removal of backend connections from slab

### DIFF
--- a/lib/src/network/http.rs
+++ b/lib/src/network/http.rs
@@ -281,6 +281,10 @@ impl ProxyClient for Client {
 
     let mut result = CloseResult::default();
 
+    if let Some(tk) = self.backend_token {
+      result.tokens.push(tk)
+    }
+
     if let (Some(app_id), Some(addr)) = self.remove_backend() {
       result.backends.push((app_id, addr.clone()));
     }
@@ -292,10 +296,6 @@ impl ProxyClient for Client {
     }
 
     result.tokens.push(self.frontend_token);
-
-    if let Some(tk) = self.backend_token {
-      result.tokens.push(tk)
-    }
 
     result
   }

--- a/lib/src/network/https_openssl.rs
+++ b/lib/src/network/https_openssl.rs
@@ -325,6 +325,10 @@ impl ProxyClient for TlsClient {
 
     let mut result = CloseResult::default();
 
+    if let Some(tk) = self.back_token() {
+      result.tokens.push(tk)
+    }
+
     if let (Some(app_id), Some(addr)) = self.remove_backend() {
       result.backends.push((app_id, addr.clone()));
     }
@@ -336,9 +340,6 @@ impl ProxyClient for TlsClient {
     }
 
     result.tokens.push(self.frontend_token);
-    if let Some(tk) = self.back_token() {
-      result.tokens.push(tk)
-    }
 
     result
   }

--- a/lib/src/network/https_rustls/client.rs
+++ b/lib/src/network/https_rustls/client.rs
@@ -311,6 +311,10 @@ impl ProxyClient for TlsClient {
 
     let mut result = CloseResult::default();
 
+    if let Some(tk) = self.back_token() {
+      result.tokens.push(tk)
+    }
+
     if let (Some(app_id), Some(addr)) = self.remove_backend() {
       result.backends.push((app_id, addr.clone()));
     }
@@ -322,9 +326,6 @@ impl ProxyClient for TlsClient {
     }
 
     result.tokens.push(self.frontend_token);
-    if let Some(tk) = self.back_token() {
-      result.tokens.push(tk)
-    }
 
     result
   }

--- a/lib/src/network/tcp.rs
+++ b/lib/src/network/tcp.rs
@@ -340,6 +340,10 @@ impl ProxyClient for Client {
 
     let mut result = CloseResult::default();
 
+    if let Some(tk) = self.backend_token {
+      result.tokens.push(tk)
+    }
+
     if let (Some(app_id), Some(addr)) = self.remove_backend() {
       result.backends.push((app_id, addr.clone()));
     }
@@ -351,9 +355,6 @@ impl ProxyClient for Client {
     }
 
     if let Some(tk) = self.token {
-      result.tokens.push(tk)
-    }
-    if let Some(tk) = self.backend_token {
       result.tokens.push(tk)
     }
 


### PR DESCRIPTION
`self.backend_token` is set to `None` when `self.remove_backend` is called
which leads to never remove the backend connection from the slab.

We now add the token to the remove list before removing the backend.

Linked to #365

I couldn't test for the `https_openssl` or `https_rustls` due to a panic ( https://github.com/sozu-proxy/sozu/issues/368 for the `https_openssl` client, I will open a separate issue for `rustls` if it's not the same panic) but the code seem to do the same thing.