### PR TITLE
This is most likely a typo

### DIFF
--- a/os-build/docker/config.toml
+++ b/os-build/docker/config.toml
@@ -163,4 +163,4 @@ tls_versions = ["TLSv1.2", "TLSv1.3"]
 # static configuration for applications
 #
 # those applications will be routed by sozu directly from start
-applications]
+[applications]


### PR DESCRIPTION
`s/^applications\]/[applictions]/`

It's been like this since August '18, so I am not totally sure whether anyone runs sozu-container built from the `Dockerfile` in this repo, though...