### PR TITLE
update to rustls 0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,27 +1310,23 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = [
- "base64",
- "log 0.4.14",
- "ring",
- "sct 0.6.1",
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "rustls"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b5ac6078ca424dc1d3ae2328526a76787fecc7f8011f520e3276730e711fc95"
 dependencies = [
  "log 0.4.14",
  "ring",
- "sct 0.7.0",
- "webpki 0.22.0",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -1354,16 +1350,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "sct"
@@ -1583,7 +1569,8 @@ dependencies = [
  "quickcheck",
  "rand",
  "regex",
- "rustls 0.19.1",
+ "rustls",
+ "rustls-pemfile",
  "rusty_ulid",
  "sha2",
  "slab",
@@ -1594,7 +1581,7 @@ dependencies = [
  "tiny_http",
  "ureq",
  "url",
- "webpki 0.22.0",
+ "webpki",
  "x509-parser",
 ]
 
@@ -1872,9 +1859,9 @@ dependencies = [
  "chunked_transfer",
  "log 0.4.14",
  "once_cell",
- "rustls 0.20.0",
+ "rustls",
  "url",
- "webpki 0.22.0",
+ "webpki",
  "webpki-roots",
 ]
 
@@ -1992,16 +1979,6 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
@@ -2016,7 +1993,7 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c475786c6f47219345717a043a37ec04cb4bc185e28853adcc4fa0a947eba630"
 dependencies = [
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -36,7 +36,8 @@ sha2 = "^0.9"
 pool = "^0.1"
 openssl = {version="^0.10.26", optional = true}
 openssl-sys = {version="^0.9", optional = true}
-rustls = "^0.19"
+rustls = "^0.20"
+rustls-pemfile = "^0.2"
 webpki = "^0.22"
 hdrhistogram = "^7.0"
 sozu-command-lib = { version = "^0.13.0", path = "../command" }

--- a/lib/src/protocol/rustls.rs
+++ b/lib/src/protocol/rustls.rs
@@ -2,7 +2,7 @@ use crate::protocol::ProtocolResult;
 use crate::Ready;
 use crate::{Readiness, SessionResult};
 use mio::net::*;
-use rustls::{ServerSession, Session};
+use rustls::ServerConnection;
 use rusty_ulid::Ulid;
 use std::io::ErrorKind;
 
@@ -15,13 +15,13 @@ pub enum TlsState {
 
 pub struct TlsHandshake {
     pub stream: TcpStream,
-    pub session: ServerSession,
+    pub session: ServerConnection,
     pub readiness: Readiness,
     pub request_id: Ulid,
 }
 
 impl TlsHandshake {
-    pub fn new(session: ServerSession, stream: TcpStream, request_id: Ulid) -> TlsHandshake {
+    pub fn new(session: ServerConnection, stream: TcpStream, request_id: Ulid) -> TlsHandshake {
         TlsHandshake {
             stream,
             session,

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -1780,7 +1780,7 @@ impl HttpsProvider {
     pub fn add_listener(&mut self, config: HttpsListener, token: Token) -> Option<Token> {
         match self {
             &mut HttpsProvider::Rustls(ref mut rustls) => {
-                rustls.borrow_mut().add_listener(config, token)
+                rustls.borrow_mut().add_listener(config, token).ok().flatten()
             }
             &mut HttpsProvider::Openssl(ref mut openssl) => {
                 openssl.borrow_mut().add_listener(config, token)
@@ -1878,7 +1878,7 @@ impl HttpsProvider {
 
     pub fn add_listener(&mut self, config: HttpsListener, token: Token) -> Option<Token> {
         let &mut HttpsProvider::Rustls(ref mut rustls) = self;
-        rustls.borrow_mut().add_listener(config, token)
+        rustls.borrow_mut().add_listener(config, token).ok().flatten()
     }
 
     pub fn activate_listener(

--- a/lib/src/socket.rs
+++ b/lib/src/socket.rs
@@ -1,7 +1,7 @@
 use mio::net::{TcpListener, TcpStream};
 #[cfg(feature = "use-openssl")]
 use openssl::ssl::{ErrorCode, SslStream, SslVersion};
-use rustls::{ProtocolVersion, ServerSession, Session};
+use rustls::{ProtocolVersion, ServerConnection};
 use socket2::{Domain, Protocol, Socket, Type};
 use std::io::{self, ErrorKind, Read, Write};
 use std::net::SocketAddr;
@@ -246,7 +246,7 @@ impl SocketHandler for SslStream<TcpStream> {
 
 pub struct FrontRustls {
     pub stream: TcpStream,
-    pub session: ServerSession,
+    pub session: ServerConnection,
 }
 
 impl SocketHandler for FrontRustls {
@@ -295,7 +295,7 @@ impl SocketHandler for FrontRustls {
             }
 
             while !self.session.wants_read() {
-                match self.session.read(&mut buf[size..]) {
+                match self.session.reader().read(&mut buf[size..]) {
                     Ok(0) => break,
                     Ok(sz) => size += sz,
                     Err(e) => match e.kind() {
@@ -344,7 +344,7 @@ impl SocketHandler for FrontRustls {
                 break;
             }
 
-            match self.session.write(&buf[buffered_size..]) {
+            match self.session.writer().write(&buf[buffered_size..]) {
                 Ok(0) => {
                     break;
                 }
@@ -421,7 +421,7 @@ impl SocketHandler for FrontRustls {
 
     fn protocol(&self) -> TransportProtocol {
         self.session
-            .get_protocol_version()
+            .protocol_version()
             .map(|version| match version {
                 ProtocolVersion::SSLv2 => TransportProtocol::Ssl2,
                 ProtocolVersion::SSLv3 => TransportProtocol::Ssl3,


### PR DESCRIPTION
A couple of caveats:
- for rustls, we now only pass the supported protocols to the configuration and log errors for others
- ~~when there is no match between configured ciphers and protocols, we now panic (which is far from ideal, but ...)~~