### PR TITLE
remove dead code

### DIFF
--- a/bin/config.toml
+++ b/bin/config.toml
@@ -67,6 +67,8 @@ handle_process_affinity = false
 # defaults to 10000 maximum connections
 max_connections = 500
 
+# maximum number of connections accepted alltogether.
+
 # maximum number of buffers in the pool used by the protocol implementations
 # for active connections (ie currently serving a request). For now, you should
 # estimate that max_buffers = number of concurrent requests * 2

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -1298,6 +1298,7 @@ pub struct Proxy {
     sessions: Rc<RefCell<SessionManager>>,
 }
 
+
 impl Proxy {
     pub fn new(
         registry: Registry,


### PR DESCRIPTION
While searching the codebase for #644, I stumbled upon dead code and confusing comments. This PR removes the code and makes those few comments relevant.