### PR TITLE
ctl: use the UpgradeWorker message to upgrade a worker

### DIFF
--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
       }
     },
     SubCmd::Upgrade { worker: None } => upgrade_master(channel, &config.command_socket_path()),
-    SubCmd::Upgrade { worker: Some(id) } => upgrade_worker(channel, timeout, id),
+    SubCmd::Upgrade { worker: Some(id) } => { upgrade_worker(channel, timeout, id); },
     SubCmd::Status{ json } => status(channel, json),
     SubCmd::Metrics{ json } => metrics(channel, json),
     SubCmd::Logging{ level } => logging_filter(channel, timeout, &level),


### PR DESCRIPTION
I changed the signature of `upgrade_worker` to make the compiler / borrow checker happy and manually implemented the `command_timeout` logic to return the channel given to the thread (here again to avoid memory issues)

Besides #430, this works well.

Fixes #332 