### PR TITLE
ctl: add a `config check` command to check configuration file

### DIFF
--- a/ctl/src/cli.rs
+++ b/ctl/src/cli.rs
@@ -71,6 +71,11 @@ pub enum SubCmd {
     json: bool,
     #[structopt(subcommand)]
     cmd: QueryCmd,
+  },
+  #[structopt(name = "config", about = "configuration file management")]
+  Config {
+    #[structopt(subcommand)]
+    cmd: ConfigCmd
   }
 }
 
@@ -249,4 +254,10 @@ pub enum QueryCmd {
     #[structopt(short = "d", long="domain", help="application domain name")]
     domain: Option<String>
   }
+}
+
+#[derive(StructOpt, PartialEq, Debug)]
+pub enum ConfigCmd {
+  #[structopt(name = "check", about = "check configuration file syntax and exit")]
+  Check {}
 }

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -31,6 +31,13 @@ fn main() {
   let config_file = matches.config;
 
   let config  = Config::load_from_path(config_file.as_str()).expect("could not parse configuration file");
+
+  // If the command is `config check` then exit because if we are here, the configuration is valid
+  if let SubCmd::Config{ cmd: ConfigCmd::Check{} } = matches.cmd {
+    println!("Configuration file is valid");
+    std::process::exit(0);
+  }
+
   let channel = create_channel(&config.command_socket_path()).expect("could not connect to the command unix socket");
   let timeout: u64 = matches.timeout.unwrap_or(config.ctl_command_timeout);
 
@@ -102,6 +109,7 @@ fn main() {
         QueryCmd::Applications{ id, domain } => query_application(channel, json, id, domain),
       }
     },
+    SubCmd::Config{ cmd: _ } => {} // noop, handled at the beginning of the method
   }
 }
 


### PR DESCRIPTION
Part of #363 

I added a new `config` subcommand, maybe we will have other things under it in the future (I was thinking about a `reload` command for example)

Let me know how you feel about this command