### PR TITLE
Better error management

### DIFF
--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -80,30 +80,22 @@ pub fn get_upgrade_fd<'a>(matches: &ArgMatches<'a>) -> i32 {
     .parse::<i32>().expect("the file descriptor must be a number")
 }
 
-pub fn upgrade_worker<'a>(matches: &ArgMatches<'a>) -> Result<Option<()>, anyhow::Error> {
-  if let Some(worker_matches) = matches.subcommand_matches("worker") {
-    let fd = get_fd(worker_matches);
-    let scm = get_scm(worker_matches);
-    let configuration_state_fd = get_configuration_state_fd(worker_matches);
-    let id = get_id(worker_matches);
-    let buffer_size = get_buffer_size(worker_matches);
-    let max_buffer_size = get_max_buffer_size(worker_matches, buffer_size);
+pub fn upgrade_worker<'a>(worker_matches: &ArgMatches<'a>) -> Result<(), anyhow::Error> {
+  let fd = get_fd(worker_matches);
+  let scm = get_scm(worker_matches);
+  let configuration_state_fd = get_configuration_state_fd(worker_matches);
+  let id = get_id(worker_matches);
+  let buffer_size = get_buffer_size(worker_matches);
+  let max_buffer_size = get_max_buffer_size(worker_matches, buffer_size);
 
-    Ok(Some(begin_worker_process(fd, scm, configuration_state_fd, id, buffer_size, max_buffer_size)?))
-  } else {
-    Ok(None)
-  }
+  begin_worker_process(fd, scm, configuration_state_fd, id, buffer_size, max_buffer_size)
 }
 
-pub fn upgrade_main<'a>(matches: &ArgMatches<'a>) -> Result<Option<()>, anyhow::Error> {
-  if let Some(upgrade_matches) = matches.subcommand_matches("upgrade") {
-    let fd = get_fd(upgrade_matches);
-    let upgrade_fd = get_upgrade_fd(upgrade_matches);
-    let buffer_size = get_buffer_size(upgrade_matches);
-    let max_buffer_size = get_max_buffer_size(upgrade_matches, buffer_size);
-      
-    Ok(Some(begin_new_main_process(fd, upgrade_fd, buffer_size, max_buffer_size)?))
-  } else {
-    Ok(None)
-  }
+pub fn upgrade_main<'a>(upgrade_matches: &ArgMatches<'a>) -> Result<(), anyhow::Error> {
+  let fd = get_fd(upgrade_matches);
+  let upgrade_fd = get_upgrade_fd(upgrade_matches);
+  let buffer_size = get_buffer_size(upgrade_matches);
+  let max_buffer_size = get_max_buffer_size(upgrade_matches, buffer_size);
+
+  begin_new_main_process(fd, upgrade_fd, buffer_size, max_buffer_size)
 }

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -1,4 +1,3 @@
-use anyhow::Error;
 use clap::{App,Arg,SubCommand,ArgMatches};
 use crate::worker::begin_worker_process;
 use crate::upgrade::begin_new_main_process;

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -206,7 +206,7 @@ impl CommandServer {
                         }
                         futures::future::Either::Right((res, cancel_rx)) => {
                             accept_cancel_rx = Some(cancel_rx);
-                            res?
+                            res.unwrap()
                         }
                     };
                 debug!("Accepted a client from upgraded");
@@ -218,10 +218,10 @@ impl CommandServer {
                     id,
                     sender: client_tx,
                 })
-                .await?;
+                .await
+                .unwrap();
                 counter += 1;
             }
-            Ok::<(), anyhow::Error>(())
         })
         .detach();
 
@@ -247,8 +247,8 @@ impl CommandServer {
                 //async fn worker(id: u32, sock: Async<UnixStream>, tx: Sender<CommandMessage>, rx: Receiver<()>) -> std::io::Result<()> {
                 smol::spawn(async move {
                     worker_loop(id, stream, command_tx, worker_rx)
-                        .await?;
-                    Ok::<(), anyhow::Error>(())
+                        .await
+                        .unwrap();
                 })
                 .detach();
 
@@ -507,7 +507,7 @@ pub fn start(
                         }
                         futures::future::Either::Right((res, cancel_rx)) => {
                             accept_cancel_rx = Some(cancel_rx);
-                            res?
+                            res.unwrap()
                         }
                     };
 
@@ -519,10 +519,10 @@ pub fn start(
                         id,
                         sender: client_tx,
                     })
-                    .await?;
+                    .await
+                    .unwrap();
                 counter += 1;
             }
-            Ok::<(), anyhow::Error>(())
         })
         .detach();
 

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -301,13 +301,14 @@ impl CommandServer {
         Ok(())
     }
 
-    pub fn enable_cloexec_after_upgrade(&mut self) {
+    pub fn enable_cloexec_after_upgrade(&mut self) -> anyhow::Result<()> {
         for ref mut worker in self.workers.iter_mut() {
             if worker.run_state == RunState::Running {
-                util::enable_close_on_exec(worker.fd);
+                util::enable_close_on_exec(worker.fd)?;
             }
         }
-        util::enable_close_on_exec(self.fd);
+        util::enable_close_on_exec(self.fd)?;
+        Ok(())
     }
 
     pub async fn load_static_application_configuration(&mut self) {
@@ -581,6 +582,7 @@ impl CommandServer {
                 }
                 CommandMessage::ClientRequest { id, message } => {
                     debug!("client {} sent {:?}", id, message);
+                    // todo: handle the result that comes from here:
                     self.handle_client_message(id, message).await;
                 }
                 CommandMessage::WorkerClose { id } => {

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -451,7 +451,7 @@ pub fn start(
 ) -> anyhow::Result<()> {
     let addr = PathBuf::from(&command_socket_path);
     
-    fs::remove_file(&addr).context(format!("could not delete previous socket at {:?}", addr))?;
+    fs::remove_file(&addr).with_context(|| format!("could not delete previous socket at {:?}", addr))?;
 
     let srv = match UnixListener::bind(&addr) {
         Err(e) => {

--- a/bin/src/command/orders.rs
+++ b/bin/src/command/orders.rs
@@ -8,7 +8,6 @@ use std::io::{self, Read, Write};
 use std::os::unix::io::{FromRawFd, IntoRawFd};
 use std::os::unix::net::UnixStream;
 use std::time::Duration;
-use anyhow::{Context, bail};
 
 use async_io::Async;
 
@@ -453,7 +452,7 @@ impl CommandServer {
         client_id: String,
         request_id: String
     ) -> Result<(), anyhow::Error> {
-        self.disable_cloexec_before_upgrade();
+        self.disable_cloexec_before_upgrade()?;
 
         if let Some(sender) = self.clients.get_mut(&client_id) {
             if let Err(e) = sender

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -124,7 +124,12 @@ fn start(matches: &ArgMatches) -> Result<(), StartupError> {
 }
 
 fn init_workers(config: &Config) -> Result<Vec<Worker>, StartupError> {
-  let path = unsafe { get_executable_path() };
+  let path = unsafe {
+    match get_executable_path() {
+      Ok(p) => p,
+      Err(e) => return Err(StartupError::WorkersSpawnFail(e)),
+    }
+  };
   match start_workers(path, &config) {
     Ok(workers) => {
       info!("created workers: {:?}", workers);

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -43,7 +43,7 @@ pub enum StartupError {
   TooManyAllowedConnections(String),
   #[allow(dead_code)]
   TooManyAllowedConnectionsForWorker(String),
-  WorkersSpawnFail(nix::Error),
+  WorkersSpawnFail(anyhow::Error),
   PIDFileNotWritable(String),
   UnknownSubcommand,
 }

--- a/bin/src/upgrade.rs
+++ b/bin/src/upgrade.rs
@@ -129,7 +129,7 @@ pub fn begin_new_main_process(
   util::setup_metrics(&config);
   //info!("new main got upgrade data: {:?}", upgrade_data);
 
-  let mut server = CommandServer::from_upgrade_data(upgrade_data);
+  let mut server = CommandServer::from_upgrade_data(upgrade_data)?;
   server.enable_cloexec_after_upgrade();
   info!("starting new main loop");
   match util::write_pid_file(&config) {

--- a/bin/src/upgrade.rs
+++ b/bin/src/upgrade.rs
@@ -61,12 +61,15 @@ pub fn start_new_main_process(
 ) -> Result<(pid_t, Channel<(),bool>), anyhow::Error> {
   trace!("parent({})", unsafe { libc::getpid() });
 
-  let mut upgrade_file = tempfile().context("could not create temporary file for upgrade")?;
+  let mut upgrade_file = tempfile()
+    .with_context(|| "could not create temporary file for upgrade")?;
 
   util::disable_close_on_exec(upgrade_file.as_raw_fd())?;
 
-  serde_json::to_writer(&mut upgrade_file, &upgrade_data).context("could not write upgrade data to temporary file")?;
-  upgrade_file.seek(SeekFrom::Start(0)).context("could not seek to beginning of file")?;
+  serde_json::to_writer(&mut upgrade_file, &upgrade_data)
+    .with_context(|| "could not write upgrade data to temporary file")?;
+  
+  upgrade_file.seek(SeekFrom::Start(0)).with_context(|| "could not seek to beginning of file")?;
 
   let (server, client) = UnixStream::pair()?;
 

--- a/bin/src/upgrade.rs
+++ b/bin/src/upgrade.rs
@@ -130,7 +130,7 @@ pub fn begin_new_main_process(
   //info!("new main got upgrade data: {:?}", upgrade_data);
 
   let mut server = CommandServer::from_upgrade_data(upgrade_data)?;
-  server.enable_cloexec_after_upgrade();
+  server.enable_cloexec_after_upgrade()?;
   info!("starting new main loop");
   match util::write_pid_file(&config) {
     Ok(()) => {

--- a/bin/src/upgrade.rs
+++ b/bin/src/upgrade.rs
@@ -83,7 +83,7 @@ pub fn start_new_main_process(
   command.set_nonblocking(false);
 
   info!("launching new main");
-  match unsafe { fork().context("fork failed")? } {
+  match unsafe { fork().with_context(|| "fork failed")? } {
     ForkResult::Parent{ child } => {
       info!("main launched: {}", child);
       command.set_nonblocking(true);
@@ -125,7 +125,7 @@ pub fn begin_new_main_process(
   command.set_blocking(true);
 
   let upgrade_file = unsafe { File::from_raw_fd(upgrade_fd) };
-  let upgrade_data: UpgradeData = serde_json::from_reader(upgrade_file).context("could not parse upgrade data")?;
+  let upgrade_data: UpgradeData = serde_json::from_reader(upgrade_file).with_context(|| "could not parse upgrade data")?;
   let config = upgrade_data.config.clone();
 
   util::setup_logging(&config);

--- a/bin/src/upgrade.rs
+++ b/bin/src/upgrade.rs
@@ -63,14 +63,14 @@ pub fn start_new_main_process(
 
   let mut upgrade_file = tempfile().context("could not create temporary file for upgrade")?;
 
-  util::disable_close_on_exec(upgrade_file.as_raw_fd());
+  util::disable_close_on_exec(upgrade_file.as_raw_fd())?;
 
   serde_json::to_writer(&mut upgrade_file, &upgrade_data).context("could not write upgrade data to temporary file")?;
   upgrade_file.seek(SeekFrom::Start(0)).context("could not seek to beginning of file")?;
 
   let (server, client) = UnixStream::pair()?;
 
-  util::disable_close_on_exec(client.as_raw_fd());
+  util::disable_close_on_exec(client.as_raw_fd())?;
 
   let mut command: Channel<(),bool> = Channel::new(
     server,

--- a/bin/src/util.rs
+++ b/bin/src/util.rs
@@ -11,7 +11,7 @@ use sozu::metrics;
 
 pub fn enable_close_on_exec(fd: RawFd) -> Result<i32, anyhow::Error> {
   let file_descriptor = fcntl(fd, FcntlArg::F_GETFD)
-    .context("could not get file descriptor flags")?;
+    .with_context(|| "could not get file descriptor flags")?;
 
   let mut new_flags = FdFlag::from_bits(file_descriptor).ok_or_else(
     || anyhow::format_err!("could not convert flags for file descriptor")

--- a/bin/src/util.rs
+++ b/bin/src/util.rs
@@ -9,25 +9,29 @@ use crate::logging;
 use sozu_command::config::Config;
 use sozu::metrics;
 
-pub fn enable_close_on_exec(fd: RawFd) -> Option<i32> {
-  fcntl(fd, FcntlArg::F_GETFD).map_err(|e| {
-    error!("could not get file descriptor flags: {:?}", e);
-  }).ok().and_then(FdFlag::from_bits).and_then(|mut new_flags| {
-    new_flags.insert(FdFlag::FD_CLOEXEC);
-    fcntl(fd, FcntlArg::F_SETFD(new_flags)).map_err(|e| {
-      error!("could not set file descriptor flags: {:?}", e);
-    }).ok()
-  })
+pub fn enable_close_on_exec(fd: RawFd) -> Result<i32, anyhow::Error> {
+  let file_descriptor = fcntl(fd, FcntlArg::F_GETFD)
+    .context("could not get file descriptor flags")?;
+
+  let mut new_flags = match FdFlag::from_bits(file_descriptor) {
+    Some(f) => f,
+    None => bail!("could not convert flags for file descriptor"),
+  };
+  new_flags.insert(FdFlag::FD_CLOEXEC);
+
+  fcntl(fd, FcntlArg::F_SETFD(new_flags)).context("could not set file descriptor flags")
 }
 
 // FD_CLOEXEC is set by default on every fd in Rust standard lib,
 // so we need to remove the flag on the client, otherwise
 // it won't be accessible
 pub fn disable_close_on_exec(fd: RawFd) -> Result<i32, anyhow::Error> {
-  let file_descriptor = fcntl(fd, FcntlArg::F_GETFD).context("could not get file descriptor flags")?;
+  let file_descriptor = fcntl(fd, FcntlArg::F_GETFD)
+    .context("could not get file descriptor flags")?;
+    
   let mut new_flags = match FdFlag::from_bits(file_descriptor) {
     Some(f) => f,
-    None => bail!("could not find flags for file descriptor"),
+    None => bail!("could not convert flags for file descriptor"),
   };
 
   new_flags.remove(FdFlag::FD_CLOEXEC);

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -133,7 +133,7 @@ pub fn start_worker_process(
   trace!("parent({})", unsafe { libc::getpid() });
 
   let mut state_file = tempfile().context("could not create temporary file for configuration state")?;
-  util::disable_close_on_exec(state_file.as_raw_fd());
+  util::disable_close_on_exec(state_file.as_raw_fd())?;
 
   serde_json::to_writer(&mut state_file, state).context("could not write upgrade data to temporary file")?;
   state_file.seek(SeekFrom::Start(0)).context("could not seek to beginning of file")?;
@@ -143,8 +143,8 @@ pub fn start_worker_process(
 
   let scm_server = ScmSocket::new(scm_server_fd.into_raw_fd());
 
-  util::disable_close_on_exec(client.as_raw_fd());
-  util::disable_close_on_exec(scm_client.as_raw_fd());
+  util::disable_close_on_exec(client.as_raw_fd())?;
+  util::disable_close_on_exec(scm_client.as_raw_fd())?;
 
   let mut command: Channel<Config,ProxyResponse> = Channel::new(
     server,
@@ -167,7 +167,7 @@ pub fn start_worker_process(
         info!("sent listeners from main: {:?}", res);
         l.close();
       };
-      util::disable_close_on_exec(scm_server.fd);
+      util::disable_close_on_exec(scm_server.fd)?;
 
       let command: Channel<ProxyRequest,ProxyResponse> = command.into();
       Ok((child.into(), command, scm_server))

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -1724,7 +1724,11 @@ fn order_command(mut channel: Channel<CommandRequest,CommandResponse>, timeout: 
 }
 
 fn print_json_response<T: ::serde::Serialize>(input: &T) -> Result<(), anyhow::Error> {
-  println!("{}", serde_json::to_string_pretty(&input).context("Error while parsing response to JSON")?);
+  println!(
+    "{}",
+    serde_json::to_string_pretty(&input)
+      .with_context(|| "Error while parsing response to JSON")?
+  );
   Ok(())
 }
 

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -59,7 +59,7 @@ fn main() -> Result<(), anyhow::Error> {
       upgrade_worker(channel, timeout, id)?;
       Ok(())
     },
-    SubCmd::Status{ json } => status(channel, json),
+    SubCmd::Status{ json } => status(channel, timeout, json),
     SubCmd::Metrics{ json } => metrics(channel, json),
     SubCmd::Logging{ level } => logging_filter(channel, timeout, &level),
     SubCmd::State{ cmd } => {

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -60,7 +60,7 @@ fn main() -> Result<(), anyhow::Error> {
       Ok(())
     },
     SubCmd::Status{ json } => status(channel, timeout, json),
-    SubCmd::Metrics{ json } => metrics(channel, json),
+    SubCmd::Metrics{ json } => metrics(channel, timeout, json),
     SubCmd::Logging{ level } => logging_filter(channel, timeout, &level),
     SubCmd::State{ cmd } => {
       match cmd {


### PR DESCRIPTION
As stated in #275, we don't like `unwrap`s and `expect`s. Let's get rid of them.

Here is the list of functions that now return a Result with `anyhow::Error` (to be expanded) :

- main()
- cli::upgrade_workers()
- cli::upgrade_main()
- worker::begin_worker_process()
- upgrade::begin_new_main_process()
- upgrade::start_new_main_process()
- CommandServer::metrics()
- CommandServer::query()
- CommandServer::worker_order()
- CommandServer::upgrade_main()
- start_workers(), 
- start_worker(), 
- start_worker_process(), 
- begin_worker_process()
- disable_close_on_exec()
- enable_close_on_exec() 
