### PR TITLE
Comprehensive timeout management

### DIFF
--- a/bin/src/command/orders.rs
+++ b/bin/src/command/orders.rs
@@ -545,7 +545,7 @@ impl CommandServer {
                 .send(CommandResponse::new(
                     request_id.clone(),
                     CommandStatus::Processing,
-                    "".to_string(),
+                    "The proxy is processing the upgrade command".to_string(),
                     None,
                 ))
                 .await

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -321,9 +321,15 @@ pub fn upgrade_main(
                     .collect::<Vec<_>>();
                 let running_count = running_workers.len();
                 for (i, ref worker) in running_workers.iter().enumerate() {
-                    println!("Upgrading worker {} (of {})", i + 1, running_count);
+                    println!(
+                        "Upgrading worker {} (#{} out of {})",
+                        worker.id,
+                        i + 1,
+                        running_count
+                    );
 
-                    upgrade_worker(&mut channel, Duration::ZERO, worker.id)?;
+                    upgrade_worker(&mut channel, Duration::ZERO, worker.id)
+                        .with_context(|| "Upgrading the worker failed")?;
                     //thread::sleep(Duration::from_millis(1000));
                 }
 

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -59,7 +59,7 @@ fn read_channel_message_with_timeout(
     timeout: Duration,
 ) -> anyhow::Result<CommandResponse> {
     match channel.read_message_blocking_timeout(Some(timeout)) {
-        None => bail!("The proxy didn't answer"),
+        None => bail!("Command timeout. The proxy didn't send an answer"),
         Some(payload) => Ok(payload),
     }
 }
@@ -328,7 +328,7 @@ pub fn upgrade_main(
                         running_count
                     );
 
-                    upgrade_worker(&mut channel, Duration::ZERO, worker.id)
+                    upgrade_worker(&mut channel, timeout, worker.id)
                         .with_context(|| "Upgrading the worker failed")?;
                     //thread::sleep(Duration::from_millis(1000));
                 }

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -35,8 +35,9 @@ pub fn ctl(matches: cli::Sozu) -> Result<(), anyhow::Error> {
         std::process::exit(0);
     }
 
-    let mut channel =
-        create_channel(&config).with_context(|| "could not connect to the command unix socket")?;
+    let mut channel = create_channel(&config).with_context(|| {
+        "could not connect to the command unix socket. Are you sure the proxy is up?"
+    })?;
     let timeout = Duration::from_millis(matches.timeout.unwrap_or(config.ctl_command_timeout));
 
     match matches.cmd {

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -35,7 +35,7 @@ pub fn ctl(matches: cli::Sozu) -> Result<(), anyhow::Error> {
         std::process::exit(0);
     }
 
-    let channel =
+    let mut channel =
         create_channel(&config).with_context(|| "could not connect to the command unix socket")?;
     let timeout = Duration::from_millis(matches.timeout.unwrap_or(config.ctl_command_timeout));
 
@@ -49,7 +49,7 @@ pub fn ctl(matches: cli::Sozu) -> Result<(), anyhow::Error> {
         }
         SubCmd::Upgrade { worker: None } => upgrade_main(channel, timeout, &config),
         SubCmd::Upgrade { worker: Some(id) } => {
-            upgrade_worker(channel, timeout, id)?;
+            upgrade_worker(&mut channel, timeout, id)?;
             Ok(())
         }
         SubCmd::Status { json } => status(channel, timeout, json),

--- a/command/src/channel.rs
+++ b/command/src/channel.rs
@@ -242,7 +242,22 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
     }
 
     pub fn read_message_blocking(&mut self) -> Option<Rx> {
+        self.read_message_blocking_timeout(None)
+    }
+
+    pub fn read_message_blocking_timeout(
+        &mut self,
+        timeout: Option<std::time::Duration>,
+    ) -> Option<Rx> {
+        let now = std::time::Instant::now();
+
         loop {
+            if timeout.is_some() {
+                if now.elapsed() >= timeout.unwrap() {
+                    return None;
+                }
+            }
+
             if let Some(pos) = self.front_buf.data().iter().position(|&x| x == 0) {
                 let mut res = None;
 

--- a/command/src/channel.rs
+++ b/command/src/channel.rs
@@ -11,6 +11,7 @@ use std::marker::PhantomData;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::net;
 use std::str::from_utf8;
+use std::time::Duration;
 
 use crate::buffer::growable::Buffer;
 use crate::ready::Ready;
@@ -247,7 +248,7 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
 
     pub fn read_message_blocking_timeout(
         &mut self,
-        timeout: Option<std::time::Duration>,
+        timeout: Option<Duration>,
     ) -> Option<Rx> {
         let now = std::time::Instant::now();
 


### PR DESCRIPTION
To solve this issue:

- #723

We need:
- a proper management of timeout on **all** sozuctl operations, 
- to remove the `command_timeout!` macro that renders development difficult (weird typing mistakes)

This PR replaces the macro with:

```rust
fn read_channel_message_with_timeout(
    mut channel: Channel<CommandRequest, CommandResponse>,
    timeout: Duration,
) -> anyhow::Result<CommandResponse> {}
```