### PR TITLE
Safeguard against thread panick scenario

### DIFF
--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -456,10 +456,10 @@ impl Server {
             debug!("got message: {:?}", msg);
 
             // it so happens that trying to upgrade a dead worker will bring no message
-            // which brings the whole main processe to crash because it unwraps a None
-            if msg.is_some() {
+            // which brings the whole main process to crash because it unwraps a None
+            if let Some(msg) = msg {
                 server.channel.write_message(&ProxyResponse {
-                    id: msg.unwrap().id,
+                    id: msg.id,
                     status: ProxyResponseStatus::Ok,
                     data: None,
                 });


### PR DESCRIPTION
This is to resolve the behaviour pointed here:

- #704 

So I put a condition on an uncanny `unwrap()` so we don't give it a `None`

This fix should definitely be merged for safety, but should not close the issue, since the main process returns this info about a **dead worker*** :

```
➤ cargo run -- --config config.toml upgrade -w 1
initializing logger
upgrading worker 1
2021-October-27T17:03:49.483098Z 1635354229483098774 29290 MAIN INFO    Worker 1 is processing: sending configuration orders
Error: Command timeout. The proxy didn't send answer
```