### PR TITLE
Close the session when we get a front hup event in TCP

### DIFF
--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -173,10 +173,7 @@ impl Session {
 
     match self.protocol {
       Some(State::Pipe(ref mut pipe)) => pipe.front_hup(),
-      Some(State::SendProxyProtocol(_)) => {
-        SessionResult::CloseSession
-      },
-      _ => unreachable!(),
+      _ => SessionResult::CloseSession,
     }
   }
 


### PR DESCRIPTION
There are missing code in tcp.rs  [front_hup()](https://github.com/sozu-proxy/sozu/blob/c2da7aca253b6037a2103c5e21db55a11bcf8b23/lib/src/tcp.rs#L171) method. The client session can get a `hup` event with `expect|relay` proxy protocol config. Currently, we catch this with an `unreachable!` and that can generate a `panic` e.g.: #535 . We should return a `SessionResult::CloseSession` to properly close the client session.