### PR TITLE
Fix main process upgrade and shutdown

### DIFF
--- a/bin/src/command/orders.rs
+++ b/bin/src/command/orders.rs
@@ -521,12 +521,12 @@ impl CommandServer {
 
         let upgrade_data = self.generate_upgrade_data();
 
-        let (new_main_pid, mut channel) =
+        let (new_main_pid, mut fork_confirmation_channel) =
             fork_main_into_new_main(self.executable_path.clone(), upgrade_data)
                 .with_context(|| "Could not start a new main process")?;
 
-        channel.set_blocking(true);
-        let received_ok_from_new_process = channel.read_message();
+        fork_confirmation_channel.set_blocking(true);
+        let received_ok_from_new_process = fork_confirmation_channel.read_message();
         debug!("upgrade channel sent {:?}", received_ok_from_new_process);
 
         // signaling the accept loop that it should stop

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -4,7 +4,6 @@ use std::{
     sync::mpsc,
     sync::{Arc, Mutex},
     thread,
-    time::Duration,
 };
 
 use anyhow::{self, bail, Context};
@@ -298,8 +297,8 @@ impl CommandManager {
 
                     // Reconnect to the new main
                     println!("Reconnecting to new main process...");
-                    // self.channel = create_channel(&self.config)
-                    //     .with_context(|| "could not reconnect to the command unix socket")?;
+                    self.channel = create_channel(&self.config)
+                        .with_context(|| "could not reconnect to the command unix socket")?;
 
                     // Do a rolling restart of the workers
                     let running_workers = workers


### PR DESCRIPTION
As explained in

- #795 

Upgrading sozu would crash after a few upgrades. The reason is because of this PR

- #742 

which prevented the main process to actually shut down leading in all sorts of chaotic behaviors. Also

- #743 

made the CTL try to upgrade the workers from the old main instead of the new one after upgrading the main process.