### PR TITLE
Rename "application" to "cluster"

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -6,7 +6,7 @@ receives configuration commands through anonymous unix sockets.
 
 This executable requires a configuration file in the TOML format, that describes
 the worker types and numbers, along with global information. This file can
-describe the applications handled by the proxy, but it is more recommended to
+describe the clusters handled by the proxy, but it is more recommended to
 use the command unix socket, through which the proxy listens for orders or
 configuration changes. The path of that unix socket is set in the configuration
 file.

--- a/bin/README.md
+++ b/bin/README.md
@@ -6,7 +6,7 @@ receives configuration commands through anonymous unix sockets.
 
 This executable requires a configuration file in the TOML format, that describes
 the worker types and numbers, along with global information. This file can
-describe the clusters handled by the proxy, but it is more recommended to
+describe clusters handled by the proxy, but it is more recommended to
 use the command unix socket, through which the proxy listens for orders or
 configuration changes. The path of that unix socket is set in the configuration
 file.

--- a/bin/config.toml
+++ b/bin/config.toml
@@ -162,7 +162,7 @@ address = "0.0.0.0:8080"
 #answer_503 = "../lib/assets/503.html"
 
 # defines the sticky session cookie's name, if `sticky_session` is activated for
-# an application. Defaults to "SOZUBALANCEID"
+# a cluster. Defaults to "SOZUBALANCEID"
 # sticky_name = "SOZUBALANCEID"
 #
 # Configures the client socket to receive a PROXY protocol header
@@ -219,34 +219,35 @@ tls_versions = ["TLSv1.3"]
 # this option is incompatible with public_address
 # expect_proxy = false
 
-# static configuration for applications
+# static configuration for cluster
 #
-# those applications will be routed by sozu directly from start
-[applications]
+# A cluster is a set of frontends, routing rules, and backends.
+# These clusters will be routed by sozu directly from start
+[clusters]
 
-# every application has an "application id", here it is "MyApp"
+# every cluster has a "cluster id", here it is "MyCluster"
 # this is an example of a routing configuration for the HTTP and HTTPS proxies
-[applications.MyApp]
+[clusters.MyCluster]
 
 # the protocol option indicates if we will use HTTP or TCP proxying
 # possible options are "http" or "tcp"
 protocol = "http"
 
-# per application load balancing algorithm. The possible values are
+# per cluster load balancing algorithm. The possible values are
 # "round_robin", "random", "least_loaded" and "power_of_two". Defaults to "round_robin"
 load_balancing = "round_robin"
 # metric evaluating the load on the backend. available options: connections, requests, connection_time
 # load_metric = "connections"
 
 # frontends configuration
-# this specifies which listeners; domains, certificates that will be configured for an application
+# this specifies which listeners; domains, certificates that will be configured for a cluster
 # each element of the array must be specified on one line (toml format limitation)
 # possible frontend options:
 # - address: TCP listener
-# - hostname: host name of the application
-# - path_begin = "/api" # optional. an application can receive requests going to a hostname and path prefix
-# - sticky_session = false # activates sticky sessions for this application
-# - https_redirect = false #  activates automatic redirection to HTTPS for this application
+# - hostname: host name of the cluster
+# - path_begin = "/api" # optional. a cluster can receive requests going to a hostname and path prefix
+# - sticky_session = false # activates sticky sessions for this cluster
+# - https_redirect = false #  activates automatic redirection to HTTPS for this cluster
 # - custom_tag: a tag to retrieve a frontend with the CLI or in the logs
 frontends = [
   { address = "0.0.0.0:8080", hostname = "lolcatho.st", tags = { key = "value" } },
@@ -255,7 +256,7 @@ frontends = [
 ]
 
 # backends configuration
-# this indicates the backend servers used by the application
+# this indicates the backend servers used by the cluster
 # possible options:
 # - address: IP and port of the backend server
 # - weight: weight used by the load balancing algorithm
@@ -265,7 +266,7 @@ backends = [
 ]
 
 # this is an example of a routing configuration for the TCP proxy
-[applications.TcpTest]
+[clusters.TcpTest]
 protocol = "tcp"
 
 frontends = [

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -132,7 +132,7 @@ pub enum SubCmd {
     },
     #[clap(
         name = "reload",
-        about = "Reloads routing configuration (applications, frontends and backends)"
+        about = "Reloads routing configuration (clusters, frontends and backends)"
     )]
     Reload {
         #[clap(
@@ -148,10 +148,10 @@ pub enum SubCmd {
         )]
         json: bool,
     },
-    #[clap(name = "application", about = "application management")]
-    Application {
+    #[clap(name = "cluster", about = "cluster management")]
+    Cluster {
         #[clap(subcommand)]
-        cmd: ApplicationCmd,
+        cmd: ClusterCmd,
     },
     #[clap(name = "backend", about = "backend management")]
     Backend {
@@ -255,15 +255,15 @@ pub enum StateCmd {
 }
 
 #[derive(Subcommand, PartialEq, Clone, Debug)]
-pub enum ApplicationCmd {
-    #[clap(name = "remove", about = "Remove an application")]
+pub enum ClusterCmd {
+    #[clap(name = "remove", about = "Remove a cluster")]
     Remove {
-        #[clap(short = 'i', long = "id")]
+        #[clap(short = 'i', long = "id", help = "cluster id")]
         id: String,
     },
-    #[clap(name = "add", about = "Add an application")]
+    #[clap(name = "add", about = "Add a cluster")]
     Add {
-        #[clap(short = 'i', long = "id")]
+        #[clap(short = 'i', long = "id", help = "cluster id")]
         id: String,
         #[clap(short = 's', long = "sticky-session")]
         sticky_session: bool,
@@ -361,9 +361,9 @@ pub enum FrontendCmd {
 
 #[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum Route {
-    /// traffic will go to the backend servers with this application id
+    /// traffic will go to the backend servers with this cluster id
     Id {
-        /// traffic will go to the backend servers with this application id
+        /// traffic will go to the backend servers with this cluster id
         id: String,
     },
     /// traffic to this frontend will be rejected with HTTP 401
@@ -423,7 +423,7 @@ pub enum HttpFrontendCmd {
 pub enum TcpFrontendCmd {
     #[clap(name = "add")]
     Add {
-        #[clap(short = 'i', long = "id", help = "app id of the frontend")]
+        #[clap(short = 'i', long = "id", help = "the id of the cluster to which the frontend belongs")]
         id: String,
         #[clap(
             short = 'a',
@@ -431,12 +431,16 @@ pub enum TcpFrontendCmd {
             help = "frontend address, format: IP:port"
         )]
         address: SocketAddr,
-        #[clap(long = "tags", help = "Specify tag (key-value pair) to apply on front-end (example: 'key=value, other-key=other-value')",  parse(try_from_str = parse_tags))]
+        #[clap(
+            long = "tags",
+            help = "Specify tag (key-value pair) to apply on front-end (example: 'key=value, other-key=other-value')",
+            parse(try_from_str = parse_tags)
+        )]
         tags: Option<BTreeMap<String, String>>,
     },
     #[clap(name = "remove")]
     Remove {
-        #[clap(short = 'i', long = "id", help = "app id of the frontend")]
+        #[clap(short = 'i', long = "id", help = "the id of the cluster to which the frontend belongs")]
         id: String,
         #[clap(
             short = 'a',
@@ -484,7 +488,7 @@ pub enum HttpListenerCmd {
         answer_404: Option<String>,
         #[clap(
             long = "answer-503",
-            help = "path to file of the 503 answer sent to the client when an application has no backends available"
+            help = "path to file of the 503 answer sent to the client when a cluster has no backends available"
         )]
         answer_503: Option<String>,
         #[clap(
@@ -542,7 +546,7 @@ pub enum HttpsListenerCmd {
         answer_404: Option<String>,
         #[clap(
             long = "answer-503",
-            help = "path to file of the 503 answer sent to the client when an application has no backends available"
+            help = "path to file of the 503 answer sent to the client when a cluster has no backends available"
         )]
         answer_503: Option<String>,
         #[clap(long = "tls-versions", help = "list of TLS versions to use")]
@@ -708,17 +712,13 @@ pub enum CertificateCmd {
 
 #[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum QueryCmd {
-    #[clap(
-        name = "applications",
-        about = "Query applications matching a specific filter"
-    )]
-    Applications {
-        #[clap(short = 'i', long = "id", help = "application identifier")]
+    #[clap(name = "clusters", about = "Query clusters matching a specific filter")]
+    Clusters {
+        #[clap(short = 'i', long = "id", help = "cluster identifier")]
         id: Option<String>,
-        #[clap(short = 'd', long = "domain", help = "application domain name")]
+        #[clap(short = 'd', long = "domain", help = "cluster domain name")]
         domain: Option<String>,
     },
-
     #[clap(
         name = "certificates",
         about = "Query certificates matching a specific filter"
@@ -729,7 +729,6 @@ pub enum QueryCmd {
         #[clap(short = 'd', long = "domain", help = "domain name")]
         domain: Option<String>,
     },
-
     #[clap(name = "metrics", about = "Query metrics matching a specific filter")]
     Metrics {
         #[clap(short, long, help = "list available metrics")]

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -534,7 +534,7 @@ impl CommandServer {
         Ok(())
     }
 
-    pub async fn load_static_application_configuration(&mut self) {
+    pub async fn load_static_cluster_configuration(&mut self) {
         let (tx, mut rx) = futures::channel::mpsc::channel(self.workers.len() * 2);
 
         let mut total_message_count = 0usize;
@@ -890,7 +890,7 @@ pub fn start_server(
         let saved_state_path = config.saved_state.clone();
 
         let mut server = CommandServer::new(fd, config, tx, command_rx, workers, accept_cancel_tx)?;
-        server.load_static_application_configuration().await;
+        server.load_static_cluster_configuration().await;
 
         if let Some(path) = saved_state_path {
             server

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -73,7 +73,7 @@ impl CommandManager {
                 StateCmd::Dump { json } => self.dump_state(json),
             },
             SubCmd::Reload { file, json } => self.reload_configuration(file, json),
-            SubCmd::Application { cmd } => self.application_command(cmd),
+            SubCmd::Cluster { cmd } => self.cluster_command(cmd),
             SubCmd::Backend { cmd } => self.backend_command(cmd),
             SubCmd::Frontend { cmd } => match cmd {
                 FrontendCmd::Http { cmd } => self.http_frontend_command(cmd),
@@ -125,7 +125,7 @@ impl CommandManager {
                 ),
             },
             SubCmd::Query { cmd, json } => match cmd {
-                QueryCmd::Applications { id, domain } => self.query_application(json, id, domain),
+                QueryCmd::Clusters { id, domain } => self.query_cluster(json, id, domain),
                 QueryCmd::Certificates {
                     fingerprint,
                     domain,

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -15,7 +15,7 @@ use sozu_command_lib::{
 
 use crate::{
     cli::{
-        ApplicationCmd, BackendCmd, HttpFrontendCmd, HttpListenerCmd, HttpsListenerCmd,
+        ClusterCmd, BackendCmd, HttpFrontendCmd, HttpListenerCmd, HttpsListenerCmd,
         LoggingLevel, TcpFrontendCmd, TcpListenerCmd,
     },
     ctl::CommandManager,
@@ -50,9 +50,9 @@ impl CommandManager {
         }
     }
 
-    pub fn application_command(&mut self, cmd: ApplicationCmd) -> Result<(), anyhow::Error> {
+    pub fn cluster_command(&mut self, cmd: ClusterCmd) -> Result<(), anyhow::Error> {
         match cmd {
-            ApplicationCmd::Add {
+            ClusterCmd::Add {
                 id,
                 sticky_session,
                 https_redirect,
@@ -76,7 +76,7 @@ impl CommandManager {
                     answer_503: None,
                 }))
             }
-            ApplicationCmd::Remove { id } => {
+            ClusterCmd::Remove { id } => {
                 self.order_command(ProxyRequestData::RemoveCluster { cluster_id: id })
             }
         }

--- a/command/README.md
+++ b/command/README.md
@@ -196,7 +196,7 @@ The data attribute will contain one of the proxy orders.
   "data": {
     "type": "ADD_HTTP_FRONT",
     "data": {
-      "app_id":     "xxx",
+      "cluster_id":     "xxx",
       "hostname":   "example.com",
       "path_begin": "/hello"
     }
@@ -213,7 +213,7 @@ The data attribute will contain one of the proxy orders.
   "data": {
     "type": "ADD_HTTPS_FRONT",
     "data": {
-      "app_id":      "xxx",
+      "cluster_id":      "xxx",
       "hostname":    "example.com",
       "path_begin":  "/hello",
       "fingerprint": "ab2618b674e15243fd02a5618c66509e4840ba60e7d64cebec84cdbfeceee0c5"
@@ -233,7 +233,7 @@ The fingerprint is the hexadecimal representation of the SHA256 hash of the cert
   "data":{
     "type": "ADD_BACKEND",
     "data": {
-      "app_id": "xxx",
+      "cluster_id": "xxx",
       "ip_address": "127.0.0.1",
       "port": 8080
     }
@@ -249,7 +249,7 @@ The fingerprint is the hexadecimal representation of the SHA256 hash of the cert
   "version":  0,
   "data": {
     "type": "REMOVE_HTTP_FRONT",
-    "app_id": "xxx",
+    "cluster_id": "xxx",
     "hostname": "yyy",
     "path_begin": "xxx",
     "port": 4242
@@ -266,7 +266,7 @@ The fingerprint is the hexadecimal representation of the SHA256 hash of the cert
   "data": {
     "type": "REMOVE_HTTPS_FRONT",
     "data": {
-      "app_id":      "xxx",
+      "cluster_id":      "xxx",
       "hostname":    "yyy",
       "path_begin":  "xxx",
       "fingerprint": "ab2618b674e15243fd02a5618c66509e4840ba60e7d64cebec84cdbfeceee0c5"
@@ -284,7 +284,7 @@ The fingerprint is the hexadecimal representation of the SHA256 hash of the cert
   "data": {
     "type": "REMOVE_BACKEND",
     "data": {
-      "app_id": "xxx",
+      "cluster_id": "xxx",
       "ip_address": "127.0.0.1",
       "port": 8080
     }

--- a/command/assets/README.md
+++ b/command/assets/README.md
@@ -1,1 +1,1 @@
-if you need to edit any of this files, open them like this `vim -b add_application.json` and then do `:set noeol` inside the editor, to keep the expected formatting
+if you need to edit any of this files, open them like this `vim -b add_certficate.json` and then do `:set noeol` inside the editor, to keep the expected formatting

--- a/command/assets/answer_metrics.json
+++ b/command/assets/answer_metrics.json
@@ -37,7 +37,7 @@
             }
           },
           "clusters": {
-            "app_1": {
+            "cluster_1": {
               "data": {
                 "request_time": {
                   "type": "PERCENTILES",
@@ -54,7 +54,7 @@
                 }
               },
               "backends": {
-                "app_1-0": {
+                "cluster_1-0": {
                   "bytes_in": {
                     "type": "COUNT",
                     "data": 256

--- a/command/assets/config.toml
+++ b/command/assets/config.toml
@@ -31,8 +31,8 @@ address = "0.0.0.0:1234"
 protocol = "tcp"
 expect_proxy = true
 
-[applications]
-[applications.MyApp]
+[clusters]
+[clusters.MyCluster]
 protocol = "http"
 #sticky_session = false
 #https_redirect = false
@@ -45,7 +45,7 @@ backends = [
   { address = "127.0.0.1:1027", weight = 100, sticky_id = "backend-1027" }
 ]
 
-[applications.example_com]
+[clusters.example_com]
 protocol = "http"
 frontends = [
   { address = "0.0.0.0:81", hostname = "example.com" }
@@ -54,7 +54,7 @@ backends = [
   { address = "127.0.0.1:1028", weight = 100 }
 ]
 
-[applications.TcpApp]
+[clusters.TcpCluster]
 protocol = "tcp"
 #send_proxy = false
 frontends = [

--- a/command/assets/protocol_mismatch.json
+++ b/command/assets/protocol_mismatch.json
@@ -5,7 +5,7 @@
   "data": {
     "type": "ADD_BACKEND",
     "data": {
-      "app_id": "xxx",
+      "cluster_id": "xxx",
       "backend_id": "xxx-0",
       "address": "127.0.0.1:8080"
     }

--- a/command/src/command.rs
+++ b/command/src/command.rs
@@ -157,7 +157,7 @@ mod tests {
     use crate::certificate::split_certificate_chain;
     use crate::config::ProxyProtocolConfig;
     use crate::proxy::{
-        AddCertificate, AppMetricsData, Backend, CertificateAndKey, CertificateFingerprint,
+        AddCertificate, ClusterMetricsData, Backend, CertificateAndKey, CertificateFingerprint,
         Cluster, FilteredData, HttpFrontend, LoadBalancingAlgorithms, LoadBalancingParams,
         MetricsData, PathRule, Percentiles, ProxyRequestData, RemoveBackend, RemoveCertificate,
         Route, RulePosition, TlsVersion,
@@ -574,8 +574,8 @@ mod tests {
                         .cloned()
                         .collect(),
                         clusters: [(
-                            String::from("app_1"),
-                            AppMetricsData {
+                            String::from("cluster_1"),
+                            ClusterMetricsData {
                                 data: [(
                                     String::from("request_time"),
                                     FilteredData::Percentiles(Percentiles {
@@ -593,7 +593,7 @@ mod tests {
                                 .cloned()
                                 .collect(),
                                 backends: [(
-                                    String::from("app_1-0"),
+                                    String::from("cluster_1-0"),
                                     [
                                         (String::from("bytes_in"), FilteredData::Count(256)),
                                         (String::from("bytes_out"), FilteredData::Count(128)),

--- a/command/src/proxy.rs
+++ b/command/src/proxy.rs
@@ -103,25 +103,25 @@ pub struct AggregatedMetricsData {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MetricsData {
     pub proxy: BTreeMap<String, FilteredData>,
-    pub clusters: BTreeMap<String, AppMetricsData>,
+    pub clusters: BTreeMap<String, ClusterMetricsData>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AppMetricsData {
+pub struct ClusterMetricsData {
     pub data: BTreeMap<String, FilteredData>,
     pub backends: BTreeMap<String, BTreeMap<String, FilteredData>>,
 }
 
-impl AppMetricsData {
+impl ClusterMetricsData {
     pub fn new() -> Self {
-        AppMetricsData {
+        ClusterMetricsData {
             data: BTreeMap::new(),
             backends: BTreeMap::new(),
         }
     }
 }
 
-impl Default for AppMetricsData {
+impl Default for ClusterMetricsData {
     fn default() -> Self {
         Self::new()
     }
@@ -795,21 +795,21 @@ pub enum MetricsConfiguration {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Query {
-    Applications(QueryApplicationType),
+    Clusters(QueryClusterType),
     Certificates(QueryCertificateType),
     Metrics(QueryMetricsType),
-    ApplicationsHashes,
+    ClustersHashes,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data", rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum QueryApplicationType {
+pub enum QueryClusterType {
     ClusterId(String),
-    Domain(QueryApplicationDomain),
+    Domain(QueryClusterDomain),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct QueryApplicationDomain {
+pub struct QueryClusterDomain {
     pub hostname: String,
     pub path: Option<String>,
 }
@@ -828,13 +828,12 @@ pub enum QueryMetricsType {
     List,
     Cluster {
         metrics: Vec<String>,
-        clusters: Vec<String>,
+        cluster_ids: Vec<String>,
         date: Option<i64>,
     },
-    // tuple cluster_id, backend_id
     Backend {
         metrics: Vec<String>,
-        backends: Vec<(String, String)>,
+        backends: Vec<(String, String)>, // (cluster_id, backend_id)
         date: Option<i64>,
     },
 }
@@ -842,15 +841,15 @@ pub enum QueryMetricsType {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum QueryAnswer {
-    Applications(Vec<QueryAnswerApplication>),
-    /// application id, hash of application information
-    ApplicationsHashes(BTreeMap<String, u64>),
+    Clusters(Vec<QueryAnswerCluster>),
+    /// cluster id, hash of cluster information
+    ClustersHashes(BTreeMap<String, u64>),
     Certificates(QueryAnswerCertificate),
     Metrics(QueryAnswerMetrics),
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct QueryAnswerApplication {
+pub struct QueryAnswerCluster {
     pub configuration: Option<Cluster>,
     pub http_frontends: Vec<HttpFrontend>,
     pub https_frontends: Vec<HttpFrontend>,

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -10,7 +10,7 @@ use crate::{
     proxy::{
         ActivateListener, AddCertificate, Backend, CertificateAndKey, CertificateFingerprint,
         Cluster, DeactivateListener, HttpFrontend, HttpListener, HttpsListener, ListenerType,
-        PathRule, ProxyRequestData, QueryAnswerApplication, RemoveBackend, RemoveCertificate,
+        PathRule, ProxyRequestData, QueryAnswerCluster, RemoveBackend, RemoveCertificate,
         RemoveListener, Route, TcpFrontend, TcpListener,
     },
 };
@@ -751,15 +751,15 @@ impl ConfigState {
         }
 
         let mut my_tcp_fronts: HashSet<(&ClusterId, &TcpFrontend)> = HashSet::new();
-        for (app_id, front_list) in self.tcp_fronts.iter() {
+        for (cluster_id, front_list) in self.tcp_fronts.iter() {
             for front in front_list.iter() {
-                my_tcp_fronts.insert((app_id, front));
+                my_tcp_fronts.insert((cluster_id, front));
             }
         }
         let mut their_tcp_fronts: HashSet<(&ClusterId, &TcpFrontend)> = HashSet::new();
-        for (app_id, front_list) in other.tcp_fronts.iter() {
+        for (cluster_id, front_list) in other.tcp_fronts.iter() {
             for front in front_list.iter() {
-                their_tcp_fronts.insert((app_id, front));
+                their_tcp_fronts.insert((cluster_id, front));
             }
         }
 
@@ -865,8 +865,8 @@ impl ConfigState {
             .collect()
     }
 
-    pub fn application_state(&self, cluster_id: &str) -> QueryAnswerApplication {
-        QueryAnswerApplication {
+    pub fn cluster_state(&self, cluster_id: &str) -> QueryAnswerCluster {
+        QueryAnswerCluster {
             configuration: self.clusters.get(cluster_id).cloned(),
             http_frontends: self
                 .http_fronts
@@ -914,7 +914,7 @@ impl ConfigState {
     }
 }
 
-pub fn get_application_ids_by_domain(
+pub fn get_cluster_ids_by_domain(
     state: &ConfigState,
     hostname: String,
     path: Option<String>,
@@ -1060,7 +1060,7 @@ mod tests {
     fn serialize() {
         let mut state: ConfigState = Default::default();
         state.handle_order(&ProxyRequestData::AddHttpFrontend(HttpFrontend {
-            route: Route::ClusterId(String::from("app_1")),
+            route: Route::ClusterId(String::from("cluster_1")),
             hostname: String::from("lolcatho.st:8080"),
             path: PathRule::Prefix(String::from("/")),
             method: None,
@@ -1069,7 +1069,7 @@ mod tests {
             tags: None,
         }));
         state.handle_order(&ProxyRequestData::AddHttpFrontend(HttpFrontend {
-            route: Route::ClusterId(String::from("app_2")),
+            route: Route::ClusterId(String::from("cluster_2")),
             hostname: String::from("test.local"),
             path: PathRule::Prefix(String::from("/abc")),
             method: None,
@@ -1078,40 +1078,40 @@ mod tests {
             tags: None,
         }));
         state.handle_order(&ProxyRequestData::AddBackend(Backend {
-            cluster_id: String::from("app_1"),
-            backend_id: String::from("app_1-0"),
+            cluster_id: String::from("cluster_1"),
+            backend_id: String::from("cluster_1-0"),
             address: "127.0.0.1:1026".parse().unwrap(),
             load_balancing_parameters: Some(LoadBalancingParams::default()),
             sticky_id: None,
             backup: None,
         }));
         state.handle_order(&ProxyRequestData::AddBackend(Backend {
-            cluster_id: String::from("app_1"),
-            backend_id: String::from("app_1-1"),
+            cluster_id: String::from("cluster_1"),
+            backend_id: String::from("cluster_1-1"),
             address: "127.0.0.2:1027".parse().unwrap(),
             load_balancing_parameters: Some(LoadBalancingParams::default()),
             sticky_id: None,
             backup: None,
         }));
         state.handle_order(&ProxyRequestData::AddBackend(Backend {
-            cluster_id: String::from("app_2"),
-            backend_id: String::from("app_2-0"),
+            cluster_id: String::from("cluster_2"),
+            backend_id: String::from("cluster_2-0"),
             address: "192.167.1.2:1026".parse().unwrap(),
             load_balancing_parameters: Some(LoadBalancingParams::default()),
             sticky_id: None,
             backup: None,
         }));
         state.handle_order(&ProxyRequestData::AddBackend(Backend {
-            cluster_id: String::from("app_1"),
-            backend_id: String::from("app_1-3"),
+            cluster_id: String::from("cluster_1"),
+            backend_id: String::from("cluster_1-3"),
             address: "192.168.1.3:1027".parse().unwrap(),
             load_balancing_parameters: Some(LoadBalancingParams::default()),
             sticky_id: None,
             backup: None,
         }));
         state.handle_order(&ProxyRequestData::RemoveBackend(RemoveBackend {
-            cluster_id: String::from("app_1"),
-            backend_id: String::from("app_1-3"),
+            cluster_id: String::from("cluster_1"),
+            backend_id: String::from("cluster_1-3"),
             address: "192.168.1.3:1027".parse().unwrap(),
         }));
 
@@ -1130,7 +1130,7 @@ mod tests {
     fn diff() {
         let mut state: ConfigState = Default::default();
         state.handle_order(&ProxyRequestData::AddHttpFrontend(HttpFrontend {
-            route: Route::ClusterId(String::from("app_1")),
+            route: Route::ClusterId(String::from("cluster_1")),
             hostname: String::from("lolcatho.st:8080"),
             path: PathRule::Prefix(String::from("/")),
             method: None,
@@ -1139,7 +1139,7 @@ mod tests {
             tags: None,
         }));
         state.handle_order(&ProxyRequestData::AddHttpFrontend(HttpFrontend {
-            route: Route::ClusterId(String::from("app_2")),
+            route: Route::ClusterId(String::from("cluster_2")),
             hostname: String::from("test.local"),
             path: PathRule::Prefix(String::from("/abc")),
             method: None,
@@ -1148,31 +1148,31 @@ mod tests {
             tags: None,
         }));
         state.handle_order(&ProxyRequestData::AddBackend(Backend {
-            cluster_id: String::from("app_1"),
-            backend_id: String::from("app_1-0"),
+            cluster_id: String::from("cluster_1"),
+            backend_id: String::from("cluster_1-0"),
             address: "127.0.0.1:1026".parse().unwrap(),
             load_balancing_parameters: Some(LoadBalancingParams::default()),
             sticky_id: None,
             backup: None,
         }));
         state.handle_order(&ProxyRequestData::AddBackend(Backend {
-            cluster_id: String::from("app_1"),
-            backend_id: String::from("app_1-1"),
+            cluster_id: String::from("cluster_1"),
+            backend_id: String::from("cluster_1-1"),
             address: "127.0.0.2:1027".parse().unwrap(),
             load_balancing_parameters: Some(LoadBalancingParams::default()),
             sticky_id: None,
             backup: None,
         }));
         state.handle_order(&ProxyRequestData::AddBackend(Backend {
-            cluster_id: String::from("app_2"),
-            backend_id: String::from("app_2-0"),
+            cluster_id: String::from("cluster_2"),
+            backend_id: String::from("cluster_2-0"),
             address: "192.167.1.2:1026".parse().unwrap(),
             load_balancing_parameters: Some(LoadBalancingParams::default()),
             sticky_id: None,
             backup: None,
         }));
         state.handle_order(&ProxyRequestData::AddCluster(Cluster {
-            cluster_id: String::from("app_2"),
+            cluster_id: String::from("cluster_2"),
             sticky_session: true,
             https_redirect: true,
             proxy_protocol: None,
@@ -1183,7 +1183,7 @@ mod tests {
 
         let mut state2: ConfigState = Default::default();
         state2.handle_order(&ProxyRequestData::AddHttpFrontend(HttpFrontend {
-            route: Route::ClusterId(String::from("app_1")),
+            route: Route::ClusterId(String::from("cluster_1")),
             hostname: String::from("lolcatho.st:8080"),
             path: PathRule::Prefix(String::from("/")),
             address: "0.0.0.0:8080".parse().unwrap(),
@@ -1192,31 +1192,31 @@ mod tests {
             tags: None,
         }));
         state2.handle_order(&ProxyRequestData::AddBackend(Backend {
-            cluster_id: String::from("app_1"),
-            backend_id: String::from("app_1-0"),
+            cluster_id: String::from("cluster_1"),
+            backend_id: String::from("cluster_1-0"),
             address: "127.0.0.1:1026".parse().unwrap(),
             load_balancing_parameters: Some(LoadBalancingParams::default()),
             sticky_id: None,
             backup: None,
         }));
         state2.handle_order(&ProxyRequestData::AddBackend(Backend {
-            cluster_id: String::from("app_1"),
-            backend_id: String::from("app_1-1"),
+            cluster_id: String::from("cluster_1"),
+            backend_id: String::from("cluster_1-1"),
             address: "127.0.0.2:1027".parse().unwrap(),
             load_balancing_parameters: Some(LoadBalancingParams::default()),
             sticky_id: None,
             backup: None,
         }));
         state2.handle_order(&ProxyRequestData::AddBackend(Backend {
-            cluster_id: String::from("app_1"),
-            backend_id: String::from("app_1-2"),
+            cluster_id: String::from("cluster_1"),
+            backend_id: String::from("cluster_1-2"),
             address: "127.0.0.2:1028".parse().unwrap(),
             load_balancing_parameters: Some(LoadBalancingParams::default()),
             sticky_id: None,
             backup: None,
         }));
         state2.handle_order(&ProxyRequestData::AddCluster(Cluster {
-            cluster_id: String::from("app_3"),
+            cluster_id: String::from("cluster_3"),
             sticky_session: false,
             https_redirect: false,
             proxy_protocol: None,
@@ -1227,7 +1227,7 @@ mod tests {
 
         let e = vec![
             ProxyRequestData::RemoveHttpFrontend(HttpFrontend {
-                route: Route::ClusterId(String::from("app_2")),
+                route: Route::ClusterId(String::from("cluster_2")),
                 hostname: String::from("test.local"),
                 path: PathRule::Prefix(String::from("/abc")),
                 method: None,
@@ -1236,23 +1236,23 @@ mod tests {
                 tags: None,
             }),
             ProxyRequestData::RemoveBackend(RemoveBackend {
-                cluster_id: String::from("app_2"),
-                backend_id: String::from("app_2-0"),
+                cluster_id: String::from("cluster_2"),
+                backend_id: String::from("cluster_2-0"),
                 address: "192.167.1.2:1026".parse().unwrap(),
             }),
             ProxyRequestData::AddBackend(Backend {
-                cluster_id: String::from("app_1"),
-                backend_id: String::from("app_1-2"),
+                cluster_id: String::from("cluster_1"),
+                backend_id: String::from("cluster_1-2"),
                 address: "127.0.0.2:1028".parse().unwrap(),
                 load_balancing_parameters: Some(LoadBalancingParams::default()),
                 sticky_id: None,
                 backup: None,
             }),
             ProxyRequestData::RemoveCluster {
-                cluster_id: String::from("app_2"),
+                cluster_id: String::from("cluster_2"),
             },
             ProxyRequestData::AddCluster(Cluster {
-                cluster_id: String::from("app_3"),
+                cluster_id: String::from("cluster_3"),
                 sticky_session: false,
                 https_redirect: false,
                 proxy_protocol: None,
@@ -1272,8 +1272,8 @@ mod tests {
         let hash2 = state2.hash_state();
         let mut state3 = state.clone();
         state3.handle_order(&ProxyRequestData::AddBackend(Backend {
-            cluster_id: String::from("app_1"),
-            backend_id: String::from("app_1-2"),
+            cluster_id: String::from("cluster_1"),
+            backend_id: String::from("cluster_1-2"),
             address: "127.0.0.2:1028".parse().unwrap(),
             load_balancing_parameters: Some(LoadBalancingParams::default()),
             sticky_id: None,
@@ -1288,10 +1288,10 @@ mod tests {
     }
 
     #[test]
-    fn application_ids_by_domain() {
+    fn cluster_ids_by_domain() {
         let mut config = ConfigState::new();
-        let http_front_app1 = HttpFrontend {
-            route: Route::ClusterId(String::from("MyApp_1")),
+        let http_front_cluster1 = HttpFrontend {
+            route: Route::ClusterId(String::from("MyCluster_1")),
             hostname: String::from("lolcatho.st"),
             path: PathRule::Prefix(String::from("")),
             method: None,
@@ -1300,8 +1300,8 @@ mod tests {
             tags: None,
         };
 
-        let https_front_app1 = HttpFrontend {
-            route: Route::ClusterId(String::from("MyApp_1")),
+        let https_front_cluster1 = HttpFrontend {
+            route: Route::ClusterId(String::from("MyCluster_1")),
             hostname: String::from("lolcatho.st"),
             path: PathRule::Prefix(String::from("")),
             method: None,
@@ -1310,8 +1310,8 @@ mod tests {
             tags: None,
         };
 
-        let http_front_app2 = HttpFrontend {
-            route: Route::ClusterId(String::from("MyApp_2")),
+        let http_front_cluster2 = HttpFrontend {
+            route: Route::ClusterId(String::from("MyCluster_2")),
             hostname: String::from("lolcatho.st"),
             path: PathRule::Prefix(String::from("/api")),
             method: None,
@@ -1320,8 +1320,8 @@ mod tests {
             tags: None,
         };
 
-        let https_front_app2 = HttpFrontend {
-            route: Route::ClusterId(String::from("MyApp_2")),
+        let https_front_cluster2 = HttpFrontend {
+            route: Route::ClusterId(String::from("MyCluster_2")),
             hostname: String::from("lolcatho.st"),
             path: PathRule::Prefix(String::from("/api")),
             method: None,
@@ -1330,41 +1330,43 @@ mod tests {
             tags: None,
         };
 
-        let add_http_front_order_app1 = ProxyRequestData::AddHttpFrontend(http_front_app1);
-        let add_http_front_order_app2 = ProxyRequestData::AddHttpFrontend(http_front_app2);
-        let add_https_front_order_app1 = ProxyRequestData::AddHttpsFrontend(https_front_app1);
-        let add_https_front_order_app2 = ProxyRequestData::AddHttpsFrontend(https_front_app2);
-        config.handle_order(&add_http_front_order_app1);
-        config.handle_order(&add_http_front_order_app2);
-        config.handle_order(&add_https_front_order_app1);
-        config.handle_order(&add_https_front_order_app2);
+        let add_http_front_order_cluster1 = ProxyRequestData::AddHttpFrontend(http_front_cluster1);
+        let add_http_front_order_cluster2 = ProxyRequestData::AddHttpFrontend(http_front_cluster2);
+        let add_https_front_order_cluster1 =
+            ProxyRequestData::AddHttpsFrontend(https_front_cluster1);
+        let add_https_front_order_cluster2 =
+            ProxyRequestData::AddHttpsFrontend(https_front_cluster2);
+        config.handle_order(&add_http_front_order_cluster1);
+        config.handle_order(&add_http_front_order_cluster2);
+        config.handle_order(&add_https_front_order_cluster1);
+        config.handle_order(&add_https_front_order_cluster2);
 
-        let mut app1_app2: HashSet<ClusterId> = HashSet::new();
-        app1_app2.insert(String::from("MyApp_1"));
-        app1_app2.insert(String::from("MyApp_2"));
+        let mut cluster1_cluster2: HashSet<ClusterId> = HashSet::new();
+        cluster1_cluster2.insert(String::from("MyCluster_1"));
+        cluster1_cluster2.insert(String::from("MyCluster_2"));
 
-        let mut app2: HashSet<ClusterId> = HashSet::new();
-        app2.insert(String::from("MyApp_2"));
+        let mut cluster2: HashSet<ClusterId> = HashSet::new();
+        cluster2.insert(String::from("MyCluster_2"));
 
         let empty: HashSet<ClusterId> = HashSet::new();
         assert_eq!(
-            get_application_ids_by_domain(&config, String::from("lolcatho.st"), None),
-            app1_app2
+            get_cluster_ids_by_domain(&config, String::from("lolcatho.st"), None),
+            cluster1_cluster2
         );
         assert_eq!(
-            get_application_ids_by_domain(
+            get_cluster_ids_by_domain(
                 &config,
                 String::from("lolcatho.st"),
                 Some(String::from("/api"))
             ),
-            app2
+            cluster2
         );
         assert_eq!(
-            get_application_ids_by_domain(&config, String::from("lolcathost"), None),
+            get_cluster_ids_by_domain(&config, String::from("lolcathost"), None),
             empty
         );
         assert_eq!(
-            get_application_ids_by_domain(
+            get_cluster_ids_by_domain(
                 &config,
                 String::from("lolcathost"),
                 Some(String::from("/sozu"))
@@ -1377,8 +1379,8 @@ mod tests {
     fn duplicate_backends() {
         let mut state: ConfigState = Default::default();
         state.handle_order(&ProxyRequestData::AddBackend(Backend {
-            cluster_id: String::from("app_1"),
-            backend_id: String::from("app_1-0"),
+            cluster_id: String::from("cluster_1"),
+            backend_id: String::from("cluster_1-0"),
             address: "127.0.0.1:1026".parse().unwrap(),
             load_balancing_parameters: Some(LoadBalancingParams::default()),
             sticky_id: None,
@@ -1386,8 +1388,8 @@ mod tests {
         }));
 
         let b = Backend {
-            cluster_id: String::from("app_1"),
-            backend_id: String::from("app_1-0"),
+            cluster_id: String::from("cluster_1"),
+            backend_id: String::from("cluster_1-0"),
             address: "127.0.0.1:1026".parse().unwrap(),
             load_balancing_parameters: Some(LoadBalancingParams::default()),
             sticky_id: Some("sticky".to_string()),
@@ -1396,7 +1398,7 @@ mod tests {
 
         state.handle_order(&ProxyRequestData::AddBackend(b.clone()));
 
-        assert_eq!(state.backends.get("app_1").unwrap(), &vec![b]);
+        assert_eq!(state.backends.get("cluster_1").unwrap(), &vec![b]);
     }
 
     #[test]

--- a/doc/README.md
+++ b/doc/README.md
@@ -2,13 +2,13 @@
 
 ## What is Sōzu?
 
-Sōzu is a reverse proxy for load balancing, written in Rust. Its main job is to balance inbound requests across two or more applications backends to spread the load.
+Sōzu is a reverse proxy for load balancing, written in Rust. Its main job is to balance inbound requests across two or more clusters backends to spread the load.
 
 * It serves as a termination point for SSL sessions. So the workload of dealing with the encryption is offloaded from the backend.
 
 * It can protect the backends by preventing direct access from the network.
 
-* It returns some metrics related to the traffic between clients and backends applications behind it.
+* It returns some metrics related to the traffic between clients and backends clusters behind it.
 
 ## Introduction
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -59,7 +59,7 @@ The logger can be invoked through a thread local storage variable accessible fro
 
 ## Load balancing
 
-For a given application, Sōzu keeps a list of backends to which the connection is redirected.
+For a given cluster, Sōzu keeps a list of backends to which the connection is redirected.
 Sōzu detects broken servers and redirects traffic only to healthy ones, with several available loadbalancing algorithms:
 round robin (default), random, least_loaded, and power of two.
 

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -10,7 +10,7 @@ Sōzu configuration process involves 3 major sources of parameters:
 
 - The `global` section, which sets process-wide parameters.
 - The definition of the protocols like `https`, `http`, `tcp`.
-- The applications sections under: `[applications]`.
+- The clusters sections under: `[clusters]`.
 
 ### Global parameters
 
@@ -84,7 +84,7 @@ answer_404 = "../lib/assets/404.html"
 answer_503 = "../lib/assets/503.html"
 
 # defines the sticky session cookie's name, if `sticky_session` is activated format
-# an application. Defaults to "SOZUBALANCEID"
+# a cluster. Defaults to "SOZUBALANCEID"
 sticky_name = "SOZUBALANCEID"
 ```
 
@@ -110,26 +110,26 @@ cipher_list = "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-E
 rustls_cipher_list = ["TLS13_CHACHA20_POLY1305_SHA256"]
 ```
 
-### Applications
+### Clusters
 
-You can declare the list of your _applications_ under the `[applications]` section.
+You can declare the list of your _clusters_ under the `[clusters]` section.
 They follow the format:
 
 _Mandatories parameters:_
 
 ```toml
-[applications]
+[clusters]
 
-[applications.NameOfYourApp]
+[clusters.NameOfYourCluster]
 # possible values are http or tcp
 # https proxies will use http here
 protocol = "http"
 
-# per application load balancing algorithm. The possible values are
+# per cluster load balancing algorithm. The possible values are
 # "roundrobin" and "random". Defaults to "roundrobin"
 # load_balancing_policy="roundrobin"
 
-# force application to redirect http traffic to https
+# force cluster to redirect http traffic to https
 # https_redirect = true
 
 frontends = [
@@ -214,7 +214,7 @@ expect_proxy = true
 
 ### Configuring Sōzu to _send_ a PROXY Protocol header to an upstream backend
 
-Send a PROXY protocol header over any connection established to the backends declared in the application.
+Send a PROXY protocol header over any connection established to the backends declared in the cluster.
 
 ```txt
                            send PROXY
@@ -232,15 +232,15 @@ _Configuration:_
 [[listeners]]
 address = "0.0.0.0:81"
 
-[applications]
-[applications.NameOfYourTcpApp]
+[clusters]
+[clusters.NameOfYourTcpCluster]
 send_proxy = true
 frontends = [
   { address = "0.0.0.0:81" }
 ]
 ```
 
-NOTE: Only for TCP applications (HTTP and HTTPS proxies will use the forwarding headers).
+NOTE: Only for TCP clusters (HTTP and HTTPS proxies will use the forwarding headers).
 
 ### Configuring Sōzu to _relay_ a PROXY Protocol header to an upstream
 
@@ -259,16 +259,16 @@ Sōzu will receive a PROXY protocol header from the client connection, check its
 
 _Configuration:_
 
-This only concerns TCP applications (HTTP and HTTPS proxies can work directly in expect mode, and will use the forwarding headers).
+This only concerns TCP clusters (HTTP and HTTPS proxies can work directly in expect mode, and will use the forwarding headers).
 
 ```toml
 [[listeners]]
 address = "0.0.0.0:80"
 expect_proxy = true
 
-[applications]
+[clusters]
 
-[applications.NameOfYourApp]
+[clusters.NameOfYourCluster]
 send_proxy = true
 frontends = [
   { address = "0.0.0.0:80" }

--- a/doc/configure_cli.md
+++ b/doc/configure_cli.md
@@ -9,24 +9,24 @@ You can specify its path by adding to your `config.toml`:
 command_socket = "path/to/your/command_folder/sock"
 ```
 
-## Add an application with an http frontend
+## Add a cluster with an http frontend
 
-First you need to create a new application with an id and a load balancing policy (roundrobin or random):
+First you need to create a new cluster with an id and a load balancing policy (roundrobin or random):
 
 ```bash
-sozu --config /etc/sozu/config.toml application add --id <my_application_id> --load-balancing-policy roundrobin
+sozu --config /etc/sozu/config.toml cluster add --id <my_cluster_id> --load-balancing-policy roundrobin
 ```
 
-It won't show anything but you can verify that the application has been added successfully by querying sozu:
+It won't show anything but you can verify that the cluster has been added successfully by querying sozu:
 
 ```bash
-sozu --config /etc/sozu/config.toml query applications
+sozu --config /etc/sozu/config.toml query clusters
 ```
 
 Then you need to add a backend:
 
 ```bash
-sozu --config /etc/sozu/config.toml backend add --address 127.0.0.1:3000 --backend-id <my_backend_id> --id <my_application_id>
+sozu --config /etc/sozu/config.toml backend add --address 127.0.0.1:3000 --backend-id <my_backend_id> --id <my_cluster_id>
 ```
 
 And an http listener:
@@ -38,7 +38,7 @@ sozu --config /etc/sozu/config.toml listener http add --address 0.0.0.0:80
 Finally you have to create a frontend to allow sozu to send traffic from the listener to your backend:
 
 ```bash
-sozu --config /etc/sozu/config.toml frontend http add --address 0.0.0.0:80 --hostname <my_application_hostname> --id <my_application_id>
+sozu --config /etc/sozu/config.toml frontend http add --address 0.0.0.0:80 --hostname <my_cluster_hostname> --id <my_cluster_id>
 ```
 
 ## Check the status of sozu
@@ -51,7 +51,7 @@ sozu --config /etc/sozu/config.toml status
 
 ## Get metrics and statistics
 
-It will show global statistics about sozu, workers and applications metrics.
+It will show global statistics about sozu, workers and clusters metrics.
 
 ```bash
 sozu --config /etc/sozu/config.toml query metrics
@@ -59,7 +59,7 @@ sozu --config /etc/sozu/config.toml query metrics
 
 ## Dump and restore state
 
-If sozu configurations (applications, frontends & backends) are not written in the config file, you can save sozu state to restore it later.
+If sozu configurations (clusters, frontends & backends) are not written in the config file, you can save sozu state to restore it later.
 
 ```bash
 sozu --config /etc/sozu/config.toml state save --file state.json
@@ -77,4 +77,4 @@ Restart sozu and restore its state:
 sozu --config /etc/sozu/config.toml state load --file state.json
 ```
 
-You should be able to request your application like before the shutdown.
+You should be able to request your cluster like before the shutdown.

--- a/doc/how_to_use.md
+++ b/doc/how_to_use.md
@@ -22,7 +22,7 @@ To start the reverse proxy:
 sozu start -c config.toml
 ```
 
-You can edit the reverse proxy's configuration with the `config.toml` file. You can declare new applications, their frontends and backends through that file.
+You can edit the reverse proxy's configuration with the `config.toml` file. You can declare new clusters, their frontends and backends through that file.
 
 **But** for more flexibility, you should use the command socket (you can find one end of that unix socket at the path designed by `command_socket` in the configuration file).
 

--- a/doc/lexicon.md
+++ b/doc/lexicon.md
@@ -1,0 +1,13 @@
+# Lexicon
+
+What terms are used in Sōzu.
+
+## User-facing
+
+*backend*: a socket address towards which Sōzu will redirect traffic.
+
+*cluster*: a set of frontends, routing rules, and backends.
+
+*frontend*: a socket address on which a cluster receives connections. Should be defined with a matching listener.
+
+*listener*: a socket address on which Sōzu will accept incoming connections.

--- a/doc/lifetime_of_a_session.md
+++ b/doc/lifetime_of_a_session.md
@@ -138,27 +138,27 @@ the `ConnectBackend` result is returned all the way up to the event loop, to ask
 It will first check if the session has triggered its circuit breaker (it will
 then refuse to connect and send back an error to the client). Then it will
 [extract the hostname and URL from the request](https://github.com/sozu-proxy/sozu/blob/e4e7488232ad6523791b94ad201239bcf7eb9b30/lib/src/https_openssl.rs#L1472-L1524)
-and [find an application](https://github.com/sozu-proxy/sozu/blob/e4e7488232ad6523791b94ad201239bcf7eb9b30/lib/src/https_openssl.rs#L1297-L1332)
-that can handle that request. If we do not find an application, we will send a
+and [find a cluster](https://github.com/sozu-proxy/sozu/blob/e4e7488232ad6523791b94ad201239bcf7eb9b30/lib/src/https_openssl.rs#L1297-L1332)
+that can handle that request. If we do not find a cluster, we will send a
 HTTP 404 Not Found response to the client.
 
-Once we know the application id, if this is the first request (not a follow up
-request in keep-alive), we must find a backend server for this application.
+Once we know the cluster id, if this is the first request (not a follow up
+request in keep-alive), we must find a backend server for this cluster.
 
 <details>
 <summary>keep-alive</summary>
 In HTTP keep-alive, a TCP connection can be kept after receiving the response,
 to send more requests. Since sozu supports routing on the URL along with the
-hostname, the next request might go to a different application.
+hostname, the next request might go to a different cluster.
 
-So when we get the application id from the request, we check if it is the same
+So when we get the cluster id from the request, we check if it is the same
 as the previous one, and if it is the same, we test if the back socket is still
 valid. If it is, we can reuse it. Otherwise, we will replace the back socket
 with a new one.
 </details>
 
 We [look up the backends list](https://github.com/sozu-proxy/sozu/blob/e4e7488232ad6523791b94ad201239bcf7eb9b30/lib/src/https_openssl.rs#L1428-L1470)
-for the application, depending on a sticky session if needed.
+for the cluster, depending on a sticky session if needed.
 
 <details>
 <summary>sticky session</summary>
@@ -168,7 +168,7 @@ coming with the same id in that cookie will be sent to the same backend server.
 
 That look up will return a result depending on which backend server are
 considered valid (if they're answering properly) and on the load balancing
-policies configured for the application.
+policies configured for the cluster.
 If a backend was found, we open a TCP connection to the backend server,
 otherwise we return a HTTP 503 response.
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -2,15 +2,15 @@
 
 `sozu_lib` provides tools to write a proxy that can be reconfigured
 without any downtime. See `examples/minimal.rs` for a small example
-of starting a HTTP proxy with one application.
+of starting a HTTP proxy with one cluster.
 
 A proxy starts as an event loop with which you communicate through
-a `Channel`. You can add or remove applications by sending messages
+a `Channel`. You can add or remove clusters by sending messages
 through that channel. Each message has an identifier that the event
 loop will use in its answer.
 
 The proxy implementations handle differently the frontend and backend
-configurations. A single application could have multiple backend
+configurations. A single cluster could have multiple backend
 servers, but it can also answer to different hostnames and various
 TLS certificates. All those settings can be changed independently
 from the currently active connections. As an example, a backend

--- a/lib/examples/main.rs
+++ b/lib/examples/main.rs
@@ -49,7 +49,7 @@ fn main() {
     });
 
     let http_front = proxy::HttpFrontend {
-        route: Route::ClusterId(String::from("app_1")),
+        route: Route::ClusterId(String::from("cluster_1")),
         address: "127.0.0.1:8080".parse().unwrap(),
         hostname: String::from("lolcatho.st"),
         path: PathRule::Prefix(String::from("/")),
@@ -59,8 +59,8 @@ fn main() {
     };
 
     let http_backend = proxy::Backend {
-        cluster_id: String::from("app_1"),
-        backend_id: String::from("app_1-0"),
+        cluster_id: String::from("cluster_1"),
+        backend_id: String::from("cluster_1-0"),
         sticky_id: None,
         address: "127.0.0.1:1026".parse().unwrap(),
         load_balancing_parameters: Some(LoadBalancingParams::default()),
@@ -128,7 +128,7 @@ fn main() {
     });
 
     let tls_front = proxy::HttpFrontend {
-        route: Route::ClusterId(String::from("app_1")),
+        route: Route::ClusterId(String::from("cluster_1")),
         address: "127.0.0.1:8443".parse().unwrap(),
         hostname: String::from("lolcatho.st"),
         path: PathRule::Prefix(String::from("/")),
@@ -142,8 +142,8 @@ fn main() {
         order: proxy::ProxyRequestData::AddHttpsFrontend(tls_front),
     });
     let tls_backend = proxy::Backend {
-        cluster_id: String::from("app_1"),
-        backend_id: String::from("app_1-0"),
+        cluster_id: String::from("cluster_1"),
+        backend_id: String::from("cluster_1-0"),
         sticky_id: None,
         address: "127.0.0.1:1026".parse().unwrap(),
         load_balancing_parameters: Some(LoadBalancingParams::default()),
@@ -176,7 +176,7 @@ fn main() {
     });
 
     let tls_front2 = proxy::HttpFrontend {
-        route: Route::ClusterId(String::from("app_2")),
+        route: Route::ClusterId(String::from("cluster_2")),
         address: "127.0.0.1:8443".parse().unwrap(),
         hostname: String::from("test.local"),
         path: PathRule::Prefix(String::from("/")),
@@ -191,8 +191,8 @@ fn main() {
     });
 
     let tls_backend2 = proxy::Backend {
-        cluster_id: String::from("app_2"),
-        backend_id: String::from("app_2-0"),
+        cluster_id: String::from("cluster_2"),
+        backend_id: String::from("cluster_2-0"),
         sticky_id: None,
         address: "127.0.0.1:1026".parse().unwrap(),
         load_balancing_parameters: Some(LoadBalancingParams::default()),

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -959,7 +959,7 @@ impl Session {
             .borrow()
             .clusters
             .get(&cluster_id)
-            .map(|app| app.https_redirect)
+            .map(|cluster| cluster.https_redirect)
             .unwrap_or(false);
         if front_should_redirect_https {
             let answer = format!("HTTP/1.1 301 Moved Permanently\r\nContent-Length: 0\r\nLocation: https://{}{}\r\n\r\n", host, uri);
@@ -992,7 +992,7 @@ impl Session {
                 .backend_from_sticky_session(cluster_id, sticky_session)
                 .map_err(|e| {
                     debug!(
-                        "Couldn't find a backend corresponding to sticky_session {} for app {}",
+                        "Couldn't find a backend corresponding to sticky_session {} for cluster {}",
                         sticky_session, cluster_id
                     );
                     e
@@ -1104,7 +1104,7 @@ impl Session {
             .borrow()
             .clusters
             .get(&cluster_id)
-            .map(|app| app.sticky_session)
+            .map(|cluster| cluster.sticky_session)
             .unwrap_or(false);
 
         let mut socket = self.backend_from_request(&cluster_id, front_should_stick)?;
@@ -1940,7 +1940,7 @@ mod tests {
         });
 
         let front = HttpFrontend {
-            route: Route::ClusterId(String::from("app_1")),
+            route: Route::ClusterId(String::from("cluster_1")),
             address: "127.0.0.1:1024".parse().unwrap(),
             hostname: String::from("localhost"),
             path: PathRule::Prefix(String::from("/")),
@@ -1953,8 +1953,8 @@ mod tests {
             order: ProxyRequestData::AddHttpFrontend(front),
         });
         let backend = Backend {
-            cluster_id: String::from("app_1"),
-            backend_id: String::from("app_1-0"),
+            cluster_id: String::from("cluster_1"),
+            backend_id: String::from("cluster_1-0"),
             address: "127.0.0.1:1025".parse().unwrap(),
             load_balancing_parameters: Some(LoadBalancingParams::default()),
             sticky_id: None,
@@ -2024,7 +2024,7 @@ mod tests {
         });
 
         let front = HttpFrontend {
-            route: Route::ClusterId(String::from("app_1")),
+            route: Route::ClusterId(String::from("cluster_1")),
             address: "127.0.0.1:1031".parse().unwrap(),
             hostname: String::from("localhost"),
             path: PathRule::Prefix(String::from("/")),
@@ -2037,8 +2037,8 @@ mod tests {
             order: ProxyRequestData::AddHttpFrontend(front),
         });
         let backend = Backend {
-            cluster_id: String::from("app_1"),
-            backend_id: String::from("app_1-0"),
+            cluster_id: String::from("cluster_1"),
+            backend_id: String::from("cluster_1-0"),
             address: "127.0.0.1:1028".parse().unwrap(),
             load_balancing_parameters: Some(LoadBalancingParams::default()),
             sticky_id: None,
@@ -2133,7 +2133,7 @@ mod tests {
         });
 
         let cluster = Cluster {
-            cluster_id: String::from("app_1"),
+            cluster_id: String::from("cluster_1"),
             sticky_session: false,
             https_redirect: true,
             proxy_protocol: None,
@@ -2146,7 +2146,7 @@ mod tests {
             order: ProxyRequestData::AddCluster(cluster),
         });
         let front = HttpFrontend {
-            route: Route::ClusterId(String::from("app_1")),
+            route: Route::ClusterId(String::from("cluster_1")),
             address: "127.0.0.1:1041".parse().unwrap(),
             hostname: String::from("localhost"),
             path: PathRule::Prefix(String::from("/")),
@@ -2159,8 +2159,8 @@ mod tests {
             order: ProxyRequestData::AddHttpFrontend(front),
         });
         let backend = Backend {
-            cluster_id: String::from("app_1"),
-            backend_id: String::from("app_1-0"),
+            cluster_id: String::from("cluster_1"),
+            backend_id: String::from("cluster_1-0"),
             address: "127.0.0.1:1040".parse().unwrap(),
             load_balancing_parameters: Some(LoadBalancingParams::default()),
             sticky_id: None,
@@ -2239,9 +2239,9 @@ mod tests {
 
     #[test]
     fn frontend_from_request_test() {
-        let cluster_id1 = "app_1".to_owned();
-        let cluster_id2 = "app_2".to_owned();
-        let cluster_id3 = "app_3".to_owned();
+        let cluster_id1 = "cluster_1".to_owned();
+        let cluster_id2 = "cluster_2".to_owned();
+        let cluster_id3 = "cluster_3".to_owned();
         let uri1 = "/".to_owned();
         let uri2 = "/yolo".to_owned();
         let uri3 = "/yolo/swag".to_owned();
@@ -2275,7 +2275,7 @@ mod tests {
             tags: None,
         });
         fronts.add_http_front(HttpFrontend {
-            route: Route::ClusterId("app_1".to_owned()),
+            route: Route::ClusterId("cluster_1".to_owned()),
             address: "0.0.0.0:80".parse().unwrap(),
             hostname: "other.domain".to_owned(),
             path: PathRule::Prefix("/test".to_owned()),
@@ -2307,19 +2307,19 @@ mod tests {
         let frontend5 = listener.frontend_from_request("domain", "/", &Method::Get);
         assert_eq!(
             frontend1.expect("should find frontend"),
-            Route::ClusterId("app_1".to_string())
+            Route::ClusterId("cluster_1".to_string())
         );
         assert_eq!(
             frontend2.expect("should find frontend"),
-            Route::ClusterId("app_1".to_string())
+            Route::ClusterId("cluster_1".to_string())
         );
         assert_eq!(
             frontend3.expect("should find frontend"),
-            Route::ClusterId("app_2".to_string())
+            Route::ClusterId("cluster_2".to_string())
         );
         assert_eq!(
             frontend4.expect("should find frontend"),
-            Route::ClusterId("app_3".to_string())
+            Route::ClusterId("cluster_3".to_string())
         );
         assert_eq!(frontend5, None);
     }

--- a/lib/src/https_openssl.rs
+++ b/lib/src/https_openssl.rs
@@ -77,7 +77,7 @@ use crate::{
 const SERVER_PROTOS: &[u8] = b"\x08http/1.1";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TlsApp {
+pub struct TlsCluster {
     pub cluster_id: String,
     pub hostname: String,
     pub path_begin: String,
@@ -1065,7 +1065,7 @@ impl Session {
                 .backend_from_sticky_session(cluster_id, sticky_session)
                 .map_err(|e| {
                     debug!(
-                        "Couldn't find a backend corresponding to sticky_session {} for app {}",
+                        "Couldn't find a backend corresponding to sticky_session {} for cluster {}",
                         sticky_session, cluster_id
                     );
                     e
@@ -1180,7 +1180,7 @@ impl Session {
             }
         }
 
-        //replacing with a connection to another application
+        //replacing with a connection to another cluster
         if old_cluster_id.is_some() && old_cluster_id.as_ref() != Some(&cluster_id) {
             if let Some(token) = self.back_token() {
                 self.close_backend();
@@ -1201,7 +1201,7 @@ impl Session {
             .borrow()
             .clusters
             .get(&cluster_id)
-            .map(|app| app.sticky_session)
+            .map(|cluster| cluster.sticky_session)
             .unwrap_or(false);
         let mut socket = self.backend_from_request(&cluster_id, front_should_stick)?;
 
@@ -2510,9 +2510,9 @@ mod tests {
 
     #[test]
     fn frontend_from_request_test() {
-        let cluster_id1 = "app_1".to_owned();
-        let cluster_id2 = "app_2".to_owned();
-        let cluster_id3 = "app_3".to_owned();
+        let cluster_id1 = "cluster_1".to_owned();
+        let cluster_id2 = "cluster_2".to_owned();
+        let cluster_id3 = "cluster_3".to_owned();
         let uri1 = "/".to_owned();
         let uri2 = "/yolo".to_owned();
         let uri3 = "/yolo/swag".to_owned();
@@ -2576,25 +2576,25 @@ mod tests {
         let frontend1 = listener.frontend_from_request("lolcatho.st", "/", &Method::Get);
         assert_eq!(
             frontend1.expect("should find a frontend"),
-            Route::ClusterId("app_1".to_string())
+            Route::ClusterId("cluster_1".to_string())
         );
         println!("TEST {}", line!());
         let frontend2 = listener.frontend_from_request("lolcatho.st", "/test", &Method::Get);
         assert_eq!(
             frontend2.expect("should find a frontend"),
-            Route::ClusterId("app_1".to_string())
+            Route::ClusterId("cluster_1".to_string())
         );
         println!("TEST {}", line!());
         let frontend3 = listener.frontend_from_request("lolcatho.st", "/yolo/test", &Method::Get);
         assert_eq!(
             frontend3.expect("should find a frontend"),
-            Route::ClusterId("app_2".to_string())
+            Route::ClusterId("cluster_2".to_string())
         );
         println!("TEST {}", line!());
         let frontend4 = listener.frontend_from_request("lolcatho.st", "/yolo/swag", &Method::Get);
         assert_eq!(
             frontend4.expect("should find a frontend"),
-            Route::ClusterId("app_3".to_string())
+            Route::ClusterId("cluster_3".to_string())
         );
         println!("TEST {}", line!());
         let frontend5 = listener.frontend_from_request("domain", "/", &Method::Get);

--- a/lib/src/https_rustls/configuration.rs
+++ b/lib/src/https_rustls/configuration.rs
@@ -45,7 +45,7 @@ use crate::{
 use super::session::Session;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TlsApp {
+pub struct TlsCluster {
     pub cluster_id: String,
     pub hostname: String,
     pub path_begin: String,

--- a/lib/src/https_rustls/session.rs
+++ b/lib/src/https_rustls/session.rs
@@ -1029,7 +1029,7 @@ impl Session {
                 .backend_from_sticky_session(cluster_id, sticky_session)
                 .map_err(|e| {
                     debug!(
-                        "Couldn't find a backend corresponding to sticky_session {} for app {}",
+                        "Couldn't find a backend corresponding to sticky_session {} for cluster {}",
                         sticky_session, cluster_id
                     );
                     e
@@ -1165,7 +1165,7 @@ impl Session {
             .borrow()
             .clusters
             .get(&cluster_id)
-            .map(|app| app.sticky_session)
+            .map(|cluster| cluster.sticky_session)
             .unwrap_or(false);
         let mut socket = self.backend_from_request(&cluster_id, front_should_stick)?;
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -41,7 +41,7 @@
 //!
 //! Once the thread is launched, the proxy will start its event loop and handle
 //! events on the listening interface and port specified in the configuration
-//! object. Since no applications to proxy for were specified, it will receive
+//! object. Since no clusters were specified for the proxy, it will receive
 //! the connections, parse the request, then send a default (but configurable)
 //! answer.
 //!
@@ -71,7 +71,7 @@
 //! println!("HTTP -> {:?}", command.read_message());
 //! ```
 //!
-//! An application is identified by its `cluster_id`, a string that will be shared
+//! A cluster is identified by its `cluster_id`, a string that will be shared
 //! between one or multiple "fronts", and one or multiple "backends".
 //!
 //! A "front" is a way to recognize a request and match it to an `cluster_id`,
@@ -79,7 +79,7 @@
 //!
 //! A backend corresponds to one backend server, indicated by its IP and port.
 //!
-//! An application can have multiple backend servers, and they can be added or
+//! A cluster can have multiple backend servers, and they can be added or
 //! removed while the proxy is running. If a backend is removed from the configuration
 //! while the proxy is handling a request to that server, it will finish that
 //! request and stop sending new traffic to that server.

--- a/lib/src/protocol/h2/mod.rs
+++ b/lib/src/protocol/h2/mod.rs
@@ -32,7 +32,7 @@ pub struct Http2<Front: SocketHandler> {
     frontend_token: Token,
     backend_token: Option<Token>,
     back_buf: Option<Checkout>,
-    pub app_id: Option<String>,
+    pub cluster_id: Option<String>,
     pub request_id: Ulid,
     pub back_readiness: Readiness,
     pub log_ctx: String,
@@ -65,7 +65,7 @@ impl<Front: SocketHandler> Http2<Front> {
             backend: None,
             backend_token: None,
             back_buf: None,
-            app_id: None,
+            cluster_id: None,
             state: Some(state::State::new()),
             request_id,
             back_readiness: Readiness {
@@ -115,8 +115,8 @@ impl<Front: SocketHandler> Http2<Front> {
     pub fn close(&mut self) {}
 
     pub fn log_context(&self) -> String {
-        if let Some(ref app_id) = self.app_id {
-            format!("{}\t{}\t", self.request_id, app_id)
+        if let Some(ref cluster_id) = self.cluster_id {
+            format!("{}\t{}\t", self.request_id, cluster_id)
         } else {
             format!("{}\tunknown\t", self.request_id)
         }
@@ -291,7 +291,7 @@ impl<Front: SocketHandler> Http2<Front> {
         SessionResult::Continue
     }
 
-    // Forward content to application
+    // Forward content to cluster
     pub fn back_writable(&mut self, metrics: &mut SessionMetrics) -> SessionResult {
         trace!("http2 back_writable");
         error!("todo[{}:{}]: back_writable", file!(), line!());
@@ -350,7 +350,7 @@ impl<Front: SocketHandler> Http2<Front> {
         */
     }
 
-    // Read content from application
+    // Read content from cluster
     pub fn back_readable(&mut self, metrics: &mut SessionMetrics) -> SessionResult {
         trace!("http2 back_readable");
         error!("todo[{}:{}]: back_readable", file!(), line!());

--- a/lib/src/protocol/http/mod.rs
+++ b/lib/src/protocol/http/mod.rs
@@ -1334,7 +1334,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Http<Front, L> {
         }
     }
 
-    // Forward content to application
+    // Forward content to cluster
     pub fn back_writable(&mut self, metrics: &mut SessionMetrics) -> SessionResult {
         if let SessionStatus::DefaultAnswer(_, _, _) = self.status {
             error!(
@@ -1499,7 +1499,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Http<Front, L> {
         }
     }
 
-    // Read content from application
+    // Read content from cluster
     pub fn back_readable(
         &mut self,
         metrics: &mut SessionMetrics,
@@ -1831,7 +1831,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Http<Front, L> {
                 }
                 TimeoutStatus::Response => {
                     error!(
-                        "backend {:?} timeout while receiving response (application {:?})",
+                        "backend {:?} timeout while receiving response (cluster {:?})",
                         self.backend_id, self.cluster_id
                     );
                     SessionResult::CloseSession

--- a/lib/src/protocol/http/parser/mod.rs
+++ b/lib/src/protocol/http/parser/mod.rs
@@ -452,7 +452,7 @@ fn is_hostname_char(i: u8) -> bool {
     is_alphanumeric(i) ||
   // the domain name should not start with a hyphen or dot
   // but is it important here, since we will match this to
-  // the list of accepted applications?
+  // the list of accepted clusters?
   // BTW each label between dots has a max of 63 chars,
   // and the whole domain shuld not be larger than 253 chars
   //
@@ -467,7 +467,7 @@ fn is_hostname_char(i: u8) -> bool {
     is_alphanumeric(i) ||
   // the domain name should not start with a hyphen or dot
   // but is it important here, since we will match this to
-  // the list of accepted applications?
+  // the list of accepted clusters?
   // BTW each label between dots has a max of 63 chars,
   // and the whole domain shuld not be larger than 253 chars
   b"-.".contains(&i)

--- a/lib/src/protocol/http/parser/response.rs
+++ b/lib/src/protocol/http/parser/response.rs
@@ -262,7 +262,7 @@ pub fn parse_response(
     buf: &[u8],
     is_head: bool,
     sticky_name: &str,
-    app_id: Option<&str>,
+    cluster_id: Option<&str>,
 ) -> (BufferMove, ResponseState) {
     match state {
         ResponseState::Initial => {
@@ -332,7 +332,7 @@ pub fn parse_response(
                             }
                         }
                         res => {
-                            error!("PARSER\tHasStatusLine could not parse header for input(app={:?}):\n{}\n", app_id, buf.to_hex(16));
+                            error!("PARSER\tHasStatusLine could not parse header for input(cluster={:?}):\n{}\n", cluster_id, buf.to_hex(16));
                             default_response_result(ResponseState::HasStatusLine(sl, conn), res)
                         }
                     }
@@ -375,7 +375,7 @@ pub fn parse_response(
                             }
                         }
                         res => {
-                            error!("PARSER\tHasLength could not parse header for input(app={:?}):\n{}\n", app_id, buf.to_hex(16));
+                            error!("PARSER\tHasLength could not parse header for input(cluster={:?}):\n{}\n", cluster_id, buf.to_hex(16));
                             default_response_result(ResponseState::HasLength(sl, conn, length), res)
                         }
                     }
@@ -412,8 +412,8 @@ pub fn parse_response(
                 }
                 res => {
                     error!(
-                        "PARSER\tHasUpgrade could not parse header for input(app={:?}):\n{}\n",
-                        app_id,
+                        "PARSER\tHasUpgrade could not parse header for input(cluster={:?}):\n{}\n",
+                        cluster_id,
                         buf.to_hex(16)
                     );
                     default_response_result(ResponseState::HasUpgrade(sl, conn, protocol), res)
@@ -446,7 +446,7 @@ pub fn parse_response_until_stop(
     added_res_header: &str,
     sticky_name: &str,
     sticky_session: Option<&StickySession>,
-    app_id: Option<&str>,
+    cluster_id: Option<&str>,
 ) -> (ResponseState, Option<usize>) {
     loop {
         //trace!("PARSER\t{}\tpos[{}]: {:?}", request_id, position, current_state);
@@ -455,7 +455,7 @@ pub fn parse_response_until_stop(
             buf.unparsed_data(),
             is_head,
             sticky_name,
-            app_id,
+            cluster_id,
         );
         //trace!("PARSER\tinput:\n{}\nmv: {:?}, new state: {:?}\n", buf.unparsed_data().to_hex(16), mv, new_state);
         //trace!("PARSER\t{}\tmv: {:?}, new state: {:?}\n", request_id, mv, new_state);

--- a/lib/src/protocol/pipe.rs
+++ b/lib/src/protocol/pipe.rs
@@ -598,7 +598,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
         SessionResult::Continue
     }
 
-    // Forward content to application
+    // Forward content to cluster
     pub fn back_writable(&mut self, metrics: &mut SessionMetrics) -> SessionResult {
         trace!("pipe back_writable");
 
@@ -678,7 +678,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
         SessionResult::Continue
     }
 
-    // Read content from application
+    // Read content from cluster
     pub fn back_readable(&mut self, metrics: &mut SessionMetrics) -> SessionResult {
         self.reset_timeouts();
 

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -837,7 +837,7 @@ impl Session {
             .cluster_id
             .is_none()
         {
-            error!("no TCP application corresponds to that front address");
+            error!("no TCP cluster corresponds to that front address");
             return Err(ConnectionError::HostNotFound);
         }
 
@@ -1387,7 +1387,7 @@ impl ProxyConfiguration<Session> for Proxy {
             if let (Some(front_buf), Some(back_buf)) = (p.checkout(), p.checkout()) {
                 if owned.cluster_id.is_none() {
                     error!(
-                        "listener at address {:?} has no linked application",
+                        "listener at address {:?} has no linked cluster",
                         owned.address
                     );
                     return Err(AcceptError::IoError);

--- a/os-build/archlinux/config.toml
+++ b/os-build/archlinux/config.toml
@@ -128,7 +128,7 @@ address = "0.0.0.0:80"
 #answer_503 = "/etc/sozu/html/503.html"
 
 # defines the sticky session cookie's name, if `sticky_session` is activated for
-# an application. Defaults to "SOZUBALANCEID"
+# a cluster. Defaults to "SOZUBALANCEID"
 # sticky_name = "SOZUBALANCEID"
 #
 # Configures the client socket to receive a PROXY protocol header
@@ -172,39 +172,39 @@ tls_versions = ["TLSv1.2", "TLSv1.3"]
 # Configures the client socket to receive a PROXY protocol header
 # expect_proxy = false
 
-# static configuration for applications
+# static configuration for clusters
 #
-# those applications will be routed by sozu directly from start
-[applications]
+# those clusters will be routed by sozu directly from start
+[clusters]
 
-# every application has an "application id", here it is "MyApp"
+# every cluster has an "cluster id", here it is "MyCluster"
 # this is an example of a routing configuration for the HTTP and HTTPS proxies
-[applications.MyApp]
+[clusters.MyCluster]
 
 # the protocol option indicates if we will use HTTP or TCP proxying
 # possible options are "http" or "tcp"
 protocol = "http"
 
-# per application load balancing algorithm. The possible values are
+# per cluster load balancing algorithm. The possible values are
 # "roundrobin" and "random". Defaults to "roundrobin"
 # load_balancing_policy="roundrobin"
 
 # frontends configuration
-# this specifies which listeners; domains, certificates that will be configured for an application
+# this specifies which listeners; domains, certificates that will be configured for a cluster
 # each element of the array must be specified on one line (toml format limitation)
 # possible frontend options:
 # - address: TCP listener
-# - hostname: host name of the application
-# - path_begin = "/api" # optional. an application can receive requests going to a hostname and path prefix
-# - sticky_session = false # activates sticky sessions for this application
-# - https_redirect = false #  activates automatic redirection to HTTPS for this application
+# - hostname: host name of the cluster
+# - path_begin = "/api" # optional. a cluster can receive requests going to a hostname and path prefix
+# - sticky_session = false # activates sticky sessions for this cluster
+# - https_redirect = false #  activates automatic redirection to HTTPS for this cluster
 frontends = [
   { address = "0.0.0.0:80", hostname = "lolcatho.st" },
   { address = "0.0.0.0:443", hostname = "lolcatho.st", certificate = "../lib/assets/certificate.pem", key = "../lib/assets/key.pem", certificate_chain = "../lib/assets/certificate_chain.pem" }
 ]
 
 # backends configuration
-# this indicates the backend servers used by the application
+# this indicates the backend servers used by the cluster
 # possible options:
 # - address: IP and port of the backend server
 # - weight: weight used by the load balancing algorithm
@@ -214,7 +214,7 @@ backends = [
 ]
 
 # this is an example of a routing configuration for the TCP proxy
-[applications.TcpTest]
+[clusters.TcpTest]
 protocol = "tcp"
 
 frontends = [

--- a/os-build/config.toml.in
+++ b/os-build/config.toml.in
@@ -128,7 +128,7 @@ address = "0.0.0.0:80"
 #answer_503 = "__DATADIR__/html/503.html"
 
 # defines the sticky session cookie's name, if `sticky_session` is activated for
-# an application. Defaults to "SOZUBALANCEID"
+# a cluster. Defaults to "SOZUBALANCEID"
 # sticky_name = "SOZUBALANCEID"
 #
 # Configures the client socket to receive a PROXY protocol header
@@ -172,39 +172,39 @@ address = "0.0.0.0:443"
 # Configures the client socket to receive a PROXY protocol header
 # expect_proxy = false
 
-# static configuration for applications
+# static configuration for clusters
 #
-# those applications will be routed by sozu directly from start
-[applications]
+# those clusters will be routed by sozu directly from start
+[clusters]
 
-# every application has an "application id", here it is "MyApp"
+# every cluster has an "cluster id", here it is "MyCluster"
 # this is an example of a routing configuration for the HTTP and HTTPS proxies
-[applications.MyApp]
+[clusters.MyCluster]
 
 # the protocol option indicates if we will use HTTP or TCP proxying
 # possible options are "http" or "tcp"
 protocol = "http"
 
-# per application load balancing algorithm. The possible values are
+# per cluster load balancing algorithm. The possible values are
 # "roundrobin" and "random". Defaults to "roundrobin"
 # load_balancing_policy="roundrobin"
 
 # frontends configuration
-# this specifies which listeners; domains, certificates that will be configured for an application
+# this specifies which listeners; domains, certificates that will be configured for an cluster
 # each element of the array must be specified on one line (toml format limitation)
 # possible frontend options:
 # - address: TCP listener
-# - hostname: host name of the application
-# - path_begin = "/api" # optional. an application can receive requests going to a hostname and path prefix
-# - sticky_session = false # activates sticky sessions for this application
-# - https_redirect = false #  activates automatic redirection to HTTPS for this application
+# - hostname: host name of the cluster
+# - path_begin = "/api" # optional. an cluster can receive requests going to a hostname and path prefix
+# - sticky_session = false # activates sticky sessions for this cluster
+# - https_redirect = false #  activates automatic redirection to HTTPS for this cluster
 frontends = [
   { address = "0.0.0.0:80", hostname = "lolcatho.st" },
   { address = "0.0.0.0:443", hostname = "lolcatho.st", certificate = "__DATADIR__/ssl/certificate.pem", key = "__DATADIR__/ssl/key.pem", certificate_chain = "__DATADIR__/ssl/certificate_chain.pem" }
 ]
 
 # backends configuration
-# this indicates the backend servers used by the application
+# this indicates the backend servers used by the cluster
 # possible options:
 # - address: IP and port of the backend server
 # - weight: weight used by the load balancing algorithm
@@ -214,7 +214,7 @@ backends = [
 ]
 
 # this is an example of a routing configuration for the TCP proxy
-[applications.TcpTest]
+[clusters.TcpTest]
 protocol = "tcp"
 
 frontends = [

--- a/os-build/docker/config.toml
+++ b/os-build/docker/config.toml
@@ -125,7 +125,7 @@ address = "0.0.0.0:80"
 #answer_503 = "/etc/sozu/html/503.html"
 
 # defines the sticky session cookie's name, if `sticky_session` is activated for
-# an application. Defaults to "SOZUBALANCEID"
+# a cluster. Defaults to "SOZUBALANCEID"
 # sticky_name = "SOZUBALANCEID"
 #
 # Configures the client socket to receive a PROXY protocol header
@@ -160,7 +160,7 @@ tls_versions = ["TLSv1.2", "TLSv1.3"]
 #rustls_cipher_list = ["TLS13_CHACHA20_POLY1305_SHA256"]
 
 
-# static configuration for applications
+# static configuration for clusters
 #
-# those applications will be routed by sozu directly from start
-[applications]
+# those clusters will be routed by sozu directly from start
+[clusters]


### PR DESCRIPTION
As a follow-up to issue #626 and for a better consistency, we need to remove the word "application" from Sōzu entirely, and finish to replace it with the more fitting "cluster".

A cluster is a set of:
- frontends (IP:port addresses, not to be confused with web apps)
- routing rules
- backends

Since the backends are usually identical instances of a same piece of software, the whole cluster may be designated as an "application" by a system administrator who would use Sōzu to redirect traffic to several instances of a same software, or "application". This, however, is a user-centric denomination and does not fit the naming framework of a reverse proxy.

"Cluster" is still a bit misleading, but is better nonetheless.

## Todo

- [x] rename all "application" (incl. structs & enums containing _app_ in their name)
- [x] write a bit of documentation to explain what a cluster is