### PR TITLE
Allow passing domain names from the command line

### DIFF
--- a/ctl/src/cli.rs
+++ b/ctl/src/cli.rs
@@ -361,6 +361,8 @@ pub enum CertificateCmd {
     #[structopt(long = "tls-versions", help = "accepted TLS versions for this certificate",
                 parse(try_from_str = parse_tls_versions))]
     tls_versions: Vec<TlsVersion>,
+    #[structopt(long = "names", use_delimiter = true, help="list of comma separated domain names (wildcard allowed)")]
+    names : Vec<String>,
   },
   #[structopt(name = "remove", about = "Remove a certificate")]
   Remove {

--- a/ctl/src/command.rs
+++ b/ctl/src/command.rs
@@ -1070,7 +1070,7 @@ pub fn remove_backend(channel: Channel<CommandRequest,CommandResponse>, timeout:
 }
 
 pub fn add_certificate(channel: Channel<CommandRequest,CommandResponse>, timeout: u64, address: SocketAddr,
-  certificate_path: &str, certificate_chain_path: &str, key_path: &str, versions: Vec<TlsVersion>) 
+  certificate_path: &str, certificate_chain_path: &str, key_path: &str, versions: Vec<TlsVersion>, names:Vec<String>) 
   -> Result<(), anyhow::Error> {
   if let Some(new_certificate) = load_full_certificate(certificate_path,
                                                        certificate_chain_path,
@@ -1078,7 +1078,7 @@ pub fn add_certificate(channel: Channel<CommandRequest,CommandResponse>, timeout
     order_command(channel, timeout, ProxyRequestData::AddCertificate(AddCertificate {
       front: address,
       certificate: new_certificate,
-      names: Vec::new(),
+      names,
     }))?;
   }
   Ok(())

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -137,8 +137,8 @@ fn main() -> Result<(), anyhow::Error> {
     }
     SubCmd::Certificate{ cmd } => {
       match cmd {
-        CertificateCmd::Add{ certificate, chain, key, address, tls_versions } => {
-          add_certificate(channel, timeout, address, &certificate, &chain, &key, tls_versions)
+        CertificateCmd::Add{ certificate, chain, key, address, tls_versions, names } => {
+          add_certificate(channel, timeout, address, &certificate, &chain, &key, tls_versions, names)
         },
         CertificateCmd::Remove{ certificate, address, fingerprint } => {
           remove_certificate(channel, timeout, address, certificate.as_deref(),


### PR DESCRIPTION
These changes allow you to specify the names in the certificate using sozuctl.   

Without this, sozu throws an error when trying to add a certificate using sozuctl.