### PR TITLE
Better follow-up of worker RunState

### DIFF
--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -608,8 +608,10 @@ impl CommandServer {
                     if let Some(w) = self.workers.iter_mut().filter(|w| w.id == id).next() {
                         if self.config.worker_automatic_restart && w.run_state == RunState::Running
                         {
+                            // we should rename this for clarity
                             self.check_worker_status(id).await;
                         }
+                        // add some stuff to ensure the worker is down in other cases
                     }
                 }
                 CommandMessage::WorkerResponse { id, message } => {

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -349,7 +349,7 @@ impl CommandServer {
             .expect("there should be a worker at that token");
         let res = kill(Pid::from_raw(worker.pid), None);
 
-        if let Ok(()) = res {
+        if res.is_ok() {
             if worker.run_state == RunState::Running {
                 error!(
                     "worker process {} (PID = {}) not answering, killing and replacing",
@@ -357,8 +357,6 @@ impl CommandServer {
                 );
                 if let Err(e) = kill(Pid::from_raw(worker.pid), Signal::SIGKILL) {
                     error!("failed to kill the worker process: {:?}", e);
-                } else {
-                    worker.run_state = RunState::Stopped;
                 }
             } else {
                 return;
@@ -382,7 +380,7 @@ impl CommandServer {
             }
         }
 
-        worker.run_state = RunState::Stopped;
+        worker.run_state = RunState::Stopping;
 
         if self.config.worker_automatic_restart {
             incr!("worker_restart");

--- a/bin/src/command/orders.rs
+++ b/bin/src/command/orders.rs
@@ -644,6 +644,7 @@ impl CommandServer {
             smol::spawn(async move {
                 while let Some(proxy_response) = rx.next().await {
                     match proxy_response.status {
+                        // this never comes actually
                         ProxyResponseStatus::Ok => {
                             info!("softstop OK");
                             if let Err(e) = command_tx

--- a/bin/src/command/orders.rs
+++ b/bin/src/command/orders.rs
@@ -644,9 +644,8 @@ impl CommandServer {
             smol::spawn(async move {
                 while let Some(proxy_response) = rx.next().await {
                     match proxy_response.status {
-                        // this never comes actually
                         ProxyResponseStatus::Ok => {
-                            info!("softstop OK");
+                            info!("softstop OK"); // this doesn't display :-(
                             if let Err(e) = command_tx
                                 .send(CommandMessage::WorkerClose { id: worker_id.clone() })
                                 .await {

--- a/bin/src/command/worker.rs
+++ b/bin/src/command/worker.rs
@@ -3,6 +3,8 @@ use libc::pid_t;
 use std::collections::VecDeque;
 use std::fmt;
 use std::os::unix::io::AsRawFd;
+use nix::sys::signal::kill;
+use nix::unistd::Pid;
 
 use sozu_command::channel::Channel;
 use sozu_command::command::RunState;
@@ -51,6 +53,14 @@ impl Worker {
             .await {
                 error!("error sending message to worker {:?}: {:?}", self.id, e);
             }
+        }
+    }
+
+    pub fn the_pid_is_alive(&self) -> bool {
+        // send a kill -0 to check on the pid, if it's dead it should be an error
+        match kill(Pid::from_raw(self.pid), None) {
+            Ok(_) => true,
+            Err(_) => false,
         }
     }
 

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -578,6 +578,7 @@ pub fn metrics(mut channel: Channel<CommandRequest,CommandResponse>, json: bool)
   ));
   //println!("message sent");
 
+  // we should add a timeout somehow, otherwise it hangs
   loop {
     match channel.read_message() {
       None          => {


### PR DESCRIPTION
The issue #631 points out that old workers are not listed by sozuctl during an upgrade.

A dive in the code reveals the `run()` method of `CommandServer` does not handle `CommandMessage::WorkerClose` properly, especially not setting the Worker to `Stopped`, which makes `sozuctl metrics` hang.

This PR:

- rewrites the handling of `CommandMessage::WorkerClose` in `CommandServer::run()`, doing checks and kills and setting to`Stopped`
- renames and clears `check_worker_status()` into the more appropriate `restart_worker()`


## Todos

- [x] test it locally (yes I should have done that before committing but here we are)

## What remains

- we need a timeout on `sozuctl metrics`, see #279 
