### PR TITLE
Fix sticky session cookie not being set and remove duplicate code

### DIFF
--- a/lib/src/protocol/http/mod.rs
+++ b/lib/src/protocol/http/mod.rs
@@ -1069,7 +1069,7 @@ impl<Front:SocketHandler> Http<Front> {
                 .and_then(|request| request.get_keep_alive())
                 .and_then(|conn| conn.sticky_session)
                 .map(|sticky_client| sticky_client != session.sticky_id)
-                .unwrap_or(false) {
+                .unwrap_or(true) {
                   Some(session)
                 } else {
                   None
@@ -1111,7 +1111,7 @@ impl<Front:SocketHandler> Http<Front> {
               .and_then(|request| request.get_keep_alive())
               .and_then(|conn| conn.sticky_session)
               .map(|sticky_client| sticky_client != session.sticky_id)
-              .unwrap_or(false) {
+              .unwrap_or(true) {
                 Some(session)
               } else {
                 None


### PR DESCRIPTION
This PR does two things:
- fixes #558 
- remove duplicate code and explain what the new function does because it's not very clear when reading the code