### PR TITLE
initialize the logger before writing the pid file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1451,6 +1457,7 @@ dependencies = [
 name = "sozu"
 version = "0.13.6"
 dependencies = [
+ "anyhow",
  "async-dup",
  "async-io",
  "clap",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -21,6 +21,7 @@ include = [
 name = "sozu"
 
 [dependencies]
+anyhow = "1.0.42"
 mio = { version = "^0.7", features = [ "os-poll", "uds" ] }
 serde = "~1.0.2"
 serde_json = "~1.0.1"

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -90,7 +90,8 @@ fn start(matches: &ArgMatches) -> Result<(), StartupError> {
   util::setup_logging(&config);
   info!("Starting up");
   util::setup_metrics(&config);
-  util::write_pid_file(&config)?;
+  util::write_pid_file(&config)
+    .or_else(|e| Err(StartupError::PIDFileNotWritable(e.to_string())))?;
 
   update_process_limits(&config)?;
 
@@ -102,7 +103,7 @@ fn start(matches: &ArgMatches) -> Result<(), StartupError> {
 
   let command_socket_path = config.command_socket_path();
 
-  // this should be transformed into a new StartupError that contains std::io::Error
+  // this could be transformed into a new StartupError that contains std::io::Error
   if let Err(e) = command::start(config, command_socket_path, workers) {
       error!("could not start worker: {:?}", e);
   }

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -57,17 +57,17 @@ fn main() {
   if upgrade == None {
     let start = get_config_file_path(&matches)
     .and_then(|config_file| load_configuration(config_file))
-    .and_then(|config| {
-      util::write_pid_file(&config)
-        .map(|()| config)
-        .map_err(|err| StartupError::PIDFileNotWritable(err))
-    })
     .map(|config| {
       util::setup_logging(&config);
       info!("Starting up");
       util::setup_metrics(&config);
 
       config
+    })
+    .and_then(|config| {
+      util::write_pid_file(&config)
+        .map(|()| config)
+        .map_err(|err| StartupError::PIDFileNotWritable(err))
     })
     .and_then(|config| update_process_limits(&config).map(|()| config))
     .and_then(|config| init_workers(&config).map(|workers| (config, workers)))


### PR DESCRIPTION
In order to fix #681 , the logger initialization needs to happen before writing the pid file.

todos:

- [x] move the logger initialization up
- [x] use `?` syntactic sugar for better readability