### PR TITLE
https_openssl: fix TlsClient::app_id type typo

### DIFF
--- a/lib/src/network/https_openssl.rs
+++ b/lib/src/network/https_openssl.rs
@@ -76,7 +76,7 @@ pub struct TlsClient {
   pool:           Weak<RefCell<Pool<BufferQueue>>>,
   sticky_session: bool,
   metrics:        SessionMetrics,
-  pub app_id:     Vec<String>,
+  pub app_id:     Option<String>,
 }
 
 impl TlsClient {


### PR DESCRIPTION
Introduced in 2ceae33f7b684528044081a51425ffa84461babb