### PR TITLE
0.14 socket connection error management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,7 @@ dependencies = [
 name = "sozu-command-lib"
 version = "0.13.6"
 dependencies = [
+ "anyhow",
  "hex",
  "libc",
  "log 0.4.14",

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -109,7 +109,7 @@ fn start(matches: &cli::Sozu) -> Result<(), anyhow::Error> {
         set_workers_affinity(&workers);
     }
 
-    let command_socket_path = config.command_socket_path();
+    let command_socket_path = config.command_socket_path()?;
 
     command::start(config, command_socket_path, workers).with_context(|| "could not start Sozu")?;
 

--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -22,6 +22,7 @@ include = [
 ]
 
 [dependencies]
+anyhow = "^1.0.42"
 hex = "^0.4"
 log = "^0.4"
 pem = "^0.8"


### PR DESCRIPTION
As mentioned in

- #721 

We have a nasty `panic!` when trying to connect to a unix socket that isn't there.

```
thread 'main' panicked at 'could not connect to the command unix socket: Os { code: 111, kind: ConnectionRefused, message: "Connection refused" }', bin/src/ctl/mod.rs:37:43
```

This pull request fixes it with `anyhow` and its `Context` that make a much nicer (and more traceable) error management:

```
Error: could not connect to the command unix socket

Caused by:
    0: Could not create Channel from the given path
    1: Connection refused (os error 111)

```