### PR TITLE
Backends: add a backup option

### DIFF
--- a/command/assets/add_backend.json
+++ b/command/assets/add_backend.json
@@ -12,7 +12,8 @@
       "sticky_id": "xxx-0",
       "load_balancing_parameters": {
         "weight": 0
-      }
+      },
+      "backup": false
     }
   }
 }

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -297,6 +297,7 @@ pub struct BackendConfig {
   pub address: SocketAddr,
   pub weight: Option<u8>,
   pub sticky_id: Option<String>,
+  pub backup: Option<bool>,
 }
 
 impl FileAppConfig {
@@ -446,6 +447,7 @@ impl HttpAppConfig {
           port:       port,
           load_balancing_parameters,
           sticky_id:  backend.sticky_id.clone(),
+          backup:     backend.backup.clone(),
         }));
 
         backend_count += 1;
@@ -500,6 +502,7 @@ impl TcpAppConfig {
         port:       port,
         load_balancing_parameters,
         sticky_id:  backend.sticky_id.clone(),
+        backup:     backend.backup.clone(),
       }));
 
       backend_count += 1;

--- a/command/src/data.rs
+++ b/command/src/data.rs
@@ -490,6 +490,7 @@ mod tests {
                   port: 8080,
                   load_balancing_parameters: Some(LoadBalancingParams{ weight: 0 }),
                   sticky_id: Some(String::from("xxx-0")),
+                  backup: Some(false),
       })),
       proxy_id: None
     });

--- a/command/src/messages.rs
+++ b/command/src/messages.rs
@@ -280,6 +280,8 @@ pub struct Backend {
     #[serde(default)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub load_balancing_parameters: Option<LoadBalancingParams>,
+    #[serde(default)]
+    pub backup:      Option<bool>,
 }
 
 #[derive(Debug,Clone,PartialEq,Eq,Hash, Serialize, Deserialize)]
@@ -546,6 +548,7 @@ mod tests {
       port: 8080,
       sticky_id: None,
       load_balancing_parameters: Some(LoadBalancingParams{ weight: 0 }),
+      backup: None,
     }));
   }
 

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -459,10 +459,10 @@ mod tests {
     let mut state:ConfigState = Default::default();
     state.handle_order(&Order::AddHttpFront(HttpFront { app_id: String::from("app_1"), hostname: String::from("lolcatho.st:8080"), path_begin: String::from("/") }));
     state.handle_order(&Order::AddHttpFront(HttpFront { app_id: String::from("app_2"), hostname: String::from("test.local"), path_begin: String::from("/abc") }));
-    state.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-0"), ip_address: String::from("127.0.0.1"), port: 1026, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None  }));
-    state.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-1"), ip_address: String::from("127.0.0.2"), port: 1027, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None  }));
-    state.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_2"), backend_id: String::from("app_2-0"), ip_address: String::from("192.167.1.2"), port: 1026, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None  }));
-    state.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-3"),ip_address: String::from("192.168.1.3"), port: 1027, load_balancing_parameters: Some(LoadBalancingParams::default()) , sticky_id: None }));
+    state.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-0"), ip_address: String::from("127.0.0.1"), port: 1026, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None, backup: None  }));
+    state.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-1"), ip_address: String::from("127.0.0.2"), port: 1027, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None, backup: None  }));
+    state.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_2"), backend_id: String::from("app_2-0"), ip_address: String::from("192.167.1.2"), port: 1026, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None, backup: None  }));
+    state.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-3"),ip_address: String::from("192.168.1.3"), port: 1027, load_balancing_parameters: Some(LoadBalancingParams::default()) , sticky_id: None, backup: None }));
     state.handle_order(&Order::RemoveBackend(RemoveBackend { app_id: String::from("app_1"), backend_id: String::from("app_1-3"), ip_address: String::from("192.168.1.3"), port: 1027 }));
 
     /*
@@ -481,22 +481,22 @@ mod tests {
     let mut state:ConfigState = Default::default();
     state.handle_order(&Order::AddHttpFront(HttpFront { app_id: String::from("app_1"), hostname: String::from("lolcatho.st:8080"), path_begin: String::from("/") }));
     state.handle_order(&Order::AddHttpFront(HttpFront { app_id: String::from("app_2"), hostname: String::from("test.local"), path_begin: String::from("/abc") }));
-    state.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-0"), ip_address: String::from("127.0.0.1"), port: 1026, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None  }));
-    state.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-1"), ip_address: String::from("127.0.0.2"), port: 1027, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None  }));
-    state.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_2"), backend_id: String::from("app_2-0"), ip_address: String::from("192.167.1.2"), port: 1026, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None  }));
+    state.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-0"), ip_address: String::from("127.0.0.1"), port: 1026, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None, backup: None  }));
+    state.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-1"), ip_address: String::from("127.0.0.2"), port: 1027, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None, backup: None  }));
+    state.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_2"), backend_id: String::from("app_2-0"), ip_address: String::from("192.167.1.2"), port: 1026, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None, backup: None  }));
     state.handle_order(&Order::AddApplication(Application { app_id: String::from("app_2"), sticky_session: true, https_redirect: true, proxy_protocol: None, load_balancing_policy: LoadBalancingAlgorithms::RoundRobin }));
 
     let mut state2:ConfigState = Default::default();
     state2.handle_order(&Order::AddHttpFront(HttpFront { app_id: String::from("app_1"), hostname: String::from("lolcatho.st:8080"), path_begin: String::from("/") }));
-    state2.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-0"), ip_address: String::from("127.0.0.1"), port: 1026, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None  }));
-    state2.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-1"), ip_address: String::from("127.0.0.2"), port: 1027, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None  }));
-    state2.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-2"), ip_address: String::from("127.0.0.2"), port: 1028, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None  }));
+    state2.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-0"), ip_address: String::from("127.0.0.1"), port: 1026, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None, backup: None  }));
+    state2.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-1"), ip_address: String::from("127.0.0.2"), port: 1027, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None, backup: None  }));
+    state2.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-2"), ip_address: String::from("127.0.0.2"), port: 1028, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None, backup: None  }));
     state2.handle_order(&Order::AddApplication(Application { app_id: String::from("app_3"), sticky_session: false, https_redirect: false, proxy_protocol: None, load_balancing_policy: LoadBalancingAlgorithms::RoundRobin }));
 
    let e = vec!(
      Order::RemoveHttpFront(HttpFront { app_id: String::from("app_2"), hostname: String::from("test.local"), path_begin: String::from("/abc") }),
      Order::RemoveBackend(RemoveBackend { app_id: String::from("app_2"), backend_id: String::from("app_2-0"), ip_address: String::from("192.167.1.2"), port: 1026 }),
-     Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-2"), ip_address: String::from("127.0.0.2"), port: 1028, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None }),
+     Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-2"), ip_address: String::from("127.0.0.2"), port: 1028, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None, backup: None }),
      Order::RemoveApplication(String::from("app_2")),
      Order::AddApplication(Application { app_id: String::from("app_3"), sticky_session: false, https_redirect: false, proxy_protocol: None, load_balancing_policy: LoadBalancingAlgorithms::RoundRobin }),
    );
@@ -510,7 +510,7 @@ mod tests {
    let hash1 = state.hash_state();
    let hash2 = state2.hash_state();
    let mut state3 = state.clone();
-   state3.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-2"), ip_address: String::from("127.0.0.2"), port: 1028, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None  }));
+   state3.handle_order(&Order::AddBackend(Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-2"), ip_address: String::from("127.0.0.2"), port: 1028, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None, backup: None }));
    let hash3 = state3.hash_state();
    println!("state 1 hashes: {:#?}", hash1);
    println!("state 2 hashes: {:#?}", hash2);

--- a/ctl/src/cli.rs
+++ b/ctl/src/cli.rs
@@ -139,6 +139,8 @@ pub enum BackendCmd {
     port: u16,
     #[structopt(short = "s", long = "sticky-id", help = "value for the sticky session cookie")]
     sticky_id: Option<String>,
+    #[structopt(short = "b", long = "backup", help = "set backend as a backup backend")]
+    backup: Option<bool>,
   },
 }
 

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -858,7 +858,7 @@ pub fn remove_http_frontend(channel: Channel<ConfigMessage,ConfigMessageAnswer>,
 }
 
 
-pub fn add_backend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, app_id: &str, backend_id: &str, ip: &str, port: u16, sticky_id: Option<String>) {
+pub fn add_backend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout: u64, app_id: &str, backend_id: &str, ip: &str, port: u16, sticky_id: Option<String>, backup: Option<bool>) {
   order_command(channel, timeout, Order::AddBackend(Backend {
       app_id: String::from(app_id),
       backend_id: String::from(backend_id),
@@ -866,6 +866,7 @@ pub fn add_backend(channel: Channel<ConfigMessage,ConfigMessageAnswer>, timeout:
       port: port,
       load_balancing_parameters: Some(LoadBalancingParams::default()),
       sticky_id: sticky_id,
+      backup:    backup
     }));
 }
 

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -62,7 +62,7 @@ fn main() {
     },
     SubCmd::Backend{ cmd } => {
       match cmd {
-        BackendCmd::Add{ id, backend_id, ip, port, sticky_id } => add_backend(channel, timeout, &id, &backend_id, &ip, port, sticky_id),
+        BackendCmd::Add{ id, backend_id, ip, port, sticky_id, backup } => add_backend(channel, timeout, &id, &backend_id, &ip, port, sticky_id, backup),
         BackendCmd::Remove{ id, backend_id, ip, port } => remove_backend(channel, timeout, &id, &backend_id, &ip, port),
       }
     },

--- a/lib/examples/main.rs
+++ b/lib/examples/main.rs
@@ -50,6 +50,7 @@ fn main() {
     ip_address:  String::from("127.0.0.1"),
     port:        1026,
     load_balancing_parameters: Some(LoadBalancingParams::default()),
+    backup:      None,
   };
 
   command.write_message(&messages::OrderMessage {
@@ -126,6 +127,7 @@ fn main() {
     ip_address:  String::from("127.0.0.1"),
     port:        1026,
     load_balancing_parameters: Some(LoadBalancingParams::default()),
+    backup:      None,
   };
 
   command2.write_message(&messages::OrderMessage {
@@ -169,6 +171,7 @@ fn main() {
     ip_address:  String::from("127.0.0.1"),
     port:        1026,
     load_balancing_parameters: Some(LoadBalancingParams::default()),
+    backup:      None,
   };
 
   command2.write_message(&messages::OrderMessage {

--- a/lib/examples/minimal.rs
+++ b/lib/examples/minimal.rs
@@ -46,6 +46,7 @@ fn main() {
     port:                      8000,
     load_balancing_parameters: Some(LoadBalancingParams::default()),
     sticky_id:                 None,
+    backup:                    None,
   };
 
   command.write_message(&messages::OrderMessage {

--- a/lib/examples/tcp.rs
+++ b/lib/examples/tcp.rs
@@ -44,7 +44,8 @@ fn main() {
     ip_address:  String::from("127.0.0.1"),
     port:        1026,
     load_balancing_parameters: Some(LoadBalancingParams::default()),
-    sticky_id: None,
+    sticky_id:   None,
+    backup:      None,
   };
 
   command.write_message(&messages::OrderMessage {

--- a/lib/src/network/http.rs
+++ b/lib/src/network/http.rs
@@ -1012,7 +1012,7 @@ impl ProxyConfiguration<Client> for ServerConfiguration {
         let addr_string = backend.ip_address + ":" + &backend.port.to_string();
         let parsed:Option<SocketAddr> = addr_string.parse().ok();
         if let Some(addr) = parsed {
-          let new_backend = Backend::new(&backend.backend_id, addr, backend.sticky_id.clone(), backend.load_balancing_parameters);
+          let new_backend = Backend::new(&backend.backend_id, addr, backend.sticky_id.clone(), backend.load_balancing_parameters, backend.backup);
           self.add_backend(&backend.app_id, new_backend, event_loop);
           OrderMessageAnswer{ id: message.id, status: OrderMessageStatus::Ok, data: None }
         } else {
@@ -1282,7 +1282,7 @@ mod tests {
 
     let front = HttpFront { app_id: String::from("app_1"), hostname: String::from("localhost"), path_begin: String::from("/") };
     command.write_message(&OrderMessage { id: String::from("ID_ABCD"), order: Order::AddHttpFront(front) });
-    let backend = Backend { app_id: String::from("app_1"),backend_id: String::from("app_1-0"), ip_address: String::from("127.0.0.1"), port: 1025, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None };
+    let backend = Backend { app_id: String::from("app_1"),backend_id: String::from("app_1-0"), ip_address: String::from("127.0.0.1"), port: 1025, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None, backup: None };
     command.write_message(&OrderMessage { id: String::from("ID_EFGH"), order: Order::AddBackend(backend) });
 
     println!("test received: {:?}", command.read_message());
@@ -1339,7 +1339,7 @@ mod tests {
 
     let front = HttpFront { app_id: String::from("app_1"), hostname: String::from("localhost"), path_begin: String::from("/") };
     command.write_message(&OrderMessage { id: String::from("ID_ABCD"), order: Order::AddHttpFront(front) });
-    let backend = Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-0"), ip_address: String::from("127.0.0.1"), port: 1028, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None };
+    let backend = Backend { app_id: String::from("app_1"), backend_id: String::from("app_1-0"), ip_address: String::from("127.0.0.1"), port: 1028, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None, backup: None };
     command.write_message(&OrderMessage { id: String::from("ID_EFGH"), order: Order::AddBackend(backend) });
 
     println!("test received: {:?}", command.read_message());
@@ -1419,7 +1419,7 @@ mod tests {
     command.write_message(&OrderMessage { id: String::from("ID_ABCD"), order: Order::AddApplication(application) });
     let front = HttpFront { app_id: String::from("app_1"), hostname: String::from("localhost"), path_begin: String::from("/") };
     command.write_message(&OrderMessage { id: String::from("ID_EFGH"), order: Order::AddHttpFront(front) });
-    let backend = Backend { app_id: String::from("app_1"),backend_id: String::from("app_1-0"), ip_address: String::from("127.0.0.1"), port: 1040, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None };
+    let backend = Backend { app_id: String::from("app_1"),backend_id: String::from("app_1-0"), ip_address: String::from("127.0.0.1"), port: 1040, load_balancing_parameters: Some(LoadBalancingParams::default()), sticky_id: None, backup: None };
     command.write_message(&OrderMessage { id: String::from("ID_IJKL"), order: Order::AddBackend(backend) });
 
     println!("test received: {:?}", command.read_message());

--- a/lib/src/network/https_openssl.rs
+++ b/lib/src/network/https_openssl.rs
@@ -1406,7 +1406,7 @@ impl ProxyConfiguration<TlsClient> for ServerConfiguration {
         let addr_string = backend.ip_address + ":" + &backend.port.to_string();
         let parsed:Option<SocketAddr> = addr_string.parse().ok();
         if let Some(addr) = parsed {
-          let new_backend = Backend::new(&backend.backend_id, addr, backend.sticky_id.clone(), backend.load_balancing_parameters);
+          let new_backend = Backend::new(&backend.backend_id, addr, backend.sticky_id.clone(), backend.load_balancing_parameters, backend.backup);
           self.add_backend(&backend.app_id, new_backend, event_loop);
           OrderMessageAnswer{ id: message.id, status: OrderMessageStatus::Ok, data: None }
         } else {

--- a/lib/src/network/https_rustls/configuration.rs
+++ b/lib/src/network/https_rustls/configuration.rs
@@ -606,7 +606,7 @@ impl ProxyConfiguration<TlsClient> for ServerConfiguration {
         let addr_string = backend.ip_address + ":" + &backend.port.to_string();
         let parsed:Option<SocketAddr> = addr_string.parse().ok();
         if let Some(addr) = parsed {
-          let new_backend = Backend::new(&backend.backend_id, addr, backend.sticky_id.clone(), backend.load_balancing_parameters);
+          let new_backend = Backend::new(&backend.backend_id, addr, backend.sticky_id.clone(), backend.load_balancing_parameters, backend.backup);
           self.add_backend(&backend.app_id, new_backend, event_loop);
           OrderMessageAnswer{ id: message.id, status: OrderMessageStatus::Ok, data: None }
         } else {

--- a/lib/src/network/load_balancing.rs
+++ b/lib/src/network/load_balancing.rs
@@ -82,6 +82,7 @@ mod test {
       active_connections: connections.unwrap_or(0),
       failures: 0,
       load_balancing_parameters: None,
+      backup: false,
     }
   }
 

--- a/lib/src/network/mod.rs
+++ b/lib/src/network/mod.rs
@@ -224,10 +224,11 @@ pub struct Backend {
   pub active_connections:        usize,
   pub failures:                  usize,
   pub load_balancing_parameters: Option<LoadBalancingParams>,
+  pub backup:                    bool,
 }
 
 impl Backend {
-  pub fn new(backend_id: &str, addr: SocketAddr, sticky_id: Option<String>, load_balancing_parameters: Option<LoadBalancingParams>) -> Backend {
+  pub fn new(backend_id: &str, addr: SocketAddr, sticky_id: Option<String>, load_balancing_parameters: Option<LoadBalancingParams>, backup: Option<bool>) -> Backend {
     let desired_policy = retry::ExponentialBackoffPolicy::new(6);
     Backend {
       sticky_id:          sticky_id,
@@ -238,6 +239,7 @@ impl Backend {
       active_connections: 0,
       failures:           0,
       load_balancing_parameters,
+      backup: backup.unwrap_or(false),
     }
   }
 

--- a/lib/src/network/tcp.rs
+++ b/lib/src/network/tcp.rs
@@ -869,7 +869,7 @@ impl ProxyConfiguration<Client> for ServerConfiguration {
       Order::AddBackend(backend) => {
         let addr_string = backend.ip_address + ":" + &backend.port.to_string();
         let addr = addr_string.parse().unwrap();
-        let new_backend = Backend::new(&backend.backend_id, addr, backend.sticky_id.clone(), backend.load_balancing_parameters);
+        let new_backend = Backend::new(&backend.backend_id, addr, backend.sticky_id.clone(), backend.load_balancing_parameters, backend.backup);
         if let Some(token) = self.add_backend(&backend.app_id, new_backend, event_loop) {
           OrderMessageAnswer{ id: message.id, status: OrderMessageStatus::Ok, data: None}
         } else {
@@ -1199,6 +1199,7 @@ mod tests {
         port: 5678,
         load_balancing_parameters: Some(LoadBalancingParams::default()),
         sticky_id: None,
+        backup: None,
       };
 
       command.write_message(&OrderMessage { id: String::from("ID_YOLO1"), order: Order::AddTcpFront(front) });
@@ -1217,6 +1218,7 @@ mod tests {
         port: 5678,
         load_balancing_parameters: Some(LoadBalancingParams::default()),
         sticky_id: None,
+        backup: None,
       };
       command.write_message(&OrderMessage { id: String::from("ID_YOLO3"), order: Order::AddTcpFront(front) });
       command.write_message(&OrderMessage { id: String::from("ID_YOLO4"), order: Order::AddBackend(backend) });


### PR DESCRIPTION
This option allows to set a backend as a backup, which means it will be
used only when non-backup backends are all down.

The load balancing policies behave exactly like non-backup backends.

It's based on work done in #499 