### PR TITLE
Parser: Add missing HasHostAndLength state in various methods

### DIFF
--- a/lib/src/protocol/http/parser.rs
+++ b/lib/src/protocol/http/parser.rs
@@ -925,9 +925,10 @@ impl RequestState {
 
   pub fn get_host(&self) -> Option<&str> {
     match *self {
-      RequestState::HasHost(_, _, ref host)            |
-      RequestState::Request(_, _, ref host)            |
-      RequestState::RequestWithBody(_, _, ref host, _) |
+      RequestState::HasHost(_, _, ref host)             |
+      RequestState::HasHostAndLength(_, _, ref host, _) |
+      RequestState::Request(_, _, ref host)             |
+      RequestState::RequestWithBody(_, _, ref host, _)  |
       RequestState::RequestWithBodyChunks(_, _, ref host, _) => Some(host.as_str()),
       RequestState::Error(_, _, ref host, _, _)              => host.as_ref().map(|s| s.as_str()),
       _                                                      => None
@@ -936,10 +937,11 @@ impl RequestState {
 
   pub fn get_uri(&self) -> Option<String> {
     match *self {
-      RequestState::HasRequestLine(ref rl, _)        |
-      RequestState::HasHost(ref rl, _, _)            |
-      RequestState::Request(ref rl , _, _)           |
-      RequestState::RequestWithBody(ref rl, _, _, _) |
+      RequestState::HasRequestLine(ref rl, _)         |
+      RequestState::HasHost(ref rl, _, _)             |
+      RequestState::HasHostAndLength(ref rl, _, _, _) |
+      RequestState::Request(ref rl , _, _)            |
+      RequestState::RequestWithBody(ref rl, _, _, _)  |
       RequestState::RequestWithBodyChunks(ref rl, _, _, _) => Some(rl.uri.clone()),
       RequestState::Error(ref rl, _, _, _, _)              => rl.as_ref().map(|r| r.uri.clone()),
       _                                                    => None
@@ -948,10 +950,11 @@ impl RequestState {
 
   pub fn get_request_line(&self) -> Option<&RRequestLine> {
     match *self {
-      RequestState::HasRequestLine(ref rl, _)        |
-      RequestState::HasHost(ref rl, _, _)            |
-      RequestState::Request(ref rl, _, _)            |
-      RequestState::RequestWithBody(ref rl, _, _, _) |
+      RequestState::HasRequestLine(ref rl, _)         |
+      RequestState::HasHost(ref rl, _, _)             |
+      RequestState::HasHostAndLength(ref rl, _, _, _) |
+      RequestState::Request(ref rl, _, _)             |
+      RequestState::RequestWithBody(ref rl, _, _, _)  |
       RequestState::RequestWithBodyChunks(ref rl, _, _, _) => Some(rl),
       RequestState::Error(ref rl, _, _, _, _) => rl.as_ref(),
       _ => None


### PR DESCRIPTION
On slow connections, a POST with a (maybe large) body and huge cookies would result in a connection reset because the proxy would end up with a `RequestState::HasHostAndLength` state but this state isn't matched in some (important I guess) places. And when sozu tries to get the [app id from request](https://github.com/sozu-proxy/sozu/blob/a82514c0fda3d55cc33c0250a5dfdf3a4635a828/lib/src/http.rs#L849) it would fail with the `ConnectionError::NoHostGiven` error leading to a connection reset.

I was able to reproduce the issue using this [simple server](https://gist.github.com/BlackYoup/378789f68377ae798c2e662f804acdbd) and by setting a huge cookie in my browser on the `/` page using `document.cookie = "sozu-id=<~4000 chars of cookie>"`. Once done, set your browser to limit your connection (I used the GPRS mode in firefox) and post the form. The connection will reset.

This PR fixes the issue and the POST request goes on as expected. It adds the `RequestState::HasHostAndLength(_, _, ref host, _)` match each time `RequestState::HasHost` is matched, maybe there are other places but I couldn't find one. The other lines changes are cosmetic.