### PR TITLE
gather and display main process metrics

### DIFF
--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -28,8 +28,8 @@ use crate::{
     ctl::{
         create_channel,
         display::{
-            print_certificates, print_frontend_list, print_json_response, print_metrics,
-            print_query_response_data,
+            print_available_metrics, print_certificates, print_frontend_list, print_json_response,
+            print_metrics, print_query_response_data,
         },
         CommandManager,
     },
@@ -823,11 +823,15 @@ impl CommandManager {
                         bail!("could not query proxy state: {}", message.message);
                     }
                 }
-                CommandStatus::Ok => {
-                    if let Some(CommandResponseData::Query(answers)) = message.data {
-                        print_metrics(answers, json, list)?;
+                CommandStatus::Ok => match message.data {
+                    Some(CommandResponseData::Metrics(aggregated_metrics_data)) => {
+                        print_metrics(aggregated_metrics_data, json)?
                     }
-                }
+                    Some(CommandResponseData::Query(lists_of_metrics)) => {
+                        print_available_metrics(&lists_of_metrics)?;
+                    }
+                    _ => println!("Wrong kind of response here"),
+                },
             }
 
             match refresh {

--- a/command/assets/answer_metrics.json
+++ b/command/assets/answer_metrics.json
@@ -22,48 +22,25 @@
       },
       "workers": {
         "0": {
-          "proxy": {
-            "sozu.count": {
-              "type": "COUNT",
-              "data": -2
-            },
-            "sozu.gauge": {
-              "type": "GAUGE",
-              "data": 1
-            },
-            "sozu.time": {
-              "type": "TIME",
-              "data": 1234
-            }
-          },
-          "clusters": {
-            "cluster_1": {
-              "cluster": {
-                "request_time": {
-                  "type": "PERCENTILES",
-                  "data": {
-                    "samples": 42,
-                    "p_50": 1,
-                    "p_90": 2,
-                    "p_99": 10,
-                    "p_99_9": 12,
-                    "p_99_99": 20,
-                    "p_99_999": 22,
-                    "p_100": 30
-                  }
-                }
+          "All": {
+            "proxy": {
+              "sozu.count": {
+                "type": "COUNT",
+                "data": -2
               },
-              "backends": {
-                "cluster_1-0": {
-                  "bytes_in": {
-                    "type": "COUNT",
-                    "data": 256
-                  },
-                  "bytes_out": {
-                    "type": "COUNT",
-                    "data": 128
-                  },
-                  "percentiles": {
+              "sozu.gauge": {
+                "type": "GAUGE",
+                "data": 1
+              },
+              "sozu.time": {
+                "type": "TIME",
+                "data": 1234
+              }
+            },
+            "clusters": {
+              "cluster_1": {
+                "cluster": {
+                  "request_time": {
                     "type": "PERCENTILES",
                     "data": {
                       "samples": 42,
@@ -74,6 +51,31 @@
                       "p_99_99": 20,
                       "p_99_999": 22,
                       "p_100": 30
+                    }
+                  }
+                },
+                "backends": {
+                  "cluster_1-0": {
+                    "bytes_in": {
+                      "type": "COUNT",
+                      "data": 256
+                    },
+                    "bytes_out": {
+                      "type": "COUNT",
+                      "data": 128
+                    },
+                    "percentiles": {
+                      "type": "PERCENTILES",
+                      "data": {
+                        "samples": 42,
+                        "p_50": 1,
+                        "p_90": 2,
+                        "p_99": 10,
+                        "p_99_9": 12,
+                        "p_99_99": 20,
+                        "p_99_999": 22,
+                        "p_100": 30
+                      }
                     }
                   }
                 }

--- a/command/src/command.rs
+++ b/command/src/command.rs
@@ -2,7 +2,8 @@ use std::{collections::BTreeMap, net::SocketAddr};
 
 use crate::{
     proxy::{
-        AggregatedMetricsData, HttpFrontend, ProxyEvent, ProxyRequestData, QueryAnswer, TcpFrontend,
+        AggregatedMetricsData, HttpFrontend, ProxyEvent, ProxyRequestData, QueryAnswer,
+        QueryAnswerMetrics, TcpFrontend,
     },
     state::ConfigState,
 };
@@ -66,7 +67,7 @@ pub enum CommandStatus {
 #[serde(tag = "type", content = "data", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum CommandResponseData {
     Workers(Vec<WorkerInfo>),
-    Metrics(AggregatedMetricsData), // this isn't used anywhere except in a test
+    Metrics(AggregatedMetricsData),
     Query(BTreeMap<String, QueryAnswer>), // worker_id -> query_answer
     State(ConfigState),
     Event(Event),
@@ -562,7 +563,7 @@ mod tests {
                 .collect(),
                 workers: [(
                     String::from("0"),
-                    WorkerMetrics {
+                    QueryAnswerMetrics::All(WorkerMetrics {
                         proxy: Some(
                             [
                                 (String::from("sozu.gauge"), FilteredData::Gauge(1)),
@@ -635,7 +636,7 @@ mod tests {
                             .cloned()
                             .collect()
                         )
-                    }
+                    })
                 )]
                 .iter()
                 .cloned()

--- a/command/src/proxy.rs
+++ b/command/src/proxy.rs
@@ -98,10 +98,8 @@ pub enum ProxyResponseData {
 /// but it isn't used anywhere here except in a test
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AggregatedMetricsData {
-    /// key -> value
     pub main: BTreeMap<String, FilteredData>,
-    /// worker_id -> proxy & clusters data
-    pub workers: BTreeMap<String, WorkerMetrics>,
+    pub workers: BTreeMap<String, QueryAnswerMetrics>,
 }
 
 /// All metrics of a worker: proxy and clusters

--- a/lib/src/metrics/mod.rs
+++ b/lib/src/metrics/mod.rs
@@ -4,6 +4,7 @@ mod writer;
 
 use std::{
     cell::RefCell,
+    collections::BTreeMap,
     io::{self, Write},
     net::SocketAddr,
     str,
@@ -12,7 +13,9 @@ use std::{
 
 use mio::net::UdpSocket;
 
-use crate::sozu_command::proxy::{MetricsConfiguration, QueryAnswerMetrics, QueryMetricsType};
+use crate::sozu_command::proxy::{
+    FilteredData, MetricsConfiguration, QueryAnswerMetrics, QueryMetricsType,
+};
 
 use self::{local_drain::LocalDrain, network_drain::NetworkDrain};
 
@@ -211,6 +214,10 @@ impl Aggregator {
         if let Some(ref mut net) = self.network.as_mut() {
             net.send_data();
         }
+    }
+
+    pub fn dump_local_proxy_metrics(&mut self) -> BTreeMap<String, FilteredData> {
+        self.local.dump_proxy_metrics(&Vec::new())
     }
 
     pub fn query(&mut self, q: &QueryMetricsType) -> QueryAnswerMetrics {


### PR DESCRIPTION
As a continuation to

- #783 
- #791 

We need to restore the display of the main process metrics next to the worker metrics, as in the 0.13.6 version, of the form:

```
MAIN PROCESS
============
┌─────────────────────────┬───────┬───────┐
│                         │ gauge │ count │
├─────────────────────────┼───────┼───────┤
│ configuration.backends  │ 3     │       │
├─────────────────────────┼───────┼───────┤
│ configuration.clusters  │ 2     │       │
├─────────────────────────┼───────┼───────┤
│ configuration.frontends │ 3     │       │
└─────────────────────────┴───────┴───────┘
```