### PR TITLE
List frontends in the CLI

### DIFF
--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -304,6 +304,15 @@ pub enum FrontendCmd {
         #[structopt(subcommand)]
         cmd: TcpFrontendCmd,
     },
+    #[structopt(name = "list", about = "list frontends using filters")]
+    List {
+        #[structopt(long = "http", help = "filter for http frontends")]
+        http: bool,
+        #[structopt(long = "https", help = "filter for https frontends")]
+        https: bool,
+        #[structopt(long = "tcp", help = "filter for tcp frontends")]
+        tcp: bool,
+    },
 }
 
 #[derive(StructOpt, PartialEq, Debug)]

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -304,7 +304,7 @@ pub enum FrontendCmd {
         #[structopt(subcommand)]
         cmd: TcpFrontendCmd,
     },
-    #[structopt(name = "list", about = "list frontends using filters")]
+    #[structopt(name = "list", about = "List frontends using filters")]
     List {
         #[structopt(long = "http", help = "filter for http frontends")]
         http: bool,
@@ -312,6 +312,12 @@ pub enum FrontendCmd {
         https: bool,
         #[structopt(long = "tcp", help = "filter for tcp frontends")]
         tcp: bool,
+        #[structopt(
+            short = "d",
+            long = "domain",
+            help = "filter by domain name (for http & https frontends)"
+        )]
+        domain: Option<String>,
     },
 }
 

--- a/bin/src/command/orders.rs
+++ b/bin/src/command/orders.rs
@@ -15,7 +15,7 @@ use async_io::Async;
 use sozu_command::buffer::fixed::Buffer;
 use sozu_command::command::{
     CommandRequest, CommandRequestData, CommandResponse, CommandResponseData, CommandStatus,
-    RunState, WorkerInfo,
+    FrontendFilters, RunState, WorkerInfo,
 };
 use sozu_command::logging;
 use sozu_command::proxy::{
@@ -42,6 +42,9 @@ impl CommandServer {
             }
             CommandRequestData::DumpState => self.dump_state(client_id, &request.id).await,
             CommandRequestData::ListWorkers => self.list_workers(client_id, request.id).await,
+            CommandRequestData::ListFrontends(filters) => {
+                self.list_frontends(client_id, &request.id, filters).await
+            }
             CommandRequestData::LoadState { path } => {
                 self.load_state(Some(client_id), request.id, &path).await
             }
@@ -347,6 +350,28 @@ impl CommandServer {
         gauge!("configuration.clusters", self.state.clusters.len());
         gauge!("configuration.backends", self.backends_count);
         gauge!("configuration.frontends", self.frontends_count);
+        Ok(())
+    }
+
+    pub async fn list_frontends(
+        &mut self,
+        client_id: String,
+        message_id: &str,
+        filters: FrontendFilters,
+    ) -> anyhow::Result<()> {
+        info!("Received a request to list frontends, along these filters: {:#?}", filters);
+
+        info!("Here is the config: {:#?}", self.config);
+
+        self.answer_success(
+            client_id,
+            message_id,
+            String::from("This message comes with answer_success()"),
+            Some(CommandResponseData::FrontendList(String::from(
+                "Hello world!",
+            ))),
+        )
+        .await;
         Ok(())
     }
 

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -178,8 +178,8 @@ pub fn ctl(matches: cli::Sozu) -> Result<(), anyhow::Error> {
                     remove_tcp_frontend(channel, timeout, &id, address)
                 }
             },
-            FrontendCmd::List { http, https, tcp } => {
-                list_frontends(channel, timeout, http, https, tcp)
+            FrontendCmd::List { http, https, tcp, domain } => {
+                list_frontends(channel, timeout, http, https, tcp, domain)
             }
         },
         SubCmd::Listener { cmd } => match cmd {

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -12,9 +12,9 @@ use std::io;
 use self::command::{
     activate_listener, add_application, add_backend, add_certificate, add_http_frontend,
     add_http_listener, add_https_listener, add_tcp_frontend, add_tcp_listener, deactivate_listener,
-    dump_state, events, hard_stop, load_state, logging_filter, metrics, query_application,
-    query_certificate, query_metrics, reload_configuration, remove_application, remove_backend,
-    remove_certificate, remove_http_frontend, remove_listener, remove_tcp_frontend,
+    dump_state, events, hard_stop, list_frontends, load_state, logging_filter, metrics,
+    query_application, query_certificate, query_metrics, reload_configuration, remove_application,
+    remove_backend, remove_certificate, remove_http_frontend, remove_listener, remove_tcp_frontend,
     replace_certificate, save_state, soft_stop, status, upgrade_main, upgrade_worker,
 };
 use crate::cli::*;
@@ -178,6 +178,9 @@ pub fn ctl(matches: cli::Sozu) -> Result<(), anyhow::Error> {
                     remove_tcp_frontend(channel, timeout, &id, address)
                 }
             },
+            FrontendCmd::List { http, https, tcp } => {
+                list_frontends(channel, timeout, http, https, tcp)
+            }
         },
         SubCmd::Listener { cmd } => match cmd {
             ListenerCmd::Http { cmd } => match cmd {

--- a/command/src/command.rs
+++ b/command/src/command.rs
@@ -14,11 +14,19 @@ pub enum CommandRequestData {
     LoadState { path: String },
     DumpState,
     ListWorkers,
+    ListFrontends(FrontendFilters),
     LaunchWorker(String),
     UpgradeMain,
     UpgradeWorker(u32),
     SubscribeEvents,
     ReloadConfiguration { path: Option<String> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct FrontendFilters {
+    pub http: bool,
+    pub https: bool,
+    pub tcp: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -58,6 +66,7 @@ pub enum CommandResponseData {
     Query(BTreeMap<String, QueryAnswer>),
     State(ConfigState),
     Event(Event),
+    FrontendList(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/command/src/command.rs
+++ b/command/src/command.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
 
-use crate::proxy::{AggregatedMetricsData, ProxyEvent, ProxyRequestData, QueryAnswer};
+use crate::proxy::{
+    AggregatedMetricsData, HttpFrontend, ProxyEvent, ProxyRequestData, QueryAnswer, TcpFrontend,
+};
 use crate::state::ConfigState;
 
 pub const PROTOCOL_VERSION: u8 = 0;
@@ -27,6 +29,7 @@ pub struct FrontendFilters {
     pub http: bool,
     pub https: bool,
     pub tcp: bool,
+    pub domain: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -66,7 +69,14 @@ pub enum CommandResponseData {
     Query(BTreeMap<String, QueryAnswer>),
     State(ConfigState),
     Event(Event),
-    FrontendList(String),
+    FrontendList(ListedFrontends),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ListedFrontends {
+    pub http_frontends: Vec<HttpFrontend>,
+    pub https_frontends: Vec<HttpFrontend>,
+    pub tcp_frontends: Vec<TcpFrontend>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/command/src/proxy.rs
+++ b/command/src/proxy.rs
@@ -989,6 +989,15 @@ fn is_default<T: Default + PartialEq>(t: &T) -> bool {
     t == &T::default()
 }
 
+impl std::fmt::Display for Route {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Route::Deny => write!(f, "deny"),
+            Route::ClusterId(string) => write!(f, "{}", string),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
As suggested in #628 , we want to list frontends using the CLI, and apply filters like:

* tcp frontends
* http frontends
* https frontends
* domain name
* etc.
