### PR TITLE
allow Dockerfile to choose Alpine base version

### DIFF
--- a/doc/how_to_use.md
+++ b/doc/how_to_use.md
@@ -48,7 +48,7 @@ You can build the image by doing:
 `docker build -t sozu .`
 
 There's also the [clevercloud/sozu](https://hub.docker.com/r/clevercloud/sozu/) image
-following the master branch.
+following the master branch (outdated).
 
 Run it with the command:
 
@@ -62,6 +62,10 @@ docker run \
   -p 8443:443 \
   sozu
 ```
+
+To build an image with a specific version of Alpine:
+
+`docker build --build-arg ALPINE_VERSION=3.14 -t sozu:main-alpine-3.14 .`
 
 ### Using a custom `config.toml` configuration file
 


### PR DESCRIPTION
As it is a Dockerfile best practice, I enable the Dockerfile to take
Alpine version as a build argument
I took the liberty to reorder Dockerfile instructions to optimize for
build speed (bubbling less often changing instruction without hindering
overall build logic)