### PR TITLE
Format all use statements

### DIFF
--- a/command/src/buffer/fixed.rs
+++ b/command/src/buffer/fixed.rs
@@ -1,6 +1,10 @@
+use std::{
+    cmp,
+    io::{self, Read, Write},
+    ptr,
+};
+
 use poule::Reset;
-use std::io::{self, Read, Write};
-use std::{cmp, ptr};
 
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct BufferMetadata {

--- a/command/src/buffer/growable.rs
+++ b/command/src/buffer/growable.rs
@@ -1,6 +1,10 @@
+use std::{
+    cmp,
+    io::{self, Read, Write},
+    ptr,
+};
+
 use pool::Reset;
-use std::io::{self, Read, Write};
-use std::{cmp, ptr};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Buffer {

--- a/command/src/channel.rs
+++ b/command/src/channel.rs
@@ -1,20 +1,22 @@
-use mio::event::Source;
-use mio::net::UnixStream;
-use serde::de::DeserializeOwned;
-use serde::ser::Serialize;
-use serde_json;
-use std::cmp::min;
-use std::fmt::Debug;
-use std::io::{self, ErrorKind, Read, Write};
-use std::iter::Iterator;
-use std::marker::PhantomData;
-use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
-use std::os::unix::net;
-use std::str::from_utf8;
-use std::time::Duration;
+use std::{
+    cmp::min,
+    fmt::Debug,
+    io::{self, ErrorKind, Read, Write},
+    iter::Iterator,
+    marker::PhantomData,
+    os::unix::{
+        io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
+        net,
+    },
+    str::from_utf8,
+    time::Duration,
+};
 
-use crate::buffer::growable::Buffer;
-use crate::ready::Ready;
+use mio::{event::Source, net::UnixStream};
+use serde::{de::DeserializeOwned, ser::Serialize};
+use serde_json;
+
+use crate::{buffer::growable::Buffer, ready::Ready};
 
 #[derive(Debug, PartialEq)]
 pub enum ConnError {

--- a/command/src/command.rs
+++ b/command/src/command.rs
@@ -1,10 +1,11 @@
-use std::collections::BTreeMap;
-use std::net::SocketAddr;
+use std::{collections::BTreeMap, net::SocketAddr};
 
-use crate::proxy::{
-    AggregatedMetricsData, HttpFrontend, ProxyEvent, ProxyRequestData, QueryAnswer, TcpFrontend,
+use crate::{
+    proxy::{
+        AggregatedMetricsData, HttpFrontend, ProxyEvent, ProxyRequestData, QueryAnswer, TcpFrontend,
+    },
+    state::ConfigState,
 };
-use crate::state::ConfigState;
 
 pub const PROTOCOL_VERSION: u8 = 0;
 

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -1,24 +1,26 @@
 //! parsing data from the configuration file
-use anyhow::{bail, Context};
-use std::collections::{HashMap, HashSet};
-use std::env;
-use std::fs::File;
-use std::io::{self, Error, ErrorKind, Read};
-
-use std::net::SocketAddr;
-use std::path::PathBuf;
-
-use crate::certificate::split_certificate_chain;
-use toml;
-
-use crate::proxy::{
-    ActivateListener, AddCertificate, Backend, CertificateAndKey, Cluster, HttpFrontend,
-    HttpListener, HttpsListener, ListenerType, LoadBalancingAlgorithms, LoadBalancingParams,
-    LoadMetric, PathRule, ProxyRequestData, Route, RulePosition, TcpFrontend, TcpListener,
-    TlsProvider, TlsVersion,
+use std::{
+    collections::{HashMap, HashSet},
+    env,
+    fs::File,
+    io::{self, Error, ErrorKind, Read},
+    net::SocketAddr,
+    path::PathBuf,
 };
 
-use crate::command::{CommandRequest, CommandRequestData, PROTOCOL_VERSION};
+use anyhow::{bail, Context};
+use toml;
+
+use crate::{
+    certificate::split_certificate_chain,
+    command::{CommandRequest, CommandRequestData, PROTOCOL_VERSION},
+    proxy::{
+        ActivateListener, AddCertificate, Backend, CertificateAndKey, Cluster, HttpFrontend,
+        HttpListener, HttpsListener, ListenerType, LoadBalancingAlgorithms, LoadBalancingParams,
+        LoadMetric, PathRule, ProxyRequestData, Route, RulePosition, TcpFrontend, TcpListener,
+        TlsProvider, TlsVersion,
+    },
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/command/src/logging.rs
+++ b/command/src/logging.rs
@@ -1,17 +1,18 @@
+use std::{
+    cell::RefCell,
+    cmp::{self, Ord},
+    env,
+    fmt::{format, Arguments},
+    fs::{File, OpenOptions},
+    io::{stdout, Stdout, Write},
+    net::{SocketAddr, TcpStream, ToSocketAddrs, UdpSocket},
+    path::Path,
+    str::FromStr,
+};
+
 use libc;
 use mio::net::UnixDatagram;
-use rand::distributions::Alphanumeric;
-use rand::{thread_rng, Rng};
-use std::cell::RefCell;
-use std::cmp::{self, Ord};
-use std::env;
-use std::fmt::{format, Arguments};
-use std::fs::File;
-use std::fs::OpenOptions;
-use std::io::{stdout, Stdout, Write};
-use std::net::{SocketAddr, TcpStream, ToSocketAddrs, UdpSocket};
-use std::path::Path;
-use std::str::FromStr;
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
 
 thread_local! {
   pub static LOGGER: RefCell<Logger> = RefCell::new(Logger::new());

--- a/command/src/proxy.rs
+++ b/command/src/proxy.rs
@@ -1,13 +1,18 @@
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, HashMap, HashSet},
+    convert::From,
+    default::Default,
+    error, fmt,
+    net::SocketAddr,
+    str::FromStr,
+};
+
 use hex::{self, FromHex};
-use serde;
-use serde::de::{self, Visitor};
-use std::cmp::Ordering;
-use std::collections::{BTreeMap, HashMap, HashSet};
-use std::convert::From;
-use std::default::Default;
-use std::net::SocketAddr;
-use std::str::FromStr;
-use std::{error, fmt};
+use serde::{
+    self,
+    de::{self, Visitor},
+};
 
 use crate::config::ProxyProtocolConfig;
 

--- a/command/src/scm_socket.rs
+++ b/command/src/scm_socket.rs
@@ -1,13 +1,15 @@
+use std::{
+    net::SocketAddr,
+    os::unix::{
+        io::{FromRawFd, IntoRawFd, RawFd},
+        net,
+    },
+    str::from_utf8,
+};
+
 use mio::net::TcpListener;
-use nix::cmsg_space;
-use nix::sys::socket;
-use nix::sys::uio;
-use nix::Result as NixResult;
+use nix::{cmsg_space, sys::socket, sys::uio, Result as NixResult};
 use serde_json;
-use std::net::SocketAddr;
-use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
-use std::os::unix::net;
-use std::str::from_utf8;
 
 pub const MAX_FDS_OUT: usize = 200;
 pub const MAX_BYTES_OUT: usize = 4096;

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -1,15 +1,18 @@
-use crate::certificate::calculate_fingerprint;
-use std::collections::hash_map::DefaultHasher;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::hash::{Hash, Hasher};
-use std::iter::{repeat, FromIterator};
-use std::net::SocketAddr;
+use std::{
+    collections::{hash_map::DefaultHasher, BTreeMap, BTreeSet, HashMap, HashSet},
+    hash::{Hash, Hasher},
+    iter::{repeat, FromIterator},
+    net::SocketAddr,
+};
 
-use crate::proxy::{
-    ActivateListener, AddCertificate, Backend, CertificateAndKey, CertificateFingerprint, Cluster,
-    DeactivateListener, HttpFrontend, HttpListener, HttpsListener, ListenerType, PathRule,
-    ProxyRequestData, QueryAnswerApplication, RemoveBackend, RemoveCertificate, RemoveListener,
-    Route, TcpFrontend, TcpListener,
+use crate::{
+    certificate::calculate_fingerprint,
+    proxy::{
+        ActivateListener, AddCertificate, Backend, CertificateAndKey, CertificateFingerprint,
+        Cluster, DeactivateListener, HttpFrontend, HttpListener, HttpsListener, ListenerType,
+        PathRule, ProxyRequestData, QueryAnswerApplication, RemoveBackend, RemoveCertificate,
+        RemoveListener, Route, TcpFrontend, TcpListener,
+    },
 };
 
 pub type ClusterId = String;

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -1,3 +1,8 @@
+use std::{
+    io::{self, Error, ErrorKind},
+    str::from_utf8,
+};
+
 #[macro_use]
 extern crate log;
 extern crate sozu_command_lib as sozu_command;
@@ -5,8 +10,6 @@ extern crate sozu_command_lib as sozu_command;
 use bytes::BytesMut;
 use futures::{SinkExt, TryStreamExt};
 use sozu_command::command::{CommandRequest, CommandResponse, CommandStatus};
-use std::io::{self, Error, ErrorKind};
-use std::str::from_utf8;
 use tokio::net::UnixStream;
 use tokio_util::codec::{Decoder, Encoder, Framed};
 

--- a/lib/examples/main.rs
+++ b/lib/examples/main.rs
@@ -5,13 +5,14 @@ extern crate sozu_lib as sozu;
 extern crate sozu_command_lib as sozu_command;
 extern crate time;
 
-use crate::sozu_command::channel::Channel;
-use crate::sozu_command::logging::{Logger, LoggerBackend};
-use crate::sozu_command::proxy;
-use crate::sozu_command::proxy::{LoadBalancingParams, PathRule, Route, RulePosition};
-use std::env;
-use std::io::stdout;
-use std::thread;
+use std::{env, io::stdout, thread};
+
+use crate::sozu_command::{
+    channel::Channel,
+    logging::{Logger, LoggerBackend},
+    proxy,
+    proxy::{LoadBalancingParams, PathRule, Route, RulePosition},
+};
 
 fn main() {
     if env::var("RUST_LOG").is_ok() {

--- a/lib/examples/minimal.rs
+++ b/lib/examples/minimal.rs
@@ -4,13 +4,14 @@ extern crate sozu_lib as sozu;
 extern crate sozu_command_lib as sozu_command;
 extern crate time;
 
-use crate::sozu_command::channel::Channel;
-use crate::sozu_command::logging::{Logger, LoggerBackend};
-use crate::sozu_command::proxy;
-use crate::sozu_command::proxy::{LoadBalancingParams, PathRule, Route, RulePosition};
-use std::env;
-use std::io::stdout;
-use std::thread;
+use std::{env, io::stdout, thread};
+
+use crate::sozu_command::{
+    channel::Channel,
+    logging::{Logger, LoggerBackend},
+    proxy,
+    proxy::{LoadBalancingParams, PathRule, Route, RulePosition},
+};
 
 fn main() {
     if env::var("RUST_LOG").is_ok() {

--- a/lib/examples/tcp.rs
+++ b/lib/examples/tcp.rs
@@ -4,11 +4,13 @@ extern crate sozu_lib as sozu;
 extern crate sozu_command_lib as sozu_command;
 extern crate time;
 
-use crate::sozu_command::channel::Channel;
-use crate::sozu_command::logging::{Logger, LoggerBackend};
-use crate::sozu_command::proxy::{self, LoadBalancingParams, TcpListener};
-use std::io::stdout;
-use std::thread;
+use std::{io::stdout, thread};
+
+use crate::sozu_command::{
+    channel::Channel,
+    logging::{Logger, LoggerBackend},
+    proxy::{self, LoadBalancingParams, TcpListener},
+};
 
 fn main() {
     /*

--- a/lib/src/backends.rs
+++ b/lib/src/backends.rs
@@ -1,13 +1,13 @@
-use mio::net::TcpStream;
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::net::SocketAddr;
-use std::rc::Rc;
+use std::{cell::RefCell, collections::HashMap, net::SocketAddr, rc::Rc};
 
-use crate::sozu_command::proxy::{self, LoadBalancingAlgorithms};
+use mio::net::TcpStream;
+
+use crate::{
+    server::push_event,
+    sozu_command::proxy::{self, LoadBalancingAlgorithms},
+};
 
 use super::{load_balancing::*, Backend, ClusterId, ConnectionError};
-use crate::server::push_event;
 
 #[derive(Debug)]
 pub struct BackendMap {

--- a/lib/src/buffer_queue.rs
+++ b/lib/src/buffer_queue.rs
@@ -1,8 +1,14 @@
-use crate::pool::{Checkout, Pool};
-use crate::pool_crate::Reset;
-use std::cmp::{max, min};
-use std::io::{self, Write};
-use std::{fmt, str};
+use std::{
+    cmp::{max, min},
+    fmt,
+    io::{self, Write},
+    str,
+};
+
+use crate::{
+    pool::{Checkout, Pool},
+    pool_crate::Reset,
+};
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum InputElement {

--- a/lib/src/features.rs
+++ b/lib/src/features.rs
@@ -1,5 +1,4 @@
-use std::cell::RefCell;
-use std::collections::HashMap;
+use std::{cell::RefCell, collections::HashMap};
 
 thread_local! {
   pub static FEATURES: RefCell<FeatureFlags> = RefCell::new(FeatureFlags::new());

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -209,17 +209,15 @@ pub mod https_openssl;
 
 pub mod https_rustls;
 
-use mio::net::TcpStream;
-use mio::Token;
-use std::cell::RefCell;
-use std::fmt;
-use std::net::SocketAddr;
-use std::rc::Rc;
-use std::str;
+use std::{cell::RefCell, fmt, net::SocketAddr, rc::Rc, str};
+
+use mio::{net::TcpStream, Token};
 use time::{Duration, Instant};
 
-use crate::sozu_command::proxy::{LoadBalancingParams, ProxyEvent, ProxyRequest, ProxyResponse};
-use crate::sozu_command::ready::Ready;
+use crate::sozu_command::{
+    proxy::{LoadBalancingParams, ProxyEvent, ProxyRequest, ProxyResponse},
+    ready::Ready,
+};
 
 use self::retry::RetryPolicy;
 

--- a/lib/src/load_balancing.rs
+++ b/lib/src/load_balancing.rs
@@ -1,14 +1,13 @@
+use std::fmt::Debug;
+use std::{cell::RefCell, rc::Rc};
+
 use rand::{
     distributions::{Distribution, WeightedIndex},
     seq::SliceRandom,
     thread_rng, Rng,
 };
 
-use crate::Backend;
-
-use crate::sozu_command::proxy::LoadMetric;
-use std::fmt::Debug;
-use std::{cell::RefCell, rc::Rc};
+use crate::{sozu_command::proxy::LoadMetric, Backend};
 
 pub trait LoadBalancingAlgorithm: Debug {
     fn next_available_backend(

--- a/lib/src/metrics/local_drain.rs
+++ b/lib/src/metrics/local_drain.rs
@@ -1,13 +1,13 @@
 #![allow(dead_code)]
+use std::{collections::BTreeMap, str, time::Instant};
+
+use hdrhistogram::Histogram;
+use time::{Duration, OffsetDateTime};
+
 use crate::sozu_command::proxy::{
     AppMetricsData, FilteredData, MetricsConfiguration, MetricsData, Percentiles,
     QueryAnswerMetrics, QueryMetricsType,
 };
-use hdrhistogram::Histogram;
-use std::collections::BTreeMap;
-use std::str;
-use std::time::Instant;
-use time::{Duration, OffsetDateTime};
 
 use super::{MetricData, Subscriber};
 

--- a/lib/src/metrics/mod.rs
+++ b/lib/src/metrics/mod.rs
@@ -1,20 +1,23 @@
-use crate::sozu_command::proxy::{
-    FilteredData, MetricsConfiguration, MetricsData, QueryAnswerMetrics, QueryMetricsType,
-};
-use mio::net::UdpSocket;
-use std::cell::RefCell;
-use std::collections::BTreeMap;
-use std::io::{self, Write};
-use std::net::SocketAddr;
-use std::str;
-use std::time::Instant;
-
 mod local_drain;
 mod network_drain;
 mod writer;
 
-use self::local_drain::LocalDrain;
-use self::network_drain::NetworkDrain;
+use std::{
+    cell::RefCell,
+    collections::BTreeMap,
+    io::{self, Write},
+    net::SocketAddr,
+    str,
+    time::Instant,
+};
+
+use mio::net::UdpSocket;
+
+use crate::sozu_command::proxy::{
+    FilteredData, MetricsConfiguration, MetricsData, QueryAnswerMetrics, QueryMetricsType,
+};
+
+use self::{local_drain::LocalDrain, network_drain::NetworkDrain};
 
 thread_local! {
   pub static METRICS: RefCell<Aggregator> = RefCell::new(Aggregator::new(String::from("sozu")));

--- a/lib/src/metrics/network_drain.rs
+++ b/lib/src/metrics/network_drain.rs
@@ -1,14 +1,17 @@
-use super::writer::{MetricSocket, MetricsWriter};
-use mio::net::UdpSocket;
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
-use std::collections::VecDeque;
-use std::io::{ErrorKind, Write};
-use std::net::SocketAddr;
-use std::str;
-use std::time::{Duration, Instant};
+use std::{
+    collections::{hash_map::Entry, HashMap, VecDeque},
+    io::{ErrorKind, Write},
+    net::SocketAddr,
+    str,
+    time::{Duration, Instant},
+};
 
-use super::{MetricData, StoredMetricData, Subscriber};
+use mio::net::UdpSocket;
+
+use super::{
+    writer::{MetricSocket, MetricsWriter},
+    MetricData, StoredMetricData, Subscriber,
+};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/lib/src/metrics/writer.rs
+++ b/lib/src/metrics/writer.rs
@@ -1,10 +1,13 @@
-use libc::{c_uint, c_void, iovec, msghdr};
-use mio::net::UdpSocket;
-use std::io::{self, Error, ErrorKind, Write};
 #[cfg(target_env = "musl")]
 use std::mem;
-use std::net::SocketAddr;
-use std::os::unix::io::AsRawFd;
+use std::{
+    io::{self, Error, ErrorKind, Write},
+    net::SocketAddr,
+    os::unix::io::AsRawFd,
+};
+
+use libc::{c_uint, c_void, iovec, msghdr};
+use mio::net::UdpSocket;
 
 pub struct MetricSocket {
     pub addr: SocketAddr,

--- a/lib/src/pool.rs
+++ b/lib/src/pool.rs
@@ -6,10 +6,14 @@
 /// Right now, we wrap the `pool` crate, but we might write a different
 /// buffer pool in the future, so this module will still be useful to
 /// test the differences
+use std::{
+    cmp,
+    io::{self, Read, Write},
+    ops, ptr,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
 use poule;
-use std::io::{self, Read, Write};
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::{cmp, ops, ptr};
 
 static BUFFER_COUNT: AtomicUsize = AtomicUsize::new(0);
 

--- a/lib/src/protocol/h2/mod.rs
+++ b/lib/src/protocol/h2/mod.rs
@@ -1,16 +1,17 @@
 //FIXME: we disallow warnings for the HTTP/2 module temporarily
 #![allow(warnings)]
-use crate::pool::{Checkout, Pool};
-use crate::socket::{SocketHandler, SocketResult};
-use crate::sozu_command::buffer::fixed::Buffer;
-use crate::sozu_command::ready::Ready;
-use crate::{Protocol, Readiness, SessionMetrics, SessionResult};
-use mio::net::TcpStream;
-use mio::*;
+use std::{cell::RefCell, net::SocketAddr, rc::Weak};
+
+use mio::{net::TcpStream, *};
 use rusty_ulid::Ulid;
-use std::cell::RefCell;
-use std::net::SocketAddr;
-use std::rc::Weak;
+
+use crate::{
+    pool::{Checkout, Pool},
+    socket::{SocketHandler, SocketResult},
+    sozu_command::buffer::fixed::Buffer,
+    sozu_command::ready::Ready,
+    {Protocol, Readiness, SessionMetrics, SessionResult},
+};
 
 mod parser;
 mod serializer;

--- a/lib/src/protocol/h2/parser.rs
+++ b/lib/src/protocol/h2/parser.rs
@@ -1,3 +1,5 @@
+use std::convert::From;
+
 use nom::{
     bytes::streaming::{tag, take},
     combinator::{complete, map, map_opt},
@@ -7,7 +9,6 @@ use nom::{
     sequence::tuple,
     Err, HexDisplay, IResult, Offset,
 };
-use std::convert::From;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct FrameHeader {

--- a/lib/src/protocol/h2/serializer.rs
+++ b/lib/src/protocol/h2/serializer.rs
@@ -1,10 +1,11 @@
-use super::parser::{FrameHeader, FrameType};
 use cookie_factory::{
     bytes::{be_u24, be_u32, be_u8},
     gen,
     sequence::tuple,
     GenError,
 };
+
+use super::parser::{FrameHeader, FrameType};
 
 pub fn gen_frame_header<'a, 'b>(
     x: (&'a mut [u8], usize),

--- a/lib/src/protocol/h2/state.rs
+++ b/lib/src/protocol/h2/state.rs
@@ -1,9 +1,10 @@
-use super::{parser, serializer};
-use crate::Ready;
-use nom::Offset;
 use std::collections::{HashMap, VecDeque};
 
-use super::stream;
+use nom::Offset;
+
+use crate::Ready;
+
+use super::{parser, serializer, stream};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct OutputFrame {

--- a/lib/src/protocol/h2/stream.rs
+++ b/lib/src/protocol/h2/stream.rs
@@ -1,9 +1,14 @@
-use hpack::Decoder;
-use std::collections::{HashMap, VecDeque};
-use std::str::from_utf8;
+use std::{
+    collections::{HashMap, VecDeque},
+    str::from_utf8,
+};
 
-use super::parser;
-use super::state::{FrameResult, OutputFrame};
+use hpack::Decoder;
+
+use super::{
+    parser,
+    state::{FrameResult, OutputFrame},
+};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum St {

--- a/lib/src/protocol/http/answers.rs
+++ b/lib/src/protocol/http/answers.rs
@@ -1,7 +1,7 @@
-use super::DefaultAnswerStatus;
 use crate::ClusterId;
-use std::collections::HashMap;
-use std::rc::Rc;
+use std::{collections::HashMap, rc::Rc};
+
+use super::DefaultAnswerStatus;
 
 #[allow(non_snake_case)]
 pub struct DefaultAnswers {

--- a/lib/src/protocol/http/mod.rs
+++ b/lib/src/protocol/http/mod.rs
@@ -1,24 +1,28 @@
-use super::super::{LogDuration, Protocol, Readiness, SessionMetrics, SessionResult};
-use crate::buffer_queue::BufferQueue;
-use crate::pool::Pool;
-use crate::protocol::ProtocolResult;
-use crate::socket::{SocketHandler, SocketResult, TransportProtocol};
-use crate::sozu_command::ready::Ready;
-use crate::timer::TimeoutContainer;
-use crate::util::UnwrapLog;
-use crate::Backend;
-use mio::net::TcpStream;
-use mio::*;
-use rusty_ulid::Ulid;
-use std::cell::RefCell;
-use std::cmp::min;
-use std::net::{IpAddr, SocketAddr};
-use std::rc::{Rc, Weak};
-use time::{Duration, Instant};
-
 pub mod answers;
 pub mod cookies;
 pub mod parser;
+
+use std::{
+    cell::RefCell,
+    cmp::min,
+    net::{IpAddr, SocketAddr},
+    rc::{Rc, Weak},
+};
+
+use mio::{net::TcpStream, *};
+use rusty_ulid::Ulid;
+use time::{Duration, Instant};
+
+use crate::{
+    buffer_queue::BufferQueue,
+    pool::Pool,
+    protocol::ProtocolResult,
+    socket::{SocketHandler, SocketResult, TransportProtocol},
+    sozu_command::ready::Ready,
+    timer::TimeoutContainer,
+    util::UnwrapLog,
+    Backend, LogDuration, {Protocol, Readiness, SessionMetrics, SessionResult},
+};
 
 use self::parser::{
     compare_no_case, parse_request_until_stop, parse_response_until_stop, Chunk, Continue, Method,

--- a/lib/src/protocol/http/parser/mod.rs
+++ b/lib/src/protocol/http/parser/mod.rs
@@ -1,5 +1,10 @@
 #![allow(dead_code)]
-use super::cookies::{parse_request_cookies, RequestCookie};
+use std::{
+    collections::HashSet,
+    convert::From,
+    str::from_utf8,
+    {fmt, str},
+};
 
 use nom::{
     branch::alt,
@@ -20,18 +25,14 @@ use nom::{
     Err, IResult, Needed, Offset,
 };
 
-use std::collections::HashSet;
-use std::convert::From;
-use std::str::from_utf8;
-use std::{fmt, str};
+use super::cookies::{parse_request_cookies, RequestCookie};
+
+pub use self::{request::*, response::*};
 
 mod request;
 mod response;
 #[cfg(test)]
 mod tests;
-
-pub use self::request::*;
-pub use self::response::*;
 
 pub fn compare_no_case(left: &[u8], right: &[u8]) -> bool {
     if left.len() != right.len() {

--- a/lib/src/protocol/http/parser/request.rs
+++ b/lib/src/protocol/http/parser/request.rs
@@ -1,17 +1,17 @@
-use crate::buffer_queue::BufferQueue;
-use crate::sozu_command::buffer::fixed::Buffer;
+use std::str;
 
 use nom::{Err, HexDisplay, IResult, Offset};
-
 use url::Url;
 
-use std::str;
+use crate::{
+    buffer_queue::BufferQueue, protocol::http::AddedRequestHeader,
+    sozu_command::buffer::fixed::Buffer,
+};
 
 use super::{
     crlf, message_header, request_line, BufferMove, Chunk, Connection, Continue, Header,
     HeaderValue, Host, LengthInformation, Method, RRequestLine, TransferEncodingValue, Version,
 };
-use crate::protocol::http::AddedRequestHeader;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum RequestState {

--- a/lib/src/protocol/http/parser/response.rs
+++ b/lib/src/protocol/http/parser/response.rs
@@ -1,10 +1,8 @@
-use crate::buffer_queue::BufferQueue;
-use crate::protocol::http::StickySession;
+use std::{convert::From, str};
 
 use nom::{Err, HexDisplay, IResult, Offset};
 
-use std::convert::From;
-use std::str;
+use crate::{buffer_queue::BufferQueue, protocol::http::StickySession};
 
 use super::{
     crlf, message_header, status_line, BufferMove, Chunk, Connection, Header, HeaderValue,

--- a/lib/src/protocol/http/parser/tests.rs
+++ b/lib/src/protocol/http/parser/tests.rs
@@ -1,10 +1,15 @@
-use super::*;
+use std::{
+    io::Write,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+};
+
+use nom::{error::ErrorKind, Err, HexDisplay};
+
 use crate::buffer_queue::{buf_with_capacity, OutputElement};
 #[cfg(test)]
 use crate::protocol::http::AddedRequestHeader;
-use nom::{error::ErrorKind, Err, HexDisplay};
-use std::io::Write;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use super::*;
 
 /*
 #[test]

--- a/lib/src/protocol/openssl.rs
+++ b/lib/src/protocol/openssl.rs
@@ -1,12 +1,13 @@
-use crate::protocol::ProtocolResult;
-use crate::sozu_command::ready::Ready;
-use crate::LogDuration;
-use crate::SessionMetrics;
-use crate::{Readiness, SessionResult};
+use std::net::SocketAddr;
+
 use mio::net::*;
 use openssl::ssl::{HandshakeError, MidHandshakeSslStream, NameType, Ssl, SslStream, SslVersion};
 use rusty_ulid::Ulid;
-use std::net::SocketAddr;
+
+use crate::{
+    protocol::ProtocolResult, sozu_command::ready::Ready, LogDuration, Readiness, SessionMetrics,
+    SessionResult,
+};
 
 pub enum TlsState {
     Initial,

--- a/lib/src/protocol/pipe.rs
+++ b/lib/src/protocol/pipe.rs
@@ -1,13 +1,16 @@
-use crate::pool::Checkout;
-use crate::socket::{SocketHandler, SocketResult, TransportProtocol};
-use crate::sozu_command::ready::Ready;
-use crate::timer::TimeoutContainer;
-use crate::{LogDuration, Protocol};
-use crate::{Readiness, SessionMetrics, SessionResult};
+use std::net::SocketAddr;
+
 use mio::net::*;
 use mio::*;
 use rusty_ulid::Ulid;
-use std::net::SocketAddr;
+
+use crate::{
+    pool::Checkout,
+    socket::{SocketHandler, SocketResult, TransportProtocol},
+    sozu_command::ready::Ready,
+    timer::TimeoutContainer,
+    {LogDuration, Protocol}, {Readiness, SessionMetrics, SessionResult},
+};
 
 #[derive(PartialEq)]
 pub enum SessionStatus {

--- a/lib/src/protocol/proxy_protocol/expect.rs
+++ b/lib/src/protocol/proxy_protocol/expect.rs
@@ -1,20 +1,19 @@
 use std::io::Read;
 
-use super::header::ProxyAddr;
-use super::parser::parse_v2_header;
-use crate::pool::Checkout;
-use crate::protocol::pipe::Pipe;
-use crate::protocol::ProtocolResult;
-use crate::socket::{SocketHandler, SocketResult};
-use crate::sozu_command::ready::Ready;
-use crate::Protocol;
-use crate::Readiness;
-use crate::SessionMetrics;
-use crate::SessionResult;
-use mio::net::TcpStream;
-use mio::*;
+use mio::{net::TcpStream, *};
 use nom::{Err, HexDisplay};
 use rusty_ulid::Ulid;
+
+use crate::{
+    pool::Checkout,
+    protocol::pipe::Pipe,
+    protocol::ProtocolResult,
+    socket::{SocketHandler, SocketResult},
+    sozu_command::ready::Ready,
+    Protocol, Readiness, SessionMetrics, SessionResult,
+};
+
+use super::{header::ProxyAddr, parser::parse_v2_header};
 
 #[derive(Clone, Copy)]
 pub enum HeaderLen {

--- a/lib/src/protocol/proxy_protocol/header.rs
+++ b/lib/src/protocol/proxy_protocol/header.rs
@@ -1,5 +1,7 @@
-use std::fmt;
-use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
+use std::{
+    fmt,
+    net::{SocketAddr, SocketAddrV4, SocketAddrV6},
+};
 
 #[derive(PartialEq, Debug)]
 pub enum ProxyProtocolHeader {

--- a/lib/src/protocol/proxy_protocol/parser.rs
+++ b/lib/src/protocol/proxy_protocol/parser.rs
@@ -1,12 +1,12 @@
+use std::convert::From;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
+
 use nom::{
     bytes::streaming::{tag, take},
     error::{Error, ErrorKind, ParseError},
     number::streaming::{be_u16, be_u8},
     Err, IResult,
 };
-
-use std::convert::From;
-use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 
 use crate::protocol::proxy_protocol::header::*;
 

--- a/lib/src/protocol/proxy_protocol/relay.rs
+++ b/lib/src/protocol/proxy_protocol/relay.rs
@@ -1,20 +1,20 @@
 use std::io::Read;
 use std::io::Write;
 
-use super::parser::parse_v2_header;
-use crate::pool::Checkout;
-use crate::protocol::pipe::Pipe;
-use crate::protocol::ProtocolResult;
-use crate::socket::{SocketHandler, SocketResult};
-use crate::sozu_command::ready::Ready;
-use crate::Protocol;
-use crate::Readiness;
-use crate::SessionMetrics;
-use crate::SessionResult;
 use mio::net::TcpStream;
 use mio::*;
 use nom::{Err, Offset};
 use rusty_ulid::Ulid;
+
+use crate::{
+    pool::Checkout,
+    protocol::{pipe::Pipe, ProtocolResult},
+    socket::{SocketHandler, SocketResult},
+    sozu_command::ready::Ready,
+    Protocol, Readiness, SessionMetrics, SessionResult,
+};
+
+use super::parser::parse_v2_header;
 
 pub struct RelayProxyProtocol<Front: SocketHandler> {
     pub header_size: Option<usize>,

--- a/lib/src/protocol/proxy_protocol/send.rs
+++ b/lib/src/protocol/proxy_protocol/send.rs
@@ -1,17 +1,15 @@
-use std::io::Read;
-use std::io::{ErrorKind, Write};
+use std::io::{ErrorKind, Read, Write};
 
-use crate::sozu_command::ready::Ready;
-use crate::Protocol;
+use mio::{net::TcpStream, *};
+use rusty_ulid::Ulid;
+
 use crate::{
     pool::Checkout,
     protocol::{pipe::Pipe, ProtocolResult},
     socket::SocketHandler,
-    BackendConnectionStatus, Readiness, SessionMetrics, SessionResult,
+    sozu_command::ready::Ready,
+    BackendConnectionStatus, Protocol, Readiness, SessionMetrics, SessionResult,
 };
-use mio::net::TcpStream;
-use mio::*;
-use rusty_ulid::Ulid;
 
 use super::header::*;
 

--- a/lib/src/protocol/rustls.rs
+++ b/lib/src/protocol/rustls.rs
@@ -1,10 +1,10 @@
-use crate::protocol::ProtocolResult;
-use crate::Ready;
-use crate::{Readiness, SessionResult};
+use std::io::ErrorKind;
+
 use mio::net::*;
 use rustls::ServerConnection;
 use rusty_ulid::Ulid;
-use std::io::ErrorKind;
+
+use crate::{protocol::ProtocolResult, Readiness, Ready, SessionResult};
 
 pub enum TlsState {
     Initial,

--- a/lib/src/retry.rs
+++ b/lib/src/retry.rs
@@ -1,7 +1,6 @@
-use rand::{self, Rng};
+use std::{cmp, fmt::Debug, time};
 
-use std::fmt::Debug;
-use std::{cmp, time};
+use rand::{self, Rng};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum RetryAction {

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -1,10 +1,13 @@
-use crate::protocol::http::parser::Method;
-use crate::sozu_command::proxy::{HttpFrontend, Route, RulePosition};
+pub mod pattern_trie;
+pub mod trie;
+
 use regex::bytes::Regex;
 use std::str::from_utf8;
 
-pub mod pattern_trie;
-pub mod trie;
+use crate::{
+    protocol::http::parser::Method,
+    sozu_command::proxy::{HttpFrontend, Route, RulePosition},
+};
 
 use self::pattern_trie::TrieNode;
 

--- a/lib/src/router/pattern_trie.rs
+++ b/lib/src/router/pattern_trie.rs
@@ -1,6 +1,7 @@
+use std::{fmt::Debug, iter, str};
+
 use hashbrown::HashMap;
 use regex::bytes::Regex;
-use std::{fmt::Debug, iter, str};
 
 pub type Key = Vec<u8>;
 pub type KeyValue<K, V> = (K, V);

--- a/lib/src/router/trie.rs
+++ b/lib/src/router/trie.rs
@@ -1,5 +1,6 @@
-use hashbrown::HashMap;
 use std::{fmt::Debug, iter, str};
+
+use hashbrown::HashMap;
 
 pub type Key = Vec<u8>;
 pub type KeyValue<K, V> = (K, V);

--- a/lib/src/socket.rs
+++ b/lib/src/socket.rs
@@ -1,10 +1,13 @@
+use std::{
+    io::{self, ErrorKind, Read, Write},
+    net::SocketAddr,
+};
+
 use mio::net::{TcpListener, TcpStream};
 #[cfg(feature = "use-openssl")]
 use openssl::ssl::{ErrorCode, SslStream, SslVersion};
 use rustls::{ProtocolVersion, ServerConnection};
 use socket2::{Domain, Protocol, Socket, Type};
-use std::io::{self, ErrorKind, Read, Write};
-use std::net::SocketAddr;
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum SocketResult {

--- a/lib/src/splice.rs
+++ b/lib/src/splice.rs
@@ -1,9 +1,14 @@
-use libc::types::os::arch::posix88::{off_t, ssize_t};
-use libc::{c_int, c_uint, size_t};
+use std::{
+    io::{Error, ErrorKind},
+    os::unix::io::AsRawFd,
+    ptr,
+};
+
+use libc::{
+    c_int, c_uint, size_t,
+    types::os::arch::posix88::{off_t, ssize_t},
+};
 use mio::tcp::TcpStream;
-use std::io::{Error, ErrorKind};
-use std::os::unix::io::AsRawFd;
-use std::ptr;
 
 const SPLICE_F_NONBLOCK: c_uint = 2;
 extern "C" {

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -1,41 +1,46 @@
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    io::ErrorKind,
+    net::{Shutdown, SocketAddr},
+    os::unix::io::AsRawFd,
+    rc::Rc,
+};
+
 use mio::net::*;
 use mio::unix::SourceFd;
 use mio::*;
 use rusty_ulid::Ulid;
 use slab::Slab;
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::io::ErrorKind;
-use std::net::{Shutdown, SocketAddr};
-use std::os::unix::io::AsRawFd;
-use std::rc::Rc;
 use time::{Duration, Instant};
 
-use crate::sozu_command::config::ProxyProtocolConfig;
-use crate::sozu_command::logging;
-use crate::sozu_command::proxy::TcpListener as TcpListenerConfig;
-use crate::sozu_command::proxy::{
-    LoadBalancingAlgorithms, ProxyEvent, ProxyRequest, ProxyRequestData, ProxyResponse,
-    ProxyResponseStatus,
-};
-use crate::sozu_command::ready::Ready;
-use crate::sozu_command::scm_socket::ScmSocket;
-
-use crate::backends::BackendMap;
-use crate::pool::{Checkout, Pool};
-use crate::protocol::proxy_protocol::expect::ExpectProxyProtocol;
-use crate::protocol::proxy_protocol::relay::RelayProxyProtocol;
-use crate::protocol::proxy_protocol::send::SendProxyProtocol;
-use crate::protocol::{Pipe, ProtocolResult};
-use crate::retry::RetryPolicy;
-use crate::server::{
-    push_event, ListenSession, ListenToken, ProxyChannel, Server, SessionManager, CONN_RETRIES,
-    TIMER,
-};
-use crate::socket::server_bind;
-use crate::timer::TimeoutContainer;
-use crate::util::UnwrapLog;
 use crate::{
+    backends::BackendMap,
+    pool::{Checkout, Pool},
+    protocol::{
+        proxy_protocol::{
+            expect::ExpectProxyProtocol, relay::RelayProxyProtocol, send::SendProxyProtocol,
+        },
+        {Pipe, ProtocolResult},
+    },
+    retry::RetryPolicy,
+    server::{
+        push_event, ListenSession, ListenToken, ProxyChannel, Server, SessionManager, CONN_RETRIES,
+        TIMER,
+    },
+    socket::server_bind,
+    sozu_command::{
+        config::ProxyProtocolConfig,
+        logging,
+        proxy::{
+            LoadBalancingAlgorithms, ProxyEvent, ProxyRequest, ProxyRequestData, ProxyResponse,
+            ProxyResponseStatus, TcpListener as TcpListenerConfig,
+        },
+        ready::Ready,
+        scm_socket::ScmSocket,
+    },
+    timer::TimeoutContainer,
+    util::UnwrapLog,
     AcceptError, Backend, BackendConnectAction, BackendConnectionStatus, ClusterId,
     ConnectionError, Protocol, ProxyConfiguration, ProxySession, Readiness, SessionMetrics,
     SessionResult,

--- a/lib/src/timer.rs
+++ b/lib/src/timer.rs
@@ -2,11 +2,13 @@
 //!
 //! code imported from mio-extras
 //! License: MIT or Apache 2.0
-use crate::server::TIMER;
+use std::{cmp, iter, u64, usize};
+
 use mio::Token;
 use slab::Slab;
-use std::{cmp, iter, u64, usize};
 use time::{Duration, Instant};
+
+use crate::server::TIMER;
 
 // Conversion utilities
 mod convert {

--- a/lib/src/tls.rs
+++ b/lib/src/tls.rs
@@ -10,12 +10,6 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::router::trie::*;
-use crate::sozu_command::proxy::{
-    AddCertificate, CertificateAndKey, CertificateFingerprint, RemoveCertificate,
-    ReplaceCertificate,
-};
-
 use rustls::{
     server::{ClientHello, ResolvesServerCert},
     sign::{CertifiedKey, RsaSigningKey},
@@ -26,6 +20,14 @@ use sozu_command::proxy::TlsVersion;
 use x509_parser::{
     oid_registry::{OID_X509_COMMON_NAME, OID_X509_EXT_SUBJECT_ALT_NAME},
     pem::{parse_x509_pem, Pem},
+};
+
+use crate::{
+    router::trie::*,
+    sozu_command::proxy::{
+        AddCertificate, CertificateAndKey, CertificateFingerprint, RemoveCertificate,
+        ReplaceCertificate,
+    },
 };
 
 // -----------------------------------------------------------------------------
@@ -598,7 +600,9 @@ impl MutexWrappedCertificateResolver {
     fn generate_certified_key(
         certificate_and_key: &ParsedCertificateAndKey,
     ) -> Option<CertifiedKey> {
-        let mut chains = vec![Certificate(certificate_and_key.certificate.contents.to_owned())];
+        let mut chains = vec![Certificate(
+            certificate_and_key.certificate.contents.to_owned(),
+        )];
         for certificate in &certificate_and_key.chain {
             chains.push(Certificate(certificate.contents.to_owned()));
         }

--- a/lib/tests/http.rs
+++ b/lib/tests/http.rs
@@ -6,19 +6,23 @@ extern crate time;
 extern crate tiny_http;
 extern crate ureq;
 
-use crate::sozu_command::channel::Channel;
-use crate::sozu_command::logging::{Logger, LoggerBackend};
-use crate::sozu_command::proxy;
-use crate::sozu_command::proxy::{LoadBalancingParams, PathRule, Route, RulePosition};
-use std::thread;
 use std::{
     io::{stdout, Read, Write},
     net::{TcpListener, TcpStream, ToSocketAddrs},
     str,
     sync::{Arc, Barrier},
+    thread,
     time::Duration,
 };
+
 use tiny_http::{Response, Server};
+
+use crate::sozu_command::{
+    channel::Channel,
+    logging::{Logger, LoggerBackend},
+    proxy,
+    proxy::{LoadBalancingParams, PathRule, Route, RulePosition},
+};
 
 #[test]
 fn test() {


### PR DESCRIPTION
In a ongoing quest for consistency, here is a thorough and opiniated formatting of all `use` statements in Sōzu, following principles [found here](https://github.com/rust-lang/rustfmt/issues/4107), that is **from the furthest dependencies to the closest**:

- std
- external crates
- workspace crates (sozu command lib…)
- the actual module (`self`, `super`)

