### PR TITLE
Error management in sozuctl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,6 +1556,7 @@ dependencies = [
 name = "sozuctl"
 version = "0.13.6"
 dependencies = [
+ "anyhow",
  "hex",
  "prettytable-rs",
  "rand",

--- a/ctl/Cargo.toml
+++ b/ctl/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["network-programming"]
 name = "sozuctl"
 
 [dependencies]
+anyhow = "1.0.42"
 rand    = "^0.8"
 prettytable-rs = { version = "^0.8", default-features = false}
 sozu-command-lib = { version = "^0.13.0", path = "../command" }

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -14,7 +14,6 @@ mod cli;
 
 use std::io;
 use structopt::StructOpt;
-// use anyhow;
 
 use sozu_command::config::Config;
 use sozu_command::channel::Channel;
@@ -56,7 +55,10 @@ fn main() -> Result<(), anyhow::Error> {
       }
     },
     SubCmd::Upgrade { worker: None } => upgrade_main(channel, &config),
-    SubCmd::Upgrade { worker: Some(id) } => { upgrade_worker(channel, timeout, id)?; Ok(()) },
+    SubCmd::Upgrade { worker: Some(id) } => {
+      upgrade_worker(channel, timeout, id)?;
+      Ok(())
+    },
     SubCmd::Status{ json } => status(channel, json),
     SubCmd::Metrics{ json } => metrics(channel, json),
     SubCmd::Logging{ level } => logging_filter(channel, timeout, &level),


### PR DESCRIPTION
The idea is to get rid of `expect`s and `unwrap`s in `command.rs` of `sozuctl` in the spirit of #317 

What I've done is use [anyhow](https://docs.rs/anyhow/1.0.42/anyhow/index.html) to **change all stderr logging and 1-exiting into [anyhow::bail!](https://docs.rs/anyhow/1.0.42/anyhow/macro.bail.html)**

```rust
eprintn!("some error occured");
exit(1);
```

becomes

```rust
bail!("some error occured");
```

This and the use of [anyhow::context](https://docs.rs/anyhow/1.0.42/anyhow/trait.Context.html#) makes for a smoother error handling.

HOWEVER, the use of the `command_timeout!` macro, that spawns a task and bails if the timeout is reached, becomes more complicated because the return type of the invoked code blocks must be **strictly** defined.