### PR TITLE
Remove unused whitespace functions from http parser.

### DIFF
--- a/lib/src/protocol/http/parser.rs
+++ b/lib/src/protocol/http/parser.rs
@@ -38,19 +38,11 @@ fn is_status_token_char(i: u8) -> bool {
 }
 
 named!(pub status_token, take_while!(is_status_token_char));
-
-fn is_ws(i: u8) -> bool {
-  i == b' ' && i == b'\t'
-}
-
 named!(pub sp<char>, char!(' '));
 named!(pub crlf, tag!("\r\n"));
 
 fn is_vchar(i: u8) -> bool {
   i > 32 && i <= 126
-}
-fn is_vchar_or_ws(i: u8) -> bool {
-  is_vchar(i) || is_ws(i)
 }
 
 // allows ISO-8859-1 characters in header values
@@ -67,8 +59,6 @@ fn is_header_value_char(i: u8) -> bool {
 }
 
 named!(pub vchar_1, take_while!(is_vchar));
-named!(pub vchar_ws_1, take_while!(is_vchar_or_ws));
-
 named!(digit_complete, take_while1_complete!(|item:u8| item.is_dec_digit()));
 
 #[derive(PartialEq,Debug,Clone)]


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sozu-proxy/sozu/636)
<!-- Reviewable:end -->
