### PR TITLE
Add / remove / activate / deactivate TCP / HTTP / HTTPS listeners

### DIFF
--- a/command/src/proxy.rs
+++ b/command/src/proxy.rs
@@ -1,13 +1,13 @@
 use serde;
 use serde::de::{self, Visitor};
 use hex::{self,FromHex};
-use std::fmt;
+use std::{error,fmt};
 use std::cmp::Ordering;
 use std::convert::From;
 use std::default::Default;
 use std::net::SocketAddr;
 use std::collections::{BTreeMap,HashSet};
-
+use std::str::FromStr;
 
 use config::{ProxyProtocolConfig, LoadBalancingAlgorithms};
 
@@ -445,6 +445,41 @@ pub enum TlsVersion {
   TLSv1_2,
   #[serde(rename = "TLSv1.3")]
   TLSv1_3,
+}
+
+impl FromStr for TlsVersion {
+  type Err = ParseErrorTlsVersion;
+
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    match s {
+      "SSLv2"   => Ok(TlsVersion::SSLv2),
+      "SSLv3"   => Ok(TlsVersion::SSLv3),
+      "TLSv1"   => Ok(TlsVersion::TLSv1_0),
+      "TLSv1.1" => Ok(TlsVersion::TLSv1_1),
+      "TLSv1.2" => Ok(TlsVersion::TLSv1_2),
+      "TLSv1.3" => Ok(TlsVersion::TLSv1_3),
+      _ => Err(ParseErrorTlsVersion{})
+    }
+  }
+}
+
+#[derive(Debug)]
+pub struct ParseErrorTlsVersion;
+
+impl fmt::Display for ParseErrorTlsVersion {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(f, "Cannot find the TLS version")
+  }
+}
+
+impl error::Error for ParseErrorTlsVersion {
+  fn description(&self) -> &str {
+    "Cannot find the TLS version"
+  }
+
+  fn cause(&self) -> Option<&error::Error> {
+    None
+  }
 }
 
 #[derive(Debug,Clone,PartialEq,Eq,Hash, Serialize, Deserialize)]

--- a/ctl/src/cli.rs
+++ b/ctl/src/cli.rs
@@ -1,4 +1,5 @@
 use sozu_command::config::LoadBalancingAlgorithms;
+use sozu_command::proxy::TlsVersion;
 use std::net::SocketAddr;
 
 #[derive(StructOpt, PartialEq, Debug)]
@@ -59,6 +60,11 @@ pub enum SubCmd {
   Frontend {
     #[structopt(subcommand)]
     cmd: FrontendCmd,
+  },
+  #[structopt(name  = "listener", about = "listener management")]
+  Listener {
+    #[structopt(subcommand)]
+    cmd: ListenerCmd
   },
   #[structopt(name = "certificate", about = "certificate management")]
   Certificate {
@@ -211,6 +217,82 @@ pub enum TcpFrontendCmd {
     #[structopt(short = "a", long = "address", help = "frontend address, format: IP:port")]
     address: SocketAddr,
   },
+}
+
+#[derive(StructOpt, PartialEq, Debug)]
+pub enum ListenerCmd {
+  #[structopt(name = "http", about = "HTTP listener management")]
+  Http {
+    #[structopt(subcommand)]
+    cmd: HttpListenerCmd,
+  },
+  #[structopt(name = "https", about = "HTTPS listener management")]
+  Https {
+    #[structopt(subcommand)]
+    cmd: HttpsListenerCmd,
+  },
+  #[structopt(name = "tcp", about = "TCP listener management")]
+  Tcp {
+    #[structopt(subcommand)]
+    cmd: TcpListenerCmd,
+  },
+}
+
+#[derive(StructOpt, PartialEq, Debug)]
+pub enum HttpListenerCmd {
+  #[structopt(name = "add")]
+  Add {
+    #[structopt(short = "a")]
+    address: SocketAddr,
+    #[structopt(long = "public-address", help = "a different IP than the one the socket sees, for logs and forwarded headers")]
+    public_address: Option<SocketAddr>,
+    #[structopt(long = "answer-404", help = "path to file of the 404 answer sent to the client when a frontend is not found")]
+    answer_404: Option<String>,
+    #[structopt(long = "answer-503", help = "path to file of the 503 answer sent to the client when an application has no backends available")]
+    answer_503: Option<String>,
+    #[structopt(long = "expect-proxy", help = "Configures the client socket to receive a PROXY protocol header")]
+    expect_proxy: bool,
+    #[structopt(long = "sticky-name", help = "sticky session cookie name")]
+    sticky_name: Option<String>
+  }
+}
+
+#[derive(StructOpt, PartialEq, Debug)]
+pub enum HttpsListenerCmd {
+  #[structopt(name = "add")]
+  Add {
+    #[structopt(short = "a")]
+    address: SocketAddr,
+    #[structopt(long = "public-address", help = "a different IP than the one the socket sees, for logs and forwarded headers")]
+    public_address: Option<SocketAddr>,
+    #[structopt(long = "answer-404", help = "path to file of the 404 answer sent to the client when a frontend is not found")]
+    answer_404: Option<String>,
+    #[structopt(long = "answer-503", help = "path to file of the 503 answer sent to the client when an application has no backends available")]
+    answer_503: Option<String>,
+    #[structopt(long = "tls-versions", help = "list of TLS versions to use")]
+    tls_versions: Vec<TlsVersion>,
+    #[structopt(long = "tls-ciphers-list", help = "list of OpenSSL TLS ciphers to use")]
+    cipher_list: Option<String>,
+    #[structopt(long = "rustls-cipher-list", help = "list of RustTLS ciphers to use")]
+    rustls_cipher_list: Vec<String>,
+    #[structopt(long = "expect-proxy", help = "Configures the client socket to receive a PROXY protocol header")]
+    expect_proxy: bool,
+    #[structopt(long = "sticky-name", help = "sticky session cookie name")]
+    sticky_name: Option<String>
+  }
+}
+
+#[derive(StructOpt, PartialEq, Debug)]
+pub enum TcpListenerCmd {
+  #[structopt(name = "add")]
+  Add {
+    #[structopt(short = "a", long = "address", help = "listener address, format: IP:port")]
+    address: SocketAddr,
+    #[structopt(long = "public-address", help = "a different IP than the one the socket sees, for logs and forwarded headers")]
+    public_address: Option<SocketAddr>,
+    #[structopt(long = "expect-proxy", help = "Configures the client socket to receive a PROXY protocol header")]
+    expect_proxy: bool
+  }
 }
 
 #[derive(StructOpt, PartialEq, Debug)]

--- a/ctl/src/cli.rs
+++ b/ctl/src/cli.rs
@@ -264,6 +264,11 @@ pub enum HttpListenerCmd {
   Activate {
     #[structopt(short = "a", long = "address", help = "listener address, format: IP:port")]
     address: SocketAddr
+  },
+  #[structopt(name = "deactivate")]
+  Deactivate {
+    #[structopt(short = "a", long = "address", help = "listener address, format: IP:port")]
+    address: SocketAddr
   }
 }
 
@@ -299,6 +304,11 @@ pub enum HttpsListenerCmd {
   Activate {
     #[structopt(short = "a", long = "address", help = "listener address, format: IP:port")]
     address: SocketAddr
+  },
+  #[structopt(name = "deactivate")]
+  Deactivate {
+    #[structopt(short = "a", long = "address", help = "listener address, format: IP:port")]
+    address: SocketAddr
   }
 }
 
@@ -320,6 +330,11 @@ pub enum TcpListenerCmd {
   },
   #[structopt(name = "activate")]
   Activate {
+    #[structopt(short = "a", long = "address", help = "listener address, format: IP:port")]
+    address: SocketAddr
+  },
+  #[structopt(name = "deactivate")]
+  Deactivate {
     #[structopt(short = "a", long = "address", help = "listener address, format: IP:port")]
     address: SocketAddr
   }

--- a/ctl/src/cli.rs
+++ b/ctl/src/cli.rs
@@ -259,6 +259,11 @@ pub enum HttpListenerCmd {
   Remove {
     #[structopt(short = "a", long = "address", help = "listener address, format: IP:port")]
     address: SocketAddr,
+  },
+  #[structopt(name = "activate")]
+  Activate {
+    #[structopt(short = "a", long = "address", help = "listener address, format: IP:port")]
+    address: SocketAddr
   }
 }
 
@@ -289,6 +294,11 @@ pub enum HttpsListenerCmd {
   Remove {
     #[structopt(short = "a", long = "address", help = "listener address, format: IP:port")]
     address: SocketAddr,
+  },
+  #[structopt(name = "activate")]
+  Activate {
+    #[structopt(short = "a", long = "address", help = "listener address, format: IP:port")]
+    address: SocketAddr
   }
 }
 
@@ -307,6 +317,11 @@ pub enum TcpListenerCmd {
   Remove {
     #[structopt(short = "a", long = "address", help = "listener address, format: IP:port")]
     address: SocketAddr,
+  },
+  #[structopt(name = "activate")]
+  Activate {
+    #[structopt(short = "a", long = "address", help = "listener address, format: IP:port")]
+    address: SocketAddr
   }
 }
 

--- a/ctl/src/cli.rs
+++ b/ctl/src/cli.rs
@@ -254,6 +254,11 @@ pub enum HttpListenerCmd {
     expect_proxy: bool,
     #[structopt(long = "sticky-name", help = "sticky session cookie name")]
     sticky_name: Option<String>
+  },
+  #[structopt(name = "remove")]
+  Remove {
+    #[structopt(short = "a", long = "address", help = "listener address, format: IP:port")]
+    address: SocketAddr,
   }
 }
 
@@ -279,6 +284,11 @@ pub enum HttpsListenerCmd {
     expect_proxy: bool,
     #[structopt(long = "sticky-name", help = "sticky session cookie name")]
     sticky_name: Option<String>
+  },
+  #[structopt(name = "remove")]
+  Remove {
+    #[structopt(short = "a", long = "address", help = "listener address, format: IP:port")]
+    address: SocketAddr,
   }
 }
 
@@ -292,6 +302,11 @@ pub enum TcpListenerCmd {
     public_address: Option<SocketAddr>,
     #[structopt(long = "expect-proxy", help = "Configures the client socket to receive a PROXY protocol header")]
     expect_proxy: bool
+  },
+  #[structopt(name = "remove")]
+  Remove {
+    #[structopt(short = "a", long = "address", help = "listener address, format: IP:port")]
+    address: SocketAddr,
   }
 }
 

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -1,10 +1,11 @@
-use sozu_command::config::{Config, ProxyProtocolConfig, LoadBalancingAlgorithms};
+use sozu_command::config::{Config, ProxyProtocolConfig, LoadBalancingAlgorithms, Listener, FileListenerProtocolConfig};
 use sozu_command::channel::Channel;
 use sozu_command::certificate::{calculate_fingerprint,split_certificate_chain};
 use sozu_command::command::{CommandResponseData,CommandRequestData,CommandRequest,CommandResponse,CommandStatus,RunState,WorkerInfo};
 use sozu_command::proxy::{Application, ProxyRequestData, Backend, HttpFront, TcpFront,
   CertificateAndKey, CertFingerprint, Query, QueryAnswer, QueryApplicationType, QueryApplicationDomain,
-  AddCertificate, RemoveCertificate, ReplaceCertificate, LoadBalancingParams, RemoveBackend};
+  AddCertificate, RemoveCertificate, ReplaceCertificate, LoadBalancingParams, RemoveBackend, TcpListener, ListenerType,
+  TlsVersion};
 
 use serde_json;
 use std::collections::{HashMap,HashSet,BTreeMap};
@@ -875,6 +876,53 @@ pub fn remove_tcp_frontend(channel: Channel<CommandRequest,CommandResponse>, tim
   order_command(channel, timeout, ProxyRequestData::RemoveTcpFront(TcpFront {
     app_id: String::from(app_id),
     address,
+  }));
+}
+
+pub fn add_http_listener(channel: Channel<CommandRequest,CommandResponse>, timeout: u64, address: SocketAddr, public_address: Option<SocketAddr>,
+  answer_404: Option<String>, answer_503: Option<String>, expect_proxy: bool, sticky_name: Option<String>) {
+  let mut listener = Listener::new(address, FileListenerProtocolConfig::Http);
+  listener.public_address = public_address;
+  listener.answer_404 = answer_404;
+  listener.answer_503 = answer_503;
+  listener.expect_proxy = Some(expect_proxy);
+  if let Some(sticky_name) = sticky_name {
+    listener.sticky_name = sticky_name;
+  }
+
+  match listener.to_http() {
+    Some(conf) => order_command(channel, timeout, ProxyRequestData::AddHttpListener(conf)),
+    None => eprintln!("Error creating HTTP listener")
+  };
+}
+
+pub fn add_https_listener(channel: Channel<CommandRequest,CommandResponse>, timeout: u64, address: SocketAddr, public_address: Option<SocketAddr>,
+  answer_404: Option<String>, answer_503: Option<String>, tls_versions: Vec<TlsVersion>, cipher_list: Option<String>,
+  rustls_cipher_list: Vec<String>, expect_proxy: bool, sticky_name: Option<String>) {
+  let mut listener = Listener::new(address, FileListenerProtocolConfig::Https);
+  listener.public_address = public_address;
+  listener.answer_404 = answer_404;
+  listener.answer_503 = answer_503;
+  listener.expect_proxy = Some(expect_proxy);
+  if let Some(sticky_name) = sticky_name {
+    listener.sticky_name = sticky_name;
+  }
+  listener.cipher_list = cipher_list;
+  listener.tls_versions = if tls_versions.len() == 0 { None } else { Some(tls_versions) };
+  listener.rustls_cipher_list = if rustls_cipher_list.len() == 0 { None } else { Some(rustls_cipher_list) };
+
+  match listener.to_tls() {
+    Some(conf) => order_command(channel, timeout, ProxyRequestData::AddHttpsListener(conf)),
+    None => eprintln!("Error creating HTTPS listener")
+  };
+}
+
+pub fn add_tcp_listener(channel: Channel<CommandRequest,CommandResponse>, timeout: u64, address: SocketAddr,
+  public_address: Option<SocketAddr>, expect_proxy: bool) {
+  order_command(channel, timeout, ProxyRequestData::AddTcpListener(TcpListener {
+    front: address,
+    public_address,
+    expect_proxy
   }));
 }
 

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -5,7 +5,7 @@ use sozu_command::command::{CommandResponseData,CommandRequestData,CommandReques
 use sozu_command::proxy::{Application, ProxyRequestData, Backend, HttpFront, TcpFront,
   CertificateAndKey, CertFingerprint, Query, QueryAnswer, QueryApplicationType, QueryApplicationDomain,
   AddCertificate, RemoveCertificate, ReplaceCertificate, LoadBalancingParams, RemoveBackend, TcpListener, ListenerType,
-  TlsVersion, RemoveListener};
+  TlsVersion, RemoveListener, ActivateListener};
 
 use serde_json;
 use std::collections::{HashMap,HashSet,BTreeMap};
@@ -930,6 +930,14 @@ pub fn remove_listener(channel: Channel<CommandRequest,CommandResponse>, timeout
   order_command(channel, timeout, ProxyRequestData::RemoveListener(RemoveListener {
     front: address,
     proxy
+  }));
+}
+
+pub fn activate_listener(channel: Channel<CommandRequest,CommandResponse>, timeout: u64, address: SocketAddr, proxy: ListenerType) {
+  order_command(channel, timeout, ProxyRequestData::ActivateListener(ActivateListener {
+    front: address,
+    proxy,
+    from_scm: false
   }));
 }
 

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -5,7 +5,7 @@ use sozu_command::command::{CommandResponseData,CommandRequestData,CommandReques
 use sozu_command::proxy::{Application, ProxyRequestData, Backend, HttpFront, TcpFront,
   CertificateAndKey, CertFingerprint, Query, QueryAnswer, QueryApplicationType, QueryApplicationDomain,
   AddCertificate, RemoveCertificate, ReplaceCertificate, LoadBalancingParams, RemoveBackend, TcpListener, ListenerType,
-  TlsVersion};
+  TlsVersion, RemoveListener};
 
 use serde_json;
 use std::collections::{HashMap,HashSet,BTreeMap};
@@ -923,6 +923,13 @@ pub fn add_tcp_listener(channel: Channel<CommandRequest,CommandResponse>, timeou
     front: address,
     public_address,
     expect_proxy
+  }));
+}
+
+pub fn remove_listener(channel: Channel<CommandRequest,CommandResponse>, timeout: u64, address: SocketAddr, proxy: ListenerType) {
+  order_command(channel, timeout, ProxyRequestData::RemoveListener(RemoveListener {
+    front: address,
+    proxy
   }));
 }
 

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -5,7 +5,7 @@ use sozu_command::command::{CommandResponseData,CommandRequestData,CommandReques
 use sozu_command::proxy::{Application, ProxyRequestData, Backend, HttpFront, TcpFront,
   CertificateAndKey, CertFingerprint, Query, QueryAnswer, QueryApplicationType, QueryApplicationDomain,
   AddCertificate, RemoveCertificate, ReplaceCertificate, LoadBalancingParams, RemoveBackend, TcpListener, ListenerType,
-  TlsVersion, RemoveListener, ActivateListener};
+  TlsVersion, RemoveListener, ActivateListener, DeactivateListener};
 
 use serde_json;
 use std::collections::{HashMap,HashSet,BTreeMap};
@@ -938,6 +938,14 @@ pub fn activate_listener(channel: Channel<CommandRequest,CommandResponse>, timeo
     front: address,
     proxy,
     from_scm: false
+  }));
+}
+
+pub fn deactivate_listener(channel: Channel<CommandRequest,CommandResponse>, timeout: u64, address: SocketAddr, proxy: ListenerType) {
+  order_command(channel, timeout, ProxyRequestData::DeactivateListener(DeactivateListener {
+    front: address,
+    proxy,
+    to_scm: false
   }));
 }
 

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -24,7 +24,7 @@ use command::{add_application,remove_application,dump_state,load_state,
   remove_tcp_frontend, add_tcp_frontend, add_certificate, remove_certificate,
   replace_certificate, query_application, logging_filter, upgrade_worker,
   events, add_tcp_listener, add_http_listener, add_https_listener,
-  remove_listener, activate_listener};
+  remove_listener, activate_listener, deactivate_listener};
 
 use cli::*;
 
@@ -110,6 +110,7 @@ fn main() {
           },
           HttpListenerCmd::Remove { address } => remove_listener(channel, timeout, address, ListenerType::HTTP),
           HttpListenerCmd::Activate{ address } => activate_listener(channel, timeout, address, ListenerType::HTTP),
+          HttpListenerCmd::Deactivate{ address } => deactivate_listener(channel, timeout, address, ListenerType::HTTP)
         },
         ListenerCmd::Https { cmd } => match cmd {
           HttpsListenerCmd::Add { address, public_address, answer_404, answer_503, tls_versions, cipher_list,
@@ -118,11 +119,13 @@ fn main() {
           },
           HttpsListenerCmd::Remove { address } => remove_listener(channel, timeout, address, ListenerType::HTTPS),
           HttpsListenerCmd::Activate{ address } => activate_listener(channel, timeout, address, ListenerType::HTTPS),
+          HttpsListenerCmd::Deactivate{ address } => deactivate_listener(channel, timeout, address, ListenerType::HTTPS),
         },
         ListenerCmd::Tcp { cmd } => match cmd {
           TcpListenerCmd::Add{ address, public_address, expect_proxy } => add_tcp_listener(channel, timeout, address, public_address, expect_proxy),
           TcpListenerCmd::Remove{ address } => remove_listener(channel, timeout, address, ListenerType::TCP),
-          TcpListenerCmd::Activate{ address } => activate_listener(channel, timeout, address, ListenerType::TCP)
+          TcpListenerCmd::Activate{ address } => activate_listener(channel, timeout, address, ListenerType::TCP),
+          TcpListenerCmd::Deactivate{ address } => deactivate_listener(channel, timeout, address, ListenerType::TCP)
         }
       }
     }

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -16,13 +16,15 @@ use structopt::StructOpt;
 use sozu_command::config::Config;
 use sozu_command::channel::Channel;
 use sozu_command::command::{CommandRequest,CommandResponse};
+use sozu_command::proxy::ListenerType;
 
 use command::{add_application,remove_application,dump_state,load_state,
   save_state, soft_stop, hard_stop, upgrade_master, status,metrics,
   remove_backend, add_backend, remove_http_frontend, add_http_frontend,
   remove_tcp_frontend, add_tcp_frontend, add_certificate, remove_certificate,
   replace_certificate, query_application, logging_filter, upgrade_worker,
-  events, add_tcp_listener, add_http_listener, add_https_listener};
+  events, add_tcp_listener, add_http_listener, add_https_listener,
+  remove_listener};
 
 use cli::*;
 
@@ -106,15 +108,18 @@ fn main() {
           HttpListenerCmd::Add { address, public_address, answer_404, answer_503, expect_proxy, sticky_name } => {
             add_http_listener(channel, timeout, address, public_address, answer_404, answer_503, expect_proxy, sticky_name)
           },
+          HttpListenerCmd::Remove { address } => remove_listener(channel, timeout, address, ListenerType::HTTP),
         },
         ListenerCmd::Https { cmd } => match cmd {
           HttpsListenerCmd::Add { address, public_address, answer_404, answer_503, tls_versions, cipher_list,
             rustls_cipher_list, expect_proxy, sticky_name } => {
             add_https_listener(channel, timeout, address, public_address, answer_404, answer_503, tls_versions, cipher_list, rustls_cipher_list, expect_proxy, sticky_name)
-          }
+          },
+          HttpsListenerCmd::Remove { address } => remove_listener(channel, timeout, address, ListenerType::HTTPS),
         },
         ListenerCmd::Tcp { cmd } => match cmd {
-          TcpListenerCmd::Add{ address, public_address, expect_proxy } => add_tcp_listener(channel, timeout, address, public_address, expect_proxy)
+          TcpListenerCmd::Add{ address, public_address, expect_proxy } => add_tcp_listener(channel, timeout, address, public_address, expect_proxy),
+          TcpListenerCmd::Remove{ address } => remove_listener(channel, timeout, address, ListenerType::TCP)
         }
       }
     }

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -24,7 +24,7 @@ use command::{add_application,remove_application,dump_state,load_state,
   remove_tcp_frontend, add_tcp_frontend, add_certificate, remove_certificate,
   replace_certificate, query_application, logging_filter, upgrade_worker,
   events, add_tcp_listener, add_http_listener, add_https_listener,
-  remove_listener};
+  remove_listener, activate_listener};
 
 use cli::*;
 
@@ -109,6 +109,7 @@ fn main() {
             add_http_listener(channel, timeout, address, public_address, answer_404, answer_503, expect_proxy, sticky_name)
           },
           HttpListenerCmd::Remove { address } => remove_listener(channel, timeout, address, ListenerType::HTTP),
+          HttpListenerCmd::Activate{ address } => activate_listener(channel, timeout, address, ListenerType::HTTP),
         },
         ListenerCmd::Https { cmd } => match cmd {
           HttpsListenerCmd::Add { address, public_address, answer_404, answer_503, tls_versions, cipher_list,
@@ -116,10 +117,12 @@ fn main() {
             add_https_listener(channel, timeout, address, public_address, answer_404, answer_503, tls_versions, cipher_list, rustls_cipher_list, expect_proxy, sticky_name)
           },
           HttpsListenerCmd::Remove { address } => remove_listener(channel, timeout, address, ListenerType::HTTPS),
+          HttpsListenerCmd::Activate{ address } => activate_listener(channel, timeout, address, ListenerType::HTTPS),
         },
         ListenerCmd::Tcp { cmd } => match cmd {
           TcpListenerCmd::Add{ address, public_address, expect_proxy } => add_tcp_listener(channel, timeout, address, public_address, expect_proxy),
-          TcpListenerCmd::Remove{ address } => remove_listener(channel, timeout, address, ListenerType::TCP)
+          TcpListenerCmd::Remove{ address } => remove_listener(channel, timeout, address, ListenerType::TCP),
+          TcpListenerCmd::Activate{ address } => activate_listener(channel, timeout, address, ListenerType::TCP)
         }
       }
     }

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -22,7 +22,7 @@ use command::{add_application,remove_application,dump_state,load_state,
   remove_backend, add_backend, remove_http_frontend, add_http_frontend,
   remove_tcp_frontend, add_tcp_frontend, add_certificate, remove_certificate,
   replace_certificate, query_application, logging_filter, upgrade_worker,
-  events};
+  events, add_tcp_listener, add_http_listener, add_https_listener};
 
 use cli::*;
 
@@ -100,6 +100,24 @@ fn main() {
         }
       }
     },
+    SubCmd::Listener{ cmd } => {
+      match cmd {
+        ListenerCmd::Http { cmd } => match cmd {
+          HttpListenerCmd::Add { address, public_address, answer_404, answer_503, expect_proxy, sticky_name } => {
+            add_http_listener(channel, timeout, address, public_address, answer_404, answer_503, expect_proxy, sticky_name)
+          },
+        },
+        ListenerCmd::Https { cmd } => match cmd {
+          HttpsListenerCmd::Add { address, public_address, answer_404, answer_503, tls_versions, cipher_list,
+            rustls_cipher_list, expect_proxy, sticky_name } => {
+            add_https_listener(channel, timeout, address, public_address, answer_404, answer_503, tls_versions, cipher_list, rustls_cipher_list, expect_proxy, sticky_name)
+          }
+        },
+        ListenerCmd::Tcp { cmd } => match cmd {
+          TcpListenerCmd::Add{ address, public_address, expect_proxy } => add_tcp_listener(channel, timeout, address, public_address, expect_proxy)
+        }
+      }
+    }
     SubCmd::Certificate{ cmd } => {
       match cmd {
         CertificateCmd::Add{ certificate, chain, key, address } => {

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -30,7 +30,7 @@ use super::protocol::http::DefaultAnswerStatus;
 use super::protocol::proxy_protocol::expect::ExpectProxyProtocol;
 use super::server::{Server,ProxyChannel,ListenToken,ListenPortState,SessionToken,
   ListenSession, CONN_RETRIES, push_event};
-use super::socket::server_bind;
+use super::socket::{server_bind,server_unbind};
 use super::retry::RetryPolicy;
 use super::protocol::http::parser::{hostname_and_port, RequestState};
 use super::trie::TrieNode;
@@ -725,6 +725,15 @@ impl Proxy {
     None
   }
 
+  pub fn deactivate_listener(&mut self, event_loop: &mut Poll, addr: &SocketAddr) -> Option<TcpListener> {
+    for listener in self.listeners.values_mut() {
+      if &listener.address == addr {
+        return listener.deactivate(event_loop);
+      }
+    }
+    None
+  }
+
   pub fn give_back_listeners(&mut self) -> Vec<(SocketAddr, TcpListener)> {
     self.listeners.values_mut().filter(|l| l.listener.is_some()).map(|l| {
       (l.address, l.listener.take().unwrap())
@@ -902,6 +911,27 @@ impl Listener {
     self.listener = listener;
     self.active = true;
     Some(self.token)
+  }
+
+  pub fn deactivate(&mut self, event_loop: &mut Poll) -> Option<TcpListener> {
+    if !self.active {
+      return None;
+    }
+
+    if let Some(listener) = self.listener.take() {
+      if let Err(e) = event_loop.deregister(&listener) {
+        error!("error deregistering socket({:?}: {:?})", listener, e);
+        self.listener = Some(listener);
+        return None;
+      } else {
+        if let Err(e) = server_unbind(&listener) {
+          error!("Failed to unbind socket {:?} with error {:?}", listener, e);
+        }
+        self.active = false;
+        return Some(listener);
+      }
+    }
+    return None;
   }
 
   pub fn add_http_front(&mut self, mut http_front: HttpFront) -> Result<(), String> {

--- a/lib/src/https_openssl.rs
+++ b/lib/src/https_openssl.rs
@@ -41,7 +41,7 @@ use backends::BackendMap;
 use server::{Server,ProxyChannel,ListenToken,ListenPortState,SessionToken,
   ListenSession, CONN_RETRIES, push_event};
 use http::{DefaultAnswers, CustomAnswers};
-use socket::server_bind;
+use socket::{server_bind,server_unbind};
 use trie::*;
 use protocol::{ProtocolResult,Http,Pipe,StickySession};
 use protocol::openssl::TlsHandshake;
@@ -836,6 +836,27 @@ impl Listener {
     Some(self.token)
   }
 
+  pub fn deactivate(&mut self, event_loop: &mut Poll) -> Option<TcpListener> {
+    if !self.active {
+      return None;
+    }
+
+    if let Some(listener) = self.listener.take() {
+      if let Err(e) = event_loop.deregister(&listener) {
+        error!("error deregistering socket({:?}: {:?})", listener, e);
+        self.listener = Some(listener);
+        return None;
+      } else {
+        if let Err(e) = server_unbind(&listener) {
+          error!("Failed to unbind socket {:?} with error {:?}", listener, e);
+        }
+        self.active = false;
+        return Some(listener);
+      }
+    }
+    return None;
+  }
+
   pub fn create_default_context(config: &HttpsListener, ref_ctx: Arc<Mutex<HashMap<CertFingerprint,TlsData>>>,
     ref_domains: Arc<Mutex<TrieNode<CertFingerprint>>>) -> Option<(SslContext, SslOptions)> {
     let ctx = SslContext::builder(SslMethod::tls());
@@ -1172,6 +1193,15 @@ impl Proxy {
     for listener in self.listeners.values_mut() {
       if &listener.address == addr {
         return listener.activate(event_loop, tcp_listener);
+      }
+    }
+    None
+  }
+
+  pub fn deactivate_listener(&mut self, event_loop: &mut Poll, addr: &SocketAddr) -> Option<TcpListener> {
+    for listener in self.listeners.values_mut() {
+      if &listener.address == addr {
+        return listener.deactivate(event_loop);
       }
     }
     None

--- a/lib/src/socket.rs
+++ b/lib/src/socket.rs
@@ -1,5 +1,6 @@
 use std::io::{self,ErrorKind,Read,Write};
 use std::net::SocketAddr;
+use std::os::unix::io::AsRawFd;
 use mio::tcp::{TcpListener,TcpStream};
 use rustls::{ServerSession, Session};
 use net2::TcpBuilder;
@@ -327,3 +328,10 @@ pub fn server_bind(addr: &SocketAddr) -> io::Result<TcpListener> {
   TcpListener::from_std(listener)
 }
 
+
+pub fn server_unbind(listener: &TcpListener) -> io::Result<()> {
+  match unsafe { libc::close(listener.as_raw_fd()) } {
+    0 => Ok(()),
+    _ => Err(io::Error::last_os_error())
+  }
+}

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -16,7 +16,7 @@ use mio_extras::timer::{Timer,Timeout};
 
 use sozu_command::scm_socket::ScmSocket;
 use sozu_command::config::{ProxyProtocolConfig, LoadBalancingAlgorithms};
-use sozu_command::proxy::{ProxyRequestData,ProxyRequest,ProxyResponse,ProxyResponseStatus,ProxyEvent};
+use sozu_command::proxy::{ProxyRequestData,ProxyRequest,ProxyResponse,ProxyResponseStatus,ProxyEvent,RemoveListener};
 use sozu_command::proxy::TcpListener as TcpListenerConfig;
 use sozu_command::logging;
 use sozu_command::buffer::Buffer;
@@ -781,6 +781,27 @@ impl Proxy {
     }
   }
 
+  pub fn remove_listener(&mut self, remove: RemoveListener) -> bool {
+    let token = self.listeners.iter()
+      .find(|(_, listener)| listener.address == remove.front)
+      .and_then(|(token, listener)| {
+        match listener.active {
+          false => Some(token.clone()),
+          true => {
+            error!("Listener {:?} is still active, not removing", listener.address);
+            None
+          }
+        }
+      });
+
+    if let Some(t) = token {
+      self.listeners.remove_entry(&t);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   pub fn activate_listener(&mut self, event_loop: &mut Poll, addr: &SocketAddr, tcp_listener: Option<TcpListener>) -> Option<Token> {
     for listener in self.listeners.values_mut() {
       if &listener.address == addr {
@@ -935,8 +956,10 @@ impl ProxyConfiguration<Session> for Proxy {
         ProxyResponse{ id: message.id, status: ProxyResponseStatus::Ok, data: None }
       },
       ProxyRequestData::RemoveListener(remove) => {
-        fixme!();
-        ProxyResponse{ id: message.id, status: ProxyResponseStatus::Error(String::from("unimplemented")), data: None }
+        match self.remove_listener(remove) {
+          true => ProxyResponse{ id: message.id, status: ProxyResponseStatus::Ok, data: None },
+          false => ProxyResponse{ id: message.id, status: ProxyResponseStatus::Error(String::from("failed to remove listener")), data: None }
+        }
       },
       command => {
         error!("{} unsupported message for TCP proxy, ignoring {:?}", message.id, command);


### PR DESCRIPTION
This pull request aims at adding support to control listeners using the cli and support some of the actions inside sozu (like deactivate / remove listener messages) as mentionned in #557. It also aims at getting feedback.
Each commit introduces a feature so the review can be done commit per commit. I didn't want to open that many pull requests.

All the commands work but I'm not sure about how I implemented them, especially:
- is there a better way to implement the `server_unbind` function?
- lots of code gets duplicated across listeners, maybe we could avoid that? In another PR?
- For the RemoveListener message, if an error occurs (for example, the listener is still active so we can't remove it), the error doesn't seem to be sent back to the CLI, which prints "Command timeout. The proxy didn't send answer" and I'm not sure why.
- I reused and mutate the `sozu_command::config::Listener` type to create the listener, I'm very not sure about that, I don't find it elegant.