### PR TITLE
0.14 refactor status command

### DIFF
--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -130,7 +130,7 @@ pub enum Success {
     Query(CommandResponseData),
     ReloadConfiguration(usize, usize), // ok, errors
     SaveState(usize, String),          // amount of written commands, path of the saved state
-    Status(Vec<WorkerInfo>),
+    Status(CommandResponseData),       // Vec<WorkerInfo>
     SubscribeEvent(String),
     UpgradeMain(i32),         // pid of the new main process
     UpgradeWorker(u32),       // worker id

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -27,7 +27,7 @@ use serde_json;
 use sozu_command_lib::{
     command::{
         CommandRequest, CommandRequestData, CommandResponse, CommandResponseData, CommandStatus,
-        Event, RunState,
+        Event, RunState, WorkerInfo,
     },
     config::Config,
     proxy::{
@@ -130,6 +130,7 @@ pub enum Success {
     Query(CommandResponseData),
     ReloadConfiguration(usize, usize), // ok, errors
     SaveState(usize, String),          // amount of written commands, path of the saved state
+    Status(Vec<WorkerInfo>),
     SubscribeEvent(String),
     UpgradeMain(i32),         // pid of the new main process
     UpgradeWorker(u32),       // worker id
@@ -180,6 +181,9 @@ impl std::fmt::Display for Success {
             ),
             Self::SaveState(counter, path) => {
                 write!(f, "saved {} config messages to {}", counter, path)
+            }
+            Self::Status(_) => {
+                write!(f, "Sent a status response to client")
             }
             Self::SubscribeEvent(client_id) => {
                 write!(f, "Successfully Added {} to subscribers", client_id)

--- a/bin/src/command/worker.rs
+++ b/bin/src/command/worker.rs
@@ -6,7 +6,7 @@ use nix::{sys::signal::kill, unistd::Pid};
 
 use sozu_command_lib::{
     channel::Channel,
-    command::RunState,
+    command::{RunState, WorkerInfo},
     config::Config,
     proxy::{ProxyRequest, ProxyRequestData, ProxyResponse},
     scm_socket::ScmSocket,
@@ -68,6 +68,14 @@ impl Worker {
         match kill(Pid::from_raw(self.pid), None) {
             Ok(_) => true,
             Err(_) => false,
+        }
+    }
+
+    pub fn info(&self) -> WorkerInfo {
+        WorkerInfo {
+            id: self.id.clone(),
+            pid: self.pid.clone(),
+            run_state: self.run_state.clone(),
         }
     }
 

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -28,7 +28,7 @@ use crate::{
         create_channel,
         display::{
             print_available_metrics, print_certificates, print_frontend_list, print_json_response,
-            print_metrics, print_query_response_data,
+            print_metrics, print_query_response_data, print_status,
         },
         CommandManager,
     },
@@ -369,7 +369,7 @@ impl CommandManager {
 
         self.channel.write_message(&CommandRequest::new(
             id.clone(),
-            CommandRequestData::ListWorkers,
+            CommandRequestData::Status,
             None,
         ));
 
@@ -392,7 +392,15 @@ impl CommandManager {
                 }
                 bail!("could not get the worker list: {}", message.message);
             }
-            CommandStatus::Ok => {}
+            CommandStatus::Ok => match message.data {
+                Some(CommandResponseData::Status(worker_info_vec)) => {
+                    print_status(worker_info_vec);
+                }
+                Some(_) => {
+                    bail!("Received the wrong kind of response data from the command server")
+                }
+                None => bail!("No data in the response"),
+            },
         }
         Ok(())
     }

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -7,12 +7,25 @@ use anyhow::{self, bail, Context};
 use prettytable::{Row, Table};
 
 use sozu_command_lib::{
-    command::{CommandResponseData, ListedFrontends},
+    command::{CommandResponseData, ListedFrontends, WorkerInfo},
     proxy::{
         AggregatedMetricsData, ClusterMetricsData, FilteredData, QueryAnswer,
         QueryAnswerCertificate, QueryAnswerMetrics, Route, WorkerMetrics,
     },
 };
+
+pub fn print_status(worker_info_vec: Vec<WorkerInfo>) {
+    let mut table = Table::new();
+    table.set_format(*prettytable::format::consts::FORMAT_BOX_CHARS);
+    table.add_row(row!["worker id", "pid", "run state"]);
+
+    for worker_info in worker_info_vec {
+        let row = row!(worker_info.id, worker_info.pid, worker_info.run_state);
+        table.add_row(row);
+    }
+
+    table.printstd();
+}
 
 pub fn print_frontend_list(frontends: ListedFrontends) {
     trace!(" We received this frontends to display {:#?}", frontends);

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -190,6 +190,7 @@ pub fn fork_main_into_worker(
 
     serde_json::to_writer(&mut state_file, state)
         .with_context(|| "could not write upgrade data to temporary file")?;
+
     state_file
         .seek(SeekFrom::Start(0))
         .with_context(|| "could not seek to beginning of file")?;

--- a/command/src/command.rs
+++ b/command/src/command.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, net::SocketAddr};
+use std::{collections::BTreeMap, fmt, net::SocketAddr};
 
 use crate::{
     proxy::{
@@ -66,6 +66,7 @@ pub enum CommandStatus {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum CommandResponseData {
+    // this is old it seems
     Workers(Vec<WorkerInfo>),
     /// used by the main process to respond to the CLI
     Metrics(AggregatedMetricsData),
@@ -74,6 +75,8 @@ pub enum CommandResponseData {
     State(ConfigState),
     Event(Event),
     FrontendList(ListedFrontends),
+    // this is new
+    Status(Vec<WorkerInfo>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -116,6 +119,12 @@ pub enum RunState {
     Stopping,
     Stopped,
     NotAnswering,
+}
+
+impl fmt::Display for RunState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/command/src/command.rs
+++ b/command/src/command.rs
@@ -23,6 +23,7 @@ pub enum CommandRequestData {
     UpgradeWorker(u32),
     SubscribeEvents,
     ReloadConfiguration { path: Option<String> },
+    Status,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]


### PR DESCRIPTION
The status querying logic, as of now, works like so:

1. the CLI asks for a list of workers
2. the CLI queries each worker individually (through the main process)

This PR aims at putting the whole logic into the main process, so that:

1. the CLI asks the main process for the status
2. the main process queries all workers individually
3. the status is sent to the CLI