### PR TITLE
input path rule in config.toml and the CLI

### DIFF
--- a/bin/config.toml
+++ b/bin/config.toml
@@ -129,7 +129,7 @@ tls_provider = "rustls"
 # by default, all listeners start a TCP listen socket o startup
 # if set to false, this option will prevent them from listening. You can then add
 # the complete configuration, and send an ActivateListener message afterwards
-activate_listeners= true
+activate_listeners = true
 
 # various statistics can be sent to a server that supports the statsd protocol
 # You can see those statistics with sozuctl, like this: `sozuctl metrics` or
@@ -245,14 +245,15 @@ load_balancing = "round_robin"
 # possible frontend options:
 # - address: TCP listener
 # - hostname: host name of the cluster
-# - path_begin = "/api" # optional. a cluster can receive requests going to a hostname and path prefix
+# - path = "/api" # optional. A routing rule for incoming requests. The path of the request must match it. Can be a prefix (default), a regex, or a strictly equal path.
+# - path_type = PREFIX | REGEX | EQUALS # defaults to PREFIX
 # - sticky_session = false # activates sticky sessions for this cluster
 # - https_redirect = false #  activates automatic redirection to HTTPS for this cluster
 # - custom_tag: a tag to retrieve a frontend with the CLI or in the logs
 frontends = [
-  { address = "0.0.0.0:8080", hostname = "lolcatho.st", tags = { key = "value" } },
+  { address = "0.0.0.0:8080", hostname = "lolcatho.st", tags = { key = "value" }, path = "/api" },
   # HTTPS frontends also have an optional `tls_versions` key like the HTTPS listeners
-  { address = "0.0.0.0:8443", hostname = "lolcatho.st", tags = { key = "value" }, certificate = "../lib/assets/certificate.pem", key = "../lib/assets/key.pem", certificate_chain = "../lib/assets/certificate_chain.pem" }
+  { address = "0.0.0.0:8443", hostname = "lolcatho.st", tags = { key = "value" }, certificate = "../lib/assets/certificate.pem", key = "../lib/assets/key.pem", certificate_chain = "../lib/assets/certificate_chain.pem" },
 ]
 
 # backends configuration

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -238,7 +238,7 @@ pub enum MetricsCmd {
         #[clap(
             short = 'b',
             long="backends",
-            help="coma-separated list of backends, 'one_backend_id, other_backend_id'",
+            help="coma-separated list of backends, 'one_backend_id,other_backend_id'",
             use_delimiter = true
             // parse(try_from_str = split_slash)
         )]
@@ -430,8 +430,12 @@ pub enum HttpFrontendCmd {
         route: Route,
         #[clap(long = "hostname", aliases = &["host"])]
         hostname: String,
-        #[clap(short = 'p', long = "path", help = "URL prefix of the frontend")]
-        path_begin: Option<String>,
+        #[clap(short = 'p', long = "path-prefix", help = "URL prefix of the frontend")]
+        path_prefix: Option<String>,
+        #[clap(long = "path-regex", help = "the frontend URL path should match this regex")]
+        path_regex: Option<String>,
+        #[clap(long = "path-equals", help = "the frontend URL path should equal this regex")]
+        path_equals: Option<String>,
         #[clap(short = 'm', long = "method", help = "HTTP method")]
         method: Option<String>,
         #[clap(long = "tags", help = "Specify tag (key-value pair) to apply on front-end (example: 'key=value, other-key=other-value')", parse(try_from_str = parse_tags))]
@@ -449,8 +453,12 @@ pub enum HttpFrontendCmd {
         route: Route,
         #[clap(long = "hostname", aliases = &["host"])]
         hostname: String,
-        #[clap(short = 'p', long = "path", help = "URL prefix of the frontend")]
-        path_begin: Option<String>,
+        #[clap(short = 'p', long = "path-prefix", help = "URL prefix of the frontend")]
+        path_prefix: Option<String>,
+        #[clap(long = "path-regex", help = "the frontend URL path should match this regex")]
+        path_regex: Option<String>,
+        #[clap(long = "path-equals", help = "the frontend URL path should equal this regex")]
+        path_equals: Option<String>,
         #[clap(short = 'm', long = "method", help = "HTTP method")]
         method: Option<String>,
     },

--- a/bin/src/command/orders.rs
+++ b/bin/src/command/orders.rs
@@ -879,7 +879,7 @@ impl CommandServer {
     }
 
     // This handles the CLI's "metrics enable", "metrics disable", "metrics clear"
-    // To get the proxy's metrics, the cli command is "query metrics", handled by the query() function
+    // To get the proxy's metrics, the cli command is "metrics get", handled by the query() function
     pub async fn configure_metrics(
         &mut self,
         request_identifier: RequestIdentifier,

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -15,8 +15,8 @@ use sozu_command_lib::{
 
 use crate::{
     cli::{
-        ClusterCmd, BackendCmd, HttpFrontendCmd, HttpListenerCmd, HttpsListenerCmd,
-        LoggingLevel, TcpFrontendCmd, TcpListenerCmd,
+        BackendCmd, ClusterCmd, HttpFrontendCmd, HttpListenerCmd, HttpsListenerCmd, LoggingLevel,
+        TcpFrontendCmd, TcpListenerCmd,
     },
     ctl::CommandManager,
 };
@@ -105,7 +105,9 @@ impl CommandManager {
         match cmd {
             HttpFrontendCmd::Add {
                 hostname,
-                path_begin,
+                path_prefix,
+                path_regex,
+                path_equals,
                 address,
                 method,
                 route,
@@ -114,7 +116,7 @@ impl CommandManager {
                 route: route.into(),
                 address,
                 hostname,
-                path: PathRule::Prefix(path_begin.unwrap_or_else(|| "".to_string())),
+                path: PathRule::from_cli_options(path_prefix, path_regex, path_equals),
                 method: method.map(String::from),
                 position: RulePosition::Tree,
                 tags,
@@ -122,7 +124,9 @@ impl CommandManager {
 
             HttpFrontendCmd::Remove {
                 hostname,
-                path_begin,
+                path_prefix,
+                path_regex,
+                path_equals,
                 address,
                 method,
                 route,
@@ -130,7 +134,7 @@ impl CommandManager {
                 route: route.into(),
                 address,
                 hostname,
-                path: PathRule::Prefix(path_begin.unwrap_or_else(|| "".to_string())),
+                path: PathRule::from_cli_options(path_prefix, path_regex, path_equals),
                 method: method.map(String::from),
                 position: RulePosition::Tree,
                 tags: None,
@@ -142,7 +146,9 @@ impl CommandManager {
         match cmd {
             HttpFrontendCmd::Add {
                 hostname,
-                path_begin,
+                path_prefix,
+                path_regex,
+                path_equals,
                 address,
                 method,
                 route,
@@ -151,14 +157,16 @@ impl CommandManager {
                 route: route.into(),
                 address,
                 hostname,
-                path: PathRule::Prefix(path_begin.unwrap_or_else(|| "".to_string())),
+                path: PathRule::from_cli_options(path_prefix, path_regex, path_equals),
                 method: method.map(String::from),
                 position: RulePosition::Tree,
                 tags,
             })),
             HttpFrontendCmd::Remove {
                 hostname,
-                path_begin,
+                path_prefix,
+                path_regex,
+                path_equals,
                 address,
                 method,
                 route,
@@ -166,7 +174,7 @@ impl CommandManager {
                 route: route.into(),
                 address,
                 hostname,
-                path: PathRule::Prefix(path_begin.unwrap_or_else(|| "".to_string())),
+                path: PathRule::from_cli_options(path_prefix, path_regex, path_equals),
                 method: method.map(String::from),
                 position: RulePosition::Tree,
                 tags: None,

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -346,7 +346,9 @@ pub enum PathRuleType {
 pub struct FileClusterFrontendConfig {
     pub address: SocketAddr,
     pub hostname: Option<String>,
+    /// creates a path routing rule where the request URL path has to match this
     pub path: Option<String>,
+    /// declares wether the path rule is Prefix (default), Regex, or Equals
     pub path_type: Option<PathRuleType>,
     pub method: Option<String>,
     pub certificate: Option<String>,

--- a/command/src/proxy.rs
+++ b/command/src/proxy.rs
@@ -327,12 +327,31 @@ impl Default for RulePosition {
     }
 }
 
+/// A filter for the path of incoming requests
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum PathRule {
+    /// filters paths that start with a pattern, typically "/api"
     Prefix(String),
+    /// filters paths that match a regex pattern
     Regex(String),
+    /// filters paths that exactly match a pattern, no more, no less
     Equals(String),
+}
+
+impl PathRule {
+    pub fn from_cli_options(
+        path_prefix: Option<String>,
+        path_regex: Option<String>,
+        path_equals: Option<String>,
+    ) -> Self {
+        match (path_prefix, path_regex, path_equals) {
+            (Some(prefix), _, _) => PathRule::Prefix(prefix),
+            (None, Some(regex), _) => PathRule::Regex(regex),
+            (None, None, Some(equals)) => PathRule::Equals(equals),
+            _ => PathRule::default(),
+        }
+    }
 }
 
 impl Default for PathRule {
@@ -362,8 +381,9 @@ impl std::fmt::Display for PathRule {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Route {
-    // send a 401 default answer
+    /// send a 401 default answer
     Deny,
+    /// Routes to a cluster.
     // TODO: create a custom type `ClusterId`
     ClusterId(String),
 }

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -46,7 +46,7 @@ impl Router {
             let mut prefix_length = 0;
             let mut res = None;
 
-            for (rule, method_rule, cluster_id) in path_rules.iter() {
+            for (rule, method_rule, cluster_id) in path_rules {
                 match rule.matches(path) {
                     PathRuleResult::Regex | PathRuleResult::Equals => {
                         match method_rule.matches(method) {


### PR DESCRIPTION
Up until now the proxy logic of Sōzu did enforce a PathRule when accepting requests on a frontend:

```rust
/// A filter for the path of incoming requests
#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
pub enum PathRule {
    /// filters paths that start with a pattern, typically "/api"
    Prefix(String),
    /// filters paths that match a regex pattern
    Regex(String),
    /// filters paths that exactly match a pattern, no more, no less
    Equals(String),
}
```

(comments added in this PR)

but it would only effectively apply the Prefix path rule, that was applied by default.

This PR ensures this path rule can be input in the `config.toml`:

```toml
frontends = [
  { address = "0.0.0.0:8080", hostname = "lolcatho.st", tags = { key = "value" }, path = "/[a-z]{3}", path_type = "REGEX" },
]
```

And in the command line

```
sozu --config config.toml frontend http add --address 0.0.0.0:8080 --hostname lolcatho.st  --path-equals api id MyCluster
```


This should please @miton18 I've been told.