### PR TITLE
Avoid decrementing backends_count and frontends_count when the value is zero

### DIFF
--- a/bin/src/command/orders.rs
+++ b/bin/src/command/orders.rs
@@ -659,14 +659,14 @@ impl CommandServer {
     );
 
     match order {
-      ProxyRequestData::AddBackend(_) => self.backends_count += 1,
-      ProxyRequestData::RemoveBackend(_) => self.backends_count -= 1,
-      ProxyRequestData::AddHttpFront(_) | ProxyRequestData::AddHttpsFront(_) | ProxyRequestData::AddTcpFront(_) => {
-        self.frontends_count += 1;
-      },
-      ProxyRequestData::RemoveHttpFront(_) | ProxyRequestData::RemoveHttpsFront(_) | ProxyRequestData::RemoveTcpFront(_) => {
-        self.frontends_count -= 1;
-      },
+      ProxyRequestData::AddBackend(_)
+      | ProxyRequestData::RemoveBackend(_) => self.backends_count = self.state.count_backends(),
+      ProxyRequestData::AddHttpFront(_)
+      | ProxyRequestData::AddHttpsFront(_)
+      | ProxyRequestData::AddTcpFront(_)
+      | ProxyRequestData::RemoveHttpFront(_)
+      | ProxyRequestData::RemoveHttpsFront(_)
+      | ProxyRequestData::RemoveTcpFront(_) => self.frontends_count = self.state.count_frontends(),
       _ => {}
     };
 

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -523,6 +523,26 @@ pub struct HttpAppConfig {
 }
 
 impl HttpAppConfig {
+  pub fn remove_backend(&mut self, address: &SocketAddr) {
+    if let Some(index) = self.backends.iter().position(|b| b.address == *address) {
+      self.backends.remove(index);
+    }
+  }
+
+  pub fn remove_frontend(&mut self, address: &SocketAddr) {
+    if let Some(index) = self.frontends.iter().position(|f| f.address == *address) {
+      self.frontends.remove(index);
+    }
+  }
+
+  pub fn contains_backend(&self, address: &SocketAddr) -> bool {
+    self.backends.iter().find(|b| b.address == *address).is_some()
+  }
+
+  pub fn contains_frontend(&self, address: &SocketAddr) -> bool {
+    self.frontends.iter().find(|f| f.address == *address).is_some()
+  }
+
   pub fn generate_orders(&self) -> Vec<ProxyRequestData> {
     let mut v = Vec::new();
 
@@ -578,6 +598,26 @@ pub struct TcpAppConfig {
 }
 
 impl TcpAppConfig {
+  pub fn remove_backend(&mut self, address: &SocketAddr) {
+    if let Some(index) = self.backends.iter().position(|b| b.address == *address) {
+      self.backends.remove(index);
+    }
+  }
+
+  pub fn remove_frontend(&mut self, address: &SocketAddr) {
+    if let Some(index) = self.frontends.iter().position(|f| f.address == *address) {
+      self.frontends.remove(index);
+    }
+  }
+
+  pub fn contains_backend(&self, address: &SocketAddr) -> bool {
+    self.backends.iter().find(|b| b.address == *address).is_some()
+  }
+
+  pub fn contains_frontend(&self, address: &SocketAddr) -> bool {
+    self.frontends.iter().find(|f| f.address == *address).is_some()
+  }
+
   pub fn generate_orders(&self) -> Vec<ProxyRequestData> {
     let mut v = Vec::new();
 
@@ -626,6 +666,34 @@ pub enum AppConfig {
 }
 
 impl AppConfig {
+  pub fn remove_backend(&mut self, address: &SocketAddr) {
+    match *self {
+      AppConfig::Http(ref mut http) => http.remove_backend(address),
+      AppConfig::Tcp(ref mut tcp)   => tcp.remove_backend(address),
+    }
+  }
+
+  pub fn remove_frontend(&mut self, address: &SocketAddr) {
+    match *self {
+      AppConfig::Http(ref mut http) => http.remove_frontend(address),
+      AppConfig::Tcp(ref mut tcp)   => tcp.remove_frontend(address),
+    }
+  }
+
+  pub fn contains_backend(&self, address: &SocketAddr) -> bool {
+    match *self {
+      AppConfig::Http(ref http) => http.contains_backend(address),
+      AppConfig::Tcp(ref tcp)   => tcp.contains_backend(address),
+    }
+  }
+
+  pub fn contains_frontend(&self, address: &SocketAddr) -> bool {
+    match *self {
+      AppConfig::Http(ref http) => http.contains_frontend(address),
+      AppConfig::Tcp(ref tcp)   => tcp.contains_frontend(address),
+    }
+  }
+
   pub fn generate_orders(&self) -> Vec<ProxyRequestData> {
     match *self {
       AppConfig::Http(ref http) => http.generate_orders(),

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -523,26 +523,6 @@ pub struct HttpAppConfig {
 }
 
 impl HttpAppConfig {
-  pub fn remove_backend(&mut self, address: &SocketAddr) {
-    if let Some(index) = self.backends.iter().position(|b| b.address == *address) {
-      self.backends.remove(index);
-    }
-  }
-
-  pub fn remove_frontend(&mut self, address: &SocketAddr) {
-    if let Some(index) = self.frontends.iter().position(|f| f.address == *address) {
-      self.frontends.remove(index);
-    }
-  }
-
-  pub fn contains_backend(&self, address: &SocketAddr) -> bool {
-    self.backends.iter().find(|b| b.address == *address).is_some()
-  }
-
-  pub fn contains_frontend(&self, address: &SocketAddr) -> bool {
-    self.frontends.iter().find(|f| f.address == *address).is_some()
-  }
-
   pub fn generate_orders(&self) -> Vec<ProxyRequestData> {
     let mut v = Vec::new();
 
@@ -598,26 +578,6 @@ pub struct TcpAppConfig {
 }
 
 impl TcpAppConfig {
-  pub fn remove_backend(&mut self, address: &SocketAddr) {
-    if let Some(index) = self.backends.iter().position(|b| b.address == *address) {
-      self.backends.remove(index);
-    }
-  }
-
-  pub fn remove_frontend(&mut self, address: &SocketAddr) {
-    if let Some(index) = self.frontends.iter().position(|f| f.address == *address) {
-      self.frontends.remove(index);
-    }
-  }
-
-  pub fn contains_backend(&self, address: &SocketAddr) -> bool {
-    self.backends.iter().find(|b| b.address == *address).is_some()
-  }
-
-  pub fn contains_frontend(&self, address: &SocketAddr) -> bool {
-    self.frontends.iter().find(|f| f.address == *address).is_some()
-  }
-
   pub fn generate_orders(&self) -> Vec<ProxyRequestData> {
     let mut v = Vec::new();
 
@@ -666,34 +626,6 @@ pub enum AppConfig {
 }
 
 impl AppConfig {
-  pub fn remove_backend(&mut self, address: &SocketAddr) {
-    match *self {
-      AppConfig::Http(ref mut http) => http.remove_backend(address),
-      AppConfig::Tcp(ref mut tcp)   => tcp.remove_backend(address),
-    }
-  }
-
-  pub fn remove_frontend(&mut self, address: &SocketAddr) {
-    match *self {
-      AppConfig::Http(ref mut http) => http.remove_frontend(address),
-      AppConfig::Tcp(ref mut tcp)   => tcp.remove_frontend(address),
-    }
-  }
-
-  pub fn contains_backend(&self, address: &SocketAddr) -> bool {
-    match *self {
-      AppConfig::Http(ref http) => http.contains_backend(address),
-      AppConfig::Tcp(ref tcp)   => tcp.contains_backend(address),
-    }
-  }
-
-  pub fn contains_frontend(&self, address: &SocketAddr) -> bool {
-    match *self {
-      AppConfig::Http(ref http) => http.contains_frontend(address),
-      AppConfig::Tcp(ref tcp)   => tcp.contains_frontend(address),
-    }
-  }
-
   pub fn generate_orders(&self) -> Vec<ProxyRequestData> {
     match *self {
       AppConfig::Http(ref http) => http.generate_orders(),


### PR DESCRIPTION
When we remove the last backend or frontend with `sozuctl` e.g.:
`./target/debug/sozuctl -c bin/config.toml backend remove --address <Ipaddress> --id <appId> --backend-id <backend-id>`
The counter `backends|frontends` is decremented and that can panic when the value is zero because the counter type is `usize`.

This PR add a guard to avoid decrementing the counter when the value is zero.
This will fix #539 .