### PR TITLE
error logging on getting saved_state from the config

### DIFF
--- a/bin/config.toml
+++ b/bin/config.toml
@@ -5,6 +5,7 @@
 # path to a file sozu can use to load an initial configuration state for its
 # routing. You can generate this file from sozu's current routing by running
 # the command `sozuctl state save -f state.json`
+# this must be RELATIVE to config.toml
 saved_state = "./state.json"
 
 # save the configuration to the saved_state file every time we receive a

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -627,11 +627,12 @@ pub fn start(
         })
         .detach();
 
-        let saved_state = config.saved_state_path();
+        let saved_state_path = config.saved_state.clone();
+
         let mut server = CommandServer::new(fd, config, tx, command_rx, workers, accept_cancel_tx)?;
         server.load_static_application_configuration().await;
 
-        if let Some(path) = saved_state {
+        if let Some(path) = saved_state_path {
             server
                 .load_state(None, "INITIALIZATION".to_string(), &path)
                 .await?;

--- a/command/assets/state.json
+++ b/command/assets/state.json
@@ -1,0 +1,2 @@
+This file is here only to check that this line in config.toml will be parsed:
+saved_state = './state.json'

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -1150,6 +1150,7 @@ impl Config {
 
         let mut config = file_config.into(path);
 
+        // replace saved_state with a verified path
         config.saved_state = config
             .saved_state_path()
             .with_context(|| "Invalid saved_state in the config. Check your config file")?;
@@ -1320,13 +1321,15 @@ impl Config {
         saved_state_path_raw.canonicalize().with_context(|| {
             format!(
                 "could not get saved state path from config file input {:?}",
-                self.saved_state
+                path
             )
         })?;
 
         let stringified_path = saved_state_path_raw
             .to_str()
-            .ok_or(anyhow::Error::msg("Unvalid character format, expected UTF8"))?
+            .ok_or(anyhow::Error::msg(
+                "Unvalid character format, expected UTF8",
+            ))?
             .to_string();
 
         return Ok(Some(stringified_path));
@@ -1444,8 +1447,9 @@ mod tests {
 
     #[test]
     fn parse() {
-        let res = Config::load_from_path("assets/config.toml");
-        let config = res.unwrap();
+        let path = "assets/config.toml";
+        let config =
+            Config::load_from_path(path).expect(&format!("Cannot load config from path {}", path));
         println!("config: {:#?}", config);
         //panic!();
     }

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -1145,7 +1145,10 @@ fn default_accept_queue_timeout() -> u32 {
 
 impl Config {
     pub fn load_from_path(path: &str) -> anyhow::Result<Config> {
-        let mut config = FileConfig::load_from_path(path).map(|config| config.into(path))?;
+        let file_config =
+            FileConfig::load_from_path(path).with_context(|| "Could not load the config file")?;
+
+        let mut config = file_config.into(path);
 
         config.saved_state = config
             .saved_state_path()
@@ -1289,7 +1292,7 @@ impl Config {
             .with_context(|| "could not parse command socket path")
     }
 
-    pub fn saved_state_path(&self) -> anyhow::Result<Option<String>> {
+    fn saved_state_path(&self) -> anyhow::Result<Option<String>> {
         let path = match self.saved_state.as_ref() {
             Some(path) => path,
             None => return Ok(None),
@@ -1323,7 +1326,7 @@ impl Config {
 
         let stringified_path = saved_state_path_raw
             .to_str()
-            .ok_or(anyhow::Error::msg("Unvalid UTF8"))?
+            .ok_or(anyhow::Error::msg("Unvalid character format, expected UTF8"))?
             .to_string();
 
         return Ok(Some(stringified_path));


### PR DESCRIPTION
I realized Sōzu would start even if the `saved_state` provided in `config.toml` is wrong when doing

```
sozu --config config.toml start
```

To solve this I put the `saved_state_path()` method of `Config` inside its loading function, instead of within a spawned and unstoppable thread in `CommandServer::Start()` as it is now.

Add error management to it and it yields neat errors like this:

```
Error: Invalid configuration file.

Caused by:
    0: Invalid saved_state in the config. Check your config file
    1: could not get saved state path from config file input Some("./wrong_state_path.json")
    2: No such file or directory (os error 2)
```