### PR TITLE
Use "Backend" wording instead of "Instance"

### DIFF
--- a/command/README.md
+++ b/command/README.md
@@ -80,7 +80,7 @@ with the same id and the `Ok` status.
 
 #### Save state message
 
-This message tells the proxy to dump the current proxy state (instances,
+This message tells the proxy to dump the current proxy state (backends,
 front domains, certificates, etc) as json, to a file. This file can be used later
 to bootstrap the proxy. This message is not forwarded to workers.
 
@@ -231,7 +231,7 @@ The fingerprint is the hexadecimal representation of the SHA256 hash of the cert
   "id":       "ID_ABCD",
   "version":  0,
   "data":{
-    "type": "ADD_INSTANCE",
+    "type": "ADD_BACKEND",
     "data": {
       "app_id": "xxx",
       "ip_address": "127.0.0.1",
@@ -282,7 +282,7 @@ The fingerprint is the hexadecimal representation of the SHA256 hash of the cert
   "id":      "ID_789",
   "version": 0,
   "data": {
-    "type": "REMOVE_INSTANCE",
+    "type": "REMOVE_BACKEND",
     "data": {
       "app_id": "xxx",
       "ip_address": "127.0.0.1",

--- a/command/assets/add_backend.json
+++ b/command/assets/add_backend.json
@@ -3,10 +3,10 @@
   "version": 0,
   "type": "PROXY",
   "data": {
-    "type": "ADD_INSTANCE",
+    "type": "ADD_BACKEND",
     "data": {
       "app_id": "xxx",
-      "instance_id": "xxx-0",
+      "backend_id": "xxx-0",
       "ip_address": "127.0.0.1",
       "port": 8080
     }

--- a/command/assets/protocol_mismatch.json
+++ b/command/assets/protocol_mismatch.json
@@ -3,10 +3,10 @@
   "version": 1,
   "type": "PROXY",
   "data": {
-    "type": "ADD_INSTANCE",
+    "type": "ADD_BACKEND",
     "data": {
       "app_id": "xxx",
-      "instance_id": "xxx-0",
+      "backend_id": "xxx-0",
       "ip_address": "127.0.0.1",
       "port": 8080
     }

--- a/command/assets/remove_backend.json
+++ b/command/assets/remove_backend.json
@@ -3,10 +3,10 @@
   "version": 0,
   "type": "PROXY",
   "data": {
-    "type": "REMOVE_INSTANCE",
+    "type": "REMOVE_BACKEND",
     "data": {
       "app_id": "xxx",
-      "instance_id": "xxx-0",
+      "backend_id": "xxx-0",
       "ip_address": "127.0.0.1",
       "port": 8080
     }

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -9,7 +9,7 @@ use certificate::{calculate_fingerprint,split_certificate_chain};
 use toml;
 
 use messages::Application;
-use messages::{CertFingerprint,CertificateAndKey,Order,HttpFront,HttpsFront,TcpFront,Instance,
+use messages::{CertFingerprint,CertificateAndKey,Order,HttpFront,HttpsFront,TcpFront,Backend,
   HttpProxyConfiguration,HttpsProxyConfiguration,AddCertificate};
 
 use data::{ConfigCommand,ConfigMessage,PROTOCOL_VERSION};
@@ -308,9 +308,9 @@ impl HttpAppConfig {
           let ip   = format!("{}", address.ip());
           let port = address.port();
 
-          v.push(Order::AddInstance(Instance {
+          v.push(Order::AddBackend(Backend {
             app_id:     self.app_id.clone(),
-            instance_id: format!("{}-{}", self.app_id, backend_count),
+            backend_id:  format!("{}-{}", self.app_id, backend_count),
             ip_address: ip,
             port:       port
           }));
@@ -359,9 +359,9 @@ impl TcpAppConfig {
           let ip   = format!("{}", address.ip());
           let port = address.port();
 
-          v.push(Order::AddInstance(Instance {
+          v.push(Order::AddBackend(Backend {
             app_id:     self.app_id.clone(),
-            instance_id: format!("{}-{}", self.app_id, backend_count),
+            backend_id: format!("{}-{}", self.app_id, backend_count),
             ip_address: ip,
             port:       port
           }));

--- a/command/src/data.rs
+++ b/command/src/data.rs
@@ -325,7 +325,7 @@ mod tests {
   use serde_json;
   use hex::FromHex;
   use certificate::split_certificate_chain;
-  use messages::{Application,CertificateAndKey,CertFingerprint,Order,HttpFront,HttpsFront,Instance};
+  use messages::{Application,CertificateAndKey,CertFingerprint,Order,HttpFront,HttpsFront,Backend};
   use messages::{BackendMetricsData,MetricsData,FilteredData,Percentiles};
   use messages::{AddCertificate,RemoveCertificate};
 
@@ -478,24 +478,24 @@ mod tests {
       proxy_id: None
     });
 
-  test_message!(add_instance, "../assets/add_instance.json", ConfigMessage {
+  test_message!(add_backend, "../assets/add_backend.json", ConfigMessage {
       id:       "ID_TEST".to_string(),
       version:  0,
-      data:     ConfigCommand::ProxyConfiguration(Order::AddInstance(Instance{
+      data:     ConfigCommand::ProxyConfiguration(Order::AddBackend(Backend{
                   app_id: String::from("xxx"),
-                  instance_id: String::from("xxx-0"),
+                  backend_id: String::from("xxx-0"),
                   ip_address: String::from("127.0.0.1"),
                   port: 8080,
       })),
       proxy_id: None
     });
 
-  test_message!(remove_instance, "../assets/remove_instance.json", ConfigMessage {
+  test_message!(remove_backend, "../assets/remove_backend.json", ConfigMessage {
       id:       "ID_TEST".to_string(),
       version:  0,
-      data:     ConfigCommand::ProxyConfiguration(Order::RemoveInstance(Instance{
+      data:     ConfigCommand::ProxyConfiguration(Order::RemoveBackend(Backend{
                   app_id: String::from("xxx"),
-                  instance_id: String::from("xxx-0"),
+                  backend_id: String::from("xxx-0"),
                   ip_address: String::from("127.0.0.1"),
                   port: 8080,
       })),

--- a/command/src/messages.rs
+++ b/command/src/messages.rs
@@ -119,8 +119,8 @@ pub enum Order {
     AddTcpFront(TcpFront),
     RemoveTcpFront(TcpFront),
 
-    AddInstance(Instance),
-    RemoveInstance(Instance),
+    AddBackend(Backend),
+    RemoveBackend(Backend),
 
     HttpProxy(HttpProxyConfiguration),
     HttpsProxy(HttpsProxyConfiguration),
@@ -253,9 +253,9 @@ pub struct TcpFront {
 }
 
 #[derive(Debug,Clone,PartialEq,Eq,Hash, Serialize, Deserialize)]
-pub struct Instance {
+pub struct Backend {
     pub app_id:      String,
-    pub instance_id: String,
+    pub backend_id:  String,
     pub ip_address:  String,
     pub port:        u16
 }
@@ -364,7 +364,7 @@ pub struct QueryAnswerApplication {
   pub http_frontends:  Vec<HttpFront>,
   pub https_frontends: Vec<HttpsFront>,
   pub tcp_frontends:   Vec<TcpFront>,
-  pub backends:        Vec<Instance>,
+  pub backends:        Vec<Backend>,
 }
 
 impl Default for QueryAnswerApplication {
@@ -393,8 +393,8 @@ impl Order {
       Order::RemoveCertificate(_) => [Topic::HttpsProxyConfig].iter().cloned().collect(),
       Order::AddTcpFront(_)       => [Topic::TcpProxyConfig].iter().cloned().collect(),
       Order::RemoveTcpFront(_)    => [Topic::TcpProxyConfig].iter().cloned().collect(),
-      Order::AddInstance(_)       => [Topic::HttpProxyConfig, Topic::HttpsProxyConfig, Topic::TcpProxyConfig].iter().cloned().collect(),
-      Order::RemoveInstance(_)    => [Topic::HttpProxyConfig, Topic::HttpsProxyConfig, Topic::TcpProxyConfig].iter().cloned().collect(),
+      Order::AddBackend(_)        => [Topic::HttpProxyConfig, Topic::HttpsProxyConfig, Topic::TcpProxyConfig].iter().cloned().collect(),
+      Order::RemoveBackend(_)     => [Topic::HttpProxyConfig, Topic::HttpsProxyConfig, Topic::TcpProxyConfig].iter().cloned().collect(),
       Order::HttpProxy(_)         => [Topic::HttpProxyConfig].iter().cloned().collect(),
       Order::HttpsProxy(_)        => [Topic::HttpsProxyConfig].iter().cloned().collect(),
       Order::Query(_)             => [Topic::HttpProxyConfig, Topic::HttpsProxyConfig, Topic::TcpProxyConfig].iter().cloned().collect(),
@@ -446,26 +446,26 @@ mod tests {
 
 
   #[test]
-  fn add_instance_test() {
-    let raw_json = r#"{"type": "ADD_INSTANCE", "data": {"app_id": "xxx", "instance_id": "xxx-0", "ip_address": "yyy", "port": 8080}}"#;
+  fn add_backend_test() {
+    let raw_json = r#"{"type": "ADD_BACKEND", "data": {"app_id": "xxx", "backend_id": "xxx-0", "ip_address": "yyy", "port": 8080}}"#;
     let command: Order = serde_json::from_str(raw_json).expect("could not parse json");
     println!("{:?}", command);
-    assert!(command == Order::AddInstance(Instance{
+    assert!(command == Order::AddBackend(Backend{
       app_id: String::from("xxx"),
-      instance_id: String::from("xxx-0"),
+      backend_id: String::from("xxx-0"),
       ip_address: String::from("yyy"),
       port: 8080
     }));
   }
 
   #[test]
-  fn remove_instance_test() {
-    let raw_json = r#"{"type": "REMOVE_INSTANCE", "data": {"app_id": "xxx", "instance_id": "xxx-0", "ip_address": "yyy", "port": 8080}}"#;
+  fn remove_backend_test() {
+    let raw_json = r#"{"type": "REMOVE_BACKEND", "data": {"app_id": "xxx", "backend_id": "xxx-0", "ip_address": "yyy", "port": 8080}}"#;
     let command: Order = serde_json::from_str(raw_json).expect("could not parse json");
     println!("{:?}", command);
-    assert!(command == Order::RemoveInstance(Instance{
+    assert!(command == Order::RemoveBackend(Backend{
       app_id: String::from("xxx"),
-      instance_id: String::from("xxx-0"),
+      backend_id: String::from("xxx-0"),
       ip_address: String::from("yyy"),
       port: 8080
     }));

--- a/ctl/src/cli.rs
+++ b/ctl/src/cli.rs
@@ -114,8 +114,8 @@ pub enum BackendCmd {
   Remove {
     #[structopt(short = "i", long = "id")]
     id: String,
-    #[structopt(long = "instance-id")]
-    instance_id: String,
+    #[structopt(long = "backend-id")]
+    backend_id: String,
     #[structopt(long = "ip")]
     ip: String,
     #[structopt(short = "p", long = "port")]
@@ -125,8 +125,8 @@ pub enum BackendCmd {
   Add {
     #[structopt(short = "i", long = "id")]
     id: String,
-    #[structopt(long = "instance-id")]
-    instance_id: String,
+    #[structopt(long = "backend-id")]
+    backend_id: String,
     #[structopt(long = "ip")]
     ip: String,
     #[structopt(short = "p", long = "port")]

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -2,7 +2,7 @@ use sozu_command::config::Config;
 use sozu_command::channel::Channel;
 use sozu_command::certificate::{calculate_fingerprint,split_certificate_chain};
 use sozu_command::data::{AnswerData,ConfigCommand,ConfigMessage,ConfigMessageAnswer,ConfigMessageStatus,RunState,WorkerInfo};
-use sozu_command::messages::{Application, Order, Instance, HttpFront, HttpsFront, TcpFront,
+use sozu_command::messages::{Application, Order, Backend, HttpFront, HttpsFront, TcpFront,
   CertificateAndKey, CertFingerprint, Query, QueryAnswer, QueryApplicationType, QueryApplicationDomain,
   AddCertificate, RemoveCertificate, ReplaceCertificate};
 
@@ -847,19 +847,19 @@ pub fn remove_http_frontend(channel: Channel<ConfigMessage,ConfigMessageAnswer>,
 }
 
 
-pub fn add_backend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, app_id: &str, instance_id: &str, ip: &str, port: u16) {
-  order_command(channel, timeout, Order::AddInstance(Instance {
+pub fn add_backend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, app_id: &str, backend_id: &str, ip: &str, port: u16) {
+  order_command(channel, timeout, Order::AddBackend(Backend {
       app_id: String::from(app_id),
-      instance_id: String::from(instance_id),
+      backend_id: String::from(backend_id),
       ip_address: String::from(ip),
       port: port
     }));
 }
 
-pub fn remove_backend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, app_id: &str, instance_id: &str, ip: &str, port: u16) {
-    order_command(channel, timeout, Order::RemoveInstance(Instance {
+pub fn remove_backend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, app_id: &str, backend_id: &str, ip: &str, port: u16) {
+    order_command(channel, timeout, Order::RemoveBackend(Backend {
       app_id: String::from(app_id),
-      instance_id: String::from(instance_id),
+      backend_id: String::from(backend_id),
       ip_address: String::from(ip),
       port: port
     }));
@@ -1008,7 +1008,7 @@ pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>
 
               let mut backend_table = Table::new();
               let mut header = Vec::new();
-              header.push(cell!("instance id"));
+              header.push(cell!("backend id"));
               header.push(cell!("IP address"));
               header.push(cell!("port"));
               for ref key in data.keys() {
@@ -1116,7 +1116,7 @@ pub fn query_application(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>
 
               for (ref key, ref values) in backend_data.iter() {
                 let mut row = Vec::new();
-                row.push(cell!(key.instance_id));
+                row.push(cell!(key.backend_id));
                 row.push(cell!(key.ip_address));
                 row.push(cell!(format!("{}", key.port)));
 
@@ -1222,8 +1222,8 @@ fn order_command(mut channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeou
             match order {
               Order::AddApplication(_) => println!("application added : {}", message.message),
               Order::RemoveApplication(_) => println!("application removed : {} ", message.message),
-              Order::AddInstance(_) => println!("backend added : {}", message.message),
-              Order::RemoveInstance(_) => println!("backend removed : {} ", message.message),
+              Order::AddBackend(_) => println!("backend added : {}", message.message),
+              Order::RemoveBackend(_) => println!("backend removed : {} ", message.message),
               Order::AddCertificate(_) => println!("certificate added: {}", message.message),
               Order::RemoveCertificate(_) => println!("certificate removed: {}", message.message),
               Order::AddHttpFront(_) => println!("front added: {}", message.message),

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -62,8 +62,8 @@ fn main() {
     },
     SubCmd::Backend{ cmd } => {
       match cmd {
-        BackendCmd::Add{ id, instance_id, ip, port } => add_backend(channel, timeout, &id, &instance_id, &ip, port),
-        BackendCmd::Remove{ id, instance_id, ip, port } => remove_backend(channel, timeout, &id, &instance_id, &ip, port),
+        BackendCmd::Add{ id, backend_id, ip, port } => add_backend(channel, timeout, &id, &backend_id, &ip, port),
+        BackendCmd::Remove{ id, backend_id, ip, port } => remove_backend(channel, timeout, &id, &backend_id, &ip, port),
       }
     },
     SubCmd::Frontend{ cmd } => {

--- a/lib/examples/main.rs
+++ b/lib/examples/main.rs
@@ -43,9 +43,9 @@ fn main() {
     path_begin: String::from("/")
   };
 
-  let http_instance = messages::Instance {
+  let http_backend = messages::Backend {
     app_id:      String::from("app_1"),
-    instance_id: String::from("app_1-0"),
+    backend_id: String::from("app_1-0"),
     ip_address:  String::from("127.0.0.1"),
     port:        1026
   };
@@ -57,7 +57,7 @@ fn main() {
 
   command.write_message(&messages::OrderMessage {
     id:    String::from("ID_EFGH"),
-    order: messages::Order::AddInstance(http_instance)
+    order: messages::Order::AddBackend(http_backend)
   });
 
   info!("MAIN\tHTTP -> {:?}", command.read_message());
@@ -117,16 +117,16 @@ fn main() {
     id:    String::from("ID_IJKL2"),
     order: messages::Order::AddHttpsFront(tls_front)
   });
-  let tls_instance = messages::Instance {
+  let tls_backend = messages::Backend {
     app_id:      String::from("app_1"),
-    instance_id: String::from("app_1-0"),
+    backend_id: String::from("app_1-0"),
     ip_address:  String::from("127.0.0.1"),
     port:        1026
   };
 
   command2.write_message(&messages::OrderMessage {
     id:    String::from("ID_MNOP"),
-    order: messages::Order::AddInstance(tls_instance)
+    order: messages::Order::AddBackend(tls_backend)
   });
 
   let cert2 = include_str!("../assets/cert_test.pem");
@@ -158,16 +158,16 @@ fn main() {
     order: messages::Order::AddHttpsFront(tls_front2)
   });
 
-  let tls_instance2 = messages::Instance {
+  let tls_backend2 = messages::Backend {
     app_id:      String::from("app_2"),
-    instance_id: String::from("app_2-0"),
+    backend_id: String::from("app_2-0"),
     ip_address:  String::from("127.0.0.1"),
     port:        1026
   };
 
   command2.write_message(&messages::OrderMessage {
     id:    String::from("ID_UVWX"),
-    order: messages::Order::AddInstance(tls_instance2)
+    order: messages::Order::AddBackend(tls_backend2)
   });
 
   info!("MAIN\tTLS -> {:?}", command2.read_message());

--- a/lib/examples/minimal.rs
+++ b/lib/examples/minimal.rs
@@ -38,9 +38,9 @@ fn main() {
     hostname:   String::from("example.com"),
     path_begin: String::from("/"),
   };
-  let http_instance = messages::Instance {
+  let http_backend = messages::Backend {
     app_id:      String::from("test"),
-    instance_id: String::from("test-0"),
+    backend_id: String::from("test-0"),
     ip_address:  String::from("127.0.0.1"),
     port:        8000
   };
@@ -52,7 +52,7 @@ fn main() {
 
   command.write_message(&messages::OrderMessage {
     id:    String::from("ID_EFGH"),
-    order: messages::Order::AddInstance(http_instance)
+    order: messages::Order::AddBackend(http_backend)
   });
 
   println!("HTTP -> {:?}", command.read_message());

--- a/lib/examples/tcp.rs
+++ b/lib/examples/tcp.rs
@@ -37,9 +37,9 @@ fn main() {
     ip_address: String::from("127.0.0.1"),
     port:       8080,
   };
-  let tcp_instance = messages::Instance {
+  let tcp_backend = messages::Backend {
     app_id:      String::from("test"),
-    instance_id: String::from("test-0"),
+    backend_id:  String::from("test-0"),
     ip_address:  String::from("127.0.0.1"),
     port:        1026,
   };
@@ -51,7 +51,7 @@ fn main() {
 
   command.write_message(&messages::OrderMessage {
     id:    String::from("ID_EFGH"),
-    order: messages::Order::AddInstance(tcp_instance)
+    order: messages::Order::AddBackend(tcp_backend)
   });
 
   info!("TCP -> {:?}", command.read_message());

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -51,7 +51,7 @@
 //!   hostname:   String::from("example.com"),
 //!   path_begin: String::from("/")
 //! };
-//! let http_instance = messages::Instance {
+//! let http_backend = messages::Backend {
 //!   app_id:     String::from("test"),
 //!   ip_address: String::from("192.0.2.1"),
 //!   port:       8080
@@ -64,7 +64,7 @@
 //!
 //! command.write_message(&messages::OrderMessage {
 //!   id:    String::from("ID_EFGH"),
-//!   order: messages::Order::AddInstance(http_instance)
+//!   order: messages::Order::AddBackend(http_backend)
 //! ));
 //!
 //! println!("HTTP -> {:?}", command.read_message());
@@ -72,19 +72,19 @@
 //! ```
 //!
 //! An application is identified by its `app_id`, a string that will be shared
-//! between one or multiple "fronts", and one or multiple "instances".
+//! between one or multiple "fronts", and one or multiple "backends".
 //!
 //! A "front" is a way to recognize a request and match it to an `app_id`,
 //! depending on the hostname and the beginning of the URL path.
 //!
-//! An instance corresponds to one backend server, indicated by its IP and port.
+//! A backend corresponds to one backend server, indicated by its IP and port.
 //!
 //! An application can have multiple backend servers, and they can be added or
 //! removed while the proxy is running. If a backend is removed from the configuration
 //! while the proxy is handling a request to that server, it will finish that
 //! request and stop sending new traffic to that server.
 //!
-//! The fronts and instances are specified with messages sent through the
+//! The fronts and backends are specified with messages sent through the
 //! communication channels with the proxy event loop. Once the configuration
 //! options are added to the proxy's state, it will send back an acknowledgement
 //! message.
@@ -126,7 +126,7 @@
 //!     hostname:   String::from("example.com"),
 //!     path_begin: String::from("/")
 //!   };
-//!   let http_instance = messages::Instance {
+//!   let http_backend = messages::Backend {
 //!     app_id:     String::from("test"),
 //!     ip_address: String::from("192.0.2.1"),
 //!     port:       8080
@@ -139,7 +139,7 @@
 //!
 //!   command.write_message(&messages::OrderMessage {
 //!     id:    String::from("ID_EFGH"),
-//!     order: messages::Order::AddInstance(http_instance)
+//!     order: messages::Order::AddBackend(http_backend)
 //!   ));
 //!
 //!   println!("HTTP -> {:?}", command.read_message());

--- a/lib/src/network/backends.rs
+++ b/lib/src/network/backends.rs
@@ -5,64 +5,64 @@ use std::collections::HashMap;
 use rand::random;
 use mio::net::TcpStream;
 
-use sozu_command::messages::Instance;
+use sozu_command::messages;
 
 use network::{AppId,Backend,ConnectionError};
 
 #[derive(Debug)]
 pub struct BackendMap {
-  pub instances:    HashMap<AppId, BackendList>,
+  pub backends:     HashMap<AppId, BackendList>,
   pub max_failures: usize,
 }
 
 impl BackendMap {
   pub fn new() -> BackendMap {
     BackendMap {
-      instances:    HashMap::new(),
+      backends:     HashMap::new(),
       max_failures: 3,
     }
   }
 
-  pub fn import_configuration_state(&mut self, instances: &HashMap<AppId, Vec<Instance>>) {
-    self.instances.extend(instances.iter().map(|(ref app_id, ref instance_vec)| {
-      (app_id.to_string(), BackendList::import_configuration_state(instance_vec))
+  pub fn import_configuration_state(&mut self, backends: &HashMap<AppId, Vec<messages::Backend>>) {
+    self.backends.extend(backends.iter().map(|(ref app_id, ref backend_vec)| {
+      (app_id.to_string(), BackendList::import_configuration_state(backend_vec))
     }));
   }
 
-  pub fn add_instance(&mut self, app_id: &str, instance_id: &str, instance_address: &SocketAddr) {
-    self.instances.entry(app_id.to_string()).or_insert(BackendList::new()).add_instance(instance_id, instance_address);
+  pub fn add_backend(&mut self, app_id: &str, backend_id: &str, backend_address: &SocketAddr) {
+    self.backends.entry(app_id.to_string()).or_insert(BackendList::new()).add_backend(backend_id, backend_address);
   }
 
-  pub fn remove_instance(&mut self, app_id: &str, instance_address: &SocketAddr) {
-    if let Some(instances) = self.instances.get_mut(app_id) {
-      instances.remove_instance(instance_address);
+  pub fn remove_backend(&mut self, app_id: &str, backend_address: &SocketAddr) {
+    if let Some(backends) = self.backends.get_mut(app_id) {
+      backends.remove_backend(backend_address);
     } else {
-      error!("Instance was already removed: app id {}, address {:?}", app_id, instance_address);
+      error!("Backend was already removed: app id {}, address {:?}", app_id, backend_address);
     }
   }
 
   pub fn close_backend_connection(&mut self, app_id: &str, addr: &SocketAddr) {
-    if let Some(app_instances) = self.instances.get_mut(app_id) {
-      if let Some(ref mut backend) = app_instances.find_instance(addr) {
+    if let Some(app_backends) = self.backends.get_mut(app_id) {
+      if let Some(ref mut backend) = app_backends.find_backend(addr) {
         (*backend.borrow_mut()).dec_connections();
       }
     }
   }
 
   pub fn has_backend(&self, app_id: &str, backend: &Backend) -> bool {
-    self.instances.get(app_id).map(|backends| {
-      backends.has_instance(&backend.address)
+    self.backends.get(app_id).map(|backends| {
+      backends.has_backend(&backend.address)
     }).unwrap_or(false)
   }
 
   pub fn backend_from_app_id(&mut self, app_id: &str) -> Result<(Rc<RefCell<Backend>>,TcpStream),ConnectionError> {
-    if let Some(ref mut app_instances) = self.instances.get_mut(app_id) {
-      if app_instances.instances.len() == 0 {
+    if let Some(ref mut app_backends) = self.backends.get_mut(app_id) {
+      if app_backends.backends.len() == 0 {
         return Err(ConnectionError::NoBackendAvailable);
       }
 
       for _ in 0..self.max_failures {
-        if let Some(ref mut b) = app_instances.next_available_instance() {
+        if let Some(ref mut b) = app_backends.next_available_backend() {
           let ref mut backend = *b.borrow_mut();
 
           debug!("Connecting {} -> {:?}", app_id, (backend.address, backend.active_connections, backend.failures));
@@ -87,9 +87,9 @@ impl BackendMap {
   }
 
   pub fn backend_from_sticky_session(&mut self, app_id: &str, sticky_session: u32) -> Result<(Rc<RefCell<Backend>>,TcpStream),ConnectionError> {
-    let sticky_conn: Option<Result<(Rc<RefCell<Backend>>,TcpStream),ConnectionError>> = self.instances
+    let sticky_conn: Option<Result<(Rc<RefCell<Backend>>,TcpStream),ConnectionError>> = self.backends
       .get_mut(app_id)
-      .and_then(|app_instances| app_instances.find_sticky(sticky_session))
+      .and_then(|app_backends| app_backends.find_sticky(sticky_session))
       .map(|b| {
         let ref mut backend = *b.borrow_mut();
         let conn = backend.try_connect();
@@ -117,53 +117,53 @@ const MAX_FAILURES_PER_BACKEND: usize = 10;
 
 #[derive(Debug)]
 pub struct BackendList {
-  pub instances: Vec<Rc<RefCell<Backend>>>,
+  pub backends:  Vec<Rc<RefCell<Backend>>>,
   pub next_id:   u32,
 }
 
 impl BackendList {
   pub fn new() -> BackendList {
     BackendList {
-      instances: Vec::new(),
+      backends:  Vec::new(),
       next_id:   0,
     }
   }
 
-  pub fn import_configuration_state(instance_vec: &Vec<Instance>) -> BackendList {
+  pub fn import_configuration_state(backend_vec: &Vec<messages::Backend>) -> BackendList {
     let mut list = BackendList::new();
-    for ref instance in instance_vec {
-      let addr_string = instance.ip_address.to_string() + ":" + &instance.port.to_string();
+    for ref backend in backend_vec {
+      let addr_string = backend.ip_address.to_string() + ":" + &backend.port.to_string();
       let parsed:Option<SocketAddr> = addr_string.parse().ok();
       if let Some(addr) = parsed {
-        list.add_instance(&instance.instance_id, &addr);
+        list.add_backend(&backend.backend_id, &addr);
       }
     }
 
     list
   }
 
-  pub fn add_instance(&mut self, instance_id: &str, instance_address: &SocketAddr) {
-    if self.instances.iter().find(|b| &(*b.borrow()).address == instance_address).is_none() {
-      let backend = Rc::new(RefCell::new(Backend::new(instance_id, *instance_address, self.next_id)));
-      self.instances.push(backend);
+  pub fn add_backend(&mut self, backend_id: &str, backend_address: &SocketAddr) {
+    if self.backends.iter().find(|b| &(*b.borrow()).address == backend_address).is_none() {
+      let backend = Rc::new(RefCell::new(Backend::new(backend_id, *backend_address, self.next_id)));
+      self.backends.push(backend);
       self.next_id += 1;
     }
   }
 
-  pub fn remove_instance(&mut self, instance_address: &SocketAddr) {
-    self.instances.retain(|backend| &(*backend.borrow()).address != instance_address);
+  pub fn remove_backend(&mut self, backend_address: &SocketAddr) {
+    self.backends.retain(|backend| &(*backend.borrow()).address != backend_address);
   }
 
-  pub fn has_instance(&self, instance_address: &SocketAddr) -> bool {
-    self.instances.iter().any(|backend| &(*backend.borrow()).address == instance_address)
+  pub fn has_backend(&self, backend_address: &SocketAddr) -> bool {
+    self.backends.iter().any(|backend| &(*backend.borrow()).address == backend_address)
   }
 
-  pub fn find_instance(&mut self, instance_address: &SocketAddr) -> Option<&mut Rc<RefCell<Backend>>> {
-    self.instances.iter_mut().find(|backend| &(*backend.borrow()).address == instance_address)
+  pub fn find_backend(&mut self, backend_address: &SocketAddr) -> Option<&mut Rc<RefCell<Backend>>> {
+    self.backends.iter_mut().find(|backend| &(*backend.borrow()).address == backend_address)
   }
 
   pub fn find_sticky(&mut self, sticky_session: u32) -> Option<&mut Rc<RefCell<Backend>>> {
-    self.instances.iter_mut()
+    self.backends.iter_mut()
       .find(|b| b.borrow().id == sticky_session )
       .and_then(|b| {
         if b.borrow().can_open() {
@@ -174,21 +174,21 @@ impl BackendList {
       })
   }
 
-  pub fn available_instances(&mut self) -> Vec<&mut Rc<RefCell<Backend>>> {
-    self.instances.iter_mut()
+  pub fn available_backends(&mut self) -> Vec<&mut Rc<RefCell<Backend>>> {
+    self.backends.iter_mut()
       .filter(|backend| (*backend.borrow()).can_open())
       .collect()
   }
 
-  pub fn next_available_instance(&mut self) -> Option<&mut Rc<RefCell<Backend>>> {
-    let mut instances:Vec<&mut Rc<RefCell<Backend>>> = self.available_instances();
-    if instances.is_empty() {
+  pub fn next_available_backend(&mut self) -> Option<&mut Rc<RefCell<Backend>>> {
+    let mut backends:Vec<&mut Rc<RefCell<Backend>>> = self.available_backends();
+    if backends.is_empty() {
       return None;
     }
 
     let rnd = random::<usize>();
-    let idx = rnd % instances.len();
+    let idx = rnd % backends.len();
 
-    Some(instances.remove(idx))
+    Some(backends.remove(idx))
   }
 }

--- a/lib/src/network/https_rustls/client.rs
+++ b/lib/src/network/https_rustls/client.rs
@@ -52,7 +52,7 @@ pub enum State {
 
 pub struct TlsClient {
   pub frontend_token: Token,
-  pub instance:       Option<Rc<RefCell<Backend>>>,
+  pub backend:        Option<Rc<RefCell<Backend>>>,
   pub back_connected: BackendConnectionStatus,
   protocol:           Option<State>,
   pub public_address: Option<IpAddr>,
@@ -68,7 +68,7 @@ impl TlsClient {
     let handshake = TlsHandshake::new(ssl, sock);
     let mut client = TlsClient {
       frontend_token: token,
-      instance:       None,
+      backend:        None,
       back_connected: BackendConnectionStatus::NotConnected,
       protocol:       Some(State::Handshake(handshake)),
       public_address: public_address,
@@ -275,8 +275,8 @@ impl TlsClient {
     self.back_connected = connected;
 
     if connected == BackendConnectionStatus::Connected {
-      self.instance.as_ref().map(|instance| {
-        let ref mut backend = *instance.borrow_mut();
+      self.backend.as_ref().map(|backend| {
+        let ref mut backend = *backend.borrow_mut();
         backend.failures = 0;
         backend.retry_policy.succeed();
       });

--- a/lib/src/network/mod.rs
+++ b/lib/src/network/mod.rs
@@ -229,7 +229,7 @@ pub enum BackendStatus {
 #[derive(Debug,PartialEq,Eq)]
 pub struct Backend {
   pub id:                 u32,
-  pub instance_id:        String,
+  pub backend_id:         String,
   pub address:            SocketAddr,
   pub status:             BackendStatus,
   pub retry_policy:       retry::RetryPolicyWrapper,
@@ -238,11 +238,11 @@ pub struct Backend {
 }
 
 impl Backend {
-  pub fn new(instance_id: &str, addr: SocketAddr, id: u32) -> Backend {
+  pub fn new(backend_id: &str, addr: SocketAddr, id: u32) -> Backend {
     let desired_policy = retry::ExponentialBackoffPolicy::new(10);
     Backend {
       id:                 id,
-      instance_id:        instance_id.to_string(),
+      backend_id:         backend_id.to_string(),
       address:            addr,
       status:             BackendStatus::Normal,
       retry_policy:       desired_policy.into(),

--- a/lib/src/network/protocol/openssl.rs
+++ b/lib/src/network/protocol/openssl.rs
@@ -44,7 +44,7 @@ impl TlsHandshake {
     match self.state {
       TlsState::Error(_) => return (ProtocolResult::Continue, ClientResult::CloseClient),
       TlsState::Initial => {
-        let ssl     = self.ssl.take().expect("TlsHandshake should have a Ssl instance");
+        let ssl     = self.ssl.take().expect("TlsHandshake should have a Ssl backend");
         let sock    = self.front.take().expect("TlsHandshake should have a front socket");
         let version = ssl.version();
         match ssl.accept(sock) {
@@ -72,7 +72,7 @@ impl TlsHandshake {
         }
       },
       TlsState::Handshake => {
-        let mid = self.mid.take().expect("TlsHandshake should have a MidHandshakeSslStream instance");
+        let mid = self.mid.take().expect("TlsHandshake should have a MidHandshakeSslStream backend");
         let version = mid.ssl().version();
         match mid.handshake() {
           Ok(stream) => {

--- a/lib/src/network/proxy.rs
+++ b/lib/src/network/proxy.rs
@@ -27,7 +27,7 @@ use sozu_command::config::Config;
 use sozu_command::channel::Channel;
 use sozu_command::scm_socket::{Listeners,ScmSocket};
 use sozu_command::state::{ConfigState,get_application_ids_by_domain};
-use sozu_command::messages::{self,TcpFront,Order,Instance,MessageId,OrderMessageAnswer,OrderMessageAnswerData,OrderMessageStatus,OrderMessage,Topic,Query,QueryAnswer,QueryApplicationType};
+use sozu_command::messages::{self,TcpFront,Order,Backend,MessageId,OrderMessageAnswer,OrderMessageAnswerData,OrderMessageStatus,OrderMessage,Topic,Query,QueryAnswer,QueryApplicationType};
 
 use network::buffer_queue::BufferQueue;
 use network::{ClientResult,ConnectionError,Protocol,RequiredEvents,ProxyClient,ProxyConfiguration,


### PR DESCRIPTION
Fixes #398 

I tried to keep the indentation in its original state (especially for struct members alignment) but I may have missed some. Let me know if that's the case

Only `instance` word left is in those files:
```
futures/Cargo.toml
ctl/Cargo.toml
command/Cargo.toml
```

In that case, `instance` refers to `sozu` as in `a sozu instance`.