### PR TITLE
implement the `get_executable_path` function for freeBSD

### DIFF
--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -21,7 +21,7 @@ use std::iter::repeat;
 use std::ptr::null_mut;
 
 #[cfg(target_os = "freebsd")]
-use libc::sysctl;
+use libc::{CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, sysctl};
 #[cfg(target_os = "freebsd")]
 use std::ffi::c_void;
 #[cfg(target_os = "freebsd")]
@@ -232,8 +232,7 @@ pub unsafe fn get_executable_path() -> String {
     let mut path: Vec<u8> = Vec::with_capacity(capacity);
     path.extend(repeat(0).take(capacity));
 
-    // [CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1];
-    let mib: Vec<i32> = vec![1, 14, 12, -1];
+    let mib: Vec<i32> = vec![CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1];
     let len = mib.len() * size_of::<i32>();
     let element_size = size_of::<i32>();
 

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -21,6 +21,8 @@ use std::iter::repeat;
 use std::ptr::null_mut;
 
 #[cfg(target_os = "freebsd")]
+use libc::sysctl;
+#[cfg(target_os = "freebsd")]
 use std::ffi::c_void;
 #[cfg(target_os = "freebsd")]
 use std::iter::repeat;
@@ -223,29 +225,6 @@ pub unsafe fn get_executable_path() -> String {
     panic!("buffer too small");
   }
 }
-
-#[cfg(target_os = "freebsd")]
-extern "C" {
-    // int
-    // sysctl(const int *name, u_int namelen, void *oldp, size_t *oldlenp,
-    // const void *newp, size_t newlen);
-    pub fn sysctl(
-        name: *const std::os::raw::c_int,
-        namelen: std::os::raw::c_uint,
-        oldp: *mut c_void,
-        oldlenp: *mut usize,
-        newp: *const c_void,
-        newlen: usize,
-    ) -> std::os::raw::c_int;
-    // char *
-    // realpath(const char * restrict pathname, char * restrict resolved_path);
-    pub fn realpath(
-        pathname: *const std::os::raw::c_char,
-        resolved_path: *mut std::os::raw::c_char,
-    ) -> *const std::os::raw::c_char;
-
-}
-
 
 #[cfg(target_os = "freebsd")]
 pub unsafe fn get_executable_path() -> String {

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -14,14 +14,14 @@ use nix::unistd::*;
 #[cfg(target_os = "macos")]
 use std::ffi::CString;
 #[cfg(target_os = "macos")]
-use libc::{c_char,uint32_t,int32_t};
+use libc::{PATH_MAX, c_char,uint32_t,int32_t};
 #[cfg(target_os = "macos")]
 use std::iter::repeat;
 #[cfg(target_os = "macos")]
 use std::ptr::null_mut;
 
 #[cfg(target_os = "freebsd")]
-use libc::{CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, sysctl};
+use libc::{CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, PATH_MAX, sysctl};
 #[cfg(target_os = "freebsd")]
 use std::ffi::c_void;
 #[cfg(target_os = "freebsd")]
@@ -200,7 +200,7 @@ extern {
 
 #[cfg(target_os = "macos")]
 pub unsafe fn get_executable_path() -> String {
-  let capacity = 2000;
+  let capacity = PATH_MAX as usize;
   let mut temp:Vec<u8> = Vec::with_capacity(capacity);
   temp.extend(repeat(0).take(capacity));
   let pathbuf = CString::from_vec_unchecked(temp);
@@ -228,7 +228,7 @@ pub unsafe fn get_executable_path() -> String {
 
 #[cfg(target_os = "freebsd")]
 pub unsafe fn get_executable_path() -> String {
-    let mut capacity = 2000;
+    let mut capacity = PATH_MAX as usize;
     let mut path: Vec<u8> = Vec::with_capacity(capacity);
     path.extend(repeat(0).take(capacity));
 


### PR DESCRIPTION
Hello, I wanted to try sozu on my server, unfortunately freeBSD does not seem to be supported because of this `get_executable_path` function.

I’ve never done this kind of `unsafe` / C call code in rust so please tell me if something is wrong with my code :)