### PR TITLE
Add a proxy protocol section in the how_to_use documentation part

### DIFF
--- a/doc/how_to_use.md
+++ b/doc/how_to_use.md
@@ -142,3 +142,48 @@ Furthermore, we can enable it, so that it is activated by default on future boot
 
 [un]: https://github.com/sozu-proxy/sozu/blob/master/os-build/systemd/sozu.service.in
 [gen]: https://github.com/sozu-proxy/sozu/blob/master/os-build/exherbo/generate.sh
+
+## PROXY Protocol
+
+Sōzu use its own IP stack to get connected on remote servers. Because of this, we lose the initial L3/4 client connection information (like source and destination IP and port).
+Sōzu support the *version 2* of the `PROXY protocol` to receive client connection information passed through proxy servers and load balancers.
+For example, this can be used to configure a website, keeping a blacklist of IP addresses, or logging/metrics purposes.
+
+The information L3/4 passed via the `PROXY protocol` is:
+ - the client IP address
+ - the proxy server IP address
+ - both port numbers.
+
+More infos here: [proxy-protocol spec](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
+
+
+### Configuring Sōzu to *expect* a PROXY Protocol
+
+Configures the client-facing connection to receive a PROXY protocol header before any byte is read from the socket.
+
+```toml
+[applications.NameOfYourApp]
+expect_proxy = true
+```
+
+### Configuring Sōzu to *send* a PROXY Protocol to an upstream backend
+
+Send a PROXY protocol header over any connection established to the backends declared in the application.
+The PROXY protocol informs the upstream backend about the L3/4 addresses of the incoming connection.
+
+```toml
+[applications.NameOfYourApp]
+send_proxy = true
+```
+
+NOTE: Currently supported only for `tcp` applications.
+
+### Configuring Sōzu to *relay* a PROXY Protocol header to an upstream
+
+Expect the client-facing connection to receive a PROXY protocol header, check its validity and then forward it to an upstream backend. This enable to chain proxies / reverse-proxies without losing the client connection information.
+
+```toml
+[applications.NameOfYourApp]
+send_proxy = true
+expect_proxy = true
+```

--- a/doc/how_to_use.md
+++ b/doc/how_to_use.md
@@ -161,6 +161,18 @@ More infos here: [proxy-protocol spec](https://www.haproxy.org/download/1.8/doc/
 
 Configures the client-facing connection to receive a PROXY protocol header before any byte is read from the socket.
 
+```
+                            send PROXY               expect PROXY
+                            protocol header          protocol header
+    +--------+
+    | client |             +---------+                   +------------+      +-----------+
+    |        |             | proxy   |                   | Sozu       |      | upstream  |
+    +--------+  ---------> | server  |  ---------------> |            |------| server    |
+   /        /              |         |                   |            |      |           |
+  /________/               +---------+                   +------------+      +-----------+
+```
+
+*Configuration:*
 ```toml
 [applications.NameOfYourApp]
 expect_proxy = true
@@ -171,6 +183,17 @@ expect_proxy = true
 Send a PROXY protocol header over any connection established to the backends declared in the application.
 The PROXY protocol informs the upstream backend about the L3/4 addresses of the incoming connection.
 
+```
+                                send PROXY
+    +--------+                  protocol header
+    | client |             +---------+                +-----------------+
+    |        |             | Sozu    |                | proxy/upstream  |
+    +--------+  ---------> |         |  ------------> | server          |
+   /        /              |         |                |                 |
+  /________/               +---------+                +-----------------+
+```
+
+*Configuration:*
 ```toml
 [applications.NameOfYourApp]
 send_proxy = true

--- a/doc/how_to_use.md
+++ b/doc/how_to_use.md
@@ -145,9 +145,9 @@ Furthermore, we can enable it, so that it is activated by default on future boot
 
 ## PROXY Protocol
 
-Sōzu use its own IP stack to get connected on remote servers. Because of this, we lose the initial L3/4 client connection information (like source and destination IP and port).
-Sōzu support the *version 2* of the `PROXY protocol` to receive client connection information passed through proxy servers and load balancers.
-For example, this can be used to configure a website, keeping a blacklist of IP addresses, or logging/metrics purposes.
+Sōzu use its own layer 3 and 4 information to get connected on remote servers. Because of this, we lose the initial L3/4 client connection information (like source and destination IP and port) which can be use by upstream proxy/server to configure a website, basic IP-level security, logging/metrics purposes...
+
+Sōzu support the *version 2* of the `PROXY protocol` to solve the problem of L3/4 connection parameters being lost when relaying L3/4 connections through proxies. Thanks to that, Sōzu will informs the other end about the L3/4 addresses of the incoming connection before any byte is exchange from the socket. Furthermore, Sōzu can forward to the upstream service this client connection information sent by downstream proxy servers and load balancers.
 
 The information L3/4 passed via the `PROXY protocol` is:
  - the client IP address

--- a/doc/how_to_use.md
+++ b/doc/how_to_use.md
@@ -205,6 +205,18 @@ NOTE: Currently supported only for `tcp` applications.
 
 Expect the client-facing connection to receive a PROXY protocol header, check its validity and then forward it to an upstream backend. This enable to chain proxies / reverse-proxies without losing the client connection information.
 
+```
+                                 send PROXY           expect PROXY    send PROXY
+                                 protocol header      protocol header protocol header
+    +--------+
+    | client |             +---------+                      +------------+             +-------------------+
+    |        |             | proxy   |                      | Sozu       |             | proxy/upstream    |
+    +--------+  +--------> | server  |  +-----------------> |            | +---------> | server            |
+   /        /              |         |                      |            |             |                   |
+  /________/               +---------+                      +------------+             +-------------------+
+```
+
+*Configuration:*
 ```toml
 [applications.NameOfYourApp]
 send_proxy = true


### PR DESCRIPTION
Work for #413
We describe:
- briefly what is the proxy protocol and it's purpose
- how to configure sozu to use it
- which version we support