### PR TITLE
fix and refactor the dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,8 @@
 target
 LICENSE
 README.md
-ctl
 doc
-os-build
 CONTRIBUTING.md
+bin/command_folder
+os-build
+!os-build/docker

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,7 @@
 target
 LICENSE
 README.md
+ctl
+doc
+os-build
+CONTRIBUTING.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN cargo build --release --features use-openssl
 
 FROM alpine:latest as bin
 
-COPY bin/config.toml /etc/sozu/config.toml
+COPY os-build/docker/config.toml /etc/sozu/config.toml
 
 RUN apk update && apk add --no-cache openssl-dev \
   llvm-libunwind \
@@ -29,7 +29,7 @@ RUN apk update && apk add --no-cache openssl-dev \
 
 COPY --from=builder /source/target/release/sozu sozu
 
-ENV SOZU_CONFIG /etc/sozu/sozu.toml
+ENV SOZU_CONFIG /etc/sozu/config.toml
 
 VOLUME /etc/sozu
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@ ENV SOZU_CONFIG /etc/sozu/sozu.toml
 
 VOLUME /etc/sozu
 
-RUN mkdir command_folder
-VOLUME command_folder
+RUN mkdir -p /run/sozu
+VOLUME /run/sozu
 
 EXPOSE 80
 EXPOSE 443

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -56,7 +56,33 @@ You can build the image by doing:
 
 And run it with the command
 
-`docker run -p 8000:80 -p 8443:443 sozu`
+```bash
+docker run \
+  --name sozu-proxy
+  -v /run/sozu:/run/sozu \
+  -v /path/to/config/file:/etc/sozu \
+  -v /my/state/:/var/lib/sozu \
+  -p 8080:80 \
+  -p 8443:443 \
+  sozu
+```
+
+#### Using a custom `config.toml` configuration file
+
+The default configuration for sozu can be found in `../os-build/docker/config.toml`.
+If `/my/custom/config.toml` is the path and name of your custom configuration file, you can start your sozu container with this in a volume to override the default configuration (note that only the directory path of the custom config file is used in this command):
+`docker run -v /my/custom:/etc/sozu sozu`
+
+#### Using sozuctl with the docker container
+
+To use `sozuctl` CLI from the host with the docker container you have to bind `/run/sozu` with the host by using a docker volume:
+`docker run -v /run/sozu:/run/sozu sozu`
+
+
+#### Provide an initial configuration state
+Sozu can use a JSON file to load an initial configuration state for its routing.
+you can mount it by using a volume, you can start your sozu container with this in a volume (note that only the directory path of the custom config file is used in this command):
+`docker run -v /my/state:/var/lib/sozu sozu`
 
 [cr]: https://crates.io/
 [cfg]: https://github.com/sozu-proxy/sozu/blob/master/bin/config.toml

--- a/os-build/docker/config.toml
+++ b/os-build/docker/config.toml
@@ -1,0 +1,151 @@
+# sozu empty config file
+
+# top level options
+
+# path to a file sozu can use to load an initial configuration state for its
+# routing. You can generate this file from sozu's current routing by running
+# the command `sozuctl state save -f state.json`
+saved_state = "/var/lib/sozu/state.json"
+
+# logging verbosity. Possible values are "error", "warn", "info", "debug" and
+# "trace". For performance reasons, the logs at "debug" or "trace" level are
+# not compiled by default. To activate them, pass the "logs-debug" and
+# "logs-trace" compilation options to cargo
+log_level = "info"
+
+# where the logs will be sent. It defaults to sending the logs on standard output,
+# but they could be written to a UDP address:
+# log_target     = "udp://127.0.0.1:9876"
+# to a TCP address:
+# log_target     = "tcp://127.0.0.1:9876"
+# to a unix socket
+# log_target = "unix:///var/sozu/logs
+# to a file
+# log_target = "file:///var/logs/sozu.log"
+# to_stdout
+log_target = "stdout"
+
+# optional different target for access logs (IP addresses, domains, URI, HTTP status, etc)
+# It supports the same options as log_target
+# log_access_target = "file:///var/logs/sozu-access.log"
+
+# path to the unix socket file used to send commands to sozu
+command_socket = "/run/sozu/sozu.sock"
+
+# size in bytes of the buffer used by the command socket protocol. If the message
+# sent to sozu is too large, or the data that sozu must return is too large, the
+# buffer will grow up to max_command_buffer_size. If the buffer is still not large
+# enough sozu will close the connection
+# defaults to 1000000
+command_buffer_size = 16384
+# defaults to command_buffer_size * 2
+max_command_buffer_size = 163840
+
+# the number of worker processes that will handle traffic
+worker_count = 2
+
+# indicates if workers should be automatically restarted if they crash / hang
+# should be true for production and false for development
+# defaults to true
+worker_automatic_restart = true
+
+# indicates if worker process will be pinned on a core. If you activate this, be sure
+# that you do not have more workers than CPU cores (and leave at least one core for
+# the kernel and the master process)
+handle_process_affinity = false
+
+# maximum number of connections to a worker. If it reached that number and
+# there are new connections available, the worker will accept and close them
+# immediately to indicate it is too busy to handle traffic
+max_connections = 500
+
+# maximum number of buffers used by the protocol implementations for active
+# connections (ie currently serving a request). For now, you should estimate
+# that max_buffers = number of concurrent requests * 2
+max_buffers = 500
+
+# size of the buffers used by the protocol implementations. Each worker will
+# preallocate max_buffers * 2 * buffer_size bytes, so you should plan for this
+# memory usage. If you plan to use sozu's runtime upgrade feature, you should
+# leave enough memory for one more worker (also for the kernel, etc), so total
+# RAM should be larger than (worker count + 1) * max_buffers * 2 * buffer_size bytes
+buffer_size = 16384
+
+# how much time (in milliseconds) sozuctl will wait for a command to complete.
+# Defaults to 1000 milliseconds
+#ctl_command_timeout = 1000
+
+# PID file is a file containing the PID of the master process of sozu.
+# It can be helpful to help systemd or any other service system to keep track
+# of the main process across upgrades. PID file is not created unless this option
+# is set or if SOZU_PID_FILE_PATH environment variable was defined at build time.
+# pid_file_path = "/run/sozu/sozu.pid"
+
+# various statistics can be sent to a server that supports the statsd protocol
+# You can see those statistics with sozuctl, like this: `sozuctl metrics` or
+# `sozuctl metrics --json` for machine consumption
+#
+#[metrics]
+# address = "127.0.0.1"
+# port = 8125
+# use InfluxDB's statsd protocol flavor to add tags
+# tagged_metrics = false
+
+# options specific to the HTTP (plaintext) proxy
+[http]
+# listening IP
+address = "0.0.0.0"
+# listening port
+port = 8080
+
+# path to custom 404 and 503 answers
+# a 404 response is sent when sozu does not know about the requested domain or path
+# a 503 response is sent if there are no backend servers available
+#answer_404 = "../lib/assets/404.html"
+#answer_503 = "../lib/assets/503.html"
+
+# defines the sticky session cookie's name, if `sticky_session` is activated for
+# an application. Defaults to "SOZUBALANCEID"
+# sticky_name = "SOZUBALANCEID"
+
+# options specific to the HTTPS (OpenSSL basedor rustls based) proxy
+[https]
+address = "0.0.0.0"
+port = 8443
+
+#answer_404 = "../lib/assets/404.html"
+#answer_503 = "../lib/assets/503.html"
+# sticky_name = "SOZUBALANCEID"
+
+# defines how the TLS protocol will be handled by sozu. Possible values
+# are "openssl" or "rustls". The "openssl" option will only work if sozu
+# was built with the "use-openssl" feature.
+# tls_provider = "rustls"
+
+# supported TLS versions. Possible values are "SSLv2", "SSLv3", "TLSv1",
+# "TLSv1.1", "TLSv1.2". Defaults to "TLSv1.2"
+#tls_versions = ["TLSv1.2"]
+
+# cipher combinations used by OpenSSL
+#cipher_list = "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256"
+
+# application whose certificate will be used by default by  OpenSSL
+default_app_id = "MyApp"
+
+# default certificate used by OpenSSL
+#default_certificate = "../lib/assets/cert_test.pem"
+# default certificate chain used by OpenSSL
+#default_certificate_chain = "../lib/assets/cert__chain_test.pem"
+# default key used by OpenSSL
+#default_key = "../lib/assets/key_test.pem"
+
+# options specific to the TCP proxy
+#
+# there is nothing here for now, but to activate the TCP proxy,
+# uncomment that section
+[tcp]
+
+# static configuration for applications
+#
+# those applications will be routed by sozu directly from start
+[applications]


### PR DESCRIPTION
The docker got stuck during the start because of the `CMD` used.
Now we compile with the feature: `use-openssl` and we are now on the latest version of alpine (it's better for the `openssl-dev` alpine package).
We use volume for the command_folder and config.toml (we should do the same for sozu state.json). 

NOTE: I removed `sozuctl` into the docker

work for #470