### PR TITLE
Use clap 3 with derive instead of StructOpt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,19 +18,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
 
 [[package]]
 name = "arrayref"
@@ -316,24 +307,48 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
 name = "concurrent-queue"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
 dependencies = [
  "cache-padded",
 ]
@@ -474,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fastrand"
@@ -665,6 +680,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "hdrhistogram"
 version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,12 +701,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -720,6 +738,16 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -984,10 +1012,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+
+[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
+name = "paw"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c0fc9b564dbc3dc2ed7c92c0c144f4de340aa94514ce2b446065417c4084e9"
+dependencies = [
+ "paw-attributes",
+ "paw-raw",
+]
+
+[[package]]
+name = "paw-attributes"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f35583365be5d148e959284f42526841917b7bfa09e2d1a7ad5dde2cf0eaa39"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "paw-raw"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f0b59668fe80c5afe998f0c0bf93322bf2cd66cafeeb80581f291716f3467f2"
 
 [[package]]
 name = "pem"
@@ -1095,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc2916cde080c1876ff40292a396541241fe0072ef928cd76582e9ea5d60d2"
+checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1160,9 +1221,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534cfe58d6a18cc17120fbf4635d53d14691c1fe4d951064df9bd326178d7d5a"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
@@ -1173,7 +1234,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
 dependencies = [
- "redox_syscall 0.2.15",
+ "redox_syscall 0.2.16",
 ]
 
 [[package]]
@@ -1424,6 +1485,7 @@ dependencies = [
  "nix",
  "nom",
  "num_cpus",
+ "paw",
  "prettytable-rs",
  "rand",
  "regex",
@@ -1433,7 +1495,6 @@ dependencies = [
  "smol",
  "sozu-command-lib",
  "sozu-lib",
- "structopt",
  "tempfile",
  "termion",
  "time",
@@ -1510,33 +1571,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1570,7 +1607,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "libc",
- "redox_syscall 0.2.15",
+ "redox_syscall 0.2.16",
  "remove_dir_all",
  "winapi",
 ]
@@ -1587,6 +1624,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "termion"
 version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,18 +1640,15 @@ checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
 dependencies = [
  "libc",
  "numtoa",
- "redox_syscall 0.2.15",
+ "redox_syscall 0.2.16",
  "redox_termios",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -1629,11 +1672,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
+checksum = "74b7cc93fc23ba97fde84f7eea56c55d1ba183f495c6715defdfc7b9cb8c870f"
 dependencies = [
  "itoa",
+ "js-sys",
  "libc",
  "num_threads",
  "time-macros",
@@ -1716,12 +1760,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,12 +1811,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -1911,6 +1943,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -20,10 +20,10 @@ include = [
 name = "sozu"
 
 [dependencies]
-anyhow = "^1.0.58"
+anyhow = "^1.0.59"
 async-dup = "^1.2.2"
 async-io = "^1.7.0"
-clap = "^2.34.0"
+clap = { version = "^3.2.16", features = ["derive"] }
 futures = "^0.3.21"
 futures-lite = "^1.12.0"
 hex = "^0.4.3"
@@ -34,10 +34,10 @@ log = "^0.4.17"
 mio = { version = "^0.8.4", features = [ "os-poll", "net" ] }
 nix  = "^0.23.1"
 nom = "^7.1.1"
+paw = "^1.0.0"
 prettytable-rs = { version = "^0.8.0", default-features = false }
 serde = { version = "^1.0.139", features = ["derive"] }
 serde_json = "^1.0.82"
-structopt = "^0.3.26"
 time = "^0.3.11"
 rand = "^0.8.5"
 regex = "^1.6.0"

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -1,71 +1,85 @@
 use std::{collections::BTreeMap, net::SocketAddr};
 
+use clap::{Parser, Subcommand};
 use sozu_command_lib::proxy::{LoadBalancingAlgorithms, TlsVersion};
-use structopt::StructOpt;
 
-#[derive(StructOpt, PartialEq, Debug)]
-#[structopt(name = "example", about = "An example of StructOpt usage.")]
-pub struct Sozu {
-    #[structopt(short = "c", long = "config", help = "Sets a custom config file")]
+#[derive(Parser, PartialEq, Clone, Debug)]
+#[clap(author, version, about)]
+pub struct Args {
+    #[clap(
+        short = 'c',
+        long = "config",
+        global = true,
+        help = "Sets a custom config file"
+    )]
     pub config: Option<String>,
-    #[structopt(
-        short = "t",
+    #[clap(
+        short = 't',
         long = "timeout",
+        global = true,
         help = "Sets a custom timeout for commands (in milliseconds). 0 disables the timeout"
     )]
     pub timeout: Option<u64>,
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     pub cmd: SubCmd,
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+impl paw::ParseArgs for Args {
+    type Error = std::io::Error;
+
+    fn parse_args() -> Result<Self, Self::Error> {
+        Ok(Self::parse())
+    }
+}
+
+#[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum SubCmd {
-    #[structopt(name = "start", about = "launch the main process")]
+    #[clap(name = "start", about = "launch the main process")]
     Start,
-    #[structopt(
+    #[clap(
         name = "worker",
         about = "start a worker (internal command, should not be used directly)"
     )]
     Worker {
-        #[structopt(long = "id", help = "worker identifier")]
+        #[clap(long = "id", help = "worker identifier")]
         id: i32,
-        #[structopt(long = "fd", help = "IPC file descriptor")]
+        #[clap(long = "fd", help = "IPC file descriptor")]
         fd: i32,
-        #[structopt(long = "scm", help = "IPC SCM_RIGHTS file descriptor")]
+        #[clap(long = "scm", help = "IPC SCM_RIGHTS file descriptor")]
         scm: i32,
-        #[structopt(
+        #[clap(
             long = "configuration-state-fd",
             help = "configuration data file descriptor"
         )]
         configuration_state_fd: i32,
-        #[structopt(
+        #[clap(
             long = "command-buffer-size",
             help = "Worker's channel buffer size",
-            default_value = "1_000_000"
+            default_value = "1000000"
         )]
         command_buffer_size: usize,
-        #[structopt(
+        #[clap(
             long = "max-command-buffer-size",
             help = "Worker's channel max buffer size"
         )]
         max_command_buffer_size: Option<usize>,
     },
-    #[structopt(
+    #[clap(
         name = "main",
         about = "start a new main process (internal command, should not be used directly)"
     )]
     Main {
-        #[structopt(long = "fd", help = "IPC file descriptor")]
+        #[clap(long = "fd", help = "IPC file descriptor")]
         fd: i32,
-        #[structopt(long = "upgrade-fd", help = "upgrade data file descriptor")]
+        #[clap(long = "upgrade-fd", help = "upgrade data file descriptor")]
         upgrade_fd: i32,
-        #[structopt(
+        #[clap(
             long = "command-buffer-size",
             help = "Main process channel buffer size",
-            default_value = "1_000_000"
+            default_value = "1000000"
         )]
         command_buffer_size: usize,
-        #[structopt(
+        #[clap(
             long = "max-command-buffer-size",
             help = "Main process channel max buffer size"
         )]
@@ -73,143 +87,142 @@ pub enum SubCmd {
     },
 
     // sozuctl commands
-    #[structopt(name = "shutdown", about = "shuts down the proxy")]
+    #[clap(name = "shutdown", about = "shuts down the proxy")]
     Shutdown {
-        #[structopt(long = "hard", help = "do not wait for connections to finish")]
+        #[clap(long = "hard", help = "do not wait for connections to finish")]
         hard: bool,
-        #[structopt(
-            short = "w",
+        #[clap(
+            short = 'w',
             long = "worker",
             help = "shuts down the worker with this id"
         )]
         worker: Option<u32>,
     },
-    #[structopt(name = "upgrade", about = "upgrade the proxy")]
+    #[clap(name = "upgrade", about = "upgrade the proxy")]
     Upgrade {
-        #[structopt(short = "w", long = "worker", help = "Upgrade the worker with this id")]
+        #[clap(short = 'w', long = "worker", help = "Upgrade the worker with this id")]
         worker: Option<u32>,
     },
-    #[structopt(name = "status", about = "gets information on the running workers")]
+    #[clap(name = "status", about = "gets information on the running workers")]
     Status {
-        #[structopt(
-            short = "j",
+        #[clap(
+            short = 'j',
             long = "json",
             help = "Print the command result in JSON format"
         )]
         json: bool,
     },
-    #[structopt(
+    #[clap(
         name = "metrics",
         about = "gets statistics on the main process and its workers"
     )]
     Metrics {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: MetricsCmd,
     },
-    #[structopt(name = "logging", about = "change logging level")]
+    #[clap(name = "logging", about = "change logging level")]
     Logging {
-        // #[structopt(short = "l", long = "level", help = "change logging level")]
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         level: LoggingLevel,
     },
-    #[structopt(name = "state", about = "state management")]
+    #[clap(name = "state", about = "state management")]
     State {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: StateCmd,
     },
-    #[structopt(
+    #[clap(
         name = "reload",
         about = "Reloads routing configuration (applications, frontends and backends)"
     )]
     Reload {
-        #[structopt(
-            short = "f",
+        #[clap(
+            short = 'f',
             long = "file",
             help = "use a different configuration file from the current one"
         )]
         file: Option<String>,
-        #[structopt(
-            short = "j",
+        #[clap(
+            short = 'j',
             long = "json",
             help = "Print the command result in JSON format"
         )]
         json: bool,
     },
-    #[structopt(name = "application", about = "application management")]
+    #[clap(name = "application", about = "application management")]
     Application {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: ApplicationCmd,
     },
-    #[structopt(name = "backend", about = "backend management")]
+    #[clap(name = "backend", about = "backend management")]
     Backend {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: BackendCmd,
     },
-    #[structopt(name = "frontend", about = "frontend management")]
+    #[clap(name = "frontend", about = "frontend management")]
     Frontend {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: FrontendCmd,
     },
-    #[structopt(name = "listener", about = "listener management")]
+    #[clap(name = "listener", about = "listener management")]
     Listener {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: ListenerCmd,
     },
-    #[structopt(name = "certificate", about = "certificate management")]
+    #[clap(name = "certificate", about = "certificate management")]
     Certificate {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: CertificateCmd,
     },
-    #[structopt(name = "query", about = "configuration state verification")]
+    #[clap(name = "query", about = "configuration state verification")]
     Query {
-        #[structopt(
-            short = "j",
+        #[clap(
+            short = 'j',
             long = "json",
             help = "Print the command result in JSON format"
         )]
         json: bool,
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: QueryCmd,
     },
-    #[structopt(name = "config", about = "configuration file management")]
+    #[clap(name = "config", about = "configuration file management")]
     Config {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: ConfigCmd,
     },
-    #[structopt(name = "events", about = "receive sozu events")]
+    #[clap(name = "events", about = "receive sozu events")]
     Events,
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum MetricsCmd {
-    #[structopt(name = "enable", about = "Enables local metrics collection")]
+    #[clap(name = "enable", about = "Enables local metrics collection")]
     Enable {
-        #[structopt(short, long, help = "Enables time metrics collection")]
+        #[clap(short, long, help = "Enables time metrics collection")]
         time: bool,
     },
-    #[structopt(name = "disable", about = "Disables local metrics collection")]
+    #[clap(name = "disable", about = "Disables local metrics collection")]
     Disable {
-        #[structopt(short, long, help = "Disables time metrics collection")]
+        #[clap(short, long, help = "Disables time metrics collection")]
         time: bool,
     },
-    #[structopt(name = "clear", about = "Deletes local metrics data")]
+    #[clap(name = "clear", about = "Deletes local metrics data")]
     Clear,
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum LoggingLevel {
-    #[structopt(name = "trace", about = "Displays a LOT of logs")]
+    #[clap(name = "trace", about = "Displays a LOT of logs")]
     Trace,
-    #[structopt(
+    #[clap(
         name = "debug",
         about = "Displays more logs about the inner workings of Sōzu"
     )]
     Debug,
-    #[structopt(name = "error", about = "Displays occurring errors")]
+    #[clap(name = "error", about = "Displays occurring errors")]
     Error,
-    #[structopt(name = "warn", about = "Displays warnings about non-critical errors")]
+    #[clap(name = "warn", about = "Displays warnings about non-critical errors")]
     Warn,
-    #[structopt(name = "info", about = "Displays logs about normal behaviour of Sōzu")]
+    #[clap(name = "info", about = "Displays logs about normal behaviour of Sōzu")]
     Info,
 }
 impl std::fmt::Display for LoggingLevel {
@@ -218,22 +231,22 @@ impl std::fmt::Display for LoggingLevel {
     }
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum StateCmd {
-    #[structopt(name = "save", about = "Save state to that file")]
+    #[clap(name = "save", about = "Save state to that file")]
     Save {
-        #[structopt(short = "f", long = "file")]
+        #[clap(short = 'f', long = "file")]
         file: String,
     },
-    #[structopt(name = "load", about = "Load state from that file")]
+    #[clap(name = "load", about = "Load state from that file")]
     Load {
-        #[structopt(short = "f", long = "file")]
+        #[clap(short = 'f', long = "file")]
         file: String,
     },
-    #[structopt(name = "dump", about = "Dump current state to STDOUT")]
+    #[clap(name = "dump", about = "Dump current state to STDOUT")]
     Dump {
-        #[structopt(
-            short = "j",
+        #[clap(
+            short = 'j',
             long = "json",
             help = "Print the command result in JSON format"
         )]
@@ -241,32 +254,32 @@ pub enum StateCmd {
     },
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum ApplicationCmd {
-    #[structopt(name = "remove", about = "Remove an application")]
+    #[clap(name = "remove", about = "Remove an application")]
     Remove {
-        #[structopt(short = "i", long = "id")]
+        #[clap(short = 'i', long = "id")]
         id: String,
     },
-    #[structopt(name = "add", about = "Add an application")]
+    #[clap(name = "add", about = "Add an application")]
     Add {
-        #[structopt(short = "i", long = "id")]
+        #[clap(short = 'i', long = "id")]
         id: String,
-        #[structopt(short = "s", long = "sticky-session")]
+        #[clap(short = 's', long = "sticky-session")]
         sticky_session: bool,
-        #[structopt(short = "h", long = "https-redirect")]
+        #[clap(short = 'h', long = "https-redirect")]
         https_redirect: bool,
-        #[structopt(
+        #[clap(
             long = "send-proxy",
             help = "Enforces use of the PROXY protocol version 2 over any connection established to this server."
         )]
         send_proxy: bool,
-        #[structopt(
+        #[clap(
             long = "expect-proxy",
             help = "Configures the client-facing connection to receive a PROXY protocol header version 2"
         )]
         expect_proxy: bool,
-        #[structopt(
+        #[clap(
             long = "load-balancing-policy",
             help = "Configures the load balancing policy. Possible values are 'roundrobin', 'random' or 'leastconnections'"
         )]
@@ -274,71 +287,71 @@ pub enum ApplicationCmd {
     },
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum BackendCmd {
-    #[structopt(name = "remove", about = "Remove a backend")]
+    #[clap(name = "remove", about = "Remove a backend")]
     Remove {
-        #[structopt(short = "i", long = "id")]
+        #[clap(short = 'i', long = "id")]
         id: String,
-        #[structopt(long = "backend-id")]
+        #[clap(long = "backend-id")]
         backend_id: String,
-        #[structopt(
-            short = "a",
+        #[clap(
+            short = 'a',
             long = "address",
             help = "server address, format: IP:port"
         )]
         address: SocketAddr,
     },
-    #[structopt(name = "add", about = "Add a backend")]
+    #[clap(name = "add", about = "Add a backend")]
     Add {
-        #[structopt(short = "i", long = "id")]
+        #[clap(short = 'i', long = "id")]
         id: String,
-        #[structopt(long = "backend-id")]
+        #[clap(long = "backend-id")]
         backend_id: String,
-        #[structopt(
-            short = "a",
+        #[clap(
+            short = 'a',
             long = "address",
             help = "server address, format: IP:port"
         )]
         address: SocketAddr,
-        #[structopt(
-            short = "s",
+        #[clap(
+            short = 's',
             long = "sticky-id",
             help = "value for the sticky session cookie"
         )]
         sticky_id: Option<String>,
-        #[structopt(short = "b", long = "backup", help = "set backend as a backup backend")]
+        #[clap(short = 'b', long = "backup", help = "set backend as a backup backend")]
         backup: Option<bool>,
     },
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum FrontendCmd {
-    #[structopt(name = "http", about = "HTTP frontend management")]
+    #[clap(name = "http", about = "HTTP frontend management")]
     Http {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: HttpFrontendCmd,
     },
-    #[structopt(name = "https", about = "HTTPS frontend management")]
+    #[clap(name = "https", about = "HTTPS frontend management")]
     Https {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: HttpFrontendCmd,
     },
-    #[structopt(name = "tcp", about = "TCP frontend management")]
+    #[clap(name = "tcp", about = "TCP frontend management")]
     Tcp {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: TcpFrontendCmd,
     },
-    #[structopt(name = "list", about = "List frontends using filters")]
+    #[clap(name = "list", about = "List frontends using filters")]
     List {
-        #[structopt(long = "http", help = "filter for http frontends")]
+        #[clap(long = "http", help = "filter for http frontends")]
         http: bool,
-        #[structopt(long = "https", help = "filter for https frontends")]
+        #[clap(long = "https", help = "filter for https frontends")]
         https: bool,
-        #[structopt(long = "tcp", help = "filter for tcp frontends")]
+        #[clap(long = "tcp", help = "filter for tcp frontends")]
         tcp: bool,
-        #[structopt(
-            short = "d",
+        #[clap(
+            short = 'd',
             long = "domain",
             help = "filter by domain name (for http & https frontends)"
         )]
@@ -346,7 +359,7 @@ pub enum FrontendCmd {
     },
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum Route {
     /// traffic will go to the backend servers with this application id
     Id {
@@ -366,148 +379,148 @@ impl std::convert::Into<sozu_command_lib::proxy::Route> for Route {
     }
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum HttpFrontendCmd {
-    #[structopt(name = "add")]
+    #[clap(name = "add")]
     Add {
-        #[structopt(
-            short = "a",
+        #[clap(
+            short = 'a',
             long = "address",
             help = "frontend address, format: IP:port"
         )]
         address: SocketAddr,
-        #[structopt(flatten, name = "route")]
+        #[clap(subcommand, name = "route")]
         route: Route,
-        #[structopt(short = "host", long = "hostname")]
+        #[clap(long = "hostname", aliases = &["host"])]
         hostname: String,
-        #[structopt(short = "p", long = "path", help = "URL prefix of the frontend")]
+        #[clap(short = 'p', long = "path", help = "URL prefix of the frontend")]
         path_begin: Option<String>,
-        #[structopt(short = "m", long = "method", help = "HTTP method")]
+        #[clap(short = 'm', long = "method", help = "HTTP method")]
         method: Option<String>,
-        #[structopt(short = "t", long = "tag", help = "custom tags", parse(try_from_str = parse_tags))]
+        #[clap(short = 't', long = "tag", help = "custom tags", parse(try_from_str = parse_tags))]
         tags: Option<BTreeMap<String, String>>,
     },
-    #[structopt(name = "remove")]
+    #[clap(name = "remove")]
     Remove {
-        #[structopt(
-            short = "a",
+        #[clap(
+            short = 'a',
             long = "address",
             help = "frontend address, format: IP:port"
         )]
         address: SocketAddr,
-        #[structopt(flatten, name = "route")]
+        #[clap(subcommand, name = "route")]
         route: Route,
-        #[structopt(short = "host", long = "hostname")]
+        #[clap(long = "hostname", aliases = &["host"])]
         hostname: String,
-        #[structopt(short = "p", long = "path", help = "URL prefix of the frontend")]
+        #[clap(short = 'p', long = "path", help = "URL prefix of the frontend")]
         path_begin: Option<String>,
-        #[structopt(short = "m", long = "method", help = "HTTP method")]
+        #[clap(short = 'm', long = "method", help = "HTTP method")]
         method: Option<String>,
-        #[structopt(short = "t", long = "tag", help = "custom tags", parse(try_from_str = parse_tags))]
+        #[clap(short = 't', long = "tag", help = "custom tags", parse(try_from_str = parse_tags))]
         tags: Option<BTreeMap<String, String>>,
     },
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum TcpFrontendCmd {
-    #[structopt(name = "add")]
+    #[clap(name = "add")]
     Add {
-        #[structopt(short = "i", long = "id", help = "app id of the frontend")]
+        #[clap(short = 'i', long = "id", help = "app id of the frontend")]
         id: String,
-        #[structopt(
-            short = "a",
+        #[clap(
+            short = 'a',
             long = "address",
             help = "frontend address, format: IP:port"
         )]
         address: SocketAddr,
-        #[structopt(short = "t", long = "tag", help = "custom tags",  parse(try_from_str = parse_tags))]
+        #[clap(short = 't', long = "tag", help = "custom tags",  parse(try_from_str = parse_tags))]
         tags: Option<BTreeMap<String, String>>,
     },
-    #[structopt(name = "remove")]
+    #[clap(name = "remove")]
     Remove {
-        #[structopt(short = "i", long = "id", help = "app id of the frontend")]
+        #[clap(short = 'i', long = "id", help = "app id of the frontend")]
         id: String,
-        #[structopt(
-            short = "a",
+        #[clap(
+            short = 'a',
             long = "address",
             help = "frontend address, format: IP:port"
         )]
         address: SocketAddr,
-        #[structopt(short = "t", long = "tag", help = "custom tags", parse(try_from_str = parse_tags))]
+        #[clap(short = 't', long = "tag", help = "custom tags", parse(try_from_str = parse_tags))]
         tags: Option<BTreeMap<String, String>>,
     },
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum ListenerCmd {
-    #[structopt(name = "http", about = "HTTP listener management")]
+    #[clap(name = "http", about = "HTTP listener management")]
     Http {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: HttpListenerCmd,
     },
-    #[structopt(name = "https", about = "HTTPS listener management")]
+    #[clap(name = "https", about = "HTTPS listener management")]
     Https {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: HttpsListenerCmd,
     },
-    #[structopt(name = "tcp", about = "TCP listener management")]
+    #[clap(name = "tcp", about = "TCP listener management")]
     Tcp {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: TcpListenerCmd,
     },
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum HttpListenerCmd {
-    #[structopt(name = "add")]
+    #[clap(name = "add")]
     Add {
-        #[structopt(short = "a")]
+        #[clap(short = 'a')]
         address: SocketAddr,
-        #[structopt(
+        #[clap(
             long = "public-address",
             help = "a different IP than the one the socket sees, for logs and forwarded headers"
         )]
         public_address: Option<SocketAddr>,
-        #[structopt(
+        #[clap(
             long = "answer-404",
             help = "path to file of the 404 answer sent to the client when a frontend is not found"
         )]
         answer_404: Option<String>,
-        #[structopt(
+        #[clap(
             long = "answer-503",
             help = "path to file of the 503 answer sent to the client when an application has no backends available"
         )]
         answer_503: Option<String>,
-        #[structopt(
+        #[clap(
             long = "expect-proxy",
             help = "Configures the client socket to receive a PROXY protocol header"
         )]
         expect_proxy: bool,
-        #[structopt(long = "sticky-name", help = "sticky session cookie name")]
+        #[clap(long = "sticky-name", help = "sticky session cookie name")]
         sticky_name: Option<String>,
     },
-    #[structopt(name = "remove")]
+    #[clap(name = "remove")]
     Remove {
-        #[structopt(
-            short = "a",
+        #[clap(
+            short = 'a',
             long = "address",
             help = "listener address, format: IP:port"
         )]
         address: SocketAddr,
     },
-    #[structopt(name = "activate")]
+    #[clap(name = "activate")]
     Activate {
-        #[structopt(
-            short = "a",
+        #[clap(
+            short = 'a',
             long = "address",
             help = "listener address, format: IP:port"
         )]
         address: SocketAddr,
     },
-    #[structopt(name = "deactivate")]
+    #[clap(name = "deactivate")]
     Deactivate {
-        #[structopt(
-            short = "a",
+        #[clap(
+            short = 'a',
             long = "address",
             help = "listener address, format: IP:port"
         )]
@@ -515,63 +528,63 @@ pub enum HttpListenerCmd {
     },
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum HttpsListenerCmd {
-    #[structopt(name = "add")]
+    #[clap(name = "add")]
     Add {
-        #[structopt(short = "a")]
+        #[clap(short = 'a')]
         address: SocketAddr,
-        #[structopt(
+        #[clap(
             long = "public-address",
             help = "a different IP than the one the socket sees, for logs and forwarded headers"
         )]
         public_address: Option<SocketAddr>,
-        #[structopt(
+        #[clap(
             long = "answer-404",
             help = "path to file of the 404 answer sent to the client when a frontend is not found"
         )]
         answer_404: Option<String>,
-        #[structopt(
+        #[clap(
             long = "answer-503",
             help = "path to file of the 503 answer sent to the client when an application has no backends available"
         )]
         answer_503: Option<String>,
-        #[structopt(long = "tls-versions", help = "list of TLS versions to use")]
+        #[clap(long = "tls-versions", help = "list of TLS versions to use")]
         tls_versions: Vec<TlsVersion>,
-        #[structopt(long = "tls-ciphers-list", help = "list of OpenSSL TLS ciphers to use")]
+        #[clap(long = "tls-ciphers-list", help = "list of OpenSSL TLS ciphers to use")]
         cipher_list: Option<String>,
-        #[structopt(long = "rustls-cipher-list", help = "list of RustTLS ciphers to use")]
+        #[clap(long = "rustls-cipher-list", help = "list of RustTLS ciphers to use")]
         rustls_cipher_list: Vec<String>,
-        #[structopt(
+        #[clap(
             long = "expect-proxy",
             help = "Configures the client socket to receive a PROXY protocol header"
         )]
         expect_proxy: bool,
-        #[structopt(long = "sticky-name", help = "sticky session cookie name")]
+        #[clap(long = "sticky-name", help = "sticky session cookie name")]
         sticky_name: Option<String>,
     },
-    #[structopt(name = "remove")]
+    #[clap(name = "remove")]
     Remove {
-        #[structopt(
-            short = "a",
+        #[clap(
+            short = 'a',
             long = "address",
             help = "listener address, format: IP:port"
         )]
         address: SocketAddr,
     },
-    #[structopt(name = "activate")]
+    #[clap(name = "activate")]
     Activate {
-        #[structopt(
-            short = "a",
+        #[clap(
+            short = 'a',
             long = "address",
             help = "listener address, format: IP:port"
         )]
         address: SocketAddr,
     },
-    #[structopt(name = "deactivate")]
+    #[clap(name = "deactivate")]
     Deactivate {
-        #[structopt(
-            short = "a",
+        #[clap(
+            short = 'a',
             long = "address",
             help = "listener address, format: IP:port"
         )]
@@ -579,49 +592,49 @@ pub enum HttpsListenerCmd {
     },
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum TcpListenerCmd {
-    #[structopt(name = "add")]
+    #[clap(name = "add")]
     Add {
-        #[structopt(
-            short = "a",
+        #[clap(
+            short = 'a',
             long = "address",
             help = "listener address, format: IP:port"
         )]
         address: SocketAddr,
-        #[structopt(
+        #[clap(
             long = "public-address",
             help = "a different IP than the one the socket sees, for logs and forwarded headers"
         )]
         public_address: Option<SocketAddr>,
-        #[structopt(
+        #[clap(
             long = "expect-proxy",
             help = "Configures the client socket to receive a PROXY protocol header"
         )]
         expect_proxy: bool,
     },
-    #[structopt(name = "remove")]
+    #[clap(name = "remove")]
     Remove {
-        #[structopt(
-            short = "a",
+        #[clap(
+            short = 'a',
             long = "address",
             help = "listener address, format: IP:port"
         )]
         address: SocketAddr,
     },
-    #[structopt(name = "activate")]
+    #[clap(name = "activate")]
     Activate {
-        #[structopt(
-            short = "a",
+        #[clap(
+            short = 'a',
             long = "address",
             help = "listener address, format: IP:port"
         )]
         address: SocketAddr,
     },
-    #[structopt(name = "deactivate")]
+    #[clap(name = "deactivate")]
     Deactivate {
-        #[structopt(
-            short = "a",
+        #[clap(
+            short = 'a',
             long = "address",
             help = "listener address, format: IP:port"
         )]
@@ -629,119 +642,119 @@ pub enum TcpListenerCmd {
     },
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum CertificateCmd {
-    #[structopt(name = "add", about = "Add a certificate")]
+    #[clap(name = "add", about = "Add a certificate")]
     Add {
-        #[structopt(
-            short = "a",
+        #[clap(
+            short = 'a',
             long = "address",
             help = "listener address, format: IP:port"
         )]
         address: SocketAddr,
-        #[structopt(long = "certificate", help = "path to the certificate")]
+        #[clap(long = "certificate", help = "path to the certificate")]
         certificate: String,
-        #[structopt(long = "certificate-chain", help = "path to the certificate chain")]
+        #[clap(long = "certificate-chain", help = "path to the certificate chain")]
         chain: String,
-        #[structopt(long = "key", help = "path to the key")]
+        #[clap(long = "key", help = "path to the key")]
         key: String,
-        #[structopt(long = "tls-versions", help = "accepted TLS versions for this certificate",
+        #[clap(long = "tls-versions", help = "accepted TLS versions for this certificate",
                 parse(try_from_str = parse_tls_versions))]
         tls_versions: Vec<TlsVersion>,
     },
-    #[structopt(name = "remove", about = "Remove a certificate")]
+    #[clap(name = "remove", about = "Remove a certificate")]
     Remove {
-        #[structopt(
-            short = "a",
+        #[clap(
+            short = 'a',
             long = "address",
             help = "listener address, format: IP:port"
         )]
         address: SocketAddr,
-        #[structopt(short = "cert", long = "certificate", help = "path to the certificate")]
+        #[clap(aliases = &["cert"], long = "certificate", help = "path to the certificate")]
         certificate: Option<String>,
-        #[structopt(short = "f", long = "fingerprint", help = "certificate fingerprint")]
+        #[clap(short = 'f', long = "fingerprint", help = "certificate fingerprint")]
         fingerprint: Option<String>,
     },
-    #[structopt(name = "replace", about = "Replace an existing certificate")]
+    #[clap(name = "replace", about = "Replace an existing certificate")]
     Replace {
-        #[structopt(
-            short = "a",
+        #[clap(
+            short = 'a',
             long = "address",
             help = "listener address, format: IP:port"
         )]
         address: SocketAddr,
-        #[structopt(long = "new-certificate", help = "path to the new certificate")]
+        #[clap(long = "new-certificate", help = "path to the new certificate")]
         certificate: String,
-        #[structopt(
+        #[clap(
             long = "new-certificate-chain",
             help = "path to the new certificate chain"
         )]
         chain: String,
-        #[structopt(long = "new-key", help = "path to the new key")]
+        #[clap(long = "new-key", help = "path to the new key")]
         key: String,
-        #[structopt(
-            short = "old-cert",
+        #[clap(
+            aliases = &["old-cert"],
             long = "old-certificate",
             help = "path to the old certificate"
         )]
         old_certificate: Option<String>,
-        #[structopt(
-            short = "f",
+        #[clap(
+            short = 'f',
             long = "fingerprint",
             help = "old certificate fingerprint"
         )]
         old_fingerprint: Option<String>,
-        #[structopt(long = "tls-versions", help = "accepted TLS versions for this certificate",
+        #[clap(long = "tls-versions", help = "accepted TLS versions for this certificate",
                 parse(try_from_str = parse_tls_versions))]
         tls_versions: Vec<TlsVersion>,
     },
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum QueryCmd {
-    #[structopt(
+    #[clap(
         name = "applications",
         about = "Query applications matching a specific filter"
     )]
     Applications {
-        #[structopt(short = "i", long = "id", help = "application identifier")]
+        #[clap(short = 'i', long = "id", help = "application identifier")]
         id: Option<String>,
-        #[structopt(short = "d", long = "domain", help = "application domain name")]
+        #[clap(short = 'd', long = "domain", help = "application domain name")]
         domain: Option<String>,
     },
 
-    #[structopt(
+    #[clap(
         name = "certificates",
         about = "Query certificates matching a specific filter"
     )]
     Certificates {
-        #[structopt(short = "f", long = "fingerprint", help = "certificate fingerprint")]
+        #[clap(short = 'f', long = "fingerprint", help = "certificate fingerprint")]
         fingerprint: Option<String>,
-        #[structopt(short = "d", long = "domain", help = "domain name")]
+        #[clap(short = 'd', long = "domain", help = "domain name")]
         domain: Option<String>,
     },
 
-    #[structopt(name = "metrics", about = "Query metrics matching a specific filter")]
+    #[clap(name = "metrics", about = "Query metrics matching a specific filter")]
     Metrics {
-        #[structopt(short, long, help = "list available metrics")]
+        #[clap(short, long, help = "list available metrics")]
         list: bool,
-        #[structopt(short, long, help = "refresh metrics results (in seconds)")]
+        #[clap(short, long, help = "refresh metrics results (in seconds)")]
         refresh: Option<u32>,
-        #[structopt(
-            short = "n",
+        #[clap(
+            short = 'n',
             long = "names",
             help = "metric names",
             use_delimiter = true
         )]
         names: Vec<String>,
-        #[structopt(
-            short = "c",
+        #[clap(
+            short = 'c',
             long = "clusters",
             help = "list of cluster ids",
             use_delimiter = true
         )]
         clusters: Vec<String>,
-        #[structopt(short = "b", long="backends", help="list of backend ids", use_delimiter = true, parse(try_from_str = split_slash))]
+        #[clap(short = 'b', long="backends", help="list of backend ids", use_delimiter = true, parse(try_from_str = split_slash))]
         backends: Vec<(String, String)>,
     },
 }
@@ -759,9 +772,9 @@ fn split_slash(input: &str) -> Result<(String, String), String> {
     }
 }
 
-#[derive(StructOpt, PartialEq, Debug)]
+#[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum ConfigCmd {
-    #[structopt(name = "check", about = "check configuration file syntax and exit")]
+    #[clap(name = "check", about = "check configuration file syntax and exit")]
     Check {},
 }
 

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -23,8 +23,8 @@ pub struct CommandManager {
     config: Config,
 }
 
-pub fn ctl(matches: cli::Sozu) -> Result<(), anyhow::Error> {
-    let config_file_path = get_config_file_path(&matches)?;
+pub fn ctl(args: cli::Args) -> Result<(), anyhow::Error> {
+    let config_file_path = get_config_file_path(&args)?;
     let config = load_configuration(config_file_path)?;
 
     util::setup_logging(&config);
@@ -32,7 +32,7 @@ pub fn ctl(matches: cli::Sozu) -> Result<(), anyhow::Error> {
     // If the command is `config check` then exit because if we are here, the configuration is valid
     if let SubCmd::Config {
         cmd: ConfigCmd::Check {},
-    } = matches.cmd
+    } = args.cmd
     {
         println!("Configuration file is valid");
         std::process::exit(0);
@@ -42,14 +42,14 @@ pub fn ctl(matches: cli::Sozu) -> Result<(), anyhow::Error> {
         "could not connect to the command unix socket. Are you sure the proxy is up?"
     })?;
 
-    let timeout = Duration::from_millis(matches.timeout.unwrap_or(config.ctl_command_timeout));
+    let timeout = Duration::from_millis(args.timeout.unwrap_or(config.ctl_command_timeout));
 
     let mut command_manager = CommandManager {
         channel,
         timeout,
         config,
     };
-    command_manager.handle_command(matches.cmd)
+    command_manager.handle_command(args.cmd)
 }
 
 impl CommandManager {

--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 ]
 
 [dependencies]
-anyhow = "^1.0.58"
+anyhow = "^1.0.59"
 hex = "^0.4.3"
 libc = "^0.2.126"
 log = "^0.4.17"

--- a/command/src/command.rs
+++ b/command/src/command.rs
@@ -396,7 +396,6 @@ mod tests {
                 address: "127.0.0.1:8080".parse().unwrap(),
                 load_balancing_parameters: Some(LoadBalancingParams {
                     weight: 0,
-                    ..Default::default()
                 }),
                 sticky_id: Some(String::from("xxx-0")),
                 backup: Some(false),

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -1324,7 +1324,7 @@ impl Config {
 
         let stringified_path = saved_state_path_raw
             .to_str()
-            .ok_or(anyhow::Error::msg(
+            .ok_or_else(|| anyhow::Error::msg(
                 "Unvalid character format, expected UTF8",
             ))?
             .to_string();

--- a/command/src/proxy.rs
+++ b/command/src/proxy.rs
@@ -557,15 +557,9 @@ impl FromStr for LoadBalancingAlgorithms {
         }
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct LoadBalancingParams {
     pub weight: u8,
-}
-
-impl Default for LoadBalancingParams {
-    fn default() -> Self {
-        Self { weight: 0 }
-    }
 }
 
 /// how sozu measures which backend is less loaded
@@ -855,25 +849,13 @@ pub enum QueryAnswer {
     Metrics(QueryAnswerMetrics),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct QueryAnswerApplication {
     pub configuration: Option<Cluster>,
     pub http_frontends: Vec<HttpFrontend>,
     pub https_frontends: Vec<HttpFrontend>,
     pub tcp_frontends: Vec<TcpFrontend>,
     pub backends: Vec<Backend>,
-}
-
-impl Default for QueryAnswerApplication {
-    fn default() -> QueryAnswerApplication {
-        QueryAnswerApplication {
-            configuration: None,
-            http_frontends: vec![],
-            https_frontends: vec![],
-            tcp_frontends: vec![],
-            backends: vec![],
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
* Remove structopt
* Bump clap to 3.2.16 with derive feature
* Add paw to 1.0.0

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>