### PR TITLE
store cluster metrics in a simpler way, query them all

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,6 +1559,7 @@ dependencies = [
 name = "sozu-lib"
 version = "0.13.6"
 dependencies = [
+ "anyhow",
  "cookie-factory",
  "foreign-types-shared",
  "hdrhistogram",

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -758,10 +758,11 @@ pub enum QueryCmd {
         #[clap(
             short = 'b',
             long="backends",
-            help="list of backends, in the form 'cluster_id/backend_id, other_cluster/other_backend'",
-            use_delimiter = true,
-            parse(try_from_str = split_slash))]
-        backends: Vec<(String, String)>,
+            help="coma-separated list of backends, 'one_backend_id, other_backend_id'",
+            use_delimiter = true
+            // parse(try_from_str = split_slash)
+        )]
+        backends: Vec<String>,
     },
 }
 

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -744,7 +744,7 @@ pub enum QueryCmd {
         #[clap(
             short = 'n',
             long = "names",
-            help = "metric names",
+            help = "Filter by metric names. Coma-separated list.",
             use_delimiter = true
         )]
         names: Vec<String>,
@@ -764,19 +764,6 @@ pub enum QueryCmd {
         )]
         backends: Vec<String>,
     },
-}
-
-fn split_slash(input: &str) -> Result<(String, String), String> {
-    let mut it = input.split('/').map(|s| s.trim().to_string());
-
-    if let (Some(cluster), Some(backend)) = (it.next(), it.next()) {
-        Ok((cluster, backend))
-    } else {
-        Err(format!(
-            "could not split cluster id and backend id in '{}', they must have the form 'cluster_id/backend_id'",
-            input
-        ))
-    }
 }
 
 #[derive(Subcommand, PartialEq, Clone, Debug)]

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -197,15 +197,9 @@ pub enum SubCmd {
 #[derive(Subcommand, PartialEq, Clone, Debug)]
 pub enum MetricsCmd {
     #[clap(name = "enable", about = "Enables local metrics collection")]
-    Enable {
-        #[clap(long, help = "Enables time metrics collection")]
-        time: bool,
-    },
+    Enable,
     #[clap(name = "disable", about = "Disables local metrics collection")]
-    Disable {
-        #[clap(long, help = "Disables time metrics collection")]
-        time: bool,
-    },
+    Disable,
     #[clap(name = "clear", about = "Deletes local metrics data")]
     Clear,
 }

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -779,10 +779,9 @@ impl CommandManager {
         refresh: Option<u32>,
         names: Vec<String>,
         cluster_ids: Vec<String>,
-        backends: Vec<(String, String)>, // (cluster_id, backend_id)
-                                         // proxy: bool,
+        backend_ids: Vec<String>, 
     ) -> Result<(), anyhow::Error> {
-        let query = match (list, cluster_ids.is_empty(), backends.is_empty()) {
+        let query = match (list, cluster_ids.is_empty(), backend_ids.is_empty()) {
             (true, _, _) => QueryMetricsType::List,
             (false, true, true) => QueryMetricsType::All,
             (false, false, _) => QueryMetricsType::Cluster {
@@ -792,7 +791,7 @@ impl CommandManager {
             },
             (false, true, false) => QueryMetricsType::Backend {
                 metrics: names,
-                backends,
+                backend_ids,
                 date: None,
             },
         };

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -777,22 +777,20 @@ impl CommandManager {
         json: bool,
         list: bool,
         refresh: Option<u32>,
-        names: Vec<String>,
+        metric_names: Vec<String>,
         cluster_ids: Vec<String>,
-        backend_ids: Vec<String>, 
+        backend_ids: Vec<String>,
     ) -> Result<(), anyhow::Error> {
         let query = match (list, cluster_ids.is_empty(), backend_ids.is_empty()) {
             (true, _, _) => QueryMetricsType::List,
-            (false, true, true) => QueryMetricsType::All,
+            (false, true, true) => QueryMetricsType::All { metric_names },
             (false, false, _) => QueryMetricsType::Cluster {
-                metrics: names,
                 cluster_ids,
-                date: None,
+                metric_names,
             },
             (false, true, false) => QueryMetricsType::Backend {
-                metrics: names,
                 backend_ids,
-                date: None,
+                metric_names,
             },
         };
 

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -538,20 +538,8 @@ impl CommandManager {
         //println!("will send message for metrics with id {}", id);
 
         let configuration = match cmd {
-            MetricsCmd::Enable { time } => {
-                if time {
-                    MetricsConfiguration::EnabledTimeMetrics(true)
-                } else {
-                    MetricsConfiguration::Enabled(true)
-                }
-            }
-            MetricsCmd::Disable { time } => {
-                if time {
-                    MetricsConfiguration::EnabledTimeMetrics(false)
-                } else {
-                    MetricsConfiguration::Enabled(false)
-                }
-            }
+            MetricsCmd::Enable => MetricsConfiguration::Enabled(true),
+            MetricsCmd::Disable => MetricsConfiguration::Enabled(false),
             MetricsCmd::Clear => MetricsConfiguration::Clear,
         };
 

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -166,7 +166,7 @@ fn filter_worker_metrics(
     }
     for (cluster_id, cluster_metric_data) in cluster_metrics.iter() {
         // cluster metrics
-        for (metric_key, filtered_value) in cluster_metric_data.data.iter() {
+        for (metric_key, filtered_value) in cluster_metric_data.cluster.iter() {
             filtered_metrics.insert(
                 format!("{} {}", cluster_id, metric_key.replace("\t", ".")),
                 filtered_value.clone(),

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -102,8 +102,9 @@ fn print_worker_metrics(query_answer: &QueryAnswer) -> anyhow::Result<()> {
             print_proxy_metrics(proxy);
             print_cluster_metrics(clusters);
         }
-        // TODO: handle and print an error of the form
-        // QueryAnswer::Metrics(QueryAnswerMetrics::Error(String)
+        QueryAnswer::Metrics(QueryAnswerMetrics::Error(error)) => {
+            println!("Proxy responded with error: {}\nMaybe check your command.", error)
+        }
         _ => bail!("The query answer is wrong."),
     }
 

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -103,7 +103,7 @@ fn print_worker_metrics(query_answer: &QueryAnswer) -> anyhow::Result<()> {
             print_cluster_metrics(clusters);
         }
         QueryAnswer::Metrics(QueryAnswerMetrics::Error(error)) => {
-            println!("Proxy responded with error: {}\nMaybe check your command.", error)
+            println!("Error: {}\nMaybe check your command.", error)
         }
         _ => bail!("The query answer is wrong."),
     }

--- a/command/assets/answer_metrics.json
+++ b/command/assets/answer_metrics.json
@@ -38,7 +38,7 @@
           },
           "clusters": {
             "cluster_1": {
-              "data": {
+              "cluster": {
                 "request_time": {
                   "type": "PERCENTILES",
                   "data": {

--- a/command/src/command.rs
+++ b/command/src/command.rs
@@ -159,8 +159,8 @@ mod tests {
     use crate::proxy::{
         AddCertificate, Backend, CertificateAndKey, CertificateFingerprint, Cluster,
         ClusterMetricsData, FilteredData, HttpFrontend, LoadBalancingAlgorithms,
-        LoadBalancingParams, WorkerMetrics, PathRule, Percentiles, ProxyRequestData, RemoveBackend,
-        RemoveCertificate, Route, RulePosition, TlsVersion,
+        LoadBalancingParams, PathRule, Percentiles, ProxyRequestData, RemoveBackend,
+        RemoveCertificate, Route, RulePosition, TlsVersion, WorkerMetrics,
     };
     use hex::FromHex;
     use serde_json;
@@ -563,40 +563,23 @@ mod tests {
                 workers: [(
                     String::from("0"),
                     WorkerMetrics {
-                        proxy: [
-                            (String::from("sozu.gauge"), FilteredData::Gauge(1)),
-                            (String::from("sozu.count"), FilteredData::Count(-2)),
-                            (String::from("sozu.time"), FilteredData::Time(1234)),
-                        ]
-                        .iter()
-                        .cloned()
-                        .collect(),
-                        clusters: [(
-                            String::from("cluster_1"),
-                            ClusterMetricsData {
-                                cluster: [(
-                                    String::from("request_time"),
-                                    FilteredData::Percentiles(Percentiles {
-                                        samples: 42,
-                                        p_50: 1,
-                                        p_90: 2,
-                                        p_99: 10,
-                                        p_99_9: 12,
-                                        p_99_99: 20,
-                                        p_99_999: 22,
-                                        p_100: 30,
-                                    })
-                                )]
-                                .iter()
-                                .cloned()
-                                .collect(),
-                                backends: [(
-                                    String::from("cluster_1-0"),
-                                    [
-                                        (String::from("bytes_in"), FilteredData::Count(256)),
-                                        (String::from("bytes_out"), FilteredData::Count(128)),
-                                        (
-                                            String::from("percentiles"),
+                        proxy: Some(
+                            [
+                                (String::from("sozu.gauge"), FilteredData::Gauge(1)),
+                                (String::from("sozu.count"), FilteredData::Count(-2)),
+                                (String::from("sozu.time"), FilteredData::Time(1234)),
+                            ]
+                            .iter()
+                            .cloned()
+                            .collect()
+                        ),
+                        clusters: Some(
+                            [(
+                                String::from("cluster_1"),
+                                ClusterMetricsData {
+                                    cluster: Some(
+                                        [(
+                                            String::from("request_time"),
                                             FilteredData::Percentiles(Percentiles {
                                                 samples: 42,
                                                 p_50: 1,
@@ -607,20 +590,51 @@ mod tests {
                                                 p_99_999: 22,
                                                 p_100: 30,
                                             })
-                                        )
-                                    ]
-                                    .iter()
-                                    .cloned()
-                                    .collect()
-                                )]
-                                .iter()
-                                .cloned()
-                                .collect(),
-                            }
-                        )]
-                        .iter()
-                        .cloned()
-                        .collect()
+                                        )]
+                                        .iter()
+                                        .cloned()
+                                        .collect()
+                                    ),
+                                    backends: Some(
+                                        [(
+                                            String::from("cluster_1-0"),
+                                            [
+                                                (
+                                                    String::from("bytes_in"),
+                                                    FilteredData::Count(256)
+                                                ),
+                                                (
+                                                    String::from("bytes_out"),
+                                                    FilteredData::Count(128)
+                                                ),
+                                                (
+                                                    String::from("percentiles"),
+                                                    FilteredData::Percentiles(Percentiles {
+                                                        samples: 42,
+                                                        p_50: 1,
+                                                        p_90: 2,
+                                                        p_99: 10,
+                                                        p_99_9: 12,
+                                                        p_99_99: 20,
+                                                        p_99_999: 22,
+                                                        p_100: 30,
+                                                    })
+                                                )
+                                            ]
+                                            .iter()
+                                            .cloned()
+                                            .collect()
+                                        )]
+                                        .iter()
+                                        .cloned()
+                                        .collect()
+                                    ),
+                                }
+                            )]
+                            .iter()
+                            .cloned()
+                            .collect()
+                        )
                     }
                 )]
                 .iter()

--- a/command/src/command.rs
+++ b/command/src/command.rs
@@ -574,7 +574,7 @@ mod tests {
                         clusters: [(
                             String::from("cluster_1"),
                             ClusterMetricsData {
-                                data: [(
+                                cluster: [(
                                     String::from("request_time"),
                                     FilteredData::Percentiles(Percentiles {
                                         samples: 42,

--- a/command/src/proxy.rs
+++ b/command/src/proxy.rs
@@ -104,7 +104,8 @@ pub struct AggregatedMetricsData {
     pub workers: BTreeMap<String, WorkerMetrics>,
 }
 
-/// All metrics of a worker, proxy and clusters
+/// All metrics of a worker: proxy and clusters
+/// Populated by Options so partial results can be sent
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkerMetrics {
     /// key -> value
@@ -852,6 +853,8 @@ pub enum QueryAnswerMetrics {
     List((Vec<String>, Vec<String>)),
     /// all worker metrics, proxy & clusters, with Options all around for partial answers
     All(WorkerMetrics),
+    /// Use to trickle up errors to the CLI
+    Error(String),
 }
 
 impl ProxyRequestData {

--- a/command/src/proxy.rs
+++ b/command/src/proxy.rs
@@ -108,33 +108,18 @@ pub struct AggregatedMetricsData {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkerMetrics {
     /// key -> value
-    pub proxy: BTreeMap<String, FilteredData>,
+    pub proxy: Option<BTreeMap<String, FilteredData>>,
     /// cluster_id -> cluster_metrics
-    pub clusters: BTreeMap<String, ClusterMetricsData>,
+    pub clusters: Option<BTreeMap<String, ClusterMetricsData>>,
 }
 
 /// the metrics of a given cluster, with several backends
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClusterMetricsData {
     /// metric name -> metric value
-    pub cluster: BTreeMap<String, FilteredData>,
+    pub cluster: Option<BTreeMap<String, FilteredData>>,
     /// backend_id -> (metric name-> metric value)
-    pub backends: BTreeMap<String, BTreeMap<String, FilteredData>>,
-}
-
-impl ClusterMetricsData {
-    pub fn new() -> Self {
-        ClusterMetricsData {
-            cluster: BTreeMap::new(),
-            backends: BTreeMap::new(),
-        }
-    }
-}
-
-impl Default for ClusterMetricsData {
-    fn default() -> Self {
-        Self::new()
-    }
+    pub backends: Option<BTreeMap<String, BTreeMap<String, FilteredData>>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -826,7 +811,7 @@ pub enum QueryMetricsType {
     },
     Backend {
         metrics: Vec<String>,
-        backends: Vec<(String, String)>, // (cluster_id, backend_id)
+        backend_ids: Vec<String>,
         date: Option<i64>,
     },
     All, // dump proxy and cluster metrics
@@ -865,11 +850,7 @@ pub enum QueryAnswerCertificate {
 pub enum QueryAnswerMetrics {
     /// (list of proxy metrics, list of cluster metrics)
     List((Vec<String>, Vec<String>)),
-    /// cluster_id -> (key -> metric)
-    Cluster(BTreeMap<String, BTreeMap<String, FilteredData>>),
-    /// cluster_id -> (backend_id -> (key -> metric))
-    Backend(BTreeMap<String, BTreeMap<String, BTreeMap<String, FilteredData>>>),
-    /// all worker metrics, proxy & clusters
+    /// all worker metrics, proxy & clusters, with Options all around for partial answers
     All(WorkerMetrics),
 }
 

--- a/command/src/proxy.rs
+++ b/command/src/proxy.rs
@@ -806,16 +806,17 @@ pub enum QueryCertificateType {
 pub enum QueryMetricsType {
     List,
     Cluster {
-        metrics: Vec<String>,
         cluster_ids: Vec<String>,
-        date: Option<i64>,
+        metric_names: Vec<String>,
     },
     Backend {
-        metrics: Vec<String>,
         backend_ids: Vec<String>,
-        date: Option<i64>,
+        metric_names: Vec<String>,
     },
-    All, // dump proxy and cluster metrics
+    /// dump proxy and cluster metrics
+    All {
+        metric_names: Vec<String>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/command/src/proxy.rs
+++ b/command/src/proxy.rs
@@ -116,16 +116,16 @@ pub struct WorkerMetrics {
 /// the metrics of a given cluster, with several backends
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClusterMetricsData {
-    /// TO_CHECK: key -> metric
-    pub data: BTreeMap<String, FilteredData>,
-    /// TO_CHECK: backend_id -> (key -> metric)
+    /// metric name -> metric value
+    pub cluster: BTreeMap<String, FilteredData>,
+    /// backend_id -> (metric name-> metric value)
     pub backends: BTreeMap<String, BTreeMap<String, FilteredData>>,
 }
 
 impl ClusterMetricsData {
     pub fn new() -> Self {
         ClusterMetricsData {
-            data: BTreeMap::new(),
+            cluster: BTreeMap::new(),
             backends: BTreeMap::new(),
         }
     }
@@ -782,7 +782,6 @@ pub struct TcpListener {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum MetricsConfiguration {
     Enabled(bool),
-    EnabledTimeMetrics(bool),
     Clear,
 }
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -24,6 +24,7 @@ include = [
 ]
 
 [dependencies]
+anyhow = "^1.0.62"
 cookie-factory = "^0.3.2"
 foreign-types-shared = "^0.1.1"
 hdrhistogram = "^7.5.0"

--- a/lib/src/metrics/local_drain.rs
+++ b/lib/src/metrics/local_drain.rs
@@ -1,9 +1,7 @@
 #![allow(dead_code)]
-use std::convert::TryInto;
 use std::{collections::BTreeMap, str, time::Instant};
 
 use hdrhistogram::Histogram;
-use time::{Duration, OffsetDateTime};
 
 use crate::sozu_command::proxy::{
     ClusterMetricsData, FilteredData, MetricsConfiguration, Percentiles, QueryAnswerMetrics,
@@ -12,6 +10,7 @@ use crate::sozu_command::proxy::{
 
 use super::{MetricData, Subscriber};
 
+/// This is how the metrics are stored in the local drain
 #[derive(Debug, Clone)]
 pub enum AggregatedMetric {
     Gauge(usize),
@@ -26,17 +25,19 @@ impl AggregatedMetric {
             MetricData::GaugeAdd(value) => AggregatedMetric::Gauge(value as usize),
             MetricData::Count(value) => AggregatedMetric::Count(value),
             MetricData::Time(value) => {
-                //FIXME: do not unwrap here
-                let mut h = ::hdrhistogram::Histogram::new(3).unwrap();
-                if let Err(e) = h.record(value as u64) {
+                //FIXME: do not expect here. We'll need error management all the way up.
+                // this will compile but may panic. DO NOT SHIP THIS INTO PRODUCTION
+                let mut histogram = ::hdrhistogram::Histogram::new(3)
+                    .expect("could not create histogram for a time metric");
+                if let Err(e) = histogram.record(value as u64) {
                     error!("could not record time metric: {:?}", e);
                 }
-                AggregatedMetric::Time(h)
+                AggregatedMetric::Time(histogram)
             }
         }
     }
 
-    fn update(&mut self, key: &'static str, m: MetricData) {
+    fn update(&mut self, key: &str, m: MetricData) {
         match (self, m) {
             (&mut AggregatedMetric::Gauge(ref mut v1), MetricData::Gauge(v2)) => {
                 *v1 = v2;
@@ -58,6 +59,16 @@ impl AggregatedMetric {
             ),
         }
     }
+
+    pub fn to_filtered(&self) -> FilteredData {
+        match *self {
+            AggregatedMetric::Gauge(i) => FilteredData::Gauge(i),
+            AggregatedMetric::Count(i) => FilteredData::Count(i),
+            AggregatedMetric::Time(ref hist) => {
+                FilteredData::Percentiles(histogram_to_percentiles(hist))
+            }
+        }
+    }
 }
 
 pub fn histogram_to_percentiles(hist: &Histogram<u32>) -> Percentiles {
@@ -73,21 +84,7 @@ pub fn histogram_to_percentiles(hist: &Histogram<u32>) -> Percentiles {
     }
 }
 
-pub fn aggregated_to_filtered(value: &AggregatedMetric) -> FilteredData {
-    match *value {
-        AggregatedMetric::Gauge(i) => FilteredData::Gauge(i),
-        AggregatedMetric::Count(i) => FilteredData::Count(i),
-        AggregatedMetric::Time(ref hist) => {
-            FilteredData::Percentiles(histogram_to_percentiles(hist))
-        }
-    }
-}
 
-#[derive(Clone, Debug)]
-pub struct ClusterMetrics {
-    pub data: BTreeMap<String, AggregatedMetric>,
-    pub backend_data: BTreeMap<String, BTreeMap<String, AggregatedMetric>>,
-}
 
 #[derive(Clone, Debug)]
 pub struct BackendMetrics {
@@ -119,16 +116,14 @@ pub struct LocalDrain {
     pub backend_tree: BTreeMap<String, u64>,
     /// metric_name -> metric value
     pub proxy_metrics: BTreeMap<String, AggregatedMetric>,
-    /// metric_nameTABcluster_id -> (metric meta, metric kind)
-    /// this is messed up, what would be better is:
-    /// BTreeMap<cluster_id or backend_id, BTreeMap<metric_name, (MetricMeta, MetricKind, u64)>>
-    /// and even better:
-    /// BTreeMap<cluster_id or backend_id, BTreeMap<metric_name, AggregatedMetric>>
-    cluster_metrics: BTreeMap<String, (MetricMeta, MetricKind)>,
+    /// backend_id -> cluster_id
+    backend_to_cluster: BTreeMap<String, String>,
+    /// BTreeMap<cluster_id OR backend_id, BTreeMap<metric_name, AggregatedMetric>>
+    /// if the key is a backend_id, we'll retrieve the cluster_id in the backend_to_cluster map
+    cluster_metrics: BTreeMap<String, BTreeMap<String, AggregatedMetric>>,
     use_tagged_metrics: bool,
     origin: String,
     enabled: bool,
-    time_enabled: bool,
 }
 
 impl LocalDrain {
@@ -141,26 +136,10 @@ impl LocalDrain {
             backend_tree: BTreeMap::new(),
             proxy_metrics: BTreeMap::new(),
             cluster_metrics: BTreeMap::new(),
+            backend_to_cluster: BTreeMap::new(),
             use_tagged_metrics: false,
             origin: String::from("x"),
             enabled: false,
-            time_enabled: false,
-        }
-    }
-
-    fn tree(&self, is_backend: bool) -> &BTreeMap<String, u64> {
-        if is_backend {
-            &self.backend_tree
-        } else {
-            &self.cluster_tree
-        }
-    }
-
-    fn tree_mut(&mut self, is_backend: bool) -> &mut BTreeMap<String, u64> {
-        if is_backend {
-            &mut self.backend_tree
-        } else {
-            &mut self.cluster_tree
         }
     }
 
@@ -169,27 +148,38 @@ impl LocalDrain {
             MetricsConfiguration::Enabled(enabled) => {
                 self.enabled = *enabled;
             }
-            MetricsConfiguration::EnabledTimeMetrics(enabled) => {
-                self.time_enabled = *enabled;
-            }
-            MetricsConfiguration::Clear => {
-                self.backend_tree.clear();
-                self.cluster_tree.clear();
-            }
+            MetricsConfiguration::Clear => self.clear(),
         }
     }
 
-    pub fn dump_metrics_data(&mut self) -> QueryAnswerMetrics {
-        QueryAnswerMetrics::All(WorkerMetrics {
-            proxy: self.dump_process_data(),
-            clusters: self.dump_cluster_data(),
-        })
+    pub fn clear(&mut self) {
+        self.backend_to_cluster.clear();
+        self.cluster_metrics.clear();
     }
 
-    pub fn dump_process_data(&mut self) -> BTreeMap<String, FilteredData> {
-        self.proxy_metrics
+    fn get_cluster_ids(&self) -> Vec<String> {
+        self.cluster_metrics
             .iter()
-            .map(|(key, value)| (key.to_string(), aggregated_to_filtered(value)))
+            .filter_map(|entry| {
+                if !self.backend_to_cluster.contains_key(entry.0) {
+                    Some(entry.0.to_owned())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    fn get_backend_ids(&self, cluster_id: &str) -> Vec<String> {
+        self.backend_to_cluster
+            .iter()
+            .filter_map(|backend_to_cluster| {
+                if backend_to_cluster.1 == cluster_id {
+                    Some(backend_to_cluster.0.to_owned())
+                } else {
+                    None
+                }
+            })
             .collect()
     }
 
@@ -200,12 +190,8 @@ impl LocalDrain {
             self
         );
         match q {
-            QueryMetricsType::List => {
-                debug!("Here are the metrics keys: {:?}", self.proxy_metrics.keys());
-                let proxy_metrics_names = self.proxy_metrics.keys().cloned().collect();
-                let cluster_metrics_names = self.cluster_metrics.keys().cloned().collect();
-                QueryAnswerMetrics::List((proxy_metrics_names, cluster_metrics_names))
-            }
+            QueryMetricsType::List => self.list_all_metric_names(),
+
             QueryMetricsType::Cluster {
                 metrics,
                 cluster_ids,
@@ -216,117 +202,83 @@ impl LocalDrain {
                 backends,
                 date,
             } => self.query_backends(metrics, backends, *date),
-            QueryMetricsType::All => self.dump_metrics_data(),
+            QueryMetricsType::All => self.dump_all_metrics(),
         }
     }
 
-    fn get_metric_from_tree(
-        &self,
-        key: &str,
-        is_backend: bool,
-        timestamp: i64,
-        kind: MetricKind,
-    ) -> Option<FilteredData> {
-        let tree = if is_backend {
-            &self.backend_tree
-        } else {
-            &self.cluster_tree
-        };
+    fn list_all_metric_names(&self) -> QueryAnswerMetrics {
+        let proxy_metrics_names = self.proxy_metrics.keys().cloned().collect();
 
-        if kind == MetricKind::Time {
-            let mut percentiles = Percentiles::default();
+        let mut cluster_metrics_names = Vec::new();
 
-            if let Some(v) = tree.get(&format!("{}.count \t{}", key, timestamp)) {
-                percentiles.samples = *v;
-            }
-            if let Some(v) = tree.get(&format!("{}.p50 \t{}", key, timestamp)) {
-                percentiles.p_50 = *v;
-            }
-            if let Some(v) = tree.get(&format!("{}.p90 \t{}", key, timestamp)) {
-                percentiles.p_90 = *v;
-            }
-            if let Some(v) = tree.get(&format!("{}.p99 \t{}", key, timestamp)) {
-                percentiles.p_99 = *v;
-            }
-            if let Some(v) = tree.get(&format!("{}.p99.9 \t{}", key, timestamp)) {
-                percentiles.p_99_9 = *v;
-            }
-            if let Some(v) = tree.get(&format!("{}.p99.99 \t{}", key, timestamp)) {
-                percentiles.p_99_99 = *v;
-            }
-            if let Some(v) = tree.get(&format!("{}.p99.999 \t{}", key, timestamp)) {
-                percentiles.p_99_999 = *v;
-            }
-            if let Some(v) = tree.get(&format!("{}.p100 \t{}", key, timestamp)) {
-                percentiles.p_100 = *v;
-            }
-
-            return Some(FilteredData::Percentiles(percentiles));
-        }
-
-        if let Some(v) = tree.get(&format!("{}\t{}", key, timestamp)) {
-            match kind {
-                MetricKind::Gauge => {
-                    return Some(FilteredData::Gauge(*v as usize));
-                }
-                MetricKind::Count => {
-                    return Some(FilteredData::Count(*v as i64));
-                }
-                MetricKind::Time => {}
+        for cluster_metrics_entry in self.cluster_metrics.iter() {
+            for (metric_name, _) in cluster_metrics_entry.1.iter() {
+                cluster_metrics_names.push(metric_name.to_owned());
             }
         }
+        QueryAnswerMetrics::List((proxy_metrics_names, cluster_metrics_names))
+    }
 
-        None
+    pub fn dump_all_metrics(&mut self) -> QueryAnswerMetrics {
+        QueryAnswerMetrics::All(WorkerMetrics {
+            proxy: self.dump_proxy_metrics(),
+            clusters: self.dump_cluster_metrics(),
+        })
+    }
+
+    pub fn dump_proxy_metrics(&mut self) -> BTreeMap<String, FilteredData> {
+        self.proxy_metrics
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.to_filtered()))
+            .collect()
+    }
+
+    pub fn dump_cluster_metrics(&mut self) -> BTreeMap<String, ClusterMetricsData> {
+        let mut cluster_data = BTreeMap::new();
+
+        for cluster_id in self.get_cluster_ids() {
+            let cluster: BTreeMap<String, FilteredData> =
+                match self.cluster_metrics.get(&cluster_id) {
+                    Some(cluster_metrics) => cluster_metrics
+                        .iter()
+                        .map(|entry| (entry.0.to_owned(), entry.1.to_filtered()))
+                        .collect::<BTreeMap<String, FilteredData>>(),
+                    None => {
+                        return cluster_data; // this is unlikely
+                    }
+                };
+
+            let mut backends = BTreeMap::new();
+            for backend_id in self.get_backend_ids(&cluster_id) {
+                match self.cluster_metrics.get(&backend_id) {
+                    Some(backend_metrics) => {
+                        let filtered_metrics: BTreeMap<String, FilteredData> = backend_metrics
+                            .iter()
+                            .map(|entry| (entry.0.to_owned(), entry.1.to_filtered()))
+                            .collect::<BTreeMap<String, FilteredData>>();
+
+                        backends.insert(backend_id, filtered_metrics);
+                    }
+                    None => continue, // unlikely
+                }
+            }
+
+            cluster_data.insert(cluster_id, ClusterMetricsData { cluster, backends });
+        }
+
+        cluster_data
     }
 
     fn query_clusters(
         &mut self,
-        metric_names: &[String],
-        cluster_ids: &[String],
+        metric_names: &Vec<String>,
+        cluster_ids: &Vec<String>,
         date: Option<i64>,
     ) -> QueryAnswerMetrics {
         debug!("Querying cluster with ids: {:?}", cluster_ids);
         let mut response: BTreeMap<String, BTreeMap<String, FilteredData>> = BTreeMap::new();
-        for cluster_id in cluster_ids.iter() {
-            response.insert(cluster_id.to_string(), BTreeMap::new());
-        }
 
-        let timestamp = date.unwrap_or_else(|| {
-            let now = OffsetDateTime::now_utc();
-            let last_minute = now - Duration::seconds(now.second() as i64);
-            last_minute.unix_timestamp()
-        });
-
-        trace!("current metrics: {:#?}", self.cluster_metrics);
-
-        // TODO: check that the cluster ids exist, and if not, reply with error
-        for metric_name in metric_names.iter() {
-            for cluster_id in cluster_ids.iter() {
-                let key = format!("{}\t{}", metric_name, cluster_id);
-
-                let (meta, kind) = match self.cluster_metrics.get(&key) {
-                    Some((m, k)) => (m, k),
-                    None => {
-                        error!("Did not find cluster metrics with the metric key '{}'", key);
-                        continue;
-                    }
-                };
-
-                if *meta == MetricMeta::ClusterBackend {
-                    error!("{} is a backend metric", key);
-                    continue;
-                }
-
-                if let Some(filtered_data) =
-                    self.get_metric_from_tree(&key, false, timestamp, *kind)
-                {
-                    response
-                        .get_mut(cluster_id)
-                        .unwrap()
-                        .insert(key.to_string(), filtered_data);
-                }
-            }
-        }
+        // if metric_names is empty, provide all metrics
 
         trace!("query result: {:#?}", response);
         QueryAnswerMetrics::Cluster(response)
@@ -340,216 +292,19 @@ impl LocalDrain {
     ) -> QueryAnswerMetrics {
         let mut response: BTreeMap<String, BTreeMap<String, BTreeMap<String, FilteredData>>> =
             BTreeMap::new();
-        for (cluster_id, backend_id) in backends.iter() {
-            response
-                .entry(cluster_id.to_string())
-                .or_insert_with(BTreeMap::new)
-                .insert(backend_id.to_string(), BTreeMap::new());
-        }
 
-        let timestamp = date.unwrap_or_else(|| {
-            let now = OffsetDateTime::now_utc();
-            let last_minute = now - Duration::seconds(now.second() as i64);
-            last_minute.unix_timestamp()
-        });
-
-        trace!("current metrics: {:#?}", self.cluster_metrics);
-        for metric_name in metric_names.iter() {
-            // TODO: check that the backend_ids & cluster_ids exist, and if not, reply with error
-            for (cluster_id, backend_id) in backends.iter() {
-                let key = format!("{}\t{}\t{}", metric_name, cluster_id, backend_id);
-
-                let (meta, kind) = match self.cluster_metrics.get(&key) {
-                    Some((m, k)) => (m, k),
-                    None => {
-                        error!("Did not find backend metrics with the metric key '{}'", key);
-                        continue;
-                    }
-                };
-
-                if *meta == MetricMeta::Cluster {
-                    error!("{} is a cluster metric", key);
-                    continue;
-                }
-
-                if let Some(filtered_data) = self.get_metric_from_tree(&key, true, timestamp, *kind)
-                {
-                    response
-                        .get_mut(cluster_id)
-                        .unwrap()
-                        .get_mut(backend_id)
-                        .unwrap()
-                        .insert(key.to_string(), filtered_data);
-                }
-            }
-        }
+        // if metric_names is empty, provide all metrics for those backends
 
         trace!("query result: {:#?}", response);
         QueryAnswerMetrics::Backend(response)
     }
 
-    fn get_last_before(&self, start: &str, end: &str, is_backend: bool) -> Option<u64> {
-        let tree = self.tree(is_backend);
-
-        //if let Some((k, v)) = tree.get_lt(end.as_bytes())? {
-        if let Some((k, v)) = tree.range(start.to_string()..end.to_string()).rev().next() {
-            if k.starts_with(start) {
-                /*
-                if is_backend {
-                    let mut it = k.split(|c: &u8| *c == b'\t');
-                    let key = std::str::from_utf8(it.next().unwrap()).unwrap();
-                    let cluster_id = std::str::from_utf8(it.next().unwrap()).unwrap();
-                    let backend_id = std::str::from_utf8(it.next().unwrap()).unwrap();
-                    let timestamp:&str = std::str::from_utf8(it.next().unwrap()).unwrap();//.parse().unwrap();
-
-                    let value = usize::from_le_bytes((*v).try_into().unwrap());
-                    info!("looking at key = {}, id = {}, backend_id = {}, ts = {} -> {}",
-                          key, cluster_id, backend_id, timestamp, value);
-                } else {
-                    info!("current key: {}", std::str::from_utf8(&k).unwrap());
-                    let mut it = k.split(|c: &u8| *c == b'\t');
-                    let key = std::str::from_utf8(it.next().unwrap()).unwrap();
-                    let cluster_id = std::str::from_utf8(it.next().unwrap()).unwrap();
-                    let timestamp:&str = std::str::from_utf8(it.next().unwrap()).unwrap();//.parse().unwrap();
-
-                    let value = usize::from_le_bytes((*v).try_into().unwrap());
-                    info!("looking at key = {}, id = {}, ts = {} -> {}",
-                          key, cluster_id, timestamp, value);
-                }*/
-
-                return Some(*v);
-            }
-        }
-
-        None
-    }
-
-    pub fn dump_cluster_data(&mut self) -> BTreeMap<String, ClusterMetricsData> {
-        let clusters = BTreeMap::new();
-        /*
-        for (key, (meta, kind)) in self.cluster_metrics.iter() {
-            let end = format!("{}\x7F", key);
-
-            match meta {
-                MetricMeta::Cluster => {
-                    for (k, v) in self.cluster_tree.range(key..&end) {
-                        // let (k, v) = res?;
-
-                        let mut it = k.split(|c: char| c == '\t');
-                        let key = it.next().unwrap();
-                        let cluster_id = it.next().unwrap();
-                        let timestamp = it.next().unwrap();
-
-                        //let timestamp:i64 = std::str::from_utf8(it.next().unwrap()).unwrap().parse().unwrap();
-
-                        info!(
-                            "looking at key = {}, id = {}, ts = {}",
-                            key, cluster_id, timestamp
-                        );
-
-                        let metrics_data = clusters
-                            .entry(cluster_id.to_string())
-                            .or_insert_with(ClusterMetricsData::new);
-                        match kind {
-                            MetricKind::Gauge => {
-                                /*if metrics_data.data.contains_key(key) {
-                                    let v2 = metrics_data.data.get(key).unwrap().clone();
-                                } else {*/
-                                metrics_data.data.insert(
-                                    key.to_string(),
-                                    FilteredData::Gauge(usize::from_le_bytes(
-                                        (*v).try_into().unwrap(),
-                                    )),
-                                );
-                                //}
-                            }
-                            MetricKind::Count => {
-                                /*if metrics_data.data.contains_key(key) {
-                                    let v2 = metrics_data.data.get(key).unwrap().clone();
-                                } else {*/
-                                metrics_data.data.insert(
-                                    key.to_string(),
-                                    FilteredData::Count(i64::from_le_bytes(
-                                        (*v).try_into().unwrap(),
-                                    )),
-                                );
-                                //}
-                            }
-                            MetricKind::Time => {
-                                //unimplemented for now
-                            }
-                        }
-                    }
-                }
-                MetricMeta::ClusterBackend => {
-                    for (k, v) in self.backend_tree.range(key..&end) {
-                        // let (k, v) = res?;
-
-                        let mut it = k.split(|c: char| c == '\t');
-                        let key = it.next().unwrap();
-                        let cluster_id = it.next().unwrap();
-                        let backend_id = it.next().unwrap();
-                        let timestamp = it.next().unwrap();
-
-                        info!(
-                            "looking at key = {}, cluster id = {}, bid: {}, ts = {}",
-                            key, cluster_id, backend_id, timestamp
-                        );
-
-                        let cluster_metrics_data = clusters
-                            .entry(cluster_id.to_string())
-                            .or_insert_with(ClusterMetricsData::new);
-                        let backend_metrics_data = cluster_metrics_data
-                            .backends
-                            .entry(backend_id.to_string())
-                            .or_insert_with(BTreeMap::new);
-                        match kind {
-                            MetricKind::Gauge => {
-                                /*if backend_metrics_data.contains_key(key) {
-                                    let v2 = backend_metrics_data.get(key).unwrap().clone();
-                                } else {*/
-                                backend_metrics_data.insert(
-                                    key.to_string(),
-                                    FilteredData::Gauge(usize::from_le_bytes(
-                                        (*v).try_into().unwrap(),
-                                    )),
-                                );
-                                //}
-                            }
-                            MetricKind::Count => {
-                                /*if backend_metrics_data.contains_key(key) {
-                                    let v2 = backend_metrics_data.get(key).unwrap().clone();
-                                } else {*/
-                                backend_metrics_data.insert(
-                                    key.to_string(),
-                                    FilteredData::Count(i64::from_le_bytes(
-                                        (*v).try_into().unwrap(),
-                                    )),
-                                );
-                                //}
-                            }
-                            MetricKind::Time => {
-                                //unimplemented for now
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        */
-
-        // still clear the DB for now
-        //self.db.clear();
-
-        clusters
-    }
-
     fn receive_cluster_metric(
         &mut self,
-        key: &str,
+        metric_name: &str,
         cluster_id: &str,
         backend_id: Option<&str>,
-        metric: MetricData,
+        metric_value: MetricData,
     ) {
         if !self.enabled {
             return;
@@ -557,575 +312,32 @@ impl LocalDrain {
 
         trace!(
             "metric: {} {} {:?} {:?}",
-            key,
+            metric_name,
             cluster_id,
             backend_id,
-            metric
+            metric_value
         );
 
-        if let MetricData::Time(t) = metric {
-            self.store_time_metric(key, cluster_id, None, t);
-            if backend_id.is_some() {
-                self.store_time_metric(key, cluster_id, backend_id, t);
+        let cluster_or_backend_id = match backend_id {
+            Some(backend_id) => {
+                self.backend_to_cluster
+                    .insert(backend_id.to_owned(), cluster_id.to_owned());
+                backend_id
             }
-            return;
-        }
-
-        self.store_metric(&format!("{}\t{}", key, cluster_id), None, &metric);
-
-        // backend metrics are stored twice, in cluster_metrics and backend_metrics
-        if let Some(bid) = backend_id {
-            self.store_metric(
-                &format!("{}\t{}\t{}", key, cluster_id, bid),
-                backend_id,
-                &metric,
-            );
-        }
-    }
-
-    fn store_metric(&mut self, key: &str, backend_id: Option<&str>, metric: &MetricData) {
-        debug!("Storing metrics with key prefix: {}", key);
-        if !self.cluster_metrics.contains_key(key) {
-            let kind = match metric {
-                MetricData::Gauge(_) => MetricKind::Gauge,
-                MetricData::GaugeAdd(_) => MetricKind::Gauge,
-                MetricData::Count(_) => MetricKind::Count,
-                MetricData::Time(_) => MetricKind::Time,
-            };
-            let meta = match backend_id {
-                Some(_) => MetricMeta::ClusterBackend,
-                None => MetricMeta::Cluster,
-            };
-
-            self.cluster_metrics.insert(key.to_string(), (meta, kind));
-        }
-
-        match metric {
-            MetricData::Gauge(i) => {
-                self.store_gauge(key, *i, backend_id.is_some());
-            }
-            MetricData::GaugeAdd(i) => {
-                self.add_gauge(key, *i, backend_id.is_some());
-            }
-            MetricData::Count(i) => {
-                self.store_count(key, *i, backend_id.is_some());
-            }
-            MetricData::Time(_) => {}
-        }
-
-        /*
-        if let (Some(first), Some(second)) = (self.db.first().unwrap(), self.db.last().unwrap()) {
-          for res in self.db.range(first.0..second.0) {
-              let (k, v) = res.unwrap();
-              info!("{} -> {:?}", unsafe { std::str::from_utf8_unchecked(&k) }, u64::from_le_bytes((*v).try_into().unwrap()));
-
-          }
-        }
-        //info!("metrics: {:?}", self.metrics);
-        info!("db size: {:?}", self.db.size_on_disk());
-        */
-    }
-
-    fn store_gauge(&mut self, key: &str, i: usize, is_backend: bool) {
-        let now = OffsetDateTime::now_utc();
-        let timestamp = now.unix_timestamp();
-        let complete_key = format!("{}\t{}", key, timestamp);
-
-        trace!("store gauge at {} -> {}", complete_key, i);
-        self.tree_mut(is_backend).insert(complete_key, i as u64);
-
-        // aggregate at the last hour
-        let second = now.second();
-        if second != 0 {
-            let previous_minute = now - time::Duration::seconds(second as i64);
-            let timestamp = previous_minute.unix_timestamp();
-
-            let complete_key = format!("{}\t{}", key, timestamp);
-
-            self.tree_mut(is_backend)
-                .entry(complete_key)
-                .or_insert(i as u64);
-            let minute = previous_minute.minute();
-            if minute != 0 {
-                let previous_hour = now - time::Duration::minutes(minute as i64);
-                let timestamp = previous_hour.unix_timestamp();
-
-                let complete_key = format!("{}\t{}", key, timestamp);
-                self.tree_mut(is_backend)
-                    .entry(complete_key)
-                    .or_insert(i as u64);
-            }
-        }
-    }
-
-    fn add_gauge(&mut self, key: &str, i: i64, is_backend: bool) {
-        let now = OffsetDateTime::now_utc();
-        let timestamp = now.unix_timestamp();
-        let complete_key = format!("{}\t{}", key, timestamp);
-
-        trace!("add gauge at {} -> {}", complete_key, i);
-
-        let value = match self.tree(is_backend).get(&complete_key) {
-            Some(v) => *v as i64,
-            // start from the last known value, or zero
-            None => match self.get_last_before(key, &complete_key, is_backend) {
-                None => 0i64,
-                Some(v) => {
-                    //i64::from_le_bytes((*v).try_into().unwrap())
-                    v as i64
-                }
-            },
+            None => cluster_id,
         };
 
-        let new_value = value + i;
-        self.tree_mut(is_backend)
-            .insert(complete_key, new_value as u64);
+        let submap = self
+            .cluster_metrics
+            .entry(cluster_or_backend_id.to_owned())
+            .or_insert(BTreeMap::new());
 
-        // aggregate at the last hour
-        let second = now.second();
-        if second != 0 {
-            let previous_minute = now - time::Duration::seconds(second as i64);
-            let timestamp = previous_minute.unix_timestamp();
-
-            let complete_key = format!("{}\t{}", key, timestamp);
-
-            let value = match self.tree(is_backend).get(&complete_key) {
-                Some(v) => *v as i64,
-                // start from the last known value, or zero
-                None => match self.get_last_before(key, &complete_key, is_backend) {
-                    None => 0i64,
-                    Some(v) => {
-                        //i64::from_le_bytes((*v).try_into().unwrap())
-                        v as i64
-                    }
-                },
-            };
-
-            let new_value = value + i;
-            self.tree_mut(is_backend)
-                .insert(complete_key, new_value as u64);
-
-            let minute = previous_minute.minute();
-            if minute != 0 {
-                let previous_hour = now - time::Duration::minutes(minute as i64);
-                let timestamp = previous_hour.unix_timestamp();
-
-                let complete_key = format!("{}\t{}", key, timestamp);
-
-                let value = match self.tree(is_backend).get(&complete_key) {
-                    Some(v) => *v as i64,
-                    // start from the last known value, or zero
-                    None => match self.get_last_before(key, &complete_key, is_backend) {
-                        None => 0i64,
-                        Some(v) => v as i64,
-                    },
-                };
-
-                let new_value = value + i;
-                self.tree_mut(is_backend)
-                    .insert(complete_key, new_value as u64);
-            }
-        }
-    }
-
-    fn store_count(&mut self, key: &str, i: i64, is_backend: bool) {
-        let now = OffsetDateTime::now_utc();
-        let timestamp = now.unix_timestamp();
-        let complete_key = format!("{}\t{}", key, timestamp);
-
-        trace!("store count at {} -> {}", complete_key, i);
-
-        match self.tree_mut(is_backend).get_mut(&complete_key) {
+        match submap.get_mut(metric_name) {
+            Some(existing_metric) => existing_metric.update(metric_name, metric_value),
             None => {
-                self.tree_mut(is_backend).insert(complete_key, i as u64);
-            }
-            Some(v) => *v += i as u64,
-        };
-
-        // aggregate at the last hour
-        let second = now.second();
-        if second != 0 {
-            let previous_minute = now - time::Duration::seconds(second as i64);
-            let timestamp = previous_minute.unix_timestamp();
-
-            let complete_key = format!("{}\t{}", key, timestamp);
-            match self.tree_mut(is_backend).get_mut(&complete_key) {
-                None => {
-                    self.tree_mut(is_backend).insert(complete_key, i as u64);
-                }
-                Some(v) => *v += i as u64,
-            };
-
-            let minute = previous_minute.minute();
-            if minute != 0 {
-                let previous_hour = now - time::Duration::minutes(minute as i64);
-                let timestamp = previous_hour.unix_timestamp();
-
-                let complete_key = format!("{}\t{}", key, timestamp);
-                match self.tree_mut(is_backend).get_mut(&complete_key) {
-                    None => {
-                        self.tree_mut(is_backend).insert(complete_key, i as u64);
-                    }
-                    Some(v) => *v += i as u64,
-                };
+                submap.insert(metric_name.to_owned(), AggregatedMetric::new(metric_value));
             }
         }
-    }
-
-    fn clear_gauge(&mut self, key: &str, now: OffsetDateTime, is_backend: bool) {
-        let timestamp = now.unix_timestamp();
-        let one_hour_ago = format!("{}\t{}", key, timestamp - 3600);
-        let one_minute_ago = format!("{}\t{}", key, timestamp - 60);
-        let now_key = format!("{}\t{}", key, timestamp);
-
-        let tree = if is_backend {
-            &mut self.backend_tree
-        } else {
-            &mut self.cluster_tree
-        };
-
-        let mut to_remove = Vec::new();
-        // aggregate 60 measures in a point at the last minute
-        for (k, v) in tree.range(one_minute_ago.clone()..now_key) {
-            debug!("removing {} -> {:?}", k, v);
-
-            to_remove.push(k.to_string());
-        }
-
-        // aggregate 60 measures in a point at the last hour
-        if now.minute() == 0 {
-            for (k, v) in tree.range(one_hour_ago..one_minute_ago) {
-                debug!("removing {} -> {:?}", &k, v);
-                to_remove.push(k.to_string());
-            }
-
-            // remove all measures older than 24h
-            let one_day_ago = format!("{}\t{}", key, timestamp - 3600 * 24);
-            for (k, v) in tree.range(key.to_string()..one_day_ago) {
-                debug!("removing {} -> {:?} (more than 24h)", k, v);
-                to_remove.push(k.to_string());
-            }
-        }
-
-        for k in to_remove.drain(..) {
-            tree.remove(&k);
-        }
-    }
-
-    /*fn clear_count(&mut self, key: &str, now: OffsetDateTime, is_backend: bool) -> Result<(), sled::Error> {
-        let timestamp = now.unix_timestamp();
-        let one_hour_ago = format!("{}\t{}", key, timestamp - 3600);
-        let one_minute_ago = format!("{}\t{}", key, timestamp - 60);
-        let now_key = format!("{}\t{}", key, timestamp);
-
-        let tree = if is_backend {
-            &mut self.backend_tree
-        } else {
-            &mut self.cluster_tree
-        };
-
-        // aggregate 60 measures in a point at the last hour
-        for res in tree.range(one_minute_ago.as_bytes()..now_key.as_bytes()) {
-            let (k, v) = res?;
-            debug!("removing {} -> {:?}", unsafe { std::str::from_utf8_unchecked(&k) }, u64::from_le_bytes((*v).try_into().unwrap()));
-            tree.remove(k)?;
-        }
-
-        // remove all measures older than 24h
-        if now.minute() == 0 {
-            for res in tree.range(one_hour_ago.as_bytes()..one_minute_ago.as_bytes()) {
-                let (k, v) = res?;
-                debug!("removing {} -> {:?}", unsafe { std::str::from_utf8_unchecked(&k) }, u64::from_le_bytes((*v).try_into().unwrap()));
-                tree.remove(k)?;
-            }
-
-            // remove all measures older than 24h
-            let one_day_ago = format!("{}\t{}", key, timestamp - 3600 * 24);
-            for res in tree.range(key.as_bytes()..one_day_ago.as_bytes()) {
-                let (k, v) = res?;
-                debug!("removing {} -> {:?} (more than 24h)", unsafe { std::str::from_utf8_unchecked(&k) }, i64::from_le_bytes((*v).try_into().unwrap()));
-                tree.remove(k)?;
-            }
-        }
-
-        Ok(())
-    }*/
-
-    fn clear_time(&mut self, key: &str, now: OffsetDateTime, is_backend: bool) {
-        self.clear_time_metric(&format!("{}.count", key), now, is_backend);
-        self.clear_time_metric(&format!("{}.mean", key), now, is_backend);
-        self.clear_time_metric(&format!("{}.var", key), now, is_backend);
-        self.clear_time_metric(&format!("{}.p50", key), now, is_backend);
-        self.clear_time_metric(&format!("{}.p90", key), now, is_backend);
-        self.clear_time_metric(&format!("{}.p99", key), now, is_backend);
-        self.clear_time_metric(&format!("{}.p99.9", key), now, is_backend);
-        self.clear_time_metric(&format!("{}.p99.99", key), now, is_backend);
-        self.clear_time_metric(&format!("{}.p99.999", key), now, is_backend);
-        self.clear_time_metric(&format!("{}.p100", key), now, is_backend);
-    }
-
-    fn clear_time_metric(&mut self, key: &str, now: OffsetDateTime, is_backend: bool) {
-        let timestamp = now.unix_timestamp();
-        let one_hour_ago = format!("{}\t{}", key, timestamp - 3600);
-        let one_minute_ago = format!("{}\t{}", key, timestamp - 60);
-        let now_key = format!("{}\t{}", key, timestamp);
-
-        let tree = if is_backend {
-            &mut self.backend_tree
-        } else {
-            &mut self.cluster_tree
-        };
-
-        let mut to_remove = Vec::new();
-        // aggregate 60 measures in a point at the last hour
-        for (k, v) in tree.range(one_minute_ago.clone()..now_key) {
-            debug!("removing {} -> {:?}", k, v);
-            to_remove.push(k.clone());
-        }
-
-        // remove all measures older than 24h
-        if now.minute() == 0 {
-            for (k, v) in tree.range(one_hour_ago..one_minute_ago) {
-                debug!("removing {} -> {:?}", k, v);
-                to_remove.push(k.clone());
-            }
-
-            // remove all measures older than 24h
-            let one_day_ago = format!("{}\t{}", key, timestamp - 3600 * 24);
-            for (k, v) in tree.range(key.to_string()..one_day_ago) {
-                debug!("removing {} -> {:?} (more than 24h)", k, v);
-                to_remove.push(k.clone());
-            }
-        }
-
-        for k in to_remove.drain(..) {
-            tree.remove(&k);
-        }
-    }
-
-    fn store_time_metric(
-        &mut self,
-        key: &str,
-        cluster_id: &str,
-        backend_id: Option<&str>,
-        t: usize,
-    ) {
-        if !self.time_enabled {
-            return;
-        }
-
-        let now = OffsetDateTime::now_utc();
-        //let timestamp = now.unix_timestamp();
-        //let _res = self.store_time_metric_at(key, cluster_id, backend_id, timestamp, t)?;
-
-        let second = now.second();
-        // we also aggregate at second zero
-        //if second != 0 {
-        let previous_minute = now - time::Duration::seconds(second as i64);
-        let timestamp = previous_minute.unix_timestamp();
-        self.store_time_metric_at(key, cluster_id, backend_id, timestamp, t);
-        //} else {
-        //}
-    }
-
-    fn store_time_metric_at(
-        &mut self,
-        key: &str,
-        cluster_id: &str,
-        backend_id: Option<&str>,
-        timestamp: i64,
-        t: usize,
-    ) {
-        let key_prefix = if let Some(bid) = backend_id {
-            format!("{}\t{}\t{}", key, cluster_id, bid)
-        } else {
-            format!("{}\t{}", key, cluster_id)
-        };
-
-        if !self.cluster_metrics.contains_key(&key_prefix) {
-            let meta = if backend_id.is_some() {
-                MetricMeta::ClusterBackend
-            } else {
-                MetricMeta::Cluster
-            };
-
-            self.cluster_metrics
-                .insert(key_prefix.to_string(), (meta, MetricKind::Time));
-        }
-
-        let tree = if backend_id.is_some() {
-            &mut self.backend_tree
-        } else {
-            &mut self.cluster_tree
-        };
-
-        let count_key = format!("{}.count \t{}", key_prefix, timestamp);
-        let mean_key = format!("{}.mean \t{}", key_prefix, timestamp);
-        let var_key = format!("{}.var \t{}", key_prefix, timestamp);
-        let p50_key = format!("{}.p50 \t{}", key_prefix, timestamp);
-        let p90_key = format!("{}.p90 \t{}", key_prefix, timestamp);
-        let p99_key = format!("{}.p99 \t{}", key_prefix, timestamp);
-        let p99_9_key = format!("{}.p99.9 \t{}", key_prefix, timestamp);
-        let p99_99_key = format!("{}.p99.99 \t{}", key_prefix, timestamp);
-        let p99_999_key = format!("{}.p99.999 \t{}", key_prefix, timestamp);
-        let p100_key = format!("{}.p100 \t{}", key_prefix, timestamp);
-
-        match tree.get(&count_key) {
-            None => {
-                tree.insert(count_key, 1u64);
-                tree.insert(mean_key, t as u64);
-                tree.insert(var_key, 0u64);
-                tree.insert(p50_key, t as u64);
-                tree.insert(p90_key, t as u64);
-                tree.insert(p99_key, t as u64);
-                tree.insert(p99_9_key, t as u64);
-                tree.insert(p99_99_key, t as u64);
-                tree.insert(p99_999_key, t as u64);
-                tree.insert(p100_key, t as u64);
-            }
-            Some(v) => {
-                let old_count = *v;
-                tree.insert(count_key, old_count + 1);
-
-                let mean = if let Some(mean_v) = tree.get_mut(&mean_key) {
-                    let old_mean = *mean_v as f64;
-                    let new_mean =
-                        (old_mean * old_count as f64 + t as f64) / (old_count as f64 + 1f64);
-
-                    *mean_v = new_mean.floor() as u64;
-                    new_mean
-                } else {
-                    return;
-                };
-
-                let standard_dev = if let Some(var_v) = tree.get_mut(&var_key) {
-                    let old_var = *var_v as f64;
-                    let deviation = t as f64 - mean;
-                    let new_var = (old_var * old_count as f64 + deviation * deviation)
-                        / (old_count as f64 + 1f64);
-                    *var_v = new_var.floor() as u64;
-
-                    new_var.sqrt()
-                } else {
-                    return;
-                };
-
-                if let Some(old_v) = tree.get(&p50_key) {
-                    let new_percentile =
-                        calculate_percentile(*old_v as usize, t, standard_dev, 0.50f64);
-                    tree.insert(p50_key, new_percentile as u64);
-                }
-
-                if let Some(old_v) = tree.get(&p90_key) {
-                    let new_percentile =
-                        calculate_percentile(*old_v as usize, t, standard_dev, 0.90f64);
-                    tree.insert(p90_key, new_percentile as u64);
-                }
-
-                if let Some(old_v) = tree.get(&p99_key) {
-                    let new_percentile =
-                        calculate_percentile(*old_v as usize, t, standard_dev, 0.99f64);
-                    tree.insert(p99_key, new_percentile as u64);
-                }
-
-                if let Some(old_v) = tree.get(&p99_9_key) {
-                    let new_percentile =
-                        calculate_percentile(*old_v as usize, t, standard_dev, 0.999f64);
-                    tree.insert(p99_9_key, new_percentile as u64);
-                }
-
-                if let Some(old_v) = tree.get(&p99_99_key) {
-                    let new_percentile =
-                        calculate_percentile(*old_v as usize, t, standard_dev, 0.9999f64);
-                    tree.insert(p99_99_key, new_percentile as u64);
-                }
-
-                if let Some(old_v) = tree.get(&p99_999_key) {
-                    let new_percentile =
-                        calculate_percentile(*old_v as usize, t, standard_dev, 0.99999f64);
-                    tree.insert(p99_999_key, new_percentile as u64);
-                }
-
-                if let Some(old_v) = tree.get(&p100_key) {
-                    // the 100 percentile is the largest value
-                    if t as u64 > *old_v {
-                        tree.insert(p100_key, t as u64);
-                    }
-                }
-            }
-        };
-    }
-
-    pub fn clear(&mut self, now: OffsetDateTime) {
-        if !self.enabled {
-            return;
-        }
-
-        info!(
-            "will clear old data from the metrics database ({} points)",
-            self.cluster_tree.len() + self.backend_tree.len()
-        );
-
-        /*
-        info!("current keys:");
-        if let (Some(first), Some(second)) = (self.cluster_tree.first()?, self.cluster_tree.last()?) {
-          for res in self.cluster_tree.range(first.0..second.0) {
-              let (k, v) = res?;
-              info!("{} -> {:?}", unsafe { std::str::from_utf8_unchecked(&k) }, u64::from_le_bytes((*v).try_into().unwrap()));
-
-          }
-        }
-        if let (Some(first), Some(second)) = (self.backend_tree.first()?, self.backend_tree.last()?) {
-          for res in self.backend_tree.range(first.0..second.0) {
-              let (k, v) = res?;
-              info!("{} -> {:?}", unsafe { std::str::from_utf8_unchecked(&k) }, u64::from_le_bytes((*v).try_into().unwrap()));
-
-          }
-        }*/
-
-        let metrics = self.cluster_metrics.clone();
-        for (key, (meta, kind)) in metrics.iter() {
-            info!("will aggregate metrics for key '{}'", key);
-
-            let is_backend = *meta == MetricMeta::ClusterBackend;
-            match kind {
-                MetricKind::Gauge => {
-                    self.clear_gauge(key, now, is_backend);
-                }
-                MetricKind::Count => {
-                    self.clear_gauge(key, now, is_backend);
-                }
-                MetricKind::Time => {
-                    self.clear_time(key, now, is_backend);
-                }
-            }
-        }
-
-        /*
-        info!("remaining keys:");
-        if let (Some(first), Some(second)) = (self.cluster_tree.first()?, self.cluster_tree.last()?) {
-          for res in self.cluster_tree.range(first.0..second.0) {
-              let (k, v) = res?;
-              info!("{} -> {:?}", unsafe { std::str::from_utf8_unchecked(&k) }, u64::from_le_bytes((*v).try_into().unwrap()));
-
-          }
-        }
-        if let (Some(first), Some(second)) = (self.backend_tree.first()?, self.backend_tree.last()?) {
-          for res in self.backend_tree.range(first.0..second.0) {
-              let (k, v) = res?;
-              info!("{} -> {:?}", unsafe { std::str::from_utf8_unchecked(&k) }, u64::from_le_bytes((*v).try_into().unwrap()));
-
-          }
-        }
-
-        info!("db size({} points): {:?} bytes",
-          self.cluster_tree.len() + self.backend_tree.len(),
-          self.db.size_on_disk());
-          */
-        info!(
-            "db size({} points)",
-            self.cluster_tree.len() + self.backend_tree.len()
-        );
     }
 }
 
@@ -1142,13 +354,13 @@ impl Subscriber for LocalDrain {
         //     key, cluster_id, backend_id, metric
         // );
 
-        // cluster metric
+        // cluster metrics
         if let Some(id) = cluster_id {
             self.receive_cluster_metric(key, id, backend_id, metric);
             return;
         }
 
-        // proxy metric
+        // proxy metrics
         match self.proxy_metrics.get_mut(key) {
             Some(stored_metric) => stored_metric.update(key, metric),
             None => {
@@ -1156,38 +368,5 @@ impl Subscriber for LocalDrain {
                     .insert(String::from(key), AggregatedMetric::new(metric));
             }
         }
-
-        /* this was rewritten above, same logic
-        if let Some(id) = cluster_id {
-            self.receive_cluster_metric(key, id, backend_id, metric);
-        } else if dbg!(!self.proxy_metrics.contains_key(key)) {
-            self.proxy_metrics
-            .insert(String::from(key), AggregatedMetric::new(metric));
-        } else if let Some(stored_metric) = self.proxy_metrics.get_mut(key) {
-            stored_metric.update(key, metric);
-        }
-        */
-    }
-}
-
-// implementation of an algorithm from https://mjambon.com/2016-07-23-moving-percentile/
-fn calculate_percentile(
-    old_value: usize,
-    measure: usize,
-    standard_deviation: f64,
-    percentile: f64,
-) -> usize {
-    // to be adated can be between 0.01 and 0.001
-    let r = 0.01f64;
-    let delta = standard_deviation * r;
-
-    if measure == old_value {
-        old_value
-    } else if measure < old_value {
-        let new_value = old_value as f64 - delta / percentile;
-        new_value as usize
-    } else {
-        let new_value = old_value as f64 + delta / (1f64 - percentile);
-        new_value as usize
     }
 }

--- a/lib/src/metrics/mod.rs
+++ b/lib/src/metrics/mod.rs
@@ -20,6 +20,7 @@ thread_local! {
   pub static METRICS: RefCell<Aggregator> = RefCell::new(Aggregator::new(String::from("sozu")));
 }
 
+/// We should rename this to MetricValue
 #[derive(Debug, Clone, PartialEq)]
 pub enum MetricData {
     Gauge(usize),
@@ -212,23 +213,12 @@ impl Aggregator {
         }
     }
 
-    /* these are never used here, only at the local drain level
-
-    pub fn dump_metrics_data(&mut self) -> MetricsData {
-        self.local.dump_metrics_data()
-    }
-
-    pub fn dump_process_data(&mut self) -> BTreeMap<String, FilteredData> {
-        self.local.dump_process_data()
-    }
-    */
-
     pub fn query(&mut self, q: &QueryMetricsType) -> QueryAnswerMetrics {
         self.local.query(q)
     }
 
-    pub fn clear_local(&mut self, now: time::OffsetDateTime) {
-        self.local.clear(now);
+    pub fn clear_local(&mut self) {
+        self.local.clear();
     }
 
     pub fn configure(&mut self, config: &MetricsConfiguration) {

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -714,8 +714,9 @@ impl Server {
             }
 
             let now = time::OffsetDateTime::now_utc();
-            // clear local metrics every night at 00:00 to prevent memory overuse
-            if now.hour() == 0 && now.minute() == 00 && now.second() == 0 {
+            // clear the local metrics drain every plain hour (01:00, 02:00, etc.) to prevent memory overuse
+            // TODO: have one-hour-lasting metrics instead
+            if now.minute() == 00 && now.second() == 0 {
                 METRICS.with(|metrics| {
                     (*metrics.borrow_mut()).clear_local();
                 });


### PR DESCRIPTION
Continuation of #783 

This pull request removes what @Geal started to work on but didn't finish.
The cluster metrics are now stored without timestamps, which reduces
the strain on the memory and thus is cleared only everyday at midgnight.
They are stored in a simple binary tree map of the form
`cluster_or_backend_id -> (key, value)`

The relation between is clusters and backend is tracked in another map of the form `backend_id -> cluster_id `

This pull request removes the option to enable the timed collection of metrics.

## to do
- [x] queries for cluster and backend metrics, providing their ids and metric names.
- [x] error management on cluster & backend ids provided by the CLI
- [x] error management alltogether

solves #790  #789 