### PR TITLE
TrieNode::domain_lookup_recursive: fix wildcard detection if multiple subdomains remain

### DIFF
--- a/lib/src/trie.rs
+++ b/lib/src/trie.rs
@@ -261,9 +261,7 @@ impl<V:Debug> TrieNode<V> {
         Some(0) => {
           if child_key[0] == '*' as u8 {
             let c = '.' as u8;
-            if partial_key.contains(&c) {
-              return None;
-            } else {
+            if !partial_key.contains(&c) {
               wildcard_res = self.children[index].key_value.as_ref();
             }
           }
@@ -272,9 +270,7 @@ impl<V:Debug> TrieNode<V> {
           // check for wildcard
           if i+1 == child_key.len() && child_key[i] == '*' as u8 {
             let c = '.' as u8;
-            if (&partial_key[i..]).contains(&c) {
-              return None;
-            } else {
+            if !(&partial_key[i..]).contains(&c) {
               wildcard_res = self.children[index].key_value.as_ref();
             }
           }


### PR DESCRIPTION
Given those certificates:
*.example.com
*.test.example.com

*.example.com would apply to 1.test.example.com and then incorrectly
return `None` even though there are still 1.test to parse. Keep trying
all child keys instead.