### PR TITLE
Proxy: don't remove the new slab entry when the connection gets replaced

### DIFF
--- a/lib/src/network/proxy.rs
+++ b/lib/src/network/proxy.rs
@@ -780,7 +780,7 @@ impl Server {
         },
       };
 
-      if res != Ok(BackendConnectAction::New) {
+      if res != Ok(BackendConnectAction::New) && res != Ok(BackendConnectAction::Replace) {
         entry.remove();
       }
       (protocol, res)


### PR DESCRIPTION
Fixes #475 

I may be wrong on this one, but if the connection gets replaced, it means that it has been closed before and that the previous connection should be out of the slab already.