### PR TITLE
 TcpProxy: AddTcpFront: check if port is already in use 

### DIFF
--- a/lib/src/network/http.rs
+++ b/lib/src/network/http.rs
@@ -32,7 +32,7 @@ use network::buffer_queue::BufferQueue;
 use network::protocol::{ProtocolResult,StickySession,TlsHandshake,Http,Pipe};
 use network::protocol::http::DefaultAnswerStatus;
 use network::protocol::proxy_protocol::expect::ExpectProxyProtocol;
-use network::proxy::{Server,ProxyChannel,ListenToken,ClientToken,ListenClient};
+use network::proxy::{Server,ProxyChannel,ListenToken,ListenPortState,ClientToken,ListenClient};
 use network::socket::{SocketHandler,SocketResult,server_bind};
 use network::retry::RetryPolicy;
 use parser::http11::hostname_and_port;
@@ -1028,6 +1028,10 @@ impl ProxyConfiguration<Client> for ServerConfiguration {
 
   fn close_backend(&mut self, app_id: String, addr: &SocketAddr) {
     self.backends.close_backend_connection(&app_id, &addr);
+  }
+
+  fn listen_port_state(&self, port: &u16) -> ListenPortState {
+    if port == &self.address.port() { ListenPortState::InUse } else { ListenPortState::Available }
   }
 }
 

--- a/lib/src/network/https_openssl.rs
+++ b/lib/src/network/https_openssl.rs
@@ -42,7 +42,7 @@ use network::{AppId,Backend,ClientResult,ConnectionError,Protocol,Readiness,Sess
   ProxyClient,ProxyConfiguration,AcceptError,BackendConnectAction,BackendConnectionStatus,
   CloseResult};
 use network::backends::BackendMap;
-use network::proxy::{Server,ProxyChannel,ListenToken,ClientToken,ListenClient};
+use network::proxy::{Server,ProxyChannel,ListenToken,ListenPortState,ClientToken,ListenClient};
 use network::http::{self,DefaultAnswers};
 use network::socket::{SocketHandler,SocketResult,server_bind};
 use network::trie::*;
@@ -1327,6 +1327,10 @@ impl ProxyConfiguration<TlsClient> for ServerConfiguration {
 
   fn close_backend(&mut self, app_id: AppId, addr: &SocketAddr) {
     self.backends.close_backend_connection(&app_id, &addr);
+  }
+
+  fn listen_port_state(&self, port: &u16) -> ListenPortState {
+    if port == &self.address.port() { ListenPortState::InUse } else { ListenPortState::Available }
   }
 }
 

--- a/lib/src/network/https_rustls/configuration.rs
+++ b/lib/src/network/https_rustls/configuration.rs
@@ -35,7 +35,7 @@ use network::buffer_queue::BufferQueue;
 use network::{AppId,Backend,ClientResult,ConnectionError,Protocol,Readiness,SessionMetrics,
   ProxyClient,ProxyConfiguration,AcceptError,BackendConnectAction,BackendConnectionStatus};
 use network::backends::BackendMap;
-use network::proxy::{Server,ProxyChannel,ListenToken,ClientToken,ListenClient};
+use network::proxy::{Server,ProxyChannel,ListenToken,ListenPortState,ClientToken,ListenClient};
 use network::http::{self,DefaultAnswers};
 use network::socket::{SocketHandler,SocketResult,server_bind,FrontRustls};
 use network::trie::*;
@@ -622,6 +622,10 @@ impl ProxyConfiguration<TlsClient> for ServerConfiguration {
 
   fn close_backend(&mut self, app_id: AppId, addr: &SocketAddr) {
     self.backends.close_backend_connection(&app_id, &addr);
+  }
+
+  fn listen_port_state(&self, port: &u16) -> ListenPortState {
+    if port == &self.address.port() { ListenPortState::InUse } else { ListenPortState::Available }
   }
 }
 

--- a/lib/src/network/mod.rs
+++ b/lib/src/network/mod.rs
@@ -85,7 +85,7 @@ pub enum AcceptError {
   WouldBlock,
 }
 
-use self::proxy::{ClientToken,ListenToken};
+use self::proxy::{ClientToken,ListenToken,ListenPortState};
 pub trait ProxyConfiguration<Client> {
   fn connect_to_backend(&mut self, event_loop: &mut Poll, client: &mut Client,
     back_token: Token) ->Result<BackendConnectAction,ConnectionError>;
@@ -94,6 +94,7 @@ pub trait ProxyConfiguration<Client> {
     -> Result<(Rc<RefCell<Client>>, bool), AcceptError>;
   fn accept_flush(&mut self) -> usize;
   fn close_backend(&mut self, app_id: String, addr: &SocketAddr);
+  fn listen_port_state(&self, port: &u16) -> ListenPortState;
 }
 
 #[derive(Debug,PartialEq,Eq)]

--- a/lib/src/network/proxy.rs
+++ b/lib/src/network/proxy.rs
@@ -463,12 +463,12 @@ impl Server {
             let entry = self.clients.vacant_entry();
 
             if entry.is_none() {
-               self.queue.push_back(OrderMessageAnswer {
-                 id,
-                 status: OrderMessageStatus::Error(String::from("client list is full, cannot add a listener")),
-                 data: None
-               });
-               return;
+              self.queue.push_back(OrderMessageAnswer {
+                id,
+                status: OrderMessageStatus::Error(String::from("client list is full, cannot add a listener")),
+                data: None
+              });
+              return;
             }
 
             let entry = entry.unwrap();
@@ -479,12 +479,12 @@ impl Server {
             let addr_string = tcp_front.ip_address + ":" + &tcp_front.port.to_string();
 
             let status = if let Ok(front) = addr_string.parse() {
-               if let Some(token) = tcp.add_tcp_front(&tcp_front.app_id, &front, &mut self.poll, token) {
-                 OrderMessageStatus::Ok
-               } else {
-                 error!("Couldn't add tcp front");
-                 OrderMessageStatus::Error(String::from("cannot add tcp front"))
-               }
+              if let Some(token) = tcp.add_tcp_front(&tcp_front.app_id, &front, &mut self.poll, token) {
+                OrderMessageStatus::Ok
+              } else {
+                error!("Couldn't add tcp front");
+                OrderMessageStatus::Error(String::from("cannot add tcp front"))
+              }
             } else {
               error!("Couldn't parse tcp front address");
               OrderMessageStatus::Error(String::from("cannot parse the address"))

--- a/lib/src/network/proxy.rs
+++ b/lib/src/network/proxy.rs
@@ -51,6 +51,12 @@ enum ProxyType {
   TCP,
 }
 
+#[derive(PartialEq)]
+pub enum ListenPortState {
+  Available,
+  InUse
+}
+
 #[derive(Copy,Clone,Debug,PartialEq,Eq,PartialOrd,Ord,Hash)]
 pub struct ListenToken(pub usize);
 #[derive(Copy,Clone,Debug,PartialEq,Eq,PartialOrd,Ord,Hash)]
@@ -460,6 +466,17 @@ impl Server {
         match message {
           // special case for AddTcpFront because we need to register a listener
           OrderMessage { id, order: Order::AddTcpFront(tcp_front) } => {
+            if self.listen_port_state(&tcp_front.port, &tcp) == ListenPortState::InUse {
+              error!("Couldn't add TCP front {:?}: port already in use", tcp_front);
+              self.queue.push_back(OrderMessageAnswer {
+                id,
+                status: OrderMessageStatus::Error(String::from("Couldn't add TCP front: port already in use")),
+                data: None
+              });
+              self.tcp = Some(tcp);
+              return;
+            }
+
             let entry = self.clients.vacant_entry();
 
             if entry.is_none() {
@@ -887,6 +904,25 @@ impl Server {
         }
       }
     }
+  }
+
+  fn listen_port_state(&self, port: &u16, tcp_proxy: &tcp::ServerConfiguration) -> ListenPortState {
+    let http_binded = self.http.as_ref().map(|http| http.listen_port_state(&port)).unwrap_or(ListenPortState::Available);
+
+    if http_binded == ListenPortState::Available {
+      let https_binded = match self.https.as_ref() {
+        #[cfg(feature = "use-openssl")]
+        Some(&HttpsProvider::Openssl(ref openssl)) => openssl.listen_port_state(&port),
+        Some(&HttpsProvider::Rustls(ref rustls)) => rustls.listen_port_state(&port),
+        None => ListenPortState::Available
+      };
+
+      if https_binded == ListenPortState::Available {
+        return tcp_proxy.listen_port_state(&port);
+      }
+    }
+
+    ListenPortState::InUse
   }
 }
 

--- a/lib/src/network/proxy.rs
+++ b/lib/src/network/proxy.rs
@@ -468,6 +468,7 @@ impl Server {
                 status: OrderMessageStatus::Error(String::from("client list is full, cannot add a listener")),
                 data: None
               });
+              self.tcp = Some(tcp);
               return;
             }
 

--- a/lib/src/network/tcp.rs
+++ b/lib/src/network/tcp.rs
@@ -29,7 +29,7 @@ use sozu_command::messages::{self,TcpFront,Order,OrderMessage,OrderMessageAnswer
 use network::{AppId,Backend,ClientResult,ConnectionError,RequiredEvents,Protocol,Readiness,SessionMetrics,
   ProxyClient,ProxyConfiguration,AcceptError,BackendConnectAction,BackendConnectionStatus,
   CloseResult};
-use network::proxy::{Server,ProxyChannel,ListenToken,ClientToken,ListenClient};
+use network::proxy::{Server,ProxyChannel,ListenToken,ListenPortState,ClientToken,ListenClient};
 use network::buffer_queue::BufferQueue;
 use network::socket::{SocketHandler,SocketResult,server_bind};
 use network::{http,https_rustls};
@@ -870,6 +870,13 @@ impl ProxyConfiguration<Client> for ServerConfiguration {
       if let Some(ref mut backend) = app_backends.iter_mut().find(|backend| &backend.address == addr) {
         backend.dec_connections();
       }
+    }
+  }
+
+  fn listen_port_state(&self, port: &u16) -> ListenPortState {
+    match self.listeners.values().find(|listener| &listener.front_address.port() == port) {
+      Some(_) => ListenPortState::InUse,
+      None => ListenPortState::Available
     }
   }
 }


### PR DESCRIPTION
Depends on #442 

This is a follow-up and a fix for #392 

I added a method on the `network::ProxyConfiguration<Client>` trait, I don't know if it's the best way to achieve this but I wanted all proxies to implement that method