### PR TITLE
Rustls Socket: break loop when we read 0 from stream

### DIFF
--- a/lib/src/socket.rs
+++ b/lib/src/socket.rs
@@ -260,6 +260,7 @@ impl SocketHandler for FrontRustls {
 
       while !self.session.wants_read() {
         match self.session.read(&mut buf[size..]) {
+          Ok(0) => break,
           Ok(sz) => size += sz,
           Err(e) => match e.kind() {
             ErrorKind::WouldBlock => {


### PR DESCRIPTION
I hit an infinite loop when uploading a file using the rustls backend. The buffer would fill and continue to read 0 because it is full.

I didn't test in version 0.11 but the code seems to be the same so I guess it could be backported.