### PR TITLE
sort use statements in files of main process

### DIFF
--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -1,5 +1,6 @@
-use sozu_command_lib::proxy::{LoadBalancingAlgorithms, TlsVersion};
 use std::net::SocketAddr;
+
+use sozu_command_lib::proxy::{LoadBalancingAlgorithms, TlsVersion};
 
 #[derive(StructOpt, PartialEq, Debug)]
 #[structopt(name = "example", about = "An example of StructOpt usage.")]

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -1,3 +1,14 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    os::unix::{
+        fs::PermissionsExt,
+        io::{AsRawFd, FromRawFd, IntoRawFd},
+        net::{UnixListener, UnixStream},
+    },
+    path::PathBuf,
+};
+
 use anyhow::{bail, Context};
 use async_dup::Arc;
 use async_io::Async;
@@ -11,16 +22,6 @@ use nix::{
     unistd::Pid,
 };
 use serde_json;
-use std::{
-    collections::{HashMap, HashSet},
-    fs,
-    os::unix::{
-        fs::PermissionsExt,
-        io::{AsRawFd, FromRawFd, IntoRawFd},
-        net::{UnixListener, UnixStream},
-    },
-    path::PathBuf,
-};
 
 use sozu_command_lib::{
     command::{

--- a/bin/src/command/orders.rs
+++ b/bin/src/command/orders.rs
@@ -1,9 +1,3 @@
-use anyhow::{bail, Context};
-use async_io::Async;
-use futures::channel::mpsc::*;
-use futures::{SinkExt, StreamExt};
-use nom::{Err, HexDisplay, Offset};
-use serde_json;
 use std::{
     collections::{BTreeMap, HashSet},
     fs::File,
@@ -12,6 +6,12 @@ use std::{
     os::unix::net::UnixStream,
     time::Duration,
 };
+
+use anyhow::{bail, Context};
+use async_io::Async;
+use futures::{channel::mpsc::*, SinkExt, StreamExt};
+use nom::{Err, HexDisplay, Offset};
+use serde_json;
 
 use sozu_command_lib::{
     buffer::fixed::Buffer,

--- a/bin/src/command/worker.rs
+++ b/bin/src/command/worker.rs
@@ -1,8 +1,8 @@
+use std::{collections::VecDeque, fmt, os::unix::io::AsRawFd};
+
 use futures::SinkExt;
 use libc::pid_t;
-use nix::sys::signal::kill;
-use nix::unistd::Pid;
-use std::{collections::VecDeque, fmt, os::unix::io::AsRawFd};
+use nix::{sys::signal::kill, unistd::Pid};
 
 use sozu_command_lib::{
     channel::Channel,

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -1,3 +1,16 @@
+use std::{
+    collections::{HashMap, HashSet},
+    process::exit,
+    sync::mpsc,
+    sync::{Arc, Mutex},
+    thread,
+    time::Duration,
+};
+
+use anyhow::{self, bail, Context};
+use prettytable::Table;
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
+
 use sozu_command_lib::{
     command::{
         CommandRequest, CommandRequestData, CommandResponse, CommandResponseData, CommandStatus,
@@ -21,17 +34,6 @@ use crate::{
     },
 };
 
-use anyhow::{self, bail, Context};
-use prettytable::Table;
-use rand::{distributions::Alphanumeric, thread_rng, Rng};
-use std::{
-    collections::{HashMap, HashSet},
-    process::exit,
-    sync::mpsc,
-    sync::{Arc, Mutex},
-    thread,
-    time::Duration,
-};
 
 // Used to display the JSON response of the status command
 #[derive(Serialize, Debug)]

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -1,13 +1,14 @@
-use anyhow::{self, bail, Context};
-use prettytable::{Row, Table};
-use sozu_command_lib::{
-    command::{CommandResponseData, ListedFrontends},
-    proxy::{FilteredData, QueryAnswer, QueryAnswerCertificate, QueryAnswerMetrics, Route},
-};
-
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     process::exit,
+};
+
+use anyhow::{self, bail, Context};
+use prettytable::{Row, Table};
+
+use sozu_command_lib::{
+    command::{CommandResponseData, ListedFrontends},
+    proxy::{FilteredData, QueryAnswer, QueryAnswerCertificate, QueryAnswerMetrics, Route},
 };
 
 pub fn print_frontend_list(frontends: ListedFrontends) {

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -2,17 +2,20 @@ mod command;
 mod display;
 mod request_builder;
 
-use crate::{
-    cli::{self, *},
-    get_config_file_path, load_configuration, util,
-};
+use std::time::Duration;
+
 use anyhow::Context;
+
 use sozu_command_lib::{
     channel::Channel,
     command::{CommandRequest, CommandResponse},
     config::Config,
 };
-use std::time::Duration;
+
+use crate::{
+    cli::{self, *},
+    get_config_file_path, load_configuration, util,
+};
 
 pub struct CommandManager {
     channel: Channel<CommandRequest, CommandResponse>,

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -1,3 +1,7 @@
+use std::{net::SocketAddr, process::exit};
+
+use anyhow::bail;
+
 use sozu_command_lib::{
     certificate::{calculate_fingerprint, split_certificate_chain},
     config::{Config, FileListenerProtocolConfig, Listener, ProxyProtocolConfig},
@@ -8,9 +12,6 @@ use sozu_command_lib::{
         RulePosition, TcpFrontend, TcpListener, TlsVersion,
     },
 };
-
-use anyhow::bail;
-use std::{net::SocketAddr, process::exit};
 
 use crate::{
     cli::{

--- a/bin/src/logging.rs
+++ b/bin/src/logging.rs
@@ -1,6 +1,9 @@
+use std::{
+    env,
+    sync::{Arc, Mutex},
+};
+
 use sozu_command_lib::logging::{target_to_backend, Logger, LoggerBackend};
-use std::env;
-use std::sync::{Arc, Mutex};
 
 lazy_static! {
     pub static ref MAIN_LOGGER: Arc<Mutex<Logger>> = Arc::new(Mutex::new(Logger::new()));

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -31,19 +31,20 @@ mod upgrade;
 mod util;
 mod worker;
 
-use anyhow::{bail, Context};
-use sozu_command_lib::config::Config;
 use std::panic;
-use structopt::StructOpt;
 
+use anyhow::{bail, Context};
 #[cfg(target_os = "linux")]
 use libc::{cpu_set_t, pid_t};
+use structopt::StructOpt;
+
+use sozu_command_lib::config::Config;
+use sozu::metrics::METRICS;
 
 use crate::{
     command::Worker,
     worker::{get_executable_path, start_workers},
 };
-use sozu::metrics::METRICS;
 
 fn main() -> anyhow::Result<()> {
     register_panic_hook();

--- a/bin/src/upgrade.rs
+++ b/bin/src/upgrade.rs
@@ -1,9 +1,3 @@
-use anyhow::{bail, Context};
-use futures_lite::future;
-use libc::{self, pid_t};
-use mio::net::UnixStream;
-use nix::unistd::*;
-use serde_json;
 use std::{
     fs::File,
     io::{Seek, SeekFrom},
@@ -11,6 +5,13 @@ use std::{
     os::unix::process::CommandExt,
     process::Command,
 };
+
+use anyhow::{bail, Context};
+use futures_lite::future;
+use libc::{self, pid_t};
+use mio::net::UnixStream;
+use nix::unistd::*;
+use serde_json;
 use tempfile::tempfile;
 
 use sozu_command_lib::{

--- a/bin/src/util.rs
+++ b/bin/src/util.rs
@@ -1,12 +1,13 @@
-use crate::logging;
+use std::{fs::File, io::Write, os::unix::io::RawFd};
 
-use anyhow;
 use anyhow::Context;
 use libc;
 use nix::fcntl::{fcntl, FcntlArg, FdFlag};
+
 use sozu::metrics;
 use sozu_command_lib::config::Config;
-use std::{fs::File, io::Write, os::unix::io::RawFd};
+
+use crate::logging;
 
 pub fn enable_close_on_exec(fd: RawFd) -> Result<i32, anyhow::Error> {
     let file_descriptor =


### PR DESCRIPTION
#749 was a good idea, but some files were forgotten, those of `/bin`, Sōzu's main process. Their use statements were already compacted but not sorted.

The sorting order of use statements:

1. std/core `use std::str::String;`
2. extern crates, `use rand::thread_rng`
3. other workspaces, `use sozu_command_lib::command::CommandRequest;`
4. this crate, `use crate::cli::MetricsCmd`

Separated by an empty line. `rustfmt` then orders each group alphabetically.