### PR TITLE
HTTP Protocol: print client readiness when a socket error occurs

### DIFF
--- a/lib/src/network/protocol/http.rs
+++ b/lib/src/network/protocol/http.rs
@@ -470,7 +470,8 @@ impl<Front:SocketHandler> Http<Front> {
 
     match res {
       SocketResult::Error => {
-        self.log_request_error(metrics, "front socket error, closing the connection");
+        let error = format!("front socket error, closing the connection. Readiness: {:?}", self.readiness);
+        self.log_request_error(metrics, &error);
         metrics.service_stop();
         incr_ereq!();
         self.readiness.reset();


### PR DESCRIPTION
This adds the client's readiness (both front and back) into the error message of the socket error log.

It should be `debug!()` but since we don't have support for including `debug` log level in the `0.5.0-release` branch when building in release mode, I appended it at the end of the error message.