### PR TITLE
Refactoring of command execution

### DIFF
--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -1,4 +1,4 @@
-use sozu_command::proxy::{LoadBalancingAlgorithms, TlsVersion};
+use sozu_command_lib::proxy::{LoadBalancingAlgorithms, TlsVersion};
 use std::net::SocketAddr;
 
 #[derive(StructOpt, PartialEq, Debug)]
@@ -355,11 +355,11 @@ pub enum Route {
     Deny,
 }
 
-impl std::convert::Into<sozu_command::proxy::Route> for Route {
-    fn into(self) -> sozu_command::proxy::Route {
+impl std::convert::Into<sozu_command_lib::proxy::Route> for Route {
+    fn into(self) -> sozu_command_lib::proxy::Route {
         match self {
-            Route::Deny => sozu_command::proxy::Route::Deny,
-            Route::Id { id } => sozu_command::proxy::Route::ClusterId(id),
+            Route::Deny => sozu_command_lib::proxy::Route::Deny,
+            Route::Id { id } => sozu_command_lib::proxy::Route::ClusterId(id),
         }
     }
 }

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -20,7 +20,9 @@ use sozu_command::command::{
 };
 use sozu_command::config::Config;
 
-use sozu_command::proxy::{ProxyRequest, ProxyRequestData, ProxyResponseData, ProxyResponseStatus};
+use sozu_command::proxy::{
+    ProxyRequest, ProxyRequestData, ProxyResponse, ProxyResponseData, ProxyResponseStatus,
+};
 use sozu_command::scm_socket::{Listeners, ScmSocket};
 use sozu_command::state::ConfigState;
 
@@ -118,14 +120,17 @@ impl CommandServer {
                 let fd = sock.into_raw_fd();
                 UnixStream::from_raw_fd(fd)
             })
-            .unwrap();
+            .with_context(|| "Could not get a unix stream from the file descriptor")?;
 
             let id = worker.id;
             let command_tx = command_tx.clone();
             smol::spawn(async move {
-                worker_loop(id, stream, command_tx, worker_rx)
+                if worker_loop(id, stream, command_tx, worker_rx)
                     .await
-                    .unwrap();
+                    .is_err()
+                {
+                    error!("The worker loop of worker {} crashed", id);
+                }
             })
             .detach();
         }
@@ -507,7 +512,7 @@ impl CommandServer {
         Ok(())
     }
 
-    async fn handle_worker_close(&mut self, id: u32) {
+    async fn handle_worker_close(&mut self, id: u32) -> anyhow::Result<OrderSuccess> {
         info!("removing worker {}", id);
 
         if let Some(w) = self.workers.iter_mut().filter(|w| w.id == id).next() {
@@ -518,14 +523,14 @@ impl CommandServer {
                     Ok(()) => info!("Worker {} has automatically restarted!", id),
                     Err(e) => error!("Could not restart worker {}: {}", id, e),
                 }
-                return;
+                return Ok(OrderSuccess::WorkerRestarted(id));
             }
 
             info!("Closing the worker {}.", w.id);
             if !w.the_pid_is_alive() {
                 info!("Worker {} is dead, setting to Stopped.", w.id);
                 w.run_state = RunState::Stopped;
-                return;
+                return Ok(OrderSuccess::WorkerStopped(id));
             }
 
             info!("Worker {} is not dead but should be. Let's kill it.", w.id);
@@ -534,10 +539,68 @@ impl CommandServer {
                 Ok(()) => {
                     info!("Worker {} was successfuly killed", id);
                     w.run_state = RunState::Stopped;
+                    return Ok(OrderSuccess::WorkerKilled(id));
                 }
-                Err(e) => error!("failed to kill the worker process: {:?}", e),
+                Err(e) => {
+                    return Err(e).with_context(|| "failed to kill the worker process");
+                }
             }
         }
+        bail!(format!("Could not find worker {}", id))
+    }
+
+    async fn handle_worker_response(
+        &mut self,
+        id: u32,
+        message: ProxyResponse,
+    ) -> anyhow::Result<OrderSuccess> {
+        debug!("worker {} sent back {:?}", id, message);
+        if let Some(ProxyResponseData::Event(data)) = message.data {
+            let event: Event = data.into();
+            for client_id in self.event_subscribers.iter() {
+                if let Some(tx) = self.clients.get_mut(client_id) {
+                    let event = CommandResponse::new(
+                        message.id.to_string(),
+                        CommandStatus::Processing,
+                        format!("{}", id),
+                        Some(CommandResponseData::Event(event.clone())),
+                    );
+                    tx.send(event).await.with_context(|| {
+                        format!("could not send message to client {}", client_id)
+                    })?
+                }
+            }
+            return Ok(OrderSuccess::PropagatedWorkerEvent);
+        }
+        match self.in_flight.remove(&message.id) {
+            None => {
+                // FIXME: this messsage happens a lot at startup because AddCluster
+                // messages receive responses from each of the HTTP, HTTPS and TCP
+                // proxys. The clusters list should be merged
+                debug!("unknown message id: {}", message.id);
+            }
+            Some((mut tx, mut nb)) => {
+                let message_id = message.id.clone();
+
+                // if a worker returned Ok or Error, we're not expecting any more
+                // messages with this id from it
+                match message.status {
+                    ProxyResponseStatus::Ok | ProxyResponseStatus::Error(_) => {
+                        nb -= 1;
+                    }
+                    _ => {}
+                };
+
+                if tx.send(message.clone()).await.is_err() {
+                    error!("Failed to send message: {}", message);
+                };
+
+                if nb > 0 {
+                    self.in_flight.insert(message_id, (tx, nb));
+                }
+            }
+        }
+        Ok(OrderSuccess::WorkerResponse)
     }
 }
 
@@ -635,7 +698,8 @@ pub fn start(
         if let Some(path) = saved_state_path {
             server
                 .load_state(None, "INITIALIZATION".to_string(), &path)
-                .await?;
+                .await
+                .with_context(|| format!("Loading {:?} failed", &path))?;
         }
         gauge!("configuration.clusters", server.state.clusters.len());
         gauge!("configuration.backends", server.backends_count);
@@ -672,75 +736,60 @@ enum CommandMessage {
 impl CommandServer {
     pub async fn run(&mut self) {
         while let Some(msg) = self.command_rx.next().await {
-            match msg {
+            let result: anyhow::Result<OrderSuccess> = match msg {
                 CommandMessage::ClientNew { id, sender } => {
                     debug!("adding new client {}", id);
-                    self.clients.insert(id, sender);
+                    self.clients.insert(id.to_owned(), sender);
+                    Ok(OrderSuccess::ClientNew(id))
                 }
                 CommandMessage::ClientClose { id } => {
                     debug!("removing client {}", id);
                     self.clients.remove(&id);
                     self.event_subscribers.remove(&id);
+                    Ok(OrderSuccess::ClientClose(id))
                 }
                 CommandMessage::ClientRequest { id, message } => {
                     debug!("client {} sent {:?}", id, message);
-                    match self.handle_client_message(id, message).await {
-                        Ok(()) => {}
-                        Err(e) => error!("{}", e),
-                    }
+                    self.handle_client_message(id, message).await
                 }
-                CommandMessage::WorkerClose { id } => {
-                    self.handle_worker_close(id).await;
-                }
-                CommandMessage::WorkerResponse { id, message } => {
-                    debug!("worker {} sent back {:?}", id, message);
-                    if let Some(ProxyResponseData::Event(data)) = message.data {
-                        let event: Event = data.into();
-                        for client_id in self.event_subscribers.iter() {
-                            if let Some(tx) = self.clients.get_mut(client_id) {
-                                let event = CommandResponse::new(
-                                    message.id.to_string(),
-                                    CommandStatus::Processing,
-                                    format!("{}", id),
-                                    Some(CommandResponseData::Event(event.clone())),
-                                );
-                                if let Err(e) = tx.send(event).await {
-                                    error!("could not send message to client: {:?}", e);
-                                }
-                            }
-                        }
-                    } else {
-                        match self.in_flight.remove(&message.id) {
-                            None => {
-                                // FIXME: this messsage happens a lot at startup because AddCluster
-                                // messages receive responses from each of the HTTP, HTTPS and TCP
-                                // proxys. The clusters list should be merged
-                                debug!("unknown message id: {}", message.id);
-                            }
-                            Some((mut tx, mut nb)) => {
-                                let message_id = message.id.clone();
-
-                                // if a worker returned Ok or Error, we're not expecting any more
-                                // messages with this id from it
-                                match message.status {
-                                    ProxyResponseStatus::Ok | ProxyResponseStatus::Error(_) => {
-                                        nb -= 1;
-                                    }
-                                    _ => {}
-                                };
-
-                                tx.send(message).await.unwrap();
-
-                                if nb > 0 {
-                                    self.in_flight.insert(message_id, (tx, nb));
-                                }
-                            }
-                        }
-                    }
-                }
+                CommandMessage::WorkerClose { id } => self
+                    .handle_worker_close(id)
+                    .await
+                    .with_context(|| "Could not close worker"),
+                CommandMessage::WorkerResponse { id, message } => self
+                    .handle_worker_response(id, message)
+                    .await
+                    .with_context(|| "Could not handle worker response"),
                 CommandMessage::MasterStop => {
                     info!("stopping main process");
-                    break;
+                    Ok(OrderSuccess::MasterStop)
+                }
+            };
+
+            match result {
+                Ok(order_success) => {
+                    info!("Order OK: {}", order_success);
+
+                    // perform shutdowns
+                    match order_success {
+                        OrderSuccess::UpgradeMain(_) => {
+                            // the main process has to shutdown after the other has launched successfully
+                            //FIXME: should do some cleanup before exiting
+                            std::thread::sleep(std::time::Duration::from_secs(2));
+                            std::process::exit(0);
+                        }
+                        OrderSuccess::MasterStop => {
+                            // breaking the loop brings run() to return and ends Sōzu
+                            // shouldn't we have the same break for both shutdowns?
+                            
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+                Err(error) => {
+                    // log the error on the main process without stopping it
+                    error!("Failed order: {:#?}", error);
                 }
             }
         }
@@ -915,4 +964,84 @@ async fn worker_loop(
     tx.send(CommandMessage::WorkerClose { id }).await.unwrap();
 
     Ok(())
+}
+
+pub enum OrderSuccess {
+    ClientClose(String),
+    ClientNew(String),
+    ClientRequest,
+    DumpState(CommandResponseData), // contains the cloned state
+    LaunchWorker(u32),
+    ListFrontends(CommandResponseData),
+    ListWorkers(CommandResponseData),
+    LoadState(String, usize, usize), // path, ok, errors
+    MasterStop,
+    // this should contain CommandResponseData but the logic does not return anything
+    // is this logic gone into sozu_command_lib::proxy::Query::Metrics(_) ?
+    Metrics,
+    PropagatedWorkerEvent,
+    Query(CommandResponseData), // same remark
+    ReloadConfiguration,
+    SaveState(usize, String),
+    SubscribeEvent(String),
+    UpgradeMain(i32),
+    UpgradeWorker(u32),
+    WorkerKilled(u32),
+    WorkerOrder(Option<u32>),
+    WorkerResponse,
+    WorkerRestarted(u32),
+    WorkerStopped(u32),
+}
+
+impl std::fmt::Display for OrderSuccess {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::ClientClose(id) => write!(f, "Close client: {}", id),
+            Self::ClientNew(id) => write!(f, "New client successfully added: {}", id),
+            Self::ClientRequest => write!(f, "Successfully executed client request"),
+            Self::DumpState(_) => write!(f, "Successfully gathered state from the main process"),
+            Self::LaunchWorker(worker_id) => {
+                write!(f, "Successfully launched worker {}", worker_id)
+            }
+            Self::ListFrontends(_) => write!(f, "Successfully gathered the list of frontends"),
+            Self::ListWorkers(_) => write!(f, "Listed all workers"),
+            Self::LoadState(path, ok, error) => write!(
+                f,
+                "Successfully loaded state from path {}, {} ok messages, {} errors",
+                path, ok, error
+            ),
+            Self::MasterStop => write!(f, "stopping main process"),
+            Self::Metrics => write!(f, "Successfully fetched the metrics"),
+            Self::PropagatedWorkerEvent => {
+                write!(f, "Sent worker response to all subscribing clients")
+            }
+            Self::Query(_) => write!(f, "Ran the query successfully"),
+            Self::ReloadConfiguration => write!(f, "Successfully reloaded configuration"),
+            Self::SaveState(counter, path) => {
+                write!(f, "saved {} config messages to {}", counter, path)
+            }
+            Self::SubscribeEvent(client_id) => {
+                write!(f, "Successfully Added {} to subscribers", client_id)
+            }
+            Self::UpgradeMain(pid) => write!(
+                f,
+                "new main process launched with pid {}, closing the old one",
+                pid
+            ),
+            Self::UpgradeWorker(id) => {
+                write!(f, "Successfully upgraded worker with new id: {}", id)
+            }
+            Self::WorkerKilled(id) => write!(f, "Successfully killed worker {}", id),
+            Self::WorkerOrder(worker) => {
+                if let Some(worker_id) = worker {
+                    write!(f, "Successfully executed the order on worker {}", worker_id)
+                } else {
+                    write!(f, "Successfully executed the order on worker")
+                }
+            }
+            Self::WorkerResponse => write!(f, "Successfully handled worker response"),
+            Self::WorkerRestarted(id) => write!(f, "Successfully restarted worker {}", id),
+            Self::WorkerStopped(id) => write!(f, "Successfully stopped worker {}", id),
+        }
+    }
 }

--- a/bin/src/command/orders.rs
+++ b/bin/src/command/orders.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use anyhow::{bail, Context};
 use futures::channel::mpsc::*;
 use futures::{SinkExt, StreamExt};
 use nom::{Err, HexDisplay, IResult, Offset};
@@ -26,7 +26,7 @@ use sozu_command::scm_socket::Listeners;
 use sozu_command::state::get_application_ids_by_domain;
 use sozu_command_lib::config::Config;
 
-use super::{CommandMessage, CommandServer};
+use super::{CommandMessage, CommandServer, OrderSuccess};
 use crate::upgrade::start_new_main_process;
 use crate::worker::start_worker;
 
@@ -35,83 +35,93 @@ impl CommandServer {
         &mut self,
         client_id: String,
         request: sozu_command::command::CommandRequest,
-    ) -> anyhow::Result<()> {
-        match request.data {
-            CommandRequestData::SaveState { path } => {
-                self.save_state(client_id, &request.id, &path).await
-            }
-            CommandRequestData::DumpState => self.dump_state(client_id, &request.id).await,
-            CommandRequestData::ListWorkers => self.list_workers(client_id, request.id).await,
-            CommandRequestData::ListFrontends(filters) => {
-                self.list_frontends(client_id, &request.id, filters).await
-            }
+    ) -> anyhow::Result<OrderSuccess> {
+        info!("Received order {:?}", request);
+        let owned_client_id = client_id.to_owned();
+        let owned_request_id = request.id.to_owned();
+
+        let result = match request.data {
+            CommandRequestData::SaveState { path } => self.save_state(&path).await,
+            CommandRequestData::DumpState => self.dump_state().await,
+            CommandRequestData::ListWorkers => self.list_workers().await,
+            CommandRequestData::ListFrontends(filters) => self.list_frontends(filters).await,
             CommandRequestData::LoadState { path } => {
-                self.load_state(Some(client_id), request.id, &path).await
+                self.load_state(Some(owned_client_id), owned_request_id.to_owned(), &path)
+                    .await
             }
             CommandRequestData::LaunchWorker(tag) => {
-                self.launch_worker(client_id, request.id, &tag).await
+                self.launch_worker(owned_client_id, owned_request_id, &tag)
+                    .await
             }
-            CommandRequestData::UpgradeMain => self.upgrade_main(client_id, request.id).await,
+            CommandRequestData::UpgradeMain => {
+                self.upgrade_main(owned_client_id, owned_request_id).await
+            }
             CommandRequestData::UpgradeWorker(worker_id) => {
-                self.upgrade_worker(client_id, request.id, worker_id).await
+                self.upgrade_worker(owned_client_id, owned_request_id, worker_id)
+                    .await
             }
-
             CommandRequestData::Proxy(proxy_request) => match proxy_request {
-                ProxyRequestData::Metrics(config) => {
-                    self.metrics(client_id, request.id, config).await
-                }
-                ProxyRequestData::Query(query) => self.query(client_id, request.id, query).await,
+                ProxyRequestData::Metrics(config) => self.metrics(owned_request_id, config).await,
+                ProxyRequestData::Query(query) => self.query(owned_request_id, query).await,
                 order => {
-                    self.worker_order(client_id, request.id, order, request.worker_id)
+                    self.worker_order(owned_client_id, owned_request_id, order, request.worker_id)
                         .await
                 }
             },
             CommandRequestData::SubscribeEvents => {
-                self.event_subscribers.insert(client_id);
-                Ok(())
+                self.event_subscribers.insert(client_id.clone());
+                Ok(OrderSuccess::SubscribeEvent(client_id.clone()))
             }
             CommandRequestData::ReloadConfiguration { path } => {
-                self.reload_configuration(Some(client_id), request.id, path)
+                self.reload_configuration(Some(owned_client_id), owned_request_id, path)
                     .await
+            }
+        };
+        match result {
+            Ok(order_success) => {
+                // no need to log the success here, it is down upstream
+
+                let success_message = order_success.to_string().to_owned();
+
+                let command_response_data = match order_success {
+                    // should list OrderSuccess::Metrics(crd) as well
+                    OrderSuccess::DumpState(crd)
+                    | OrderSuccess::ListFrontends(crd)
+                    | OrderSuccess::ListWorkers(crd)
+                    | OrderSuccess::Query(crd) => Some(crd),
+                    _ => None,
+                };
+
+                self.answer_success(
+                    client_id,
+                    request.id,
+                    success_message,
+                    command_response_data,
+                )
+                .await;
+
+                Ok(OrderSuccess::ClientRequest)
+            }
+            Err(error) => {
+                // no need to log the error here, it is down upstream
+                self.answer_error(client_id, request.id, error.to_string(), None)
+                    .await;
+                Err(error)
             }
         }
     }
 
-    pub async fn save_state(
-        &mut self,
-        client_id: String,
-        message_id: &str,
-        path: &str,
-    ) -> anyhow::Result<()> {
-        if let Ok(mut f) = fs::File::create(&path) {
-            match self.save_state_to_file(&mut f) {
-                Ok(counter) => {
-                    info!("wrote {} commands to {}", counter, path);
-                    self.answer_success(
-                        client_id,
-                        message_id,
-                        format!("saved {} config messages to {}", counter, path),
-                        None,
-                    )
-                    .await;
-                    Ok(())
-                }
-                Err(e) => {
-                    error!("failed writing state to file: {:?}", e);
-                    self.answer_error(client_id, message_id, "could not save state to file", None)
-                        .await;
-                    Err(anyhow::Error::from(e))
-                }
-            }
-        } else {
-            error!("could not open file: {}", &path);
-            self.answer_error(client_id, message_id, "could not open file", None)
-                .await;
-            Err(anyhow::Error::msg(format!(
-                "could not open file: {}",
-                &path
-            )))
-        }
+    pub async fn save_state(&mut self, path: &str) -> anyhow::Result<OrderSuccess> {
+        let mut file = fs::File::create(&path)
+            .with_context(|| format!("could not open file at path: {}", &path))?;
+
+        let counter = self
+            .save_state_to_file(&mut file)
+            .with_context(|| "failed writing state to file")?;
+
+        info!("wrote {} commands to {}", counter, path);
+
+        Ok(OrderSuccess::SaveState(counter, path.into()))
     }
 
     pub fn save_state_to_file(&mut self, f: &mut fs::File) -> anyhow::Result<usize> {
@@ -147,16 +157,10 @@ impl CommandServer {
         Ok(res?)
     }
 
-    pub async fn dump_state(&mut self, client_id: String, message_id: &str) -> anyhow::Result<()> {
+    pub async fn dump_state(&mut self) -> anyhow::Result<OrderSuccess> {
         let state = self.state.clone();
-        self.answer_success(
-            client_id,
-            message_id,
-            String::new(),
-            Some(CommandResponseData::State(state)),
-        )
-        .await;
-        Ok(())
+
+        Ok(OrderSuccess::DumpState(CommandResponseData::State(state)))
     }
 
     pub async fn load_state(
@@ -164,7 +168,7 @@ impl CommandServer {
         client_id: Option<String>,
         message_id: String,
         path: &str,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<OrderSuccess> {
         let mut file = match fs::File::open(&path) {
             Err(e) => {
                 error!("cannot open file at path '{}': {:?}", path, e);
@@ -193,12 +197,16 @@ impl CommandServer {
         loop {
             let previous = buffer.available_data();
             //FIXME: we should read in streaming here
-            let sz = file
-                .read(buffer.space())
-                .with_context(|| "error reading state file")?;
-            buffer.fill(sz);
+            match file.read(buffer.space()) {
+                Ok(sz) => buffer.fill(sz),
+                Err(e) => {
+                    error!("error reading state file: {}", e);
+                    break;
+                }
+            };
 
             if buffer.available_data() == 0 {
+                debug!("Empty buffer");
                 break;
             }
 
@@ -206,7 +214,7 @@ impl CommandServer {
             match parse(buffer.data()) {
                 Ok((i, orders)) => {
                     if i.len() > 0 {
-                        //info!("could not parse {} bytes", i.len());
+                        debug!("could not parse {} bytes", i.len());
                         if previous == buffer.available_data() {
                             error!("error consuming load state message");
                             break;
@@ -280,12 +288,13 @@ impl CommandServer {
 
         error!("stopped loading data from file, remaining: {} bytes, saw {} messages, generated {} diff messages",
         buffer.available_data(), message_counter, diff_counter);
+        let mut oks_and_errors: [usize; 2] = [0, 0];
         if diff_counter > 0 {
             info!(
                 "state loaded from {}, will start sending {} messages to workers",
                 path, diff_counter
             );
-            smol::spawn(async move {
+            let task = smol::spawn(async move {
                 let mut ok = 0usize;
                 let mut error = 0usize;
                 while let Some(proxy_response) = load_state_rx.next().await {
@@ -335,8 +344,9 @@ impl CommandServer {
                         error!("loading state: {} ok messages, {} errors", ok, error);
                     }
                 }
-            })
-            .detach();
+                [ok, error]
+            });
+            oks_and_errors = task.await;
         } else {
             info!("no messages sent to workers: local state already had those messages");
             if let Some(id) = client_id {
@@ -350,15 +360,24 @@ impl CommandServer {
         gauge!("configuration.clusters", self.state.clusters.len());
         gauge!("configuration.backends", self.backends_count);
         gauge!("configuration.frontends", self.frontends_count);
-        Ok(())
+        match oks_and_errors[0] {
+            0 => Ok(OrderSuccess::LoadState(
+                path.to_string(),
+                oks_and_errors[0],
+                oks_and_errors[1],
+            )),
+            _ => bail!(format!(
+                "Partially loaded stated: {} ok, {} errors",
+                oks_and_errors[0], oks_and_errors[1]
+            )),
+        }
     }
 
     pub async fn list_frontends(
         &mut self,
-        client_id: String,
-        message_id: &str,
+
         filters: FrontendFilters,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<OrderSuccess> {
         info!(
             "Received a request to list frontends, along these filters: {:#?}",
             filters
@@ -405,21 +424,12 @@ impl CommandServer {
             }
         }
 
-        self.answer_success(
-            client_id,
-            message_id,
-            String::from("This message comes with answer_success()"),
-            Some(CommandResponseData::FrontendList(listed_frontends)),
-        )
-        .await;
-        Ok(())
+        Ok(OrderSuccess::ListFrontends(
+            CommandResponseData::FrontendList(listed_frontends),
+        ))
     }
 
-    pub async fn list_workers(
-        &mut self,
-        client_id: String,
-        request_id: String,
-    ) -> anyhow::Result<()> {
+    pub async fn list_workers(&mut self) -> anyhow::Result<OrderSuccess> {
         let workers: Vec<WorkerInfo> = self
             .workers
             .iter()
@@ -429,14 +439,10 @@ impl CommandServer {
                 run_state: worker.run_state.clone(),
             })
             .collect();
-        self.answer_success(
-            client_id,
-            request_id,
-            "",
-            Some(CommandResponseData::Workers(workers)),
-        )
-        .await;
-        Ok(())
+
+        Ok(OrderSuccess::ListWorkers(CommandResponseData::Workers(
+            workers,
+        )))
     }
 
     pub async fn launch_worker(
@@ -444,7 +450,7 @@ impl CommandServer {
         client_id: String,
         request_id: String,
         _tag: &str,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<OrderSuccess> {
         let mut worker = match start_worker(
             self.next_id,
             &self.config,
@@ -530,14 +536,14 @@ impl CommandServer {
 
         self.answer_success(client_id, request_id, "", None).await;
 
-        Ok(())
+        Ok(OrderSuccess::LaunchWorker(id))
     }
 
     pub async fn upgrade_main(
         &mut self,
         client_id: String,
         request_id: String,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<OrderSuccess> {
         self.disable_cloexec_before_upgrade()?;
 
         if let Some(sender) = self.clients.get_mut(&client_id) {
@@ -566,37 +572,11 @@ impl CommandServer {
         }
 
         if let Some(true) = res {
-            if let Some(sender) = self.clients.get_mut(&client_id) {
-                if let Err(e) = sender
-                    .send(CommandResponse::new(
-                        request_id.clone(),
-                        CommandStatus::Ok,
-                        format!(
-                            "new main process launched with pid {}, closing the old one",
-                            pid
-                        ),
-                        None,
-                    ))
-                    .await
-                {
-                    error!("could not send message to client {:?}: {:?}", client_id, e);
-                }
-            }
-
             info!("wrote final message, closing");
 
-            //FIXME: should do some cleanup before exiting
-            std::thread::sleep(Duration::from_secs(2));
-            std::process::exit(0);
+            return Ok(OrderSuccess::UpgradeMain(pid));
         } else {
-            self.answer_error(
-                client_id,
-                request_id,
-                "could not upgrade main process",
-                None,
-            )
-            .await;
-            Ok(())
+            bail!("could not upgrade main process")
         }
     }
 
@@ -605,7 +585,7 @@ impl CommandServer {
         client_id: String,
         request_id: String,
         id: u32,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<OrderSuccess> {
         info!(
             "client[{}] msg {} wants to upgrade worker {}",
             client_id, request_id, id
@@ -621,17 +601,10 @@ impl CommandServer {
             })
             .is_none()
         {
-            self.answer_error(
-                client_id,
-                &request_id,
-                format!(
-                    "The worker {} does not exist, or is stopped / stopping.",
-                    &id
-                ),
-                None,
-            )
-            .await;
-            return Ok(());
+            bail!(format!(
+                "The worker {} does not exist, or is stopped / stopping.",
+                &id
+            ));
         }
 
         // same as launch_worker
@@ -662,16 +635,14 @@ impl CommandServer {
 
             worker
         } else {
-            return Ok(self
-                .answer_error(client_id, &request_id, "failed creating worker", None)
-                .await);
+            bail!("failed creating worker")
         };
 
         let sock = worker.channel.take().unwrap().sock;
         let (worker_tx, worker_rx) = channel(10000);
         worker.sender = Some(worker_tx);
 
-        if let Err(e) = worker
+        worker
             .sender
             .as_mut()
             .unwrap()
@@ -680,12 +651,7 @@ impl CommandServer {
                 order: ProxyRequestData::Status,
             })
             .await
-        {
-            error!(
-                "could not send status message to worker {:?}: {:?}",
-                worker.id, e
-            );
-        }
+            .with_context(|| format!("could not send status message to worker {:?}", worker.id,))?;
 
         let mut listeners = None;
         {
@@ -828,7 +794,7 @@ impl CommandServer {
 
         self.answer_success(client_id, request_id, "", None).await;
         info!("finished upgrade");
-        Ok(())
+        Ok(OrderSuccess::UpgradeWorker(id))
     }
 
     pub async fn reload_configuration(
@@ -836,27 +802,11 @@ impl CommandServer {
         client_id: Option<String>,
         message_id: String,
         config_path: Option<String>,
-    ) -> anyhow::Result<()> {
-        let new_config = match Config::load_from_path(
-            config_path.as_deref().unwrap_or(&self.config.config_path),
-        ) {
-            Err(e) => {
-                if let Some(id) = client_id {
-                    self.answer_error(
-                        id,
-                        message_id,
-                        format!(
-                            "cannot load configuration from '{}': {:?}",
-                            self.config.config_path, e
-                        ),
-                        None,
-                    )
-                    .await;
-                }
-                return Err(anyhow::Error::from(e));
-            }
-            Ok(c) => c,
-        };
+    ) -> anyhow::Result<OrderSuccess> {
+        // check that this works
+        let path = config_path.as_deref().unwrap_or(&self.config.config_path);
+        let new_config = Config::load_from_path(path)
+            .with_context(|| format!("cannot load configuration from '{}'", path))?;
 
         let mut diff_counter = 0usize;
 
@@ -955,6 +905,7 @@ impl CommandServer {
             .detach();
         } else {
             info!("no messages sent to workers: local state already had those messages");
+            // this may be redundant with the Ok(OrderSuccess) return value
             if let Some(id) = client_id {
                 self.answer_success(id, message_id, format!("ok: 0 messages, error: 0"), None)
                     .await;
@@ -968,15 +919,14 @@ impl CommandServer {
         gauge!("configuration.frontends", self.frontends_count);
 
         self.config = new_config;
-        Ok(())
+        Ok(OrderSuccess::ReloadConfiguration)
     }
 
     pub async fn metrics(
         &mut self,
-        client_id: String,
         request_id: String,
         config: MetricsConfiguration,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<OrderSuccess> {
         let (tx, mut rx) = futures::channel::mpsc::channel(self.workers.len() * 2);
         let mut count = 0usize;
         for ref mut worker in self
@@ -992,9 +942,10 @@ impl CommandServer {
             self.in_flight.insert(req_id, (tx.clone(), 1));
         }
 
-        let mut client_tx = self.clients.get_mut(&client_id).unwrap().clone();
         let prefix = format!("{}-metrics-", request_id);
-        smol::spawn(async move {
+        // It would be great if we could just return OrderSuccess::Metrics from this thread
+
+        let task: smol::Task<anyhow::Result<OrderSuccess>> = smol::spawn(async move {
             let mut v = Vec::new();
             let mut i = 0;
             while let Some(proxy_response) = rx.next().await {
@@ -1018,29 +969,32 @@ impl CommandServer {
                     break;
                 }
             }
-
+            // the legacy code does not return anything, how weird is that?
+            /*
             if let Err(e) = client_tx
-                .send(CommandResponse::new(
-                    request_id.clone(),
-                    CommandStatus::Ok,
-                    "".to_string(),
-                    None,
-                ))
-                .await
+            .send(CommandResponse::new(
+                request_id.clone(),
+                CommandStatus::Ok,
+                "".to_string(),
+                None,
+            ))
+            .await
             {
                 error!("could not send back metrics to client: {:?}", e);
             }
-        })
-        .detach();
-        Ok(())
+            */
+            // TODO : make sure this returns with CommandResponseData
+            Ok(OrderSuccess::Metrics)
+        });
+        task.await
+        // .detach();
     }
 
     pub async fn query(
         &mut self,
-        client_id: String,
         request_id: String,
         query: Query,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<OrderSuccess> {
         let (tx, mut rx) = futures::channel::mpsc::channel(self.workers.len() * 2);
         let mut count = 0usize;
         for ref mut worker in self
@@ -1083,9 +1037,9 @@ impl CommandServer {
             &Query::Metrics(_) => {}
         };
 
-        let mut client_tx = self.clients.get_mut(&client_id).unwrap().clone();
         let prefix = format!("{}-query-", request_id);
-        smol::spawn(async move {
+
+        let task: smol::Task<anyhow::Result<OrderSuccess>> = smol::spawn(async move {
             let mut v = Vec::new();
             let mut i = 0;
             while let Some(proxy_response) = rx.next().await {
@@ -1110,7 +1064,7 @@ impl CommandServer {
                 }
             }
 
-            let mut data: BTreeMap<String, QueryAnswer> = v
+            let mut query_answers_map: BTreeMap<String, QueryAnswer> = v
                 .into_iter()
                 .filter_map(|(tag, query)| {
                     if let Some(ProxyResponseData::Query(d)) = query.data {
@@ -1122,67 +1076,28 @@ impl CommandServer {
                 .collect();
 
             match &query {
-                &Query::ApplicationsHashes => {
+                &Query::ApplicationsHashes | &Query::Applications(_) => {
                     let main = main_query_answer.unwrap();
-                    data.insert(String::from("main"), main);
-
-                    if let Err(e) = client_tx
-                        .send(CommandResponse::new(
-                            request_id.clone(),
-                            CommandStatus::Ok,
-                            "".to_string(),
-                            Some(CommandResponseData::Query(data)),
-                        ))
-                        .await
-                    {
-                        error!("could not send message to client {:?}: {:?}", client_id, e);
-                    }
-                }
-                &Query::Applications(_) => {
-                    let main = main_query_answer.unwrap();
-                    data.insert(String::from("main"), main);
-
-                    if let Err(e) = client_tx
-                        .send(CommandResponse::new(
-                            request_id.clone(),
-                            CommandStatus::Ok,
-                            "".to_string(),
-                            Some(CommandResponseData::Query(data)),
-                        ))
-                        .await
-                    {
-                        error!("could not send message to client {:?}: {:?}", client_id, e);
-                    }
+                    query_answers_map.insert(String::from("main"), main);
+                    Ok(OrderSuccess::Query(CommandResponseData::Query(
+                        query_answers_map,
+                    )))
                 }
                 &Query::Certificates(_) => {
-                    info!("certificates query received: {:?}", data);
-                    if let Err(e) = client_tx
-                        .send(CommandResponse::new(
-                            request_id.clone(),
-                            CommandStatus::Ok,
-                            "".to_string(),
-                            Some(CommandResponseData::Query(data)),
-                        ))
-                        .await
-                    {
-                        error!("could not send message to client {:?}: {:?}", client_id, e);
-                    }
+                    info!("certificates query received: {:?}", query_answers_map);
+                    Ok(OrderSuccess::Query(CommandResponseData::Query(
+                        query_answers_map,
+                    )))
                 }
                 &Query::Metrics(_) => {
-                    debug!("metrics query received: {:?}", data);
-                    let _res = client_tx
-                        .send(CommandResponse::new(
-                            request_id.clone(),
-                            CommandStatus::Ok,
-                            "".to_string(),
-                            Some(CommandResponseData::Query(data)),
-                        ))
-                        .await;
+                    debug!("metrics query received: {:?}", query_answers_map);
+                    Ok(OrderSuccess::Query(CommandResponseData::Query(
+                        query_answers_map,
+                    )))
                 }
-            };
-        })
-        .detach();
-        Ok(())
+            }
+        });
+        task.await
     }
 
     pub async fn worker_order(
@@ -1191,7 +1106,7 @@ impl CommandServer {
         request_id: String,
         order: ProxyRequestData,
         worker_id: Option<u32>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<OrderSuccess> {
         if let &ProxyRequestData::AddCertificate(_) = &order {
             debug!("workerconfig client order AddCertificate()");
         } else {
@@ -1214,13 +1129,10 @@ impl CommandServer {
             if worker_id.is_none() {
                 match order {
                     ProxyRequestData::RemoveBackend(ref backend) => {
-                        let msg = format!(
+                        bail!(format!(
                             "cannot remove backend: cluster {} has no backends {} at {}",
                             backend.cluster_id, backend.backend_id, backend.address,
-                        );
-                        error!("{}", msg);
-                        self.answer_error(client_id, request_id, msg, None).await;
-                        return Ok(());
+                        ));
                     }
                     ProxyRequestData::RemoveHttpFrontend(h)
                     | ProxyRequestData::RemoveHttpsFrontend(h) => {
@@ -1231,36 +1143,31 @@ impl CommandServer {
                             ),
                             Route::Deny => format!("No such frontend at {}", h.address),
                         };
-                        error!("{}", msg);
-                        self.answer_error(client_id, request_id, msg, None).await;
-                        return Ok(());
+                        bail!(msg);
                     }
                     ProxyRequestData::RemoveTcpFrontend(TcpFrontend {
                         ref cluster_id,
                         ref address,
                     }) => {
-                        let msg = format!(
+                        bail!(format!(
                             "cannot remove TCP frontend: cluster {} has no frontends at {}",
                             cluster_id, address,
-                        );
-                        error!("{}", msg);
-                        self.answer_error(client_id, request_id, msg, None).await;
-                        return Ok(());
+                        ));
                     }
                     _ => {}
                 };
             }
         }
 
-        if self.config.automatic_state_save {
-            if order != ProxyRequestData::SoftStop || order != ProxyRequestData::HardStop {
-                if let Some(path) = self.config.saved_state.clone() {
-                    if let Ok(mut f) = fs::File::create(&path) {
-                        let _ = self.save_state_to_file(&mut f).map_err(|e| {
-                            error!("could not save state automatically to {}: {:?}", path, e);
-                        });
-                    }
-                }
+        if self.config.automatic_state_save
+            & (order != ProxyRequestData::SoftStop || order != ProxyRequestData::HardStop)
+        {
+            if let Some(path) = self.config.saved_state.clone() {
+                let mut file = fs::File::create(&path)
+                    .with_context(|| "Could not create file to automatically save the state")?;
+
+                self.save_state_to_file(&mut file)
+                    .with_context(|| format!("could not save state automatically to {}", path))?;
             }
         }
 
@@ -1403,7 +1310,7 @@ impl CommandServer {
         gauge!("configuration.clusters", self.state.clusters.len());
         gauge!("configuration.backends", self.backends_count);
         gauge!("configuration.frontends", self.frontends_count);
-        Ok(())
+        Ok(OrderSuccess::WorkerOrder(worker_id))
     }
 }
 

--- a/bin/src/command/worker.rs
+++ b/bin/src/command/worker.rs
@@ -2,15 +2,15 @@ use futures::SinkExt;
 use libc::pid_t;
 use nix::sys::signal::kill;
 use nix::unistd::Pid;
-use std::collections::VecDeque;
-use std::fmt;
-use std::os::unix::io::AsRawFd;
+use std::{collections::VecDeque, fmt, os::unix::io::AsRawFd};
 
-use sozu_command::channel::Channel;
-use sozu_command::command::RunState;
-use sozu_command::config::Config;
-use sozu_command::proxy::{ProxyRequest, ProxyRequestData, ProxyResponse};
-use sozu_command::scm_socket::ScmSocket;
+use sozu_command_lib::{
+    channel::Channel,
+    command::RunState,
+    config::Config,
+    proxy::{ProxyRequest, ProxyRequestData, ProxyResponse},
+    scm_socket::ScmSocket,
+};
 
 pub struct Worker {
     pub id: u32,

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -1,33 +1,37 @@
 use crate::cli::{LoggingLevel, MetricsCmd};
-use sozu_command::certificate::{calculate_fingerprint, split_certificate_chain};
-use sozu_command::channel::Channel;
-use sozu_command::command::{
-    CommandRequest, CommandRequestData, CommandResponse, CommandResponseData, CommandStatus,
-    FrontendFilters, RunState, WorkerInfo,
-};
-use sozu_command::config::{Config, FileListenerProtocolConfig, Listener, ProxyProtocolConfig};
-use sozu_command::proxy::{
-    ActivateListener, AddCertificate, Backend, CertificateAndKey, CertificateFingerprint, Cluster,
-    DeactivateListener, FilteredData, HttpFrontend, ListenerType, LoadBalancingAlgorithms,
-    LoadBalancingParams, MetricsConfiguration, PathRule, ProxyRequestData, Query, QueryAnswer,
-    QueryAnswerCertificate, QueryAnswerMetrics, QueryApplicationDomain, QueryApplicationType,
-    QueryCertificateType, QueryMetricsType, RemoveBackend, RemoveCertificate, RemoveListener,
-    ReplaceCertificate, Route, RulePosition, TcpFrontend, TcpListener, TlsVersion,
+use sozu_command_lib::{
+    certificate::{calculate_fingerprint, split_certificate_chain},
+    channel::Channel,
+    command::{
+        CommandRequest, CommandRequestData, CommandResponse, CommandResponseData, CommandStatus,
+        FrontendFilters, RunState, WorkerInfo,
+    },
+    config::{Config, FileListenerProtocolConfig, Listener, ProxyProtocolConfig},
+    proxy::{
+        ActivateListener, AddCertificate, Backend, CertificateAndKey, CertificateFingerprint,
+        Cluster, DeactivateListener, FilteredData, HttpFrontend, ListenerType,
+        LoadBalancingAlgorithms, LoadBalancingParams, MetricsConfiguration, PathRule,
+        ProxyRequestData, Query, QueryAnswer, QueryAnswerCertificate, QueryAnswerMetrics,
+        QueryApplicationDomain, QueryApplicationType, QueryCertificateType, QueryMetricsType,
+        RemoveBackend, RemoveCertificate, RemoveListener, ReplaceCertificate, Route, RulePosition,
+        TcpFrontend, TcpListener, TlsVersion,
+    },
 };
 
 use super::create_channel;
 use anyhow::{self, bail, Context};
 use prettytable::{Row, Table};
-use rand::distributions::Alphanumeric;
-use rand::{thread_rng, Rng};
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use serde_json;
-use std::collections::{BTreeMap, HashMap, HashSet};
-use std::net::SocketAddr;
-use std::process::exit;
-use std::sync::mpsc;
-use std::sync::{Arc, Mutex};
-use std::thread;
-use std::time::Duration;
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    net::SocketAddr,
+    process::exit,
+    sync::mpsc,
+    sync::{Arc, Mutex},
+    thread,
+    time::Duration,
+};
 
 // Used to display the JSON response of the status command
 #[derive(Serialize, Debug)]

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -1,13 +1,16 @@
 mod command;
 
-use crate::cli;
-use crate::util;
-use crate::{get_config_file_path, load_configuration};
+use crate::{
+    cli::{self, *},
+    get_config_file_path, load_configuration, util,
+};
 use anyhow::Context;
-use sozu_command::channel::Channel;
-use sozu_command::command::{CommandRequest, CommandResponse};
-use sozu_command::config::Config;
-use sozu_command::proxy::ListenerType;
+use sozu_command_lib::{
+    channel::Channel,
+    command::{CommandRequest, CommandResponse},
+    config::Config,
+    proxy::ListenerType,
+};
 use std::time::Duration;
 
 use self::command::{
@@ -18,7 +21,6 @@ use self::command::{
     remove_backend, remove_certificate, remove_http_frontend, remove_listener, remove_tcp_frontend,
     replace_certificate, save_state, soft_stop, status, upgrade_main, upgrade_worker,
 };
-use crate::cli::*;
 
 pub fn ctl(matches: cli::Sozu) -> Result<(), anyhow::Error> {
     let config_file_path = get_config_file_path(&matches)?;

--- a/bin/src/logging.rs
+++ b/bin/src/logging.rs
@@ -1,4 +1,4 @@
-use sozu_command::logging::{target_to_backend, Logger, LoggerBackend};
+use sozu_command_lib::logging::{target_to_backend, Logger, LoggerBackend};
 use std::env;
 use std::sync::{Arc, Mutex};
 
@@ -20,7 +20,7 @@ macro_rules! log {
 
     (__inner__ $target:expr, $lvl:expr, $format:expr, $level_tag:expr,
      [$($final_args:ident),*], [$($idents:ident),*]) => ({
-      static _META: $crate::sozu_command::logging::Metadata = $crate::sozu_command::logging::Metadata {
+      static _META: $crate::sozu_command_lib::logging::Metadata = $crate::sozu_command_lib::logging::Metadata {
           level:  $lvl,
           target: module_path!(),
       };
@@ -29,7 +29,7 @@ macro_rules! log {
         let pid = (*logger).pid;
         let tag = &*$crate::logging::TAG;
 
-        let (now, precise_time) = $crate::sozu_command::logging::now();
+        let (now, precise_time) = $crate::sozu_command_lib::logging::now();
         (*logger).log(
             &_META,
             format_args!(
@@ -54,7 +54,7 @@ pub fn init(
     backend: LoggerBackend,
     access_backend: Option<LoggerBackend>,
 ) {
-    let directives = crate::sozu_command::logging::parse_logging_spec(spec);
+    let directives = crate::sozu_command_lib::logging::parse_logging_spec(spec);
     let mut logger = MAIN_LOGGER.lock().unwrap();
     if !logger.initialized {
         println!("initializing logger");

--- a/bin/src/upgrade.rs
+++ b/bin/src/upgrade.rs
@@ -4,21 +4,23 @@ use libc::{self, pid_t};
 use mio::net::UnixStream;
 use nix::unistd::*;
 use serde_json;
-use std::fs::File;
-use std::io::{Seek, SeekFrom};
-use std::os::unix::io::{AsRawFd, FromRawFd};
-use std::os::unix::process::CommandExt;
-use std::process::Command;
+use std::{
+    fs::File,
+    io::{Seek, SeekFrom},
+    os::unix::io::{AsRawFd, FromRawFd},
+    os::unix::process::CommandExt,
+    process::Command,
+};
 use tempfile::tempfile;
 
-use sozu_command::channel::Channel;
-use sozu_command::command::RunState;
-use sozu_command::config::Config;
-use sozu_command::proxy::ProxyRequest;
-use sozu_command::state::ConfigState;
+use sozu_command_lib::{
+    channel::Channel, command::RunState, config::Config, proxy::ProxyRequest, state::ConfigState,
+};
 
-use crate::command::{CommandServer, Worker};
-use crate::util;
+use crate::{
+    command::{CommandServer, Worker},
+    util,
+};
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct SerializedWorker {

--- a/bin/src/util.rs
+++ b/bin/src/util.rs
@@ -1,14 +1,12 @@
+use crate::logging;
+
+use anyhow;
 use anyhow::Context;
 use libc;
 use nix::fcntl::{fcntl, FcntlArg, FdFlag};
-use std::fs::File;
-use std::io::Write;
-use std::os::unix::io::RawFd;
-
-use crate::logging;
-use anyhow;
 use sozu::metrics;
-use sozu_command::config::Config;
+use sozu_command_lib::config::Config;
+use std::{fs::File, io::Write, os::unix::io::RawFd};
 
 pub fn enable_close_on_exec(fd: RawFd) -> Result<i32, anyhow::Error> {
     let file_descriptor =

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -1,14 +1,15 @@
 use anyhow::{bail, Context};
 use libc::{self, pid_t};
 use mio::net::UnixStream;
-use nix;
-use nix::unistd::*;
+use nix::{self, unistd::*};
 use serde_json;
-use std::fs::File;
-use std::io::{Seek, SeekFrom};
-use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
-use std::os::unix::process::CommandExt;
-use std::process::Command;
+use std::{
+    fs::File,
+    io::{Seek, SeekFrom},
+    os::unix::io::{AsRawFd, FromRawFd, IntoRawFd},
+    os::unix::process::CommandExt,
+    process::Command,
+};
 use tempfile::tempfile;
 
 #[cfg(target_os = "macos")]
@@ -31,13 +32,15 @@ use std::mem::size_of;
 
 use sozu::metrics;
 use sozu::server::Server;
-use sozu_command::channel::Channel;
-use sozu_command::config::Config;
-use sozu_command::logging::target_to_backend;
-use sozu_command::proxy::{ProxyRequest, ProxyRequestData, ProxyResponse};
-use sozu_command::ready::Ready;
-use sozu_command::scm_socket::{Listeners, ScmSocket};
-use sozu_command::state::ConfigState;
+use sozu_command_lib::{
+    channel::Channel,
+    config::Config,
+    logging::target_to_backend,
+    proxy::{ProxyRequest, ProxyRequestData, ProxyResponse},
+    ready::Ready,
+    scm_socket::{Listeners, ScmSocket},
+    state::ConfigState,
+};
 
 use crate::command::Worker;
 use crate::logging;


### PR DESCRIPTION
This other pull request :

- #731

started small and turned into a whole refactoring of command execution. Debugging the ensuing chaos was difficult.

This PR here does only the refactoring of the command execution. Each order received in the loop of the `CommandServer`'s run function is pattern-matched and sent to specialized executing functions that return :

- `anyhow::Result` for error management, which in turn contains…
- a new enum called `OrderSuccess` that contains, depending on the case, relevant information about the order being successfull, as well as `CommandResponseData`.