### PR TITLE
[WIP] Implement circuit breaker for TCP

### DIFF
--- a/lib/src/network/tcp.rs
+++ b/lib/src/network/tcp.rs
@@ -29,6 +29,7 @@ use sozu_command::messages::{self,TcpFront,Order,OrderMessage,OrderMessageAnswer
 use network::{AppId,Backend,ClientResult,ConnectionError,RequiredEvents,Protocol,Readiness,SessionMetrics,
   ProxyClient,ProxyConfiguration,AcceptError,BackendConnectAction,BackendConnectionStatus,
   CloseResult};
+use network::backends::BackendMap;
 use network::proxy::{Server,ProxyChannel,ListenToken,ListenPortState,ClientToken,ListenClient};
 use network::buffer_queue::BufferQueue;
 use network::socket::{SocketHandler,SocketResult,server_bind};
@@ -60,7 +61,7 @@ pub enum State {
 
 pub struct Client {
   sock:           TcpStream,
-  backend:        Option<TcpStream>,
+  backend:        Option<Rc<RefCell<Backend>>>,
   frontend_token: Token,
   backend_token:  Option<Token>,
   back_connected: BackendConnectionStatus,
@@ -126,7 +127,9 @@ impl Client {
       Some(SocketAddr::V6(addr)) => format!("{}", addr),
     };
 
-    let backend = match self.backend.as_ref().and_then(|backend| backend.peer_addr().ok()) {
+    let backend_address = self.backend.as_ref().map(|backend| (*backend.borrow_mut()).address);
+
+    let backend = match backend_address {
       None => String::from("-"),
       Some(SocketAddr::V4(addr)) => format!("{}", addr),
       Some(SocketAddr::V6(addr)) => format!("{}", addr),
@@ -320,7 +323,8 @@ impl Client {
 
   fn remove_backend(&mut self) -> (Option<String>, Option<SocketAddr>) {
 
-    let addr = self.backend.as_ref().and_then(|sock| sock.peer_addr().ok());
+    let addr = self.backend.as_ref().map(|backend| (*backend.borrow_mut()).address);
+
     self.backend       = None;
     self.backend_token = None;
     (self.app_id.clone(), addr)
@@ -523,7 +527,7 @@ pub struct ApplicationConfiguration {
 
 pub struct ServerConfiguration {
   fronts:          HashMap<String, Token>,
-  backends:        HashMap<String, Vec<Backend>>,
+  backends:        BackendMap,
   listeners:       HashMap<Token, ApplicationListener>,
   configs:         HashMap<AppId, ApplicationConfiguration>,
   pool:            Rc<RefCell<Pool<BufferQueue>>>,
@@ -534,7 +538,7 @@ impl ServerConfiguration {
     mut tcp_listener: Vec<(AppId, TcpListener)>, mut tokens: Vec<Token>) -> (ServerConfiguration, HashSet<Token>) {
 
     let mut configuration = ServerConfiguration {
-      backends:      HashMap::new(),
+      backends:      BackendMap::new(),
       listeners:     HashMap::new(),
       configs:       HashMap::new(),
       fronts:        HashMap::new(),
@@ -588,8 +592,8 @@ impl ServerConfiguration {
     }
 
     if let Ok(listener) = server_bind(front) {
-      let addresses: Vec<SocketAddr> = if let Some(ads) = self.backends.get(app_id) {
-        let v: Vec<SocketAddr> = ads.iter().map(|backend| backend.address).collect();
+      let addresses: Vec<SocketAddr> = if let Some(backend_list) = self.backends.backends.get(app_id) {
+        let v: Vec<SocketAddr> = backend_list.backends.iter().map(|backend| (*backend.borrow_mut()).address).collect();
         v
       } else {
         Vec::new()
@@ -632,18 +636,7 @@ impl ServerConfiguration {
 
   pub fn add_backend(&mut self, app_id: &str, backend_id: &str, backend_address: &SocketAddr, event_loop: &mut Poll) -> Option<ListenToken> {
     use std::borrow::BorrowMut;
-    if let Some(addrs) = self.backends.get_mut(app_id) {
-      let id = addrs.last().map(|mut b| (*b.borrow_mut()).id ).unwrap_or(0) + 1;
-      let backend = Backend::new(backend_id, *backend_address, id);
-      if !addrs.contains(&backend) {
-        addrs.push(backend);
-      }
-    }
-
-    if self.backends.get(app_id).is_none() {
-      let backend = Backend::new(backend_id, *backend_address, 0);
-      self.backends.insert(String::from(app_id), vec![backend]);
-    }
+    self.backends.add_backend(app_id, backend_id, backend_address);
 
     let opt_tok = self.fronts.get(app_id).clone();
     if let Some(tok) = opt_tok {
@@ -665,6 +658,17 @@ impl ServerConfiguration {
       None
   }
 
+  fn backend_from_app_id(&mut self, client: &mut Client, app_id: &str) -> Result<TcpStream,ConnectionError> {
+    match self.backends.backend_from_app_id(app_id) {
+      Err(e) => Err(e),
+      Ok((backend, conn))  => {
+        client.back_connected = BackendConnectionStatus::Connecting;
+        client.backend = Some(backend);
+
+        Ok(conn)
+      }
+    }
+  }
 }
 
 impl ProxyConfiguration<Client> for ServerConfiguration {
@@ -680,22 +684,30 @@ impl ProxyConfiguration<Client> for ServerConfiguration {
     let rnd = random::<usize>();
     let idx = rnd % len;
 
-    client.app_id = Some(self.listeners[&client.accept_token].app_id.clone());
-    let backend_addr = try!(self.listeners[&client.accept_token].back_addresses.get(idx).ok_or(ConnectionError::ToBeDefined));
-    let stream = try!(TcpStream::connect(backend_addr).map_err(|_| ConnectionError::ToBeDefined));
-    stream.set_nodelay(true);
+    let app_id = self.listeners[&client.accept_token].app_id.clone();
+    client.app_id = Some(app_id.clone());
 
-    poll.register(
-      &stream,
-      back_token,
-      Ready::readable() | Ready::writable() | Ready::from(UnixReady::hup() | UnixReady::error()),
-      PollOpt::edge()
-    );
+    let conn = self.backend_from_app_id(client, &app_id);
+    match conn {
+      Ok(stream) => {
+        stream.set_nodelay(true);
 
-    client.set_back_token(back_token);
-    client.set_back_socket(stream);
-    client.set_back_connected(BackendConnectionStatus::Connecting);
-    Ok(BackendConnectAction::New)
+        poll.register(
+          &stream,
+          back_token,
+          Ready::readable() | Ready::writable() | Ready::from(UnixReady::hup() | UnixReady::error()),
+          PollOpt::edge()
+        );
+
+        client.set_back_token(back_token);
+        client.set_back_socket(stream);
+        Ok(BackendConnectAction::New)
+      },
+      Err(ConnectionError::NoBackendAvailable) => Err(ConnectionError::NoBackendAvailable),
+      Err(e) => {
+        panic!(format!("tcp connect_to_backend: unexpected error: {:?}", e));
+      }
+    }
   }
 
   fn notify(&mut self, event_loop: &mut Poll, message: OrderMessage) -> OrderMessageAnswer {
@@ -845,11 +857,7 @@ impl ProxyConfiguration<Client> for ServerConfiguration {
   }
 
   fn close_backend(&mut self, app_id: String, addr: &SocketAddr) {
-    if let Some(app_backends) = self.backends.get_mut(&app_id) {
-      if let Some(ref mut backend) = app_backends.iter_mut().find(|backend| &backend.address == addr) {
-        backend.dec_connections();
-      }
-    }
+    self.backends.close_backend_connection(&app_id, &addr);
   }
 
   fn listen_port_state(&self, port: &u16) -> ListenPortState {


### PR DESCRIPTION
This PR implements the circuit breaker for TCP. It first migrates the backend management of the TCP proxy to what's in place for the HTTP or HTTPS proxies (using the `Backend` structure).

Then, the circuit breaker comes in.

I can't test it much because it seems I'm having the sames troubles as described in #420 (well, it shouldn't answer a 503 but it should close the connection, which it doesn't). It hangs too when it can't connect to the backend. But at least, it doesn't try to connect indefinitely anymore :)

Let me know about those changes, I mostly copy / pasted code from what's been implemented for HTTP