### PR TITLE
0.14 http499

### DIFF
--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -15,8 +15,8 @@ use sozu_command_lib::{
 
 use crate::{
     cli::{
-        ClusterCmd, BackendCmd, HttpFrontendCmd, HttpListenerCmd, HttpsListenerCmd,
-        LoggingLevel, TcpFrontendCmd, TcpListenerCmd,
+        BackendCmd, ClusterCmd, HttpFrontendCmd, HttpListenerCmd, HttpsListenerCmd, LoggingLevel,
+        TcpFrontendCmd, TcpListenerCmd,
     },
     ctl::CommandManager,
 };

--- a/command/src/proxy.rs
+++ b/command/src/proxy.rs
@@ -359,12 +359,14 @@ impl std::fmt::Display for PathRule {
     }
 }
 
+/// The cluster to which the traffic will be redirected
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Route {
-    // send a 401 default answer
+    /// send a 401 default answer
     Deny,
     // TODO: create a custom type `ClusterId`
+    /// the cluster to which the frontend belongs
     ClusterId(String),
 }
 
@@ -592,6 +594,7 @@ pub struct HttpListener {
     #[serde(default)]
     #[serde(skip_serializing_if = "is_false")]
     pub expect_proxy: bool,
+    // TODO: explain what this does
     #[serde(default = "default_sticky_name")]
     pub sticky_name: String,
     /// client inactive time

--- a/command/src/ready.rs
+++ b/command/src/ready.rs
@@ -1,11 +1,13 @@
 use std::fmt;
 
+/// Binary representation of a file descriptor readiness (obtained through epoll)
 #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
 pub struct Ready(pub u16);
 
 const READABLE: u16 = 0b00001;
 const WRITABLE: u16 = 0b00010;
 const ERROR: u16 = 0b00100;
+/// Hang UP (see EPOLLHUP in epoll_ctl man page)
 const HUP: u16 = 0b01000;
 
 impl Ready {
@@ -39,7 +41,7 @@ impl Ready {
     }
 
     #[inline]
-    pub fn is_none(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.0 == 0
     }
 

--- a/lib/src/backends.rs
+++ b/lib/src/backends.rs
@@ -288,10 +288,10 @@ impl BackendList {
         }
 
         if backends.is_empty() {
-            None
-        } else {
-            self.load_balancing.next_available_backend(&mut backends)
+            return None;
         }
+        
+        self.load_balancing.next_available_backend(&mut backends)
     }
 
     pub fn set_load_balancing_policy(

--- a/lib/src/buffer_queue.rs
+++ b/lib/src/buffer_queue.rs
@@ -148,6 +148,7 @@ impl BufferQueue {
         acc
     }
 
+    // same as available_input_data, TODO: delete one of them?
     pub fn input_data_size(&self) -> usize {
         let mut acc = 0usize;
         for el in self.input_queue.iter() {
@@ -316,7 +317,7 @@ impl BufferQueue {
                         delete_ended = true;
                         match el {
                             OutputElement::Slice(sz) => largest_size += *sz,
-                            OutputElement::Insert(v) => return v,
+                            OutputElement::Insert(vec) => return vec,
                             _ => break,
                         }
                     }

--- a/lib/src/https_rustls/session.rs
+++ b/lib/src/https_rustls/session.rs
@@ -933,7 +933,7 @@ impl Session {
     pub fn extract_route(&self) -> Result<(&str, &str, &Method), ConnectionError> {
         let h = self
             .http()
-            .and_then(|h| h.request.as_ref())
+            .and_then(|h| h.request_state.as_ref())
             .and_then(|r| r.get_host())
             .ok_or(ConnectionError::NoHostGiven)?;
 
@@ -975,7 +975,7 @@ impl Session {
 
         let rl: &RRequestLine = self
             .http()
-            .and_then(|h| h.request.as_ref())
+            .and_then(|h| h.request_state.as_ref())
             .and_then(|r| r.get_request_line())
             .ok_or(ConnectionError::NoRequestLineGiven)?;
 
@@ -1017,7 +1017,7 @@ impl Session {
     ) -> Result<TcpStream, ConnectionError> {
         let sticky_session = self
             .http()
-            .and_then(|http| http.request.as_ref())
+            .and_then(|http| http.request_state.as_ref())
             .and_then(|r| r.get_sticky_session());
 
         let res = match (front_should_stick, sticky_session) {
@@ -1258,7 +1258,7 @@ impl ProxySession for Session {
 
         if let Some(State::Http(ref mut http)) = self.protocol {
             //if the state was initial, the connection was already reset
-            if http.request != Some(RequestState::Initial) {
+            if http.request_state != Some(RequestState::Initial) {
                 gauge_add!("http.active_requests", -1);
                 if let Some(b) = http.backend_data.as_mut() {
                     let mut backend = b.borrow_mut();

--- a/lib/src/https_rustls/session.rs
+++ b/lib/src/https_rustls/session.rs
@@ -19,7 +19,7 @@ use crate::{
     protocol::{
         http::{
             answers::HttpAnswers,
-            parser::{hostname_and_port, Method, RRequestLine, RequestState},
+            parser::{hostname_and_port, Method, RequestLine, RequestState},
             DefaultAnswerStatus,
         },
         proxy_protocol::expect::ExpectProxyProtocol,
@@ -973,7 +973,7 @@ impl Session {
             return Err(ConnectionError::InvalidHost);
         };
 
-        let rl: &RRequestLine = self
+        let rl: &RequestLine = self
             .http()
             .and_then(|h| h.request_state.as_ref())
             .and_then(|r| r.get_request_line())

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -222,6 +222,7 @@ use self::retry::RetryPolicy;
 
 pub type ClusterId = String;
 
+/// Anything that can be registered in mio (subscibe to kernel events)
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Protocol {
     HTTP,
@@ -558,7 +559,9 @@ impl std::ops::Drop for Backend {
 
 #[derive(Clone)]
 pub struct Readiness {
+    /// the current readiness
     pub event: Ready,
+    /// the readiness we wish to attain
     pub interest: Ready,
 }
 
@@ -579,6 +582,11 @@ impl Readiness {
     pub fn reset(&mut self) {
         self.event = Ready::empty();
         self.interest = Ready::empty();
+    }
+
+    /// filters the readiness we actually want
+    pub fn filter_interest(&self) -> Ready {
+        self.event & self.interest
     }
 }
 

--- a/lib/src/protocol/http/mod.rs
+++ b/lib/src/protocol/http/mod.rs
@@ -26,7 +26,7 @@ use crate::{
 
 use self::parser::{
     compare_no_case, parse_request_until_stop, parse_response_until_stop, Chunk, Continue, Method,
-    RRequestLine, RStatusLine, RequestState, ResponseState,
+    RequestLine, StatusLine, RequestState, ResponseState,
 };
 
 #[derive(Clone)]
@@ -531,7 +531,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Http<Front, L> {
     }
 
     /// Retrieve the response status from the http response state
-    pub fn get_response_status(&self) -> Option<&RStatusLine> {
+    pub fn get_response_status(&self) -> Option<&StatusLine> {
         self.response.as_ref().and_then(|r| r.get_status_line())
     }
 
@@ -539,7 +539,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Http<Front, L> {
         self.request_state.as_ref().and_then(|r| r.get_host())
     }
 
-    pub fn get_request_line(&self) -> Option<&RRequestLine> {
+    pub fn get_request_line(&self) -> Option<&RequestLine> {
         self.request_state
             .as_ref()
             .and_then(|r| r.get_request_line())
@@ -1877,7 +1877,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Http<Front, L> {
 }
 
 /// Save the backend http response status code metric
-fn save_http_status_metric(rs_status_line: Option<&RStatusLine>) {
+fn save_http_status_metric(rs_status_line: Option<&StatusLine>) {
     if let Some(rs_status_line) = rs_status_line {
         match rs_status_line.status {
             100..=199 => {

--- a/lib/src/protocol/http/mod.rs
+++ b/lib/src/protocol/http/mod.rs
@@ -1800,6 +1800,10 @@ impl<Front: SocketHandler, L: ListenerHandler> Http<Front, L> {
                     self.res_header_end = header_end2;
                 };
 
+                // we may check for 499 with get_status_line
+                // here and return (ProtocolResult::Continue, SessionResult::CloseSession)
+                // this should close the connection without sending a response to the client
+
                 if unwrap_msg!(self.response_state.as_ref()).is_back_error() {
                     self.set_answer(DefaultAnswerStatus::Answer502, None);
                     return (ProtocolResult::Continue, self.writable(metrics));

--- a/lib/src/protocol/http/parser/mod.rs
+++ b/lib/src/protocol/http/parser/mod.rs
@@ -485,10 +485,9 @@ pub fn hostname_and_port(i: &[u8]) -> IResult<&[u8], (&[u8], Option<&[u8]>)> {
     let (i, port) = opt(preceded(bytes::complete::tag(":"), digit_complete))(i)?;
 
     if !i.is_empty() {
-        Err(Err::Error(Error::new(i, ErrorKind::Eof)))
-    } else {
-        Ok((i, (host, port)))
+        return Err(Err::Error(Error::new(i, ErrorKind::Eof)));
     }
+    Ok((i, (host, port)))
 }
 
 pub fn is_hex_digit(chr: u8) -> bool {
@@ -1010,6 +1009,7 @@ pub struct Connection {
     pub upgrade: Option<String>,
     pub to_delete: Option<HashSet<Vec<u8>>>,
     pub continues: Continue,
+    /// ensures that a session always redirects to the same backend
     pub sticky_session: Option<String>,
     pub forwarded: ForwardedHeaders,
 }

--- a/lib/src/protocol/http/parser/request.rs
+++ b/lib/src/protocol/http/parser/request.rs
@@ -10,26 +10,26 @@ use crate::{
 
 use super::{
     crlf, message_header, request_line, BufferMove, Chunk, Connection, Continue, Header,
-    HeaderValue, Host, LengthInformation, Method, RRequestLine, TransferEncodingValue, Version,
+    HeaderValue, Host, LengthInformation, Method, RequestLine, TransferEncodingValue, Version,
 };
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum RequestState {
     Initial,
     Error(
-        Option<RRequestLine>,
+        Option<RequestLine>,
         Option<Connection>,
         Option<Host>,
         Option<LengthInformation>,
         Option<Chunk>,
     ),
-    HasRequestLine(RRequestLine, Connection),
-    HasHost(RRequestLine, Connection, Host),
-    HasLength(RRequestLine, Connection, LengthInformation),
-    HasHostAndLength(RRequestLine, Connection, Host, LengthInformation),
-    Request(RRequestLine, Connection, Host),
-    RequestWithBody(RRequestLine, Connection, Host, usize),
-    RequestWithBodyChunks(RRequestLine, Connection, Host, Chunk),
+    HasRequestLine(RequestLine, Connection),
+    HasHost(RequestLine, Connection, Host),
+    HasLength(RequestLine, Connection, LengthInformation),
+    HasHostAndLength(RequestLine, Connection, Host, LengthInformation),
+    Request(RequestLine, Connection, Host),
+    RequestWithBody(RequestLine, Connection, Host, usize),
+    RequestWithBodyChunks(RequestLine, Connection, Host, Chunk),
 }
 
 impl RequestState {
@@ -126,7 +126,7 @@ impl RequestState {
         }
     }
 
-    pub fn get_request_line(&self) -> Option<&RRequestLine> {
+    pub fn get_request_line(&self) -> Option<&RequestLine> {
         match *self {
             RequestState::HasRequestLine(ref rl, _)
             | RequestState::HasHost(ref rl, _, _)
@@ -359,7 +359,7 @@ pub fn parse_request(
                 res => return default_request_result(state, res),
             };
 
-            let request_line = match RRequestLine::from_request_line(raw_request_line) {
+            let request_line = match RequestLine::from_raw_request_line(raw_request_line) {
                 Some(request_line) => request_line,
                 None => return (BufferMove::None, (RequestState::Initial).into_error()),
             };

--- a/lib/src/protocol/http/parser/request.rs
+++ b/lib/src/protocol/http/parser/request.rs
@@ -346,6 +346,7 @@ pub fn parse_header<'a>(
     }
 }
 
+/// a request parsing step, depending on the request state
 pub fn parse_request(
     state: RequestState,
     buf: &[u8],
@@ -353,45 +354,41 @@ pub fn parse_request(
 ) -> (BufferMove, RequestState) {
     match state {
         RequestState::Initial => {
-            match request_line(buf) {
-                Ok((i, r)) => {
-                    if let Some(rl) = RRequestLine::from_request_line(r) {
-                        let conn = Connection::new();
-                        //FIXME: what if it's not absolute path or complete URL, but an authority with CONNECT?
-                        if !rl.uri.is_empty() && rl.uri.as_bytes()[0] != b'/' {
-                            if let Some(host) = Url::parse(&rl.uri)
-                                .ok()
-                                .and_then(|u| u.host_str().map(|s| s.to_string()))
-                            {
-                                (
-                                    BufferMove::Advance(buf.offset(i)),
-                                    RequestState::HasHost(rl, conn, host),
-                                )
-                            } else {
-                                (BufferMove::None, (RequestState::Initial).into_error())
-                            }
-                        } else {
-                            /*let conn = if rl.version == "11" {
-                              Connection::keep_alive()
-                            } else {
-                              Connection::close()
-                            };
-                            */
-                            (
-                                BufferMove::Advance(buf.offset(i)),
-                                RequestState::HasRequestLine(rl, conn),
-                            )
-                        }
-                    } else {
-                        (BufferMove::None, (RequestState::Initial).into_error())
-                    }
-                }
-                res => default_request_result(state, res),
+            let (input, raw_request_line) = match request_line(buf) {
+                Ok((i, r)) => (i, r),
+                res => return default_request_result(state, res),
+            };
+
+            let request_line = match RRequestLine::from_request_line(raw_request_line) {
+                Some(request_line) => request_line,
+                None => return (BufferMove::None, (RequestState::Initial).into_error()),
+            };
+
+            let conn = Connection::new();
+            //FIXME: what if it's not absolute path or complete URL, but an authority with CONNECT?
+            if request_line.uri.is_empty() || request_line.uri.as_bytes()[0] == b'/' {
+                return (
+                    BufferMove::Advance(buf.offset(input)),
+                    RequestState::HasRequestLine(request_line, conn),
+                );
             }
+
+            let host = match Url::parse(&request_line.uri)
+                .ok()
+                .and_then(|url| url.host_str().map(|s| s.to_string()))
+            {
+                Some(host) => host,
+                None => return (BufferMove::None, (RequestState::Initial).into_error()),
+            };
+
+            (
+                BufferMove::Advance(buf.offset(input)),
+                RequestState::HasHost(request_line, conn, host),
+            )
         }
         RequestState::HasRequestLine(rl, conn) => match message_header(buf) {
             Ok((i, header)) => {
-                let mv = if header.should_delete(&conn, sticky_name) {
+                let buffer_move = if header.should_delete(&conn, sticky_name) {
                     BufferMove::Delete(buf.offset(i))
                 } else if header.must_mutate() {
                     BufferMove::Multiple(header.mutate_header(buf, buf.offset(i), sticky_name))
@@ -399,7 +396,7 @@ pub fn parse_request(
                     BufferMove::Advance(buf.offset(i))
                 };
                 (
-                    mv,
+                    buffer_move,
                     validate_request_header(
                         RequestState::HasRequestLine(rl, conn),
                         &header,
@@ -412,7 +409,7 @@ pub fn parse_request(
         RequestState::HasHost(rl, conn, h) => {
             match message_header(buf) {
                 Ok((i, header)) => {
-                    let mv = if header.should_delete(&conn, sticky_name) {
+                    let buffer_move = if header.should_delete(&conn, sticky_name) {
                         BufferMove::Delete(buf.offset(i))
                     } else if header.must_mutate() {
                         BufferMove::Multiple(header.mutate_header(buf, buf.offset(i), sticky_name))
@@ -420,7 +417,7 @@ pub fn parse_request(
                         BufferMove::Advance(buf.offset(i))
                     };
                     (
-                        mv,
+                        buffer_move,
                         validate_request_header(
                             RequestState::HasHost(rl, conn, h),
                             &header,
@@ -445,7 +442,7 @@ pub fn parse_request(
         }
         RequestState::HasLength(rl, conn, l) => match message_header(buf) {
             Ok((i, header)) => {
-                let mv = if header.should_delete(&conn, sticky_name) {
+                let buffer_move = if header.should_delete(&conn, sticky_name) {
                     BufferMove::Delete(buf.offset(i))
                 } else if header.must_mutate() {
                     BufferMove::Multiple(header.mutate_header(buf, buf.offset(i), sticky_name))
@@ -453,7 +450,7 @@ pub fn parse_request(
                     BufferMove::Advance(buf.offset(i))
                 };
                 (
-                    mv,
+                    buffer_move,
                     validate_request_header(
                         RequestState::HasLength(rl, conn, l),
                         &header,
@@ -465,7 +462,7 @@ pub fn parse_request(
         },
         RequestState::HasHostAndLength(rl, conn, h, l) => match message_header(buf) {
             Ok((i, header)) => {
-                let mv = if header.should_delete(&conn, sticky_name) {
+                let buffer_move = if header.should_delete(&conn, sticky_name) {
                     BufferMove::Delete(buf.offset(i))
                 } else if header.must_mutate() {
                     BufferMove::Multiple(header.mutate_header(buf, buf.offset(i), sticky_name))
@@ -473,7 +470,7 @@ pub fn parse_request(
                     BufferMove::Advance(buf.offset(i))
                 };
                 (
-                    mv,
+                    buffer_move,
                     validate_request_header(
                         RequestState::HasHostAndLength(rl, conn, h, l),
                         &header,
@@ -523,6 +520,7 @@ pub fn parse_request(
     }
 }
 
+/// it seems this function parse a request until the end of headers (including the delimiting CRLF)
 pub fn parse_request_until_stop(
     mut current_state: RequestState,
     mut header_end: Option<usize>,
@@ -531,17 +529,18 @@ pub fn parse_request_until_stop(
     sticky_name: &str,
 ) -> (RequestState, Option<usize>) {
     loop {
-        let (mv, new_state) = parse_request(current_state, buf.unparsed_data(), sticky_name);
+        let (buffer_move, new_state) =
+            parse_request(current_state, buf.unparsed_data(), sticky_name);
         //println!("PARSER\t{}\tinput:\n{}\nmv: {:?}, new state: {:?}\n", request_id, &buf.unparsed_data().to_hex(16), mv, new_state);
         //trace!("PARSER\t{}\tinput:\n{}\nmv: {:?}, new state: {:?}\n", request_id, &buf.unparsed_data().to_hex(16), mv, new_state);
         //trace!("PARSER\t{}\tmv: {:?}, new state: {:?}\n", request_id, mv, new_state);
         current_state = new_state;
 
-        match mv {
-            BufferMove::Advance(sz) => {
-                assert!(sz != 0, "buffer move should not be 0");
+        match buffer_move {
+            BufferMove::Advance(size) => {
+                assert!(size != 0, "buffer move should not be 0");
                 //FIXME: what if we advance past the buffer's end? Splice?
-                buf.consume_parsed_data(sz);
+                buf.consume_parsed_data(size);
                 if header_end.is_none() {
                     match current_state {
                         RequestState::Request(_, ref conn, _)
@@ -554,7 +553,7 @@ pub fn parse_request_until_stop(
                                 buf.insert_output(s.into_bytes());
                             }
 
-                            buf.slice_output(sz);
+                            buf.slice_output(size);
                         }
                         RequestState::RequestWithBody(_, ref mut conn, _, content_length) => {
                             header_end = Some(buf.start_parsing_position);
@@ -566,19 +565,19 @@ pub fn parse_request_until_stop(
 
                             // If we got "Expects: 100-continue", the body will be sent later
                             if conn.continues == Continue::None {
-                                buf.slice_output(sz + content_length);
+                                buf.slice_output(size + content_length);
                                 buf.consume_parsed_data(content_length);
                             } else {
-                                buf.slice_output(sz);
+                                buf.slice_output(size);
                                 conn.continues = Continue::Expects(content_length);
                             }
                         }
                         _ => {
-                            buf.slice_output(sz);
+                            buf.slice_output(size);
                         }
                     }
                 } else {
-                    buf.slice_output(sz);
+                    buf.slice_output(size);
                 }
             }
             BufferMove::Delete(length) => {

--- a/lib/src/protocol/http/parser/response.rs
+++ b/lib/src/protocol/http/parser/response.rs
@@ -269,10 +269,6 @@ pub fn parse_response(
             match status_line(buf) {
                 Ok((input, raw_status_line)) => {
                     match StatusLine::from_raw_status_line(raw_status_line) {
-                        // We may handle 499
-                        // Some(499) => {
-                        //     (BufferMove::None, ResponseState::Error())
-                        // }
                         Some(status_line) => {
                             let conn = Connection::new();
                             /*let conn = if rl.version == "11" {

--- a/lib/src/protocol/http/parser/tests.rs
+++ b/lib/src/protocol/http/parser/tests.rs
@@ -25,7 +25,7 @@ fn size_test() {
 fn request_line_test() {
     let input = b"GET /index.html HTTP/1.1\r\n";
     let result = request_line(input);
-    let expected = RequestLine {
+    let expected = RawRequestLine {
         method: b"GET",
         uri: b"/index.html",
         version: Version::V11,
@@ -133,7 +133,7 @@ fn parse_state_host_in_url_test() {
         result,
         (
             RequestState::RequestWithBody(
-                RRequestLine {
+                RequestLine {
                     method: Method::Get,
                     uri: String::from("http://example.com:8888/index.html"),
                     version: Version::V11
@@ -175,7 +175,7 @@ fn parse_state_host_in_url_conflict_test() {
         result,
         (
             RequestState::Error(
-                Some(RRequestLine {
+                Some(RequestLine {
                     method: Method::Get,
                     uri: String::from("http://example.com:8888/index.html"),
                     version: Version::V11
@@ -225,7 +225,7 @@ fn parse_state_content_length_test() {
         result,
         (
             RequestState::RequestWithBody(
-                RRequestLine {
+                RequestLine {
                     method: Method::Get,
                     uri: String::from("/index.html"),
                     version: Version::V11
@@ -248,7 +248,7 @@ fn parse_state_content_length_partial() {
           Content-Length: 200\r\n\
           \r\n";
     let initial = RequestState::HasRequestLine(
-        RRequestLine {
+        RequestLine {
             method: Method::Get,
             uri: String::from("/index.html"),
             version: Version::V11,
@@ -293,7 +293,7 @@ fn parse_state_content_length_partial() {
         result,
         (
             RequestState::RequestWithBody(
-                RRequestLine {
+                RequestLine {
                     method: Method::Get,
                     uri: String::from("/index.html"),
                     version: Version::V11
@@ -327,7 +327,7 @@ fn parse_state_chunked_test() {
         result,
         (
             RequestState::RequestWithBodyChunks(
-                RRequestLine {
+                RequestLine {
                     method: Method::Get,
                     uri: String::from("/index.html"),
                     version: Version::V11
@@ -362,7 +362,7 @@ fn parse_state_duplicate_content_length_test() {
         result,
         (
             RequestState::Error(
-                Some(RRequestLine {
+                Some(RequestLine {
                     method: Method::Get,
                     uri: String::from("/index.html"),
                     version: Version::V11
@@ -399,7 +399,7 @@ fn parse_state_content_length_and_chunked_test() {
         result,
         (
             RequestState::RequestWithBodyChunks(
-                RRequestLine {
+                RequestLine {
                     method: Method::Get,
                     uri: String::from("/index.html"),
                     version: Version::V11
@@ -443,7 +443,7 @@ fn parse_request_without_length() {
         result,
         (
             RequestState::Request(
-                RRequestLine {
+                RequestLine {
                     method: Method::Get,
                     uri: String::from("/"),
                     version: Version::V11
@@ -474,7 +474,7 @@ fn parse_request_http_1_0_connection_close() {
         result,
         (
             RequestState::Request(
-                RRequestLine {
+                RequestLine {
                     method: Method::Get,
                     uri: String::from("/"),
                     version: Version::V10
@@ -518,7 +518,7 @@ fn parse_request_http_1_0_connection_keep_alive() {
         result,
         (
             RequestState::Request(
-                RRequestLine {
+                RequestLine {
                     method: Method::Get,
                     uri: String::from("/"),
                     version: Version::V10
@@ -559,7 +559,7 @@ fn parse_request_http_1_1_connection_keep_alive() {
         result,
         (
             RequestState::Request(
-                RRequestLine {
+                RequestLine {
                     method: Method::Get,
                     uri: String::from("/"),
                     version: Version::V11
@@ -602,7 +602,7 @@ fn parse_request_http_1_1_connection_close() {
         result,
         (
             RequestState::Request(
-                RRequestLine {
+                RequestLine {
                     method: Method::Get,
                     uri: String::from("/"),
                     version: Version::V11
@@ -668,7 +668,7 @@ fn parse_request_add_header_test() {
         result,
         (
             RequestState::RequestWithBody(
-                RRequestLine {
+                RequestLine {
                     method: Method::Get,
                     uri: String::from("/index.html"),
                     version: Version::V11
@@ -739,7 +739,7 @@ fn parse_request_delete_forwarded_headers() {
         result,
         (
             RequestState::Request(
-                RRequestLine {
+                RequestLine {
                     method: Method::Get,
                     uri: String::from("/index.html"),
                     version: Version::V11
@@ -836,7 +836,7 @@ fn parse_requests_and_chunks_test() {
         result,
         (
             RequestState::RequestWithBodyChunks(
-                RRequestLine {
+                RequestLine {
                     method: Method::Post,
                     uri: String::from("/index.html"),
                     version: Version::V11
@@ -878,7 +878,7 @@ fn parse_requests_and_chunks_partial_test() {
         result,
         (
             RequestState::RequestWithBodyChunks(
-                RRequestLine {
+                RequestLine {
                     method: Method::Post,
                     uri: String::from("/index.html"),
                     version: Version::V11
@@ -902,7 +902,7 @@ fn parse_requests_and_chunks_partial_test() {
         result,
         (
             RequestState::RequestWithBodyChunks(
-                RRequestLine {
+                RequestLine {
                     method: Method::Post,
                     uri: String::from("/index.html"),
                     version: Version::V11
@@ -924,7 +924,7 @@ fn parse_requests_and_chunks_partial_test() {
         result,
         (
             RequestState::RequestWithBodyChunks(
-                RRequestLine {
+                RequestLine {
                     method: Method::Post,
                     uri: String::from("/index.html"),
                     version: Version::V11
@@ -974,7 +974,7 @@ fn parse_response_and_chunks_partial_test() {
         result,
         (
             ResponseState::ResponseWithBodyChunks(
-                RStatusLine {
+                StatusLine {
                     version: Version::V11,
                     status: 200,
                     reason: String::from("OK")
@@ -1006,7 +1006,7 @@ fn parse_response_and_chunks_partial_test() {
         result,
         (
             ResponseState::ResponseWithBodyChunks(
-                RStatusLine {
+                StatusLine {
                     version: Version::V11,
                     status: 200,
                     reason: String::from("OK")
@@ -1038,7 +1038,7 @@ fn parse_response_and_chunks_partial_test() {
         result,
         (
             ResponseState::ResponseWithBodyChunks(
-                RStatusLine {
+                StatusLine {
                     version: Version::V11,
                     status: 200,
                     reason: String::from("OK")
@@ -1069,7 +1069,7 @@ fn parse_response_and_chunks_partial_test() {
         result,
         (
             ResponseState::ResponseWithBodyChunks(
-                RStatusLine {
+                StatusLine {
                     version: Version::V11,
                     status: 200,
                     reason: String::from("OK")
@@ -1099,7 +1099,7 @@ fn parse_incomplete_chunk_header_test() {
           0\r\n\
           \r\n";
     let initial = ResponseState::HasLength(
-        RStatusLine {
+        StatusLine {
             version: Version::V11,
             status: 200,
             reason: String::from("OK"),
@@ -1135,7 +1135,7 @@ fn parse_incomplete_chunk_header_test() {
         result,
         (
             ResponseState::ResponseWithBodyChunks(
-                RStatusLine {
+                StatusLine {
                     version: Version::V11,
                     status: 200,
                     reason: String::from("OK")
@@ -1166,7 +1166,7 @@ fn parse_incomplete_chunk_header_test() {
         result,
         (
             ResponseState::ResponseWithBodyChunks(
-                RStatusLine {
+                StatusLine {
                     version: Version::V11,
                     status: 200,
                     reason: String::from("OK")
@@ -1199,7 +1199,7 @@ fn parse_incomplete_chunk_header_test() {
         result,
         (
             ResponseState::ResponseWithBodyChunks(
-                RStatusLine {
+                StatusLine {
                     version: Version::V11,
                     status: 200,
                     reason: String::from("OK")
@@ -1228,7 +1228,7 @@ fn parse_incomplete_chunk_header_test() {
         result,
         (
             ResponseState::ResponseWithBodyChunks(
-                RStatusLine {
+                StatusLine {
                     version: Version::V11,
                     status: 200,
                     reason: String::from("OK")
@@ -1286,7 +1286,7 @@ fn parse_response_302() {
         result,
         (
             ResponseState::ResponseWithBody(
-                RStatusLine {
+                StatusLine {
                     version: Version::V11,
                     status: 302,
                     reason: String::from("Found")
@@ -1343,7 +1343,7 @@ fn parse_response_303() {
         result,
         (
             ResponseState::ResponseWithBody(
-                RStatusLine {
+                StatusLine {
                     version: Version::V11,
                     status: 303,
                     reason: String::from("See Other")
@@ -1398,7 +1398,7 @@ fn parse_response_304() {
         result,
         (
             ResponseState::Response(
-                RStatusLine {
+                StatusLine {
                     version: Version::V11,
                     status: 304,
                     reason: String::from("Not Modified")
@@ -1497,7 +1497,7 @@ fn parse_state_head_with_content_length_test() {
         result,
         (
             ResponseState::Response(
-                RStatusLine {
+                StatusLine {
                     version: Version::V11,
                     status: 200,
                     reason: String::from("Ok")
@@ -1546,7 +1546,7 @@ fn parse_connection_upgrade_test() {
         result,
         (
             RequestState::Request(
-                RRequestLine {
+                RequestLine {
                     method: Method::Get,
                     uri: String::from("/index.html"),
                     version: Version::V11

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -33,7 +33,7 @@ impl Router {
     }
 
     pub fn lookup(&self, hostname: &[u8], path: &[u8], method: &Method) -> Option<Route> {
-        for (domain_rule, path_rule, method_rule, cluster_id) in self.pre.iter() {
+        for (domain_rule, path_rule, method_rule, cluster_id) in &self.pre {
             if domain_rule.matches(hostname)
                 && path_rule.matches(path) != PathRuleResult::None
                 && method_rule.matches(method) != MethodRuleResult::None
@@ -46,7 +46,7 @@ impl Router {
             let mut prefix_length = 0;
             let mut res = None;
 
-            for (rule, method_rule, cluster_id) in path_rules.iter() {
+            for (rule, method_rule, cluster_id) in path_rules {
                 match rule.matches(path) {
                     PathRuleResult::Regex | PathRuleResult::Equals => {
                         match method_rule.matches(method) {
@@ -58,16 +58,16 @@ impl Router {
                             MethodRuleResult::None => {}
                         }
                     }
-                    PathRuleResult::Prefix(sz) => {
-                        if sz >= prefix_length {
+                    PathRuleResult::Prefix(size) => {
+                        if size >= prefix_length {
                             match method_rule.matches(method) {
                                 // FIXME: the rule order will be important here
                                 MethodRuleResult::Equals => {
-                                    prefix_length = sz;
+                                    prefix_length = size;
                                     res = Some(cluster_id);
                                 }
                                 MethodRuleResult::All => {
-                                    prefix_length = sz;
+                                    prefix_length = size;
                                     res = Some(cluster_id);
                                 }
                                 MethodRuleResult::None => {}


### PR DESCRIPTION
Tackling the issue

- #767

we found inconsistencies in variable names around request parsing.
We may still introduce the 499 status code handling, but this should be merged anyway.