### PR TITLE
The "start" argument is missing

### DIFF
--- a/doc/how_to_use.md
+++ b/doc/how_to_use.md
@@ -6,7 +6,7 @@
 
 If you used the `cargo install` way, `sozu` and `sozuctl` are already in your `$PATH`.
 
-`sozu -c <path/to/your/config.toml>`
+`sozu start -c <path/to/your/config.toml>`
 
 However, if you built the project from source, `sozu` and `sozuctl` are placed in the `target` directory.
 


### PR DESCRIPTION
Salut @Geal je pense qu'il y a un oubli ici, car j'ai utilisé les commandes cargo pour installer Sōzu et je dois tout de même passer l'argument "start" avant de spécifier le fichier de configuration via l'option "-c" pour lancer Sōzu.