### PR TITLE
rework how we handle LimitNOFile

### DIFF
--- a/os-build/systemd/sozu.service.in
+++ b/os-build/systemd/sozu.service.in
@@ -8,7 +8,6 @@ Wants=network-online.target
 PIDFile=__RUNDIR__/sozu/sozu.pid
 ExecStart=__BINDIR__/sozu start --config __SYSCONFDIR__/sozu/config.toml
 Restart=on-failure
-LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Nowadays, while the soft limit is still quite low (often 1024 by default),
the hard limit has grown up to 524288 by default for lots of distribution.
Instead of hardcoding soft = hard = 65536, let's try and me way more flexible,
by increasing our limit if we can, while keeping it lower that 64k when not required.