### PR TITLE
0.14 More verbose CLI logging command

### DIFF
--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -106,8 +106,9 @@ pub enum SubCmd {
     },
     #[structopt(name = "logging", about = "change logging level")]
     Logging {
-        #[structopt(short = "l", long = "level", help = "change logging level")]
-        level: String,
+        // #[structopt(short = "l", long = "level", help = "change logging level")]
+        #[structopt(subcommand)]
+        level: LoggingLevel,
     },
     #[structopt(name = "state", about = "state management")]
     State {
@@ -191,6 +192,28 @@ pub enum MetricsCmd {
     },
     #[structopt(name = "clear", about = "Deletes local metrics data")]
     Clear,
+}
+
+#[derive(StructOpt, PartialEq, Debug)]
+pub enum LoggingLevel {
+    #[structopt(name = "trace", about = "Displays a LOT of logs")]
+    Trace,
+    #[structopt(
+        name = "debug",
+        about = "Displays more logs about the inner workings of Sōzu"
+    )]
+    Debug,
+    #[structopt(name = "error", about = "Displays occurring errors")]
+    Error,
+    #[structopt(name = "warn", about = "Displays warnings about non-critical errors")]
+    Warn,
+    #[structopt(name = "info", about = "Displays logs about normal behaviour of Sōzu")]
+    Info,
+}
+impl std::fmt::Display for LoggingLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 #[derive(StructOpt, PartialEq, Debug)]

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -1,4 +1,4 @@
-use crate::cli::MetricsCmd;
+use crate::cli::{LoggingLevel, MetricsCmd};
 use sozu_command::certificate::{calculate_fingerprint, split_certificate_chain};
 use sozu_command::channel::Channel;
 use sozu_command::command::{
@@ -1859,12 +1859,12 @@ pub fn query_metrics(
 pub fn logging_filter(
     channel: Channel<CommandRequest, CommandResponse>,
     timeout: u64,
-    filter: &str,
+    filter: &LoggingLevel,
 ) -> Result<(), anyhow::Error> {
     order_command(
         channel,
         timeout,
-        ProxyRequestData::Logging(String::from(filter)),
+        ProxyRequestData::Logging(filter.to_string().to_lowercase()),
     )
 }
 


### PR DESCRIPTION
Now we can do:

```
sozu logging
```

It displays a more user-friendly interface:

```
sozu-logging 0.13.6
change logging level

USAGE:
    sozu logging <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    debug    Displays more logs about the inner workings of Sōzu
    error    Displays occurring errors
    help     Prints this message or the help of the given subcommand(s)
    info     Displays logs about normal behaviour of Sōzu
    trace    Displays a LOT of logs
    warn     Displays warnings about non-critical errors

```