### PR TITLE
Pipe: don't close the client's connection if there is some data left to send

### DIFF
--- a/lib/src/network/protocol/pipe.rs
+++ b/lib/src/network/protocol/pipe.rs
@@ -122,7 +122,11 @@ impl<Front:SocketHandler> Pipe<Front> {
   }
 
   pub fn back_hup(&mut self) -> ClientResult {
-    ClientResult::CloseClient
+    if self.back_buf.output_data_size() == 0 || self.back_buf.next_output_data().len() == 0 {
+      ClientResult::CloseClient
+    } else {
+      ClientResult::Continue
+    }
   }
 
   // Read content from the client


### PR DESCRIPTION
Adapted from f7533bbe142cb2f220604347a3b63198063d07fa