### PR TITLE
rand::Rng::gen_ascii_chars is deprecated since rand v0.5

### DIFF
--- a/bin/src/logging.rs
+++ b/bin/src/logging.rs
@@ -6,6 +6,7 @@ use rand::{Rng,thread_rng};
 use mio_uds::UnixDatagram;
 use std::net::{TcpStream,UdpSocket,ToSocketAddrs};
 use sozu::logging::{Logger,LoggerBackend};
+use rand::distributions::Alphanumeric;
 
 pub fn setup(tag: String, level: &str, target: &str, access_target: Option<&str>) {
   let backend = target_to_backend(target);
@@ -53,7 +54,7 @@ pub fn target_to_backend(target: &str) -> LoggerBackend {
       LoggerBackend::Stdout(stdout())
     } else {
       let mut dir = env::temp_dir();
-      let s: String = thread_rng().gen_ascii_chars().take(12).collect();
+      let s: String = thread_rng().sample_iter(&Alphanumeric).take(12).collect();
       dir.push(s);
       let socket = UnixDatagram::bind(dir).unwrap();
       socket.connect(path).unwrap();

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -17,6 +17,7 @@ use rand::{thread_rng, Rng};
 use prettytable::Table;
 use prettytable::row::Row;
 use super::create_channel;
+use rand::distributions::Alphanumeric;
 
 
 // Used to display the JSON response of the status command
@@ -27,12 +28,12 @@ struct WorkerStatus<'a> {
 }
 
 fn generate_id() -> String {
-  let s: String = thread_rng().gen_ascii_chars().take(6).collect();
+  let s: String = thread_rng().sample_iter(&Alphanumeric).take(6).collect();
   format!("ID-{}", s)
 }
 
 fn generate_tagged_id(tag: &str) -> String {
-  let s: String = thread_rng().gen_ascii_chars().take(6).collect();
+  let s: String = thread_rng().sample_iter(&Alphanumeric).take(6).collect();
   format!("{}-{}", tag, s)
 }
 


### PR DESCRIPTION
Use rand::Rng::sample_iter()

Generated IDs for messages were all uppercase before this change, now it seems `sample_iter` returns lowercase. I don't know if uppercase was intentional or not.