### PR TITLE
0.14 request identifier/summary in the Command Server

### DIFF
--- a/bin/config.toml
+++ b/bin/config.toml
@@ -17,7 +17,7 @@
 # "trace". For performance reasons, the logs at "debug" or "trace" level are
 # not compiled by default. To activate them, pass the "logs-debug" and
 # "logs-trace" compilation options to cargo
-log_level = "info"
+log_level = "debug"
 
 # where the logs will be sent. It defaults to sending the logs on standard output,
 # but they could be written to a UDP address:
@@ -50,7 +50,7 @@ max_command_buffer_size = 163840
 
 # the number of worker processes that will handle traffic
 # defaults to 2 workers
-worker_count = 2
+worker_count = 1
 
 # indicates if workers should be automatically restarted if they crash / hang
 # should be true for production and false for development
@@ -89,7 +89,7 @@ buffer_size = 16393
 
 # how much time (in milliseconds) sozuctl will wait for a command to complete.
 # Defaults to 1000 milliseconds
-#ctl_command_timeout = 1000
+ctl_command_timeout = 5000
 
 # PID file is a file containing the PID of the main process of sozu.
 # It can be helpful to help systemd or any other service system to keep track

--- a/bin/src/command/request_summary.rs
+++ b/bin/src/command/request_summary.rs
@@ -1,0 +1,76 @@
+use serde::{Deserialize, Serialize};
+
+/// keeps track of a request metadata, as handled by the CommandServer
+#[derive(Clone, Debug, Serialize)]
+pub struct RequestSummary {
+    /// the worker we send the request to
+    pub worker_id: u32,
+    /// the request id as sent within ProxyRequest
+    pub id: String,
+    /// the client who sent the request
+    pub client: Option<String>,
+    /// In certain cases, the same response may need to be transmitted several times over
+    pub expected_responses: usize,
+}
+
+impl RequestSummary {
+    pub fn default_with_request_id(id: &str) -> Self {
+        Self {
+            worker_id: 0, // defaults to zero, don't forget to update!
+            id: id.to_owned(),
+            client: None,
+            expected_responses: 1,
+        }
+    }
+
+    pub fn with_worker(&self, worker_id: &u32) -> Self {
+        Self {
+            id: self.id,
+            worker_id: worker_id.to_owned(),
+            client: self.client,
+            expected_responses: self.expected_responses,
+        }
+    }
+
+    pub fn with_client(self, client_id: &str) -> Self {
+        self.client = Some(client_id.to_owned());
+        self
+    }
+
+    pub fn with_expected_responses(&mut self, expected_responses: usize) {
+        self.expected_responses = expected_responses;
+    }
+
+    pub fn append_suffix_to_id(&self, suffix: &str) -> Self {
+        let mut new_request_id = String::new();
+        match self.client {
+            Some(client) => new_request_id.push_str(&format!("{}-", &client)),
+            None => {}
+        }
+        new_request_id.push_str(&format!("{}-", suffix));
+        new_request_id.push_str(&format!("{}-", self.id));
+        match self.client {
+            Some(worker) => new_request_id.push_str(&format!("{}", &worker)),
+            None => {}
+        }
+        Self {
+            id: new_request_id,
+            worker_id: self.worker_id,
+            client: self.client,
+            expected_responses: self.expected_responses,
+        }
+    }
+
+    pub fn add_counter(&self, counter: usize) -> Self {
+        Self {
+            id: format!("{}-{}", self.id, counter),
+            worker_id: self.worker_id,
+            client: self.client,
+            expected_responses: self.expected_responses,
+        }
+    }
+
+    pub fn id(&self) -> String {
+        self.id.to_owned()
+    }
+}

--- a/bin/src/command/worker.rs
+++ b/bin/src/command/worker.rs
@@ -46,12 +46,12 @@ impl Worker {
         }
     }
 
-    pub async fn send(&mut self, request_id: String, data: ProxyRequestOrder) {
+    pub async fn send(&mut self, request_id: String, order: ProxyRequestOrder) {
         if let Some(worker_tx) = self.sender.as_mut() {
             if let Err(e) = worker_tx
                 .send(ProxyRequest {
                     id: request_id.clone(),
-                    order: data,
+                    order,
                 })
                 .await
             {

--- a/bin/src/command/worker.rs
+++ b/bin/src/command/worker.rs
@@ -8,7 +8,7 @@ use sozu_command_lib::{
     channel::Channel,
     command::RunState,
     config::Config,
-    proxy::{ProxyRequest, ProxyRequestData, ProxyResponse},
+    proxy::{ProxyRequest, ProxyRequestOrder, ProxyResponse},
     scm_socket::ScmSocket,
 };
 
@@ -46,7 +46,7 @@ impl Worker {
         }
     }
 
-    pub async fn send(&mut self, request_id: String, data: ProxyRequestData) {
+    pub async fn send(&mut self, request_id: String, data: ProxyRequestOrder) {
         if let Some(worker_tx) = self.sender.as_mut() {
             if let Err(e) = worker_tx
                 .send(ProxyRequest {

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -14,11 +14,11 @@ use serde::Serialize;
 
 use sozu_command_lib::{
     command::{
-        CommandRequest, CommandRequestData, CommandResponse, CommandResponseData, CommandStatus,
+        CommandRequest, CommandRequestOrder, CommandResponse, CommandResponseContent, CommandStatus,
         FrontendFilters, RunState, WorkerInfo,
     },
     proxy::{
-        MetricsConfiguration, ProxyRequestData, Query, QueryCertificateType, QueryClusterDomain,
+        MetricsConfiguration, ProxyRequestOrder, Query, QueryCertificateType, QueryClusterDomain,
         QueryClusterType, QueryMetricsOptions,
     },
 };
@@ -75,7 +75,7 @@ impl CommandManager {
         let id = generate_id();
         self.channel.write_message(&CommandRequest::new(
             id.clone(),
-            CommandRequestData::SaveState { path },
+            CommandRequestOrder::SaveState { path },
             None,
         ));
 
@@ -105,7 +105,7 @@ impl CommandManager {
         let id = generate_id();
         self.channel.write_message(&CommandRequest::new(
             id.clone(),
-            CommandRequestData::LoadState { path: path.clone() },
+            CommandRequestOrder::LoadState { path: path.clone() },
             None,
         ));
 
@@ -135,7 +135,7 @@ impl CommandManager {
         let id = generate_id();
         self.channel.write_message(&CommandRequest::new(
             id.clone(),
-            CommandRequestData::DumpState,
+            CommandRequestOrder::DumpState,
             None,
         ));
 
@@ -157,7 +157,7 @@ impl CommandManager {
                 bail!("could not dump proxy state: {}", message.message);
             }
             CommandStatus::Ok => {
-                if let Some(CommandResponseData::State(state)) = message.data {
+                if let Some(CommandResponseContent::State(state)) = message.content {
                     if json {
                         print_json_response(&state)?;
                     } else {
@@ -176,7 +176,7 @@ impl CommandManager {
         let id = generate_id();
         self.channel.write_message(&CommandRequest::new(
             id.clone(),
-            CommandRequestData::Proxy(ProxyRequestData::SoftStop),
+            CommandRequestOrder::Proxy(ProxyRequestOrder::SoftStop),
             proxy_id,
         ));
 
@@ -205,7 +205,7 @@ impl CommandManager {
         let id = generate_id();
         self.channel.write_message(&CommandRequest::new(
             id.clone(),
-            CommandRequestData::Proxy(ProxyRequestData::HardStop),
+            CommandRequestOrder::Proxy(ProxyRequestOrder::HardStop),
             proxy_id,
         ));
 
@@ -236,7 +236,7 @@ impl CommandManager {
         let id = generate_tagged_id("LIST-WORKERS");
         self.channel.write_message(&CommandRequest::new(
             id.clone(),
-            CommandRequestData::ListWorkers,
+            CommandRequestOrder::ListWorkers,
             None,
         ));
 
@@ -256,7 +256,7 @@ impl CommandManager {
                 );
             }
             CommandStatus::Ok => {
-                if let Some(CommandResponseData::Workers(ref workers)) = message.data {
+                if let Some(CommandResponseContent::Workers(ref workers)) = message.content {
                     let mut table = Table::new();
                     table.set_format(*prettytable::format::consts::FORMAT_BOX_CHARS);
                     table.add_row(row!["Worker", "pid", "run state"]);
@@ -271,7 +271,7 @@ impl CommandManager {
                     let id = generate_tagged_id("UPGRADE-MAIN");
                     self.channel.write_message(&CommandRequest::new(
                         id.clone(),
-                        CommandRequestData::UpgradeMain,
+                        CommandRequestOrder::UpgradeMain,
                         None,
                     ));
                     println!("Upgrading main process");
@@ -332,7 +332,7 @@ impl CommandManager {
         let id = generate_id();
         self.channel.write_message(&CommandRequest::new(
             id.clone(),
-            CommandRequestData::UpgradeWorker(worker_id),
+            CommandRequestOrder::UpgradeWorker(worker_id),
             //FIXME: we should be able to soft stop one specific worker
             None,
         ));
@@ -375,7 +375,7 @@ impl CommandManager {
 
         channel.write_message(&CommandRequest::new(
             id.clone(),
-            CommandRequestData::ListWorkers,
+            CommandRequestOrder::ListWorkers,
             None,
         ));
 
@@ -398,7 +398,7 @@ impl CommandManager {
             }
             CommandStatus::Ok => {
                 //println!("Worker list:\n{:?}", message.data);
-                if let Some(CommandResponseData::Workers(ref workers)) = message.data {
+                if let Some(CommandResponseContent::Workers(ref workers)) = message.content {
                     let mut expecting: HashSet<String> = HashSet::new();
 
                     let mut h = HashMap::new();
@@ -409,7 +409,7 @@ impl CommandManager {
                         let id = generate_id();
                         let msg = CommandRequest::new(
                             id.clone(),
-                            CommandRequestData::Proxy(ProxyRequestData::Status),
+                            CommandRequestOrder::Proxy(ProxyRequestOrder::Status),
                             Some(worker.id),
                         );
                         //println!("sending message: {:?}", msg);
@@ -550,7 +550,7 @@ impl CommandManager {
 
         self.channel.write_message(&CommandRequest::new(
             id.clone(),
-            CommandRequestData::Proxy(ProxyRequestData::ConfigureMetrics(configuration)),
+            CommandRequestOrder::Proxy(ProxyRequestOrder::ConfigureMetrics(configuration)),
             None,
         ));
 
@@ -581,7 +581,7 @@ impl CommandManager {
         cluster_ids: Vec<String>,
         backend_ids: Vec<String>,
     ) -> Result<(), anyhow::Error> {
-        let command = CommandRequestData::Proxy(ProxyRequestData::Query(Query::Metrics(
+        let command = CommandRequestOrder::Proxy(ProxyRequestOrder::Query(Query::Metrics(
             QueryMetricsOptions {
                 list,
                 cluster_ids,
@@ -617,11 +617,11 @@ impl CommandManager {
                         bail!("could not query proxy state: {}", message.message);
                     }
                 }
-                CommandStatus::Ok => match message.data {
-                    Some(CommandResponseData::Metrics(aggregated_metrics_data)) => {
+                CommandStatus::Ok => match message.content {
+                    Some(CommandResponseContent::Metrics(aggregated_metrics_data)) => {
                         print_metrics(aggregated_metrics_data, json)?
                     }
-                    Some(CommandResponseData::Query(lists_of_metrics)) => {
+                    Some(CommandResponseContent::Query(lists_of_metrics)) => {
                         print_available_metrics(&lists_of_metrics)?;
                     }
                     _ => println!("Wrong kind of response here"),
@@ -651,7 +651,7 @@ impl CommandManager {
         let id = generate_id();
         self.channel.write_message(&CommandRequest::new(
             id.clone(),
-            CommandRequestData::ReloadConfiguration { path },
+            CommandRequestOrder::ReloadConfiguration { path },
             None,
         ));
 
@@ -689,7 +689,7 @@ impl CommandManager {
         tcp: bool,
         domain: Option<String>,
     ) -> Result<(), anyhow::Error> {
-        let command = CommandRequestData::ListFrontends(FrontendFilters {
+        let command = CommandRequestOrder::ListFrontends(FrontendFilters {
             http,
             https,
             tcp,
@@ -711,9 +711,9 @@ impl CommandManager {
                 println!("could not query proxy state: {}", message.message)
             }
             CommandStatus::Ok => {
-                debug!("We received this response: {:?}", message.data);
+                debug!("We received this response: {:?}", message.content);
 
-                if let Some(CommandResponseData::FrontendList(frontends)) = message.data {
+                if let Some(CommandResponseContent::FrontendList(frontends)) = message.content {
                     print_frontend_list(frontends);
                 }
             }
@@ -733,7 +733,7 @@ impl CommandManager {
         }
 
         let command = if let Some(ref cluster_id) = cluster_id {
-            CommandRequestData::Proxy(ProxyRequestData::Query(Query::Clusters(
+            CommandRequestOrder::Proxy(ProxyRequestOrder::Query(Query::Clusters(
                 QueryClusterType::ClusterId(cluster_id.to_string()),
             )))
         } else if let Some(ref domain) = domain {
@@ -752,11 +752,11 @@ impl CommandManager {
                 path: splitted.get(1).cloned().map(|path| format!("/{}", path)), // We add the / again because of the splitn removing it
             };
 
-            CommandRequestData::Proxy(ProxyRequestData::Query(Query::Clusters(
+            CommandRequestOrder::Proxy(ProxyRequestOrder::Query(Query::Clusters(
                 QueryClusterType::Domain(query_domain),
             )))
         } else {
-            CommandRequestData::Proxy(ProxyRequestData::Query(Query::ClustersHashes))
+            CommandRequestOrder::Proxy(ProxyRequestOrder::Query(Query::ClustersHashes))
         };
 
         let id = generate_id();
@@ -784,7 +784,7 @@ impl CommandManager {
                 bail!("could not query proxy state: {}", message.message);
             }
             CommandStatus::Ok => {
-                print_query_response_data(cluster_id, domain, message.data, json)?;
+                print_query_response_data(cluster_id, domain, message.content, json)?;
             }
         }
 
@@ -812,7 +812,7 @@ impl CommandManager {
         };
 
         let command =
-            CommandRequestData::Proxy(ProxyRequestData::Query(Query::Certificates(query)));
+            CommandRequestOrder::Proxy(ProxyRequestOrder::Query(Query::Certificates(query)));
 
         let id = generate_id();
         self.channel
@@ -838,10 +838,10 @@ impl CommandManager {
                 }
             }
             CommandStatus::Ok => {
-                if let Some(CommandResponseData::Query(data)) = message.data {
+                if let Some(CommandResponseContent::Query(data)) = message.content {
                     print_certificates(data, json)?;
                 } else {
-                    bail!("unexpected response: {:?}", message.data);
+                    bail!("unexpected response: {:?}", message.content);
                 }
             }
         }
@@ -852,14 +852,14 @@ impl CommandManager {
         let id = generate_id();
         self.channel.write_message(&CommandRequest::new(
             id.clone(),
-            CommandRequestData::SubscribeEvents,
+            CommandRequestOrder::SubscribeEvents,
             None,
         ));
 
         let message = self.read_channel_message_with_timeout()?;
         match message.status {
             CommandStatus::Processing => {
-                if let Some(CommandResponseData::Event(event)) = message.data {
+                if let Some(CommandResponseContent::Event(event)) = message.content {
                     println!("got event from worker({}): {:?}", message.message, event);
                 }
             }
@@ -873,11 +873,11 @@ impl CommandManager {
         Ok(())
     }
 
-    pub fn order_command(&mut self, order: ProxyRequestData) -> Result<(), anyhow::Error> {
+    pub fn order_command(&mut self, order: ProxyRequestOrder) -> Result<(), anyhow::Error> {
         let id = generate_id();
         self.channel.write_message(&CommandRequest::new(
             id.clone(),
-            CommandRequestData::Proxy(order.clone()),
+            CommandRequestOrder::Proxy(order.clone()),
             None,
         ));
 

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -7,7 +7,7 @@ use anyhow::{self, bail, Context};
 use prettytable::{Row, Table};
 
 use sozu_command_lib::{
-    command::{CommandResponseData, ListedFrontends},
+    command::{CommandResponseContent, ListedFrontends},
     proxy::{
         AggregatedMetricsData, ClusterMetricsData, FilteredData, QueryAnswer,
         QueryAnswerCertificate, QueryAnswerMetrics, Route, WorkerMetrics,
@@ -276,11 +276,11 @@ pub fn create_queried_cluster_table(
 pub fn print_query_response_data(
     cluster_id: Option<String>,
     domain: Option<String>,
-    data: Option<CommandResponseData>,
+    data: Option<CommandResponseContent>,
     json: bool,
 ) -> anyhow::Result<()> {
     if let Some(needle) = cluster_id.or_else(|| domain) {
-        if let Some(CommandResponseData::Query(data)) = &data {
+        if let Some(CommandResponseContent::Query(data)) = &data {
             if json {
                 return print_json_response(data);
             }
@@ -463,7 +463,7 @@ pub fn print_query_response_data(
             backend_table.printstd();
         }
     } else {
-        if let Some(CommandResponseData::Query(data)) = &data {
+        if let Some(CommandResponseContent::Query(data)) = &data {
             let mut table = Table::new();
             table.set_format(*prettytable::format::consts::FORMAT_BOX_CHARS);
             let mut header = vec![cell!("key")];

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -34,7 +34,7 @@ use sozu_command_lib::{
     channel::Channel,
     config::Config,
     logging::target_to_backend,
-    proxy::{ProxyRequest, ProxyRequestData, ProxyResponse},
+    proxy::{ProxyRequest, ProxyRequestOrder, ProxyResponse},
     ready::Ready,
     scm_socket::{Listeners, ScmSocket},
     state::ConfigState,
@@ -66,7 +66,7 @@ pub fn start_workers(executable_path: String, config: &Config) -> anyhow::Result
             command_channel.set_blocking(true);
             command_channel.write_message(&ProxyRequest {
                 id: format!("start-status-{}", index),
-                order: ProxyRequestData::Status,
+                order: ProxyRequestOrder::Status,
             });
             command_channel.set_nonblocking(true);
         }

--- a/command/README.md
+++ b/command/README.md
@@ -17,7 +17,7 @@ You send a `CommandRequest`, defined as follows:
 pub struct CommandRequest {
   pub id:        String,
   pub version:   u8,
-  pub data:      CommandRequestData,
+  pub order:      CommandRequestOrder,
   pub worker_id: Option<String>,
 }
 ```
@@ -29,8 +29,8 @@ When serialized to JSON it looks like this:
     "id":        "ID_TEST",
     "version":   0,
     "worker_id": 0,
-    "type":      "<CommandRequestData enum name>",
-    "data":      { <CommandRequestData wrapped value> }
+    "type":      "<CommandRequestOrder enum name>",
+    "data":      { <CommandRequestOrder wrapped value> }
 }"
 ```
 

--- a/command/assets/answer_metrics.json
+++ b/command/assets/answer_metrics.json
@@ -3,7 +3,7 @@
   "version": 0,
   "status": "OK",
   "message": "",
-  "data": {
+  "content": {
     "type": "METRICS",
     "data": {
       "main": {

--- a/command/assets/answer_workers_status.json
+++ b/command/assets/answer_workers_status.json
@@ -3,7 +3,7 @@
   "version": 0,
   "status": "OK",
   "message": "",
-  "data": {
+  "content": {
     "type": "WORKERS",
     "data": [
       {

--- a/command/assets/protocol_mismatch.json
+++ b/command/assets/protocol_mismatch.json
@@ -2,7 +2,7 @@
   "id": "ID_TEST",
   "version": 1,
   "type": "PROXY",
-  "data": {
+  "content": {
     "type": "ADD_BACKEND",
     "data": {
       "cluster_id": "xxx",

--- a/command/src/parser.rs
+++ b/command/src/parser.rs
@@ -74,13 +74,13 @@ where
 mod test {
     use super::*;
 
-    use crate::command::{CommandRequest, CommandRequestData};
+    use crate::command::{CommandRequest, CommandRequestOrder};
 
     #[test]
     fn parse_one_command_request_works() {
         let command_request = CommandRequest::new(
             "Some request".to_string(),
-            CommandRequestData::DumpState,
+            CommandRequestOrder::DumpState,
             Some(5),
         );
 
@@ -105,19 +105,19 @@ mod test {
         let commands = vec![
             CommandRequest::new(
                 "Some request".to_string(),
-                CommandRequestData::SaveState {
+                CommandRequestOrder::SaveState {
                     path: "/some/path".to_string(),
                 },
                 Some(5),
             ),
             CommandRequest::new(
                 "Some other request".to_string(),
-                CommandRequestData::SubscribeEvents,
+                CommandRequestOrder::SubscribeEvents,
                 Some(4),
             ),
             CommandRequest::new(
                 "Yet another request".to_string(),
-                CommandRequestData::DumpState,
+                CommandRequestOrder::DumpState,
                 None,
             ),
         ];

--- a/command/src/proxy.rs
+++ b/command/src/proxy.rs
@@ -22,7 +22,7 @@ pub type MessageId = String;
 pub struct ProxyResponse {
     pub id: MessageId,
     pub status: ProxyResponseStatus,
-    pub data: Option<ProxyResponseData>,
+    pub content: Option<ProxyResponseContent>,
 }
 
 impl ProxyResponse {
@@ -33,7 +33,7 @@ impl ProxyResponse {
         Self {
             id: id.to_string(),
             status: ProxyResponseStatus::Ok,
-            data: None,
+            content: None,
         }
     }
 
@@ -45,7 +45,7 @@ impl ProxyResponse {
         Self {
             id: id.to_string(),
             status: ProxyResponseStatus::Error(error.to_string()),
-            data: None,
+            content: None,
         }
     }
 
@@ -56,7 +56,7 @@ impl ProxyResponse {
         Self {
             id: id.to_string(),
             status: ProxyResponseStatus::Processing,
-            data: None,
+            content: None,
         }
     }
 
@@ -67,7 +67,7 @@ impl ProxyResponse {
         Self {
             id: id.to_string(),
             status,
-            data: None,
+            content: None,
         }
     }
 }
@@ -87,7 +87,7 @@ pub enum ProxyResponseStatus {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data", rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum ProxyResponseData {
+pub enum ProxyResponseContent {
     /// contains proxy & cluster metrics
     Metrics(WorkerMetrics),
     Query(QueryAnswer),
@@ -181,7 +181,7 @@ pub enum ProxyEvent {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProxyRequest {
     pub id: MessageId,
-    pub order: ProxyRequestData,
+    pub order: ProxyRequestOrder,
 }
 
 impl fmt::Display for ProxyRequest {
@@ -192,7 +192,7 @@ impl fmt::Display for ProxyRequest {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data", rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum ProxyRequestData {
+pub enum ProxyRequestOrder {
     AddCluster(Cluster),
     RemoveCluster { cluster_id: String },
 
@@ -848,10 +848,10 @@ pub enum QueryAnswerMetrics {
     Error(String),
 }
 
-impl ProxyRequestData {
+impl ProxyRequestOrder {
     pub fn get_topics(&self) -> HashSet<Topic> {
         match *self {
-            ProxyRequestData::AddCluster(_) => [
+            ProxyRequestOrder::AddCluster(_) => [
                 Topic::HttpProxyConfig,
                 Topic::HttpsProxyConfig,
                 Topic::TcpProxyConfig,
@@ -859,7 +859,7 @@ impl ProxyRequestData {
             .iter()
             .cloned()
             .collect(),
-            ProxyRequestData::RemoveCluster { cluster_id: _ } => [
+            ProxyRequestOrder::RemoveCluster { cluster_id: _ } => [
                 Topic::HttpProxyConfig,
                 Topic::HttpsProxyConfig,
                 Topic::TcpProxyConfig,
@@ -867,34 +867,34 @@ impl ProxyRequestData {
             .iter()
             .cloned()
             .collect(),
-            ProxyRequestData::AddHttpFrontend(_) => {
+            ProxyRequestOrder::AddHttpFrontend(_) => {
                 [Topic::HttpProxyConfig].iter().cloned().collect()
             }
-            ProxyRequestData::RemoveHttpFrontend(_) => {
+            ProxyRequestOrder::RemoveHttpFrontend(_) => {
                 [Topic::HttpProxyConfig].iter().cloned().collect()
             }
-            ProxyRequestData::AddHttpsFrontend(_) => {
+            ProxyRequestOrder::AddHttpsFrontend(_) => {
                 [Topic::HttpsProxyConfig].iter().cloned().collect()
             }
-            ProxyRequestData::RemoveHttpsFrontend(_) => {
+            ProxyRequestOrder::RemoveHttpsFrontend(_) => {
                 [Topic::HttpsProxyConfig].iter().cloned().collect()
             }
-            ProxyRequestData::AddCertificate(_) => {
+            ProxyRequestOrder::AddCertificate(_) => {
                 [Topic::HttpsProxyConfig].iter().cloned().collect()
             }
-            ProxyRequestData::ReplaceCertificate(_) => {
+            ProxyRequestOrder::ReplaceCertificate(_) => {
                 [Topic::HttpsProxyConfig].iter().cloned().collect()
             }
-            ProxyRequestData::RemoveCertificate(_) => {
+            ProxyRequestOrder::RemoveCertificate(_) => {
                 [Topic::HttpsProxyConfig].iter().cloned().collect()
             }
-            ProxyRequestData::AddTcpFrontend(_) => {
+            ProxyRequestOrder::AddTcpFrontend(_) => {
                 [Topic::TcpProxyConfig].iter().cloned().collect()
             }
-            ProxyRequestData::RemoveTcpFrontend(_) => {
+            ProxyRequestOrder::RemoveTcpFrontend(_) => {
                 [Topic::TcpProxyConfig].iter().cloned().collect()
             }
-            ProxyRequestData::AddBackend(_) => [
+            ProxyRequestOrder::AddBackend(_) => [
                 Topic::HttpProxyConfig,
                 Topic::HttpsProxyConfig,
                 Topic::TcpProxyConfig,
@@ -902,7 +902,7 @@ impl ProxyRequestData {
             .iter()
             .cloned()
             .collect(),
-            ProxyRequestData::RemoveBackend(_) => [
+            ProxyRequestOrder::RemoveBackend(_) => [
                 Topic::HttpProxyConfig,
                 Topic::HttpsProxyConfig,
                 Topic::TcpProxyConfig,
@@ -910,16 +910,16 @@ impl ProxyRequestData {
             .iter()
             .cloned()
             .collect(),
-            ProxyRequestData::AddHttpListener(_) => {
+            ProxyRequestOrder::AddHttpListener(_) => {
                 [Topic::HttpProxyConfig].iter().cloned().collect()
             }
-            ProxyRequestData::AddHttpsListener(_) => {
+            ProxyRequestOrder::AddHttpsListener(_) => {
                 [Topic::HttpsProxyConfig].iter().cloned().collect()
             }
-            ProxyRequestData::AddTcpListener(_) => {
+            ProxyRequestOrder::AddTcpListener(_) => {
                 [Topic::TcpProxyConfig].iter().cloned().collect()
             }
-            ProxyRequestData::RemoveListener(_) => [
+            ProxyRequestOrder::RemoveListener(_) => [
                 Topic::HttpProxyConfig,
                 Topic::HttpsProxyConfig,
                 Topic::TcpProxyConfig,
@@ -927,7 +927,7 @@ impl ProxyRequestData {
             .iter()
             .cloned()
             .collect(),
-            ProxyRequestData::ActivateListener(_) => [
+            ProxyRequestOrder::ActivateListener(_) => [
                 Topic::HttpProxyConfig,
                 Topic::HttpsProxyConfig,
                 Topic::TcpProxyConfig,
@@ -935,7 +935,7 @@ impl ProxyRequestData {
             .iter()
             .cloned()
             .collect(),
-            ProxyRequestData::DeactivateListener(_) => [
+            ProxyRequestOrder::DeactivateListener(_) => [
                 Topic::HttpProxyConfig,
                 Topic::HttpsProxyConfig,
                 Topic::TcpProxyConfig,
@@ -943,8 +943,8 @@ impl ProxyRequestData {
             .iter()
             .cloned()
             .collect(),
-            ProxyRequestData::Query(_) => [Topic::HttpsProxyConfig].iter().cloned().collect(),
-            ProxyRequestData::SoftStop => [
+            ProxyRequestOrder::Query(_) => [Topic::HttpsProxyConfig].iter().cloned().collect(),
+            ProxyRequestOrder::SoftStop => [
                 Topic::HttpProxyConfig,
                 Topic::HttpsProxyConfig,
                 Topic::TcpProxyConfig,
@@ -952,7 +952,7 @@ impl ProxyRequestData {
             .iter()
             .cloned()
             .collect(),
-            ProxyRequestData::HardStop => [
+            ProxyRequestOrder::HardStop => [
                 Topic::HttpProxyConfig,
                 Topic::HttpsProxyConfig,
                 Topic::TcpProxyConfig,
@@ -960,7 +960,7 @@ impl ProxyRequestData {
             .iter()
             .cloned()
             .collect(),
-            ProxyRequestData::Status => [
+            ProxyRequestOrder::Status => [
                 Topic::HttpProxyConfig,
                 Topic::HttpsProxyConfig,
                 Topic::TcpProxyConfig,
@@ -968,8 +968,8 @@ impl ProxyRequestData {
             .iter()
             .cloned()
             .collect(),
-            ProxyRequestData::ConfigureMetrics(_) => HashSet::new(),
-            ProxyRequestData::Logging(_) => [
+            ProxyRequestOrder::ConfigureMetrics(_) => HashSet::new(),
+            ProxyRequestOrder::Logging(_) => [
                 Topic::HttpsProxyConfig,
                 Topic::HttpProxyConfig,
                 Topic::TcpProxyConfig,
@@ -977,7 +977,7 @@ impl ProxyRequestData {
             .iter()
             .cloned()
             .collect(),
-            ProxyRequestData::ReturnListenSockets => HashSet::new(),
+            ProxyRequestOrder::ReturnListenSockets => HashSet::new(),
         }
     }
 }
@@ -1019,12 +1019,12 @@ mod tests {
     #[test]
     fn add_front_test() {
         let raw_json = r#"{"type": "ADD_HTTP_FRONTEND", "data": {"route": { "CLUSTER_ID": "xxx"}, "hostname": "yyy", "path": {"PREFIX": "xxx"}, "address": "127.0.0.1:4242", "sticky_session": false}}"#;
-        let command: ProxyRequestData =
+        let command: ProxyRequestOrder =
             serde_json::from_str(raw_json).expect("could not parse json");
         println!("{:?}", command);
         assert!(
             command
-                == ProxyRequestData::AddHttpFrontend(HttpFrontend {
+                == ProxyRequestOrder::AddHttpFrontend(HttpFrontend {
                     route: Route::ClusterId(String::from("xxx")),
                     hostname: String::from("yyy"),
                     path: PathRule::Prefix(String::from("xxx")),
@@ -1039,12 +1039,12 @@ mod tests {
     #[test]
     fn remove_front_test() {
         let raw_json = r#"{"type": "REMOVE_HTTP_FRONTEND", "data": {"route": {"CLUSTER_ID": "xxx"}, "hostname": "yyy", "path": {"PREFIX": "xxx"}, "address": "127.0.0.1:4242", "tags": { "owner": "John", "id": "some-long-id" }}}"#;
-        let command: ProxyRequestData =
+        let command: ProxyRequestOrder =
             serde_json::from_str(raw_json).expect("could not parse json");
         println!("{:?}", command);
         assert!(
             command
-                == ProxyRequestData::RemoveHttpFrontend(HttpFrontend {
+                == ProxyRequestOrder::RemoveHttpFrontend(HttpFrontend {
                     route: Route::ClusterId(String::from("xxx")),
                     hostname: String::from("yyy"),
                     path: PathRule::Prefix(String::from("xxx")),
@@ -1062,12 +1062,12 @@ mod tests {
     #[test]
     fn add_backend_test() {
         let raw_json = r#"{"type": "ADD_BACKEND", "data": {"cluster_id": "xxx", "backend_id": "xxx-0", "address": "0.0.0.0:8080", "load_balancing_parameters": { "weight": 0 }}}"#;
-        let command: ProxyRequestData =
+        let command: ProxyRequestOrder =
             serde_json::from_str(raw_json).expect("could not parse json");
         println!("{:?}", command);
         assert!(
             command
-                == ProxyRequestData::AddBackend(Backend {
+                == ProxyRequestOrder::AddBackend(Backend {
                     cluster_id: String::from("xxx"),
                     backend_id: String::from("xxx-0"),
                     address: "0.0.0.0:8080".parse().unwrap(),
@@ -1081,12 +1081,12 @@ mod tests {
     #[test]
     fn remove_backend_test() {
         let raw_json = r#"{"type": "REMOVE_BACKEND", "data": {"cluster_id": "xxx", "backend_id": "xxx-0", "address": "0.0.0.0:8080"}}"#;
-        let command: ProxyRequestData =
+        let command: ProxyRequestOrder =
             serde_json::from_str(raw_json).expect("could not parse json");
         println!("{:?}", command);
         assert!(
             command
-                == ProxyRequestData::RemoveBackend(RemoveBackend {
+                == ProxyRequestOrder::RemoveBackend(RemoveBackend {
                     cluster_id: String::from("xxx"),
                     backend_id: String::from("xxx-0"),
                     address: "0.0.0.0:8080".parse().unwrap(),
@@ -1097,12 +1097,12 @@ mod tests {
     #[test]
     fn http_front_crash_test() {
         let raw_json = r#"{"type": "ADD_HTTP_FRONTEND", "data": {"route": {"CLUSTER_ID": "aa"}, "hostname": "cltdl.fr", "path": {"PREFIX": ""}, "address": "127.0.0.1:4242", "tags": { "owner": "John", "id": "some-long-id" }}}"#;
-        let command: ProxyRequestData =
+        let command: ProxyRequestOrder =
             serde_json::from_str(raw_json).expect("could not parse json");
         println!("{:?}", command);
         assert!(
             command
-                == ProxyRequestData::AddHttpFrontend(HttpFrontend {
+                == ProxyRequestOrder::AddHttpFrontend(HttpFrontend {
                     route: Route::ClusterId(String::from("aa")),
                     hostname: String::from("cltdl.fr"),
                     path: PathRule::Prefix(String::from("")),

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -13,7 +13,7 @@ use crate::{
     proxy::{
         ActivateListener, AddCertificate, Backend, CertificateAndKey, CertificateFingerprint,
         Cluster, DeactivateListener, HttpFrontend, HttpListener, HttpsListener, ListenerType,
-        PathRule, ProxyRequestData, QueryAnswerCluster, RemoveBackend, RemoveCertificate,
+        PathRule, ProxyRequestOrder, QueryAnswerCluster, RemoveBackend, RemoveCertificate,
         RemoveListener, Route, TcpFrontend, TcpListener,
     },
 };
@@ -71,17 +71,17 @@ impl ConfigState {
     }
 
     /// returns true if the order modified something
-    pub fn handle_order(&mut self, order: &ProxyRequestData) -> bool {
+    pub fn handle_order(&mut self, order: &ProxyRequestOrder) -> bool {
         match order {
-            &ProxyRequestData::AddCluster(ref cluster) => {
+            &ProxyRequestOrder::AddCluster(ref cluster) => {
                 let cluster = cluster.clone();
                 self.clusters.insert(cluster.cluster_id.clone(), cluster);
                 true
             }
-            &ProxyRequestData::RemoveCluster { ref cluster_id } => {
+            &ProxyRequestOrder::RemoveCluster { ref cluster_id } => {
                 self.clusters.remove(cluster_id).is_some()
             }
-            &ProxyRequestData::AddHttpListener(ref listener) => {
+            &ProxyRequestOrder::AddHttpListener(ref listener) => {
                 if let std::collections::hash_map::Entry::Vacant(e) =
                     self.http_listeners.entry(listener.address)
                 {
@@ -91,7 +91,7 @@ impl ConfigState {
                     false
                 }
             }
-            &ProxyRequestData::AddHttpsListener(ref listener) => {
+            &ProxyRequestOrder::AddHttpsListener(ref listener) => {
                 if let std::collections::hash_map::Entry::Vacant(e) =
                     self.https_listeners.entry(listener.address)
                 {
@@ -101,7 +101,7 @@ impl ConfigState {
                     false
                 }
             }
-            &ProxyRequestData::AddTcpListener(ref listener) => {
+            &ProxyRequestOrder::AddTcpListener(ref listener) => {
                 if let std::collections::hash_map::Entry::Vacant(e) =
                     self.tcp_listeners.entry(listener.address)
                 {
@@ -111,12 +111,12 @@ impl ConfigState {
                     false
                 }
             }
-            &ProxyRequestData::RemoveListener(ref remove) => match remove.proxy {
+            &ProxyRequestOrder::RemoveListener(ref remove) => match remove.proxy {
                 ListenerType::HTTP => self.http_listeners.remove(&remove.address).is_some(),
                 ListenerType::HTTPS => self.https_listeners.remove(&remove.address).is_some(),
                 ListenerType::TCP => self.tcp_listeners.remove(&remove.address).is_some(),
             },
-            &ProxyRequestData::ActivateListener(ref activate) => match activate.proxy {
+            &ProxyRequestOrder::ActivateListener(ref activate) => match activate.proxy {
                 ListenerType::HTTP => self
                     .http_listeners
                     .get_mut(&activate.address)
@@ -133,7 +133,7 @@ impl ConfigState {
                     .map(|t| t.1 = true)
                     .is_some(),
             },
-            &ProxyRequestData::DeactivateListener(ref deactivate) => match deactivate.proxy {
+            &ProxyRequestOrder::DeactivateListener(ref deactivate) => match deactivate.proxy {
                 ListenerType::HTTP => self
                     .http_listeners
                     .get_mut(&deactivate.address)
@@ -150,7 +150,7 @@ impl ConfigState {
                     .map(|t| t.1 = false)
                     .is_some(),
             },
-            &ProxyRequestData::AddHttpFrontend(ref front) => {
+            &ProxyRequestOrder::AddHttpFrontend(ref front) => {
                 if let std::collections::btree_map::Entry::Vacant(e) =
                     self.http_fronts.entry(RouteKey(
                         front.address,
@@ -165,7 +165,7 @@ impl ConfigState {
                     false
                 }
             }
-            &ProxyRequestData::RemoveHttpFrontend(ref front) => self
+            &ProxyRequestOrder::RemoveHttpFrontend(ref front) => self
                 .http_fronts
                 .remove(&RouteKey(
                     front.address,
@@ -174,7 +174,7 @@ impl ConfigState {
                     front.method.clone(),
                 ))
                 .is_some(),
-            &ProxyRequestData::AddCertificate(ref add) => {
+            &ProxyRequestOrder::AddCertificate(ref add) => {
                 let fingerprint =
                     match calculate_fingerprint(add.certificate.certificate.as_bytes()) {
                         Some(f) => CertificateFingerprint(f),
@@ -202,12 +202,12 @@ impl ConfigState {
                     false
                 }
             }
-            &ProxyRequestData::RemoveCertificate(ref remove) => self
+            &ProxyRequestOrder::RemoveCertificate(ref remove) => self
                 .certificates
                 .get_mut(&remove.address)
                 .and_then(|certs| certs.remove(&remove.fingerprint))
                 .is_some(),
-            &ProxyRequestData::ReplaceCertificate(ref replace) => {
+            &ProxyRequestOrder::ReplaceCertificate(ref replace) => {
                 let changed = self
                     .certificates
                     .get_mut(&replace.address)
@@ -241,7 +241,7 @@ impl ConfigState {
                     changed
                 }
             }
-            &ProxyRequestData::AddHttpsFrontend(ref front) => {
+            &ProxyRequestOrder::AddHttpsFrontend(ref front) => {
                 if let std::collections::btree_map::Entry::Vacant(e) =
                     self.https_fronts.entry(RouteKey(
                         front.address,
@@ -256,7 +256,7 @@ impl ConfigState {
                     false
                 }
             }
-            &ProxyRequestData::RemoveHttpsFrontend(ref front) => self
+            &ProxyRequestOrder::RemoveHttpsFrontend(ref front) => self
                 .https_fronts
                 .remove(&RouteKey(
                     front.address,
@@ -265,7 +265,7 @@ impl ConfigState {
                     front.method.clone(),
                 ))
                 .is_some(),
-            &ProxyRequestData::AddTcpFrontend(ref front) => {
+            &ProxyRequestOrder::AddTcpFrontend(ref front) => {
                 let front_vec = self
                     .tcp_fronts
                     .entry(front.cluster_id.clone())
@@ -277,7 +277,7 @@ impl ConfigState {
                     false
                 }
             }
-            &ProxyRequestData::RemoveTcpFrontend(ref front) => {
+            &ProxyRequestOrder::RemoveTcpFrontend(ref front) => {
                 if let Some(front_list) = self.tcp_fronts.get_mut(&front.cluster_id) {
                     let len = front_list.len();
                     front_list.retain(|el| el.address != front.address);
@@ -286,7 +286,7 @@ impl ConfigState {
                     false
                 }
             }
-            &ProxyRequestData::AddBackend(ref backend) => {
+            &ProxyRequestOrder::AddBackend(ref backend) => {
                 let backend_vec = self
                     .backends
                     .entry(backend.cluster_id.clone())
@@ -300,7 +300,7 @@ impl ConfigState {
 
                 true
             }
-            &ProxyRequestData::RemoveBackend(ref backend) => {
+            &ProxyRequestOrder::RemoveBackend(ref backend) => {
                 if let Some(backend_list) = self.backends.get_mut(&backend.cluster_id) {
                     let len = backend_list.len();
                     backend_list.retain(|b| {
@@ -313,9 +313,9 @@ impl ConfigState {
                 }
             }
             // This is to avoid the error message
-            &ProxyRequestData::Logging(_)
-            | &ProxyRequestData::Status
-            | &ProxyRequestData::Query(_) => false,
+            &ProxyRequestOrder::Logging(_)
+            | &ProxyRequestOrder::Status
+            | &ProxyRequestOrder::Query(_) => false,
             o => {
                 error!("state cannot handle order message: {:#?}", o);
                 false
@@ -323,13 +323,13 @@ impl ConfigState {
         }
     }
 
-    pub fn generate_orders(&self) -> Vec<ProxyRequestData> {
+    pub fn generate_orders(&self) -> Vec<ProxyRequestOrder> {
         let mut v = Vec::new();
 
         for &(ref listener, active) in self.http_listeners.values() {
-            v.push(ProxyRequestData::AddHttpListener(listener.clone()));
+            v.push(ProxyRequestOrder::AddHttpListener(listener.clone()));
             if active {
-                v.push(ProxyRequestData::ActivateListener(ActivateListener {
+                v.push(ProxyRequestOrder::ActivateListener(ActivateListener {
                     address: listener.address,
                     proxy: ListenerType::HTTP,
                     from_scm: false,
@@ -338,9 +338,9 @@ impl ConfigState {
         }
 
         for &(ref listener, active) in self.https_listeners.values() {
-            v.push(ProxyRequestData::AddHttpsListener(listener.clone()));
+            v.push(ProxyRequestOrder::AddHttpsListener(listener.clone()));
             if active {
-                v.push(ProxyRequestData::ActivateListener(ActivateListener {
+                v.push(ProxyRequestOrder::ActivateListener(ActivateListener {
                     address: listener.address,
                     proxy: ListenerType::HTTPS,
                     from_scm: false,
@@ -349,9 +349,9 @@ impl ConfigState {
         }
 
         for &(ref listener, active) in self.tcp_listeners.values() {
-            v.push(ProxyRequestData::AddTcpListener(listener.clone()));
+            v.push(ProxyRequestOrder::AddTcpListener(listener.clone()));
             if active {
-                v.push(ProxyRequestData::ActivateListener(ActivateListener {
+                v.push(ProxyRequestOrder::ActivateListener(ActivateListener {
                     address: listener.address,
                     proxy: ListenerType::TCP,
                     from_scm: false,
@@ -360,16 +360,16 @@ impl ConfigState {
         }
 
         for cluster in self.clusters.values() {
-            v.push(ProxyRequestData::AddCluster(cluster.clone()));
+            v.push(ProxyRequestOrder::AddCluster(cluster.clone()));
         }
 
         for front in self.http_fronts.values() {
-            v.push(ProxyRequestData::AddHttpFrontend(front.clone()));
+            v.push(ProxyRequestOrder::AddHttpFrontend(front.clone()));
         }
 
         for (front, certs) in self.certificates.iter() {
             for &(ref certificate_and_key, ref names) in certs.values() {
-                v.push(ProxyRequestData::AddCertificate(AddCertificate {
+                v.push(ProxyRequestOrder::AddCertificate(AddCertificate {
                     address: *front,
                     certificate: certificate_and_key.clone(),
                     names: names.clone(),
@@ -379,25 +379,25 @@ impl ConfigState {
         }
 
         for front in self.https_fronts.values() {
-            v.push(ProxyRequestData::AddHttpsFrontend(front.clone()));
+            v.push(ProxyRequestOrder::AddHttpsFrontend(front.clone()));
         }
 
         for front_list in self.tcp_fronts.values() {
             for front in front_list {
-                v.push(ProxyRequestData::AddTcpFrontend(front.clone()));
+                v.push(ProxyRequestOrder::AddTcpFrontend(front.clone()));
             }
         }
 
         for backend_list in self.backends.values() {
             for backend in backend_list {
-                v.push(ProxyRequestData::AddBackend(backend.clone()));
+                v.push(ProxyRequestOrder::AddBackend(backend.clone()));
             }
         }
 
         v
     }
 
-    pub fn generate_activate_orders(&self) -> Vec<ProxyRequestData> {
+    pub fn generate_activate_orders(&self) -> Vec<ProxyRequestOrder> {
         let mut v = Vec::new();
         for front in self
             .http_listeners
@@ -405,7 +405,7 @@ impl ConfigState {
             .filter(|(_, t)| t.1)
             .map(|(k, _)| k)
         {
-            v.push(ProxyRequestData::ActivateListener(ActivateListener {
+            v.push(ProxyRequestOrder::ActivateListener(ActivateListener {
                 address: *front,
                 proxy: ListenerType::HTTP,
                 from_scm: false,
@@ -418,7 +418,7 @@ impl ConfigState {
             .filter(|(_, t)| t.1)
             .map(|(k, _)| k)
         {
-            v.push(ProxyRequestData::ActivateListener(ActivateListener {
+            v.push(ProxyRequestOrder::ActivateListener(ActivateListener {
                 address: *front,
                 proxy: ListenerType::HTTPS,
                 from_scm: false,
@@ -430,7 +430,7 @@ impl ConfigState {
             .filter(|(_, t)| t.1)
             .map(|(k, _)| k)
         {
-            v.push(ProxyRequestData::ActivateListener(ActivateListener {
+            v.push(ProxyRequestOrder::ActivateListener(ActivateListener {
                 address: *front,
                 proxy: ListenerType::TCP,
                 from_scm: false,
@@ -440,7 +440,7 @@ impl ConfigState {
         v
     }
 
-    pub fn diff(&self, other: &ConfigState) -> Vec<ProxyRequestData> {
+    pub fn diff(&self, other: &ConfigState) -> Vec<ProxyRequestOrder> {
         //pub tcp_listeners:   HashMap<SocketAddr, (TcpListener, bool)>,
         let my_tcp_listeners: HashSet<&SocketAddr> = self.tcp_listeners.keys().collect();
         let their_tcp_listeners: HashSet<&SocketAddr> = other.tcp_listeners.keys().collect();
@@ -461,26 +461,26 @@ impl ConfigState {
 
         for address in removed_tcp_listeners {
             if self.tcp_listeners[address].1 {
-                v.push(ProxyRequestData::DeactivateListener(DeactivateListener {
+                v.push(ProxyRequestOrder::DeactivateListener(DeactivateListener {
                     address: **address,
                     proxy: ListenerType::TCP,
                     to_scm: false,
                 }));
             }
 
-            v.push(ProxyRequestData::RemoveListener(RemoveListener {
+            v.push(ProxyRequestOrder::RemoveListener(RemoveListener {
                 address: **address,
                 proxy: ListenerType::TCP,
             }));
         }
 
         for address in added_tcp_listeners.clone() {
-            v.push(ProxyRequestData::AddTcpListener(
+            v.push(ProxyRequestOrder::AddTcpListener(
                 other.tcp_listeners[address].0.clone(),
             ));
 
             if other.tcp_listeners[address].1 {
-                v.push(ProxyRequestData::ActivateListener(ActivateListener {
+                v.push(ProxyRequestOrder::ActivateListener(ActivateListener {
                     address: **address,
                     proxy: ListenerType::TCP,
                     from_scm: false,
@@ -490,26 +490,26 @@ impl ConfigState {
 
         for address in removed_http_listeners {
             if self.http_listeners[address].1 {
-                v.push(ProxyRequestData::DeactivateListener(DeactivateListener {
+                v.push(ProxyRequestOrder::DeactivateListener(DeactivateListener {
                     address: **address,
                     proxy: ListenerType::HTTP,
                     to_scm: false,
                 }));
             }
 
-            v.push(ProxyRequestData::RemoveListener(RemoveListener {
+            v.push(ProxyRequestOrder::RemoveListener(RemoveListener {
                 address: **address,
                 proxy: ListenerType::HTTP,
             }));
         }
 
         for address in added_http_listeners.clone() {
-            v.push(ProxyRequestData::AddHttpListener(
+            v.push(ProxyRequestOrder::AddHttpListener(
                 other.http_listeners[address].0.clone(),
             ));
 
             if other.http_listeners[address].1 {
-                v.push(ProxyRequestData::ActivateListener(ActivateListener {
+                v.push(ProxyRequestOrder::ActivateListener(ActivateListener {
                     address: **address,
                     proxy: ListenerType::HTTP,
                     from_scm: false,
@@ -519,26 +519,26 @@ impl ConfigState {
 
         for address in removed_https_listeners {
             if self.https_listeners[address].1 {
-                v.push(ProxyRequestData::DeactivateListener(DeactivateListener {
+                v.push(ProxyRequestOrder::DeactivateListener(DeactivateListener {
                     address: **address,
                     proxy: ListenerType::HTTPS,
                     to_scm: false,
                 }));
             }
 
-            v.push(ProxyRequestData::RemoveListener(RemoveListener {
+            v.push(ProxyRequestOrder::RemoveListener(RemoveListener {
                 address: **address,
                 proxy: ListenerType::HTTPS,
             }));
         }
 
         for address in added_https_listeners.clone() {
-            v.push(ProxyRequestData::AddHttpsListener(
+            v.push(ProxyRequestOrder::AddHttpsListener(
                 other.https_listeners[address].0.clone(),
             ));
 
             if other.https_listeners[address].1 {
-                v.push(ProxyRequestData::ActivateListener(ActivateListener {
+                v.push(ProxyRequestOrder::ActivateListener(ActivateListener {
                     address: **address,
                     proxy: ListenerType::HTTPS,
                     from_scm: false,
@@ -551,16 +551,16 @@ impl ConfigState {
             let (their_listener, their_active) = &other.tcp_listeners[addr];
 
             if my_listener != their_listener {
-                v.push(ProxyRequestData::RemoveListener(RemoveListener {
+                v.push(ProxyRequestOrder::RemoveListener(RemoveListener {
                     address: **addr,
                     proxy: ListenerType::TCP,
                 }));
 
-                v.push(ProxyRequestData::AddTcpListener(their_listener.clone()));
+                v.push(ProxyRequestOrder::AddTcpListener(their_listener.clone()));
             }
 
             if *my_active && !*their_active {
-                v.push(ProxyRequestData::DeactivateListener(DeactivateListener {
+                v.push(ProxyRequestOrder::DeactivateListener(DeactivateListener {
                     address: **addr,
                     proxy: ListenerType::TCP,
                     to_scm: false,
@@ -568,7 +568,7 @@ impl ConfigState {
             }
 
             if !*my_active && *their_active {
-                v.push(ProxyRequestData::ActivateListener(ActivateListener {
+                v.push(ProxyRequestOrder::ActivateListener(ActivateListener {
                     address: **addr,
                     proxy: ListenerType::TCP,
                     from_scm: false,
@@ -581,16 +581,16 @@ impl ConfigState {
             let (their_listener, their_active) = &other.http_listeners[addr];
 
             if my_listener != their_listener {
-                v.push(ProxyRequestData::RemoveListener(RemoveListener {
+                v.push(ProxyRequestOrder::RemoveListener(RemoveListener {
                     address: **addr,
                     proxy: ListenerType::HTTP,
                 }));
 
-                v.push(ProxyRequestData::AddHttpListener(their_listener.clone()));
+                v.push(ProxyRequestOrder::AddHttpListener(their_listener.clone()));
             }
 
             if *my_active && !*their_active {
-                v.push(ProxyRequestData::DeactivateListener(DeactivateListener {
+                v.push(ProxyRequestOrder::DeactivateListener(DeactivateListener {
                     address: **addr,
                     proxy: ListenerType::HTTP,
                     to_scm: false,
@@ -598,7 +598,7 @@ impl ConfigState {
             }
 
             if !*my_active && *their_active {
-                v.push(ProxyRequestData::ActivateListener(ActivateListener {
+                v.push(ProxyRequestOrder::ActivateListener(ActivateListener {
                     address: **addr,
                     proxy: ListenerType::HTTP,
                     from_scm: false,
@@ -611,16 +611,16 @@ impl ConfigState {
             let (their_listener, their_active) = &other.https_listeners[addr];
 
             if my_listener != their_listener {
-                v.push(ProxyRequestData::RemoveListener(RemoveListener {
+                v.push(ProxyRequestOrder::RemoveListener(RemoveListener {
                     address: **addr,
                     proxy: ListenerType::HTTPS,
                 }));
 
-                v.push(ProxyRequestData::AddHttpsListener(their_listener.clone()));
+                v.push(ProxyRequestOrder::AddHttpsListener(their_listener.clone()));
             }
 
             if *my_active && !*their_active {
-                v.push(ProxyRequestData::DeactivateListener(DeactivateListener {
+                v.push(ProxyRequestOrder::DeactivateListener(DeactivateListener {
                     address: **addr,
                     proxy: ListenerType::HTTPS,
                     to_scm: false,
@@ -628,7 +628,7 @@ impl ConfigState {
             }
 
             if !*my_active && *their_active {
-                v.push(ProxyRequestData::ActivateListener(ActivateListener {
+                v.push(ProxyRequestOrder::ActivateListener(ActivateListener {
                     address: **addr,
                     proxy: ListenerType::HTTPS,
                     from_scm: false,
@@ -638,10 +638,10 @@ impl ConfigState {
 
         for (cluster_id, res) in diff_map(self.clusters.iter(), other.clusters.iter()) {
             match res {
-                DiffResult::Added | DiffResult::Changed => v.push(ProxyRequestData::AddCluster(
+                DiffResult::Added | DiffResult::Changed => v.push(ProxyRequestOrder::AddCluster(
                     other.clusters.get(cluster_id).unwrap().clone(),
                 )),
-                DiffResult::Removed => v.push(ProxyRequestData::RemoveCluster {
+                DiffResult::Removed => v.push(ProxyRequestOrder::RemoveCluster {
                     cluster_id: cluster_id.to_string(),
                 }),
             }
@@ -664,7 +664,7 @@ impl ConfigState {
                         .get(cluster_id)
                         .and_then(|v| v.iter().find(|b| &b.backend_id == backend_id))
                         .unwrap();
-                    v.push(ProxyRequestData::AddBackend(backend.clone()));
+                    v.push(ProxyRequestOrder::AddBackend(backend.clone()));
                 }
                 DiffResult::Removed => {
                     let backend = self
@@ -673,7 +673,7 @@ impl ConfigState {
                         .and_then(|v| v.iter().find(|b| &b.backend_id == backend_id))
                         .unwrap();
 
-                    v.push(ProxyRequestData::RemoveBackend(RemoveBackend {
+                    v.push(ProxyRequestOrder::RemoveBackend(RemoveBackend {
                         cluster_id: backend.cluster_id.clone(),
                         backend_id: backend.backend_id.clone(),
                         address: backend.address,
@@ -686,7 +686,7 @@ impl ConfigState {
                         .and_then(|v| v.iter().find(|b| &b.backend_id == backend_id))
                         .unwrap();
 
-                    v.push(ProxyRequestData::RemoveBackend(RemoveBackend {
+                    v.push(ProxyRequestOrder::RemoveBackend(RemoveBackend {
                         cluster_id: backend.cluster_id.clone(),
                         backend_id: backend.backend_id.clone(),
                         address: backend.address,
@@ -697,7 +697,7 @@ impl ConfigState {
                         .get(cluster_id)
                         .and_then(|v| v.iter().find(|b| &b.backend_id == backend_id))
                         .unwrap();
-                    v.push(ProxyRequestData::AddBackend(backend.clone()));
+                    v.push(ProxyRequestOrder::AddBackend(backend.clone()));
                 }
             }
         }
@@ -715,11 +715,11 @@ impl ConfigState {
         let added_http_fronts = their_http_fronts.difference(&my_http_fronts);
 
         for &(_, front) in removed_http_fronts {
-            v.push(ProxyRequestData::RemoveHttpFrontend(front.clone()));
+            v.push(ProxyRequestOrder::RemoveHttpFrontend(front.clone()));
         }
 
         for &(_, front) in added_http_fronts {
-            v.push(ProxyRequestData::AddHttpFrontend(front.clone()));
+            v.push(ProxyRequestOrder::AddHttpFrontend(front.clone()));
         }
 
         let mut my_https_fronts: HashSet<(&RouteKey, &HttpFrontend)> = HashSet::new();
@@ -734,11 +734,11 @@ impl ConfigState {
         let added_https_fronts = their_https_fronts.difference(&my_https_fronts);
 
         for &(_, front) in removed_https_fronts {
-            v.push(ProxyRequestData::RemoveHttpsFrontend(front.clone()));
+            v.push(ProxyRequestOrder::RemoveHttpsFrontend(front.clone()));
         }
 
         for &(_, front) in added_https_fronts {
-            v.push(ProxyRequestData::AddHttpsFrontend(front.clone()));
+            v.push(ProxyRequestOrder::AddHttpsFrontend(front.clone()));
         }
 
         let mut my_tcp_fronts: HashSet<(&ClusterId, &TcpFrontend)> = HashSet::new();
@@ -758,11 +758,11 @@ impl ConfigState {
         let added_tcp_fronts = their_tcp_fronts.difference(&my_tcp_fronts);
 
         for &(_, front) in removed_tcp_fronts {
-            v.push(ProxyRequestData::RemoveTcpFrontend(front.clone()));
+            v.push(ProxyRequestOrder::RemoveTcpFrontend(front.clone()));
         }
 
         for &(_, front) in added_tcp_fronts {
-            v.push(ProxyRequestData::AddTcpFrontend(front.clone()));
+            v.push(ProxyRequestOrder::AddTcpFrontend(front.clone()));
         }
 
         //pub certificates:    HashMap<SocketAddr, HashMap<CertificateFingerprint, (CertificateAndKey, Vec<String>)>>,
@@ -782,7 +782,7 @@ impl ConfigState {
         let added_certificates = their_certificates.difference(&my_certificates);
 
         for &(address, fingerprint) in removed_certificates {
-            v.push(ProxyRequestData::RemoveCertificate(RemoveCertificate {
+            v.push(ProxyRequestOrder::RemoveCertificate(RemoveCertificate {
                 address,
                 fingerprint: fingerprint.clone(),
             }));
@@ -794,7 +794,7 @@ impl ConfigState {
                 .get(&address)
                 .and_then(|certs| certs.get(fingerprint))
             {
-                v.push(ProxyRequestData::AddCertificate(AddCertificate {
+                v.push(ProxyRequestOrder::AddCertificate(AddCertificate {
                     address,
                     certificate: certificate_and_key.clone(),
                     names: names.clone(),
@@ -806,7 +806,7 @@ impl ConfigState {
         for address in added_tcp_listeners {
             let listener = &other.tcp_listeners[address];
             if listener.1 {
-                v.push(ProxyRequestData::ActivateListener(ActivateListener {
+                v.push(ProxyRequestOrder::ActivateListener(ActivateListener {
                     address: listener.0.address,
                     proxy: ListenerType::TCP,
                     from_scm: false,
@@ -1044,13 +1044,13 @@ mod tests {
     use super::*;
     use crate::proxy::{
         Backend, HttpFrontend, LoadBalancingAlgorithms, LoadBalancingParams, PathRule,
-        ProxyRequestData, Route, RulePosition, TlsProvider,
+        ProxyRequestOrder, Route, RulePosition, TlsProvider,
     };
 
     #[test]
     fn serialize() {
         let mut state: ConfigState = Default::default();
-        state.handle_order(&ProxyRequestData::AddHttpFrontend(HttpFrontend {
+        state.handle_order(&ProxyRequestOrder::AddHttpFrontend(HttpFrontend {
             route: Route::ClusterId(String::from("cluster_1")),
             hostname: String::from("lolcatho.st:8080"),
             path: PathRule::Prefix(String::from("/")),
@@ -1059,7 +1059,7 @@ mod tests {
             position: RulePosition::Tree,
             tags: None,
         }));
-        state.handle_order(&ProxyRequestData::AddHttpFrontend(HttpFrontend {
+        state.handle_order(&ProxyRequestOrder::AddHttpFrontend(HttpFrontend {
             route: Route::ClusterId(String::from("cluster_2")),
             hostname: String::from("test.local"),
             path: PathRule::Prefix(String::from("/abc")),
@@ -1068,7 +1068,7 @@ mod tests {
             position: RulePosition::Pre,
             tags: None,
         }));
-        state.handle_order(&ProxyRequestData::AddBackend(Backend {
+        state.handle_order(&ProxyRequestOrder::AddBackend(Backend {
             cluster_id: String::from("cluster_1"),
             backend_id: String::from("cluster_1-0"),
             address: "127.0.0.1:1026".parse().unwrap(),
@@ -1076,7 +1076,7 @@ mod tests {
             sticky_id: None,
             backup: None,
         }));
-        state.handle_order(&ProxyRequestData::AddBackend(Backend {
+        state.handle_order(&ProxyRequestOrder::AddBackend(Backend {
             cluster_id: String::from("cluster_1"),
             backend_id: String::from("cluster_1-1"),
             address: "127.0.0.2:1027".parse().unwrap(),
@@ -1084,7 +1084,7 @@ mod tests {
             sticky_id: None,
             backup: None,
         }));
-        state.handle_order(&ProxyRequestData::AddBackend(Backend {
+        state.handle_order(&ProxyRequestOrder::AddBackend(Backend {
             cluster_id: String::from("cluster_2"),
             backend_id: String::from("cluster_2-0"),
             address: "192.167.1.2:1026".parse().unwrap(),
@@ -1092,7 +1092,7 @@ mod tests {
             sticky_id: None,
             backup: None,
         }));
-        state.handle_order(&ProxyRequestData::AddBackend(Backend {
+        state.handle_order(&ProxyRequestOrder::AddBackend(Backend {
             cluster_id: String::from("cluster_1"),
             backend_id: String::from("cluster_1-3"),
             address: "192.168.1.3:1027".parse().unwrap(),
@@ -1100,7 +1100,7 @@ mod tests {
             sticky_id: None,
             backup: None,
         }));
-        state.handle_order(&ProxyRequestData::RemoveBackend(RemoveBackend {
+        state.handle_order(&ProxyRequestOrder::RemoveBackend(RemoveBackend {
             cluster_id: String::from("cluster_1"),
             backend_id: String::from("cluster_1-3"),
             address: "192.168.1.3:1027".parse().unwrap(),
@@ -1120,7 +1120,7 @@ mod tests {
     #[test]
     fn diff() {
         let mut state: ConfigState = Default::default();
-        state.handle_order(&ProxyRequestData::AddHttpFrontend(HttpFrontend {
+        state.handle_order(&ProxyRequestOrder::AddHttpFrontend(HttpFrontend {
             route: Route::ClusterId(String::from("cluster_1")),
             hostname: String::from("lolcatho.st:8080"),
             path: PathRule::Prefix(String::from("/")),
@@ -1129,7 +1129,7 @@ mod tests {
             position: RulePosition::Post,
             tags: None,
         }));
-        state.handle_order(&ProxyRequestData::AddHttpFrontend(HttpFrontend {
+        state.handle_order(&ProxyRequestOrder::AddHttpFrontend(HttpFrontend {
             route: Route::ClusterId(String::from("cluster_2")),
             hostname: String::from("test.local"),
             path: PathRule::Prefix(String::from("/abc")),
@@ -1138,7 +1138,7 @@ mod tests {
             position: RulePosition::Tree,
             tags: None,
         }));
-        state.handle_order(&ProxyRequestData::AddBackend(Backend {
+        state.handle_order(&ProxyRequestOrder::AddBackend(Backend {
             cluster_id: String::from("cluster_1"),
             backend_id: String::from("cluster_1-0"),
             address: "127.0.0.1:1026".parse().unwrap(),
@@ -1146,7 +1146,7 @@ mod tests {
             sticky_id: None,
             backup: None,
         }));
-        state.handle_order(&ProxyRequestData::AddBackend(Backend {
+        state.handle_order(&ProxyRequestOrder::AddBackend(Backend {
             cluster_id: String::from("cluster_1"),
             backend_id: String::from("cluster_1-1"),
             address: "127.0.0.2:1027".parse().unwrap(),
@@ -1154,7 +1154,7 @@ mod tests {
             sticky_id: None,
             backup: None,
         }));
-        state.handle_order(&ProxyRequestData::AddBackend(Backend {
+        state.handle_order(&ProxyRequestOrder::AddBackend(Backend {
             cluster_id: String::from("cluster_2"),
             backend_id: String::from("cluster_2-0"),
             address: "192.167.1.2:1026".parse().unwrap(),
@@ -1162,7 +1162,7 @@ mod tests {
             sticky_id: None,
             backup: None,
         }));
-        state.handle_order(&ProxyRequestData::AddCluster(Cluster {
+        state.handle_order(&ProxyRequestOrder::AddCluster(Cluster {
             cluster_id: String::from("cluster_2"),
             sticky_session: true,
             https_redirect: true,
@@ -1173,7 +1173,7 @@ mod tests {
         }));
 
         let mut state2: ConfigState = Default::default();
-        state2.handle_order(&ProxyRequestData::AddHttpFrontend(HttpFrontend {
+        state2.handle_order(&ProxyRequestOrder::AddHttpFrontend(HttpFrontend {
             route: Route::ClusterId(String::from("cluster_1")),
             hostname: String::from("lolcatho.st:8080"),
             path: PathRule::Prefix(String::from("/")),
@@ -1182,7 +1182,7 @@ mod tests {
             position: RulePosition::Post,
             tags: None,
         }));
-        state2.handle_order(&ProxyRequestData::AddBackend(Backend {
+        state2.handle_order(&ProxyRequestOrder::AddBackend(Backend {
             cluster_id: String::from("cluster_1"),
             backend_id: String::from("cluster_1-0"),
             address: "127.0.0.1:1026".parse().unwrap(),
@@ -1190,7 +1190,7 @@ mod tests {
             sticky_id: None,
             backup: None,
         }));
-        state2.handle_order(&ProxyRequestData::AddBackend(Backend {
+        state2.handle_order(&ProxyRequestOrder::AddBackend(Backend {
             cluster_id: String::from("cluster_1"),
             backend_id: String::from("cluster_1-1"),
             address: "127.0.0.2:1027".parse().unwrap(),
@@ -1198,7 +1198,7 @@ mod tests {
             sticky_id: None,
             backup: None,
         }));
-        state2.handle_order(&ProxyRequestData::AddBackend(Backend {
+        state2.handle_order(&ProxyRequestOrder::AddBackend(Backend {
             cluster_id: String::from("cluster_1"),
             backend_id: String::from("cluster_1-2"),
             address: "127.0.0.2:1028".parse().unwrap(),
@@ -1206,7 +1206,7 @@ mod tests {
             sticky_id: None,
             backup: None,
         }));
-        state2.handle_order(&ProxyRequestData::AddCluster(Cluster {
+        state2.handle_order(&ProxyRequestOrder::AddCluster(Cluster {
             cluster_id: String::from("cluster_3"),
             sticky_session: false,
             https_redirect: false,
@@ -1217,7 +1217,7 @@ mod tests {
         }));
 
         let e = vec![
-            ProxyRequestData::RemoveHttpFrontend(HttpFrontend {
+            ProxyRequestOrder::RemoveHttpFrontend(HttpFrontend {
                 route: Route::ClusterId(String::from("cluster_2")),
                 hostname: String::from("test.local"),
                 path: PathRule::Prefix(String::from("/abc")),
@@ -1226,12 +1226,12 @@ mod tests {
                 position: RulePosition::Tree,
                 tags: None,
             }),
-            ProxyRequestData::RemoveBackend(RemoveBackend {
+            ProxyRequestOrder::RemoveBackend(RemoveBackend {
                 cluster_id: String::from("cluster_2"),
                 backend_id: String::from("cluster_2-0"),
                 address: "192.167.1.2:1026".parse().unwrap(),
             }),
-            ProxyRequestData::AddBackend(Backend {
+            ProxyRequestOrder::AddBackend(Backend {
                 cluster_id: String::from("cluster_1"),
                 backend_id: String::from("cluster_1-2"),
                 address: "127.0.0.2:1028".parse().unwrap(),
@@ -1239,10 +1239,10 @@ mod tests {
                 sticky_id: None,
                 backup: None,
             }),
-            ProxyRequestData::RemoveCluster {
+            ProxyRequestOrder::RemoveCluster {
                 cluster_id: String::from("cluster_2"),
             },
-            ProxyRequestData::AddCluster(Cluster {
+            ProxyRequestOrder::AddCluster(Cluster {
                 cluster_id: String::from("cluster_3"),
                 sticky_session: false,
                 https_redirect: false,
@@ -1252,7 +1252,7 @@ mod tests {
                 answer_503: None,
             }),
         ];
-        let expected_diff: HashSet<&ProxyRequestData> = HashSet::from_iter(e.iter());
+        let expected_diff: HashSet<&ProxyRequestOrder> = HashSet::from_iter(e.iter());
 
         let d = state.diff(&state2);
         let diff = HashSet::from_iter(d.iter());
@@ -1262,7 +1262,7 @@ mod tests {
         let hash1 = state.hash_state();
         let hash2 = state2.hash_state();
         let mut state3 = state.clone();
-        state3.handle_order(&ProxyRequestData::AddBackend(Backend {
+        state3.handle_order(&ProxyRequestOrder::AddBackend(Backend {
             cluster_id: String::from("cluster_1"),
             backend_id: String::from("cluster_1-2"),
             address: "127.0.0.2:1028".parse().unwrap(),
@@ -1321,12 +1321,12 @@ mod tests {
             tags: None,
         };
 
-        let add_http_front_order_cluster1 = ProxyRequestData::AddHttpFrontend(http_front_cluster1);
-        let add_http_front_order_cluster2 = ProxyRequestData::AddHttpFrontend(http_front_cluster2);
+        let add_http_front_order_cluster1 = ProxyRequestOrder::AddHttpFrontend(http_front_cluster1);
+        let add_http_front_order_cluster2 = ProxyRequestOrder::AddHttpFrontend(http_front_cluster2);
         let add_https_front_order_cluster1 =
-            ProxyRequestData::AddHttpsFrontend(https_front_cluster1);
+            ProxyRequestOrder::AddHttpsFrontend(https_front_cluster1);
         let add_https_front_order_cluster2 =
-            ProxyRequestData::AddHttpsFrontend(https_front_cluster2);
+            ProxyRequestOrder::AddHttpsFrontend(https_front_cluster2);
         config.handle_order(&add_http_front_order_cluster1);
         config.handle_order(&add_http_front_order_cluster2);
         config.handle_order(&add_https_front_order_cluster1);
@@ -1369,7 +1369,7 @@ mod tests {
     #[test]
     fn duplicate_backends() {
         let mut state: ConfigState = Default::default();
-        state.handle_order(&ProxyRequestData::AddBackend(Backend {
+        state.handle_order(&ProxyRequestOrder::AddBackend(Backend {
             cluster_id: String::from("cluster_1"),
             backend_id: String::from("cluster_1-0"),
             address: "127.0.0.1:1026".parse().unwrap(),
@@ -1387,7 +1387,7 @@ mod tests {
             backup: None,
         };
 
-        state.handle_order(&ProxyRequestData::AddBackend(b.clone()));
+        state.handle_order(&ProxyRequestOrder::AddBackend(b.clone()));
 
         assert_eq!(state.backends.get("cluster_1").unwrap(), &vec![b]);
     }
@@ -1395,7 +1395,7 @@ mod tests {
     #[test]
     fn listener_diff() {
         let mut state: ConfigState = Default::default();
-        state.handle_order(&ProxyRequestData::AddTcpListener(TcpListener {
+        state.handle_order(&ProxyRequestOrder::AddTcpListener(TcpListener {
             address: "0.0.0.0:1234".parse().unwrap(),
             public_address: None,
             expect_proxy: false,
@@ -1403,12 +1403,12 @@ mod tests {
             back_timeout: 30,
             connect_timeout: 3,
         }));
-        state.handle_order(&ProxyRequestData::ActivateListener(ActivateListener {
+        state.handle_order(&ProxyRequestOrder::ActivateListener(ActivateListener {
             address: "0.0.0.0:1234".parse().unwrap(),
             proxy: ListenerType::TCP,
             from_scm: false,
         }));
-        state.handle_order(&ProxyRequestData::AddHttpListener(HttpListener {
+        state.handle_order(&ProxyRequestOrder::AddHttpListener(HttpListener {
             address: "0.0.0.0:8080".parse().unwrap(),
             public_address: None,
             expect_proxy: false,
@@ -1420,7 +1420,7 @@ mod tests {
             back_timeout: 30,
             connect_timeout: 3,
         }));
-        state.handle_order(&ProxyRequestData::AddHttpsListener(HttpsListener {
+        state.handle_order(&ProxyRequestOrder::AddHttpsListener(HttpsListener {
             address: "0.0.0.0:8443".parse().unwrap(),
             public_address: None,
             expect_proxy: false,
@@ -1439,14 +1439,14 @@ mod tests {
             back_timeout: 30,
             connect_timeout: 3,
         }));
-        state.handle_order(&ProxyRequestData::ActivateListener(ActivateListener {
+        state.handle_order(&ProxyRequestOrder::ActivateListener(ActivateListener {
             address: "0.0.0.0:8443".parse().unwrap(),
             proxy: ListenerType::HTTPS,
             from_scm: false,
         }));
 
         let mut state2: ConfigState = Default::default();
-        state2.handle_order(&ProxyRequestData::AddTcpListener(TcpListener {
+        state2.handle_order(&ProxyRequestOrder::AddTcpListener(TcpListener {
             address: "0.0.0.0:1234".parse().unwrap(),
             public_address: None,
             expect_proxy: true,
@@ -1454,7 +1454,7 @@ mod tests {
             back_timeout: 30,
             connect_timeout: 3,
         }));
-        state2.handle_order(&ProxyRequestData::AddHttpListener(HttpListener {
+        state2.handle_order(&ProxyRequestOrder::AddHttpListener(HttpListener {
             address: "0.0.0.0:8080".parse().unwrap(),
             public_address: None,
             expect_proxy: false,
@@ -1466,12 +1466,12 @@ mod tests {
             back_timeout: 30,
             connect_timeout: 3,
         }));
-        state2.handle_order(&ProxyRequestData::ActivateListener(ActivateListener {
+        state2.handle_order(&ProxyRequestOrder::ActivateListener(ActivateListener {
             address: "0.0.0.0:8080".parse().unwrap(),
             proxy: ListenerType::HTTP,
             from_scm: false,
         }));
-        state2.handle_order(&ProxyRequestData::AddHttpsListener(HttpsListener {
+        state2.handle_order(&ProxyRequestOrder::AddHttpsListener(HttpsListener {
             address: "0.0.0.0:8443".parse().unwrap(),
             public_address: None,
             expect_proxy: false,
@@ -1490,18 +1490,18 @@ mod tests {
             back_timeout: 30,
             connect_timeout: 3,
         }));
-        state2.handle_order(&ProxyRequestData::ActivateListener(ActivateListener {
+        state2.handle_order(&ProxyRequestOrder::ActivateListener(ActivateListener {
             address: "0.0.0.0:8443".parse().unwrap(),
             proxy: ListenerType::HTTPS,
             from_scm: false,
         }));
 
         let e = vec![
-            ProxyRequestData::RemoveListener(RemoveListener {
+            ProxyRequestOrder::RemoveListener(RemoveListener {
                 address: "0.0.0.0:1234".parse().unwrap(),
                 proxy: ListenerType::TCP,
             }),
-            ProxyRequestData::AddTcpListener(TcpListener {
+            ProxyRequestOrder::AddTcpListener(TcpListener {
                 address: "0.0.0.0:1234".parse().unwrap(),
                 public_address: None,
                 expect_proxy: true,
@@ -1509,16 +1509,16 @@ mod tests {
                 back_timeout: 30,
                 connect_timeout: 3,
             }),
-            ProxyRequestData::DeactivateListener(DeactivateListener {
+            ProxyRequestOrder::DeactivateListener(DeactivateListener {
                 address: "0.0.0.0:1234".parse().unwrap(),
                 proxy: ListenerType::TCP,
                 to_scm: false,
             }),
-            ProxyRequestData::RemoveListener(RemoveListener {
+            ProxyRequestOrder::RemoveListener(RemoveListener {
                 address: "0.0.0.0:8080".parse().unwrap(),
                 proxy: ListenerType::HTTP,
             }),
-            ProxyRequestData::AddHttpListener(HttpListener {
+            ProxyRequestOrder::AddHttpListener(HttpListener {
                 address: "0.0.0.0:8080".parse().unwrap(),
                 public_address: None,
                 expect_proxy: false,
@@ -1530,16 +1530,16 @@ mod tests {
                 back_timeout: 30,
                 connect_timeout: 3,
             }),
-            ProxyRequestData::ActivateListener(ActivateListener {
+            ProxyRequestOrder::ActivateListener(ActivateListener {
                 address: "0.0.0.0:8080".parse().unwrap(),
                 proxy: ListenerType::HTTP,
                 from_scm: false,
             }),
-            ProxyRequestData::RemoveListener(RemoveListener {
+            ProxyRequestOrder::RemoveListener(RemoveListener {
                 address: "0.0.0.0:8443".parse().unwrap(),
                 proxy: ListenerType::HTTPS,
             }),
-            ProxyRequestData::AddHttpsListener(HttpsListener {
+            ProxyRequestOrder::AddHttpsListener(HttpsListener {
                 address: "0.0.0.0:8443".parse().unwrap(),
                 public_address: None,
                 expect_proxy: false,

--- a/lib/examples/main.rs
+++ b/lib/examples/main.rs
@@ -69,12 +69,12 @@ fn main() {
 
     command.write_message(&proxy::ProxyRequest {
         id: String::from("ID_ABCD"),
-        order: proxy::ProxyRequestData::AddHttpFrontend(http_front),
+        order: proxy::ProxyRequestOrder::AddHttpFrontend(http_front),
     });
 
     command.write_message(&proxy::ProxyRequest {
         id: String::from("ID_EFGH"),
-        order: proxy::ProxyRequestData::AddBackend(http_backend),
+        order: proxy::ProxyRequestOrder::AddBackend(http_backend),
     });
 
     info!("MAIN\tHTTP -> {:?}", command.read_message());
@@ -119,7 +119,7 @@ fn main() {
     };
     command2.write_message(&proxy::ProxyRequest {
         id: String::from("ID_IJKL1"),
-        order: proxy::ProxyRequestData::AddCertificate(proxy::AddCertificate {
+        order: proxy::ProxyRequestOrder::AddCertificate(proxy::AddCertificate {
             address: "127.0.0.1:8443".parse().unwrap(),
             certificate: certificate_and_key,
             names: vec![],
@@ -139,7 +139,7 @@ fn main() {
 
     command2.write_message(&proxy::ProxyRequest {
         id: String::from("ID_IJKL2"),
-        order: proxy::ProxyRequestData::AddHttpsFrontend(tls_front),
+        order: proxy::ProxyRequestOrder::AddHttpsFrontend(tls_front),
     });
     let tls_backend = proxy::Backend {
         cluster_id: String::from("cluster_1"),
@@ -152,7 +152,7 @@ fn main() {
 
     command2.write_message(&proxy::ProxyRequest {
         id: String::from("ID_MNOP"),
-        order: proxy::ProxyRequestData::AddBackend(tls_backend),
+        order: proxy::ProxyRequestOrder::AddBackend(tls_backend),
     });
 
     let cert2 = include_str!("../assets/cert_test.pem");
@@ -167,7 +167,7 @@ fn main() {
 
     command2.write_message(&proxy::ProxyRequest {
         id: String::from("ID_QRST1"),
-        order: proxy::ProxyRequestData::AddCertificate(proxy::AddCertificate {
+        order: proxy::ProxyRequestOrder::AddCertificate(proxy::AddCertificate {
             address: "127.0.0.1:8443".parse().unwrap(),
             certificate: certificate_and_key2,
             names: vec![],
@@ -187,7 +187,7 @@ fn main() {
 
     command2.write_message(&proxy::ProxyRequest {
         id: String::from("ID_QRST2"),
-        order: proxy::ProxyRequestData::AddHttpsFrontend(tls_front2),
+        order: proxy::ProxyRequestOrder::AddHttpsFrontend(tls_front2),
     });
 
     let tls_backend2 = proxy::Backend {
@@ -201,7 +201,7 @@ fn main() {
 
     command2.write_message(&proxy::ProxyRequest {
         id: String::from("ID_UVWX"),
-        order: proxy::ProxyRequestData::AddBackend(tls_backend2),
+        order: proxy::ProxyRequestOrder::AddBackend(tls_backend2),
     });
 
     info!("MAIN\tTLS -> {:?}", command2.read_message());

--- a/lib/examples/minimal.rs
+++ b/lib/examples/minimal.rs
@@ -68,12 +68,12 @@ fn main() {
 
     command.write_message(&proxy::ProxyRequest {
         id: String::from("ID_ABCD"),
-        order: proxy::ProxyRequestData::AddHttpFrontend(http_front),
+        order: proxy::ProxyRequestOrder::AddHttpFrontend(http_front),
     });
 
     command.write_message(&proxy::ProxyRequest {
         id: String::from("ID_EFGH"),
-        order: proxy::ProxyRequestData::AddBackend(http_backend),
+        order: proxy::ProxyRequestOrder::AddBackend(http_backend),
     });
 
     println!("HTTP -> {:?}", command.read_message());

--- a/lib/examples/tcp.rs
+++ b/lib/examples/tcp.rs
@@ -68,12 +68,12 @@ fn main() {
 
     command.write_message(&proxy::ProxyRequest {
         id: String::from("ID_ABCD"),
-        order: proxy::ProxyRequestData::AddTcpFrontend(tcp_front),
+        order: proxy::ProxyRequestOrder::AddTcpFrontend(tcp_front),
     });
 
     command.write_message(&proxy::ProxyRequest {
         id: String::from("ID_EFGH"),
-        order: proxy::ProxyRequestData::AddBackend(tcp_backend),
+        order: proxy::ProxyRequestOrder::AddBackend(tcp_backend),
     });
 
     info!("TCP -> {:?}", command.read_message());

--- a/lib/tests/http.rs
+++ b/lib/tests/http.rs
@@ -56,7 +56,7 @@ fn test() {
 
     command.write_message(&proxy::ProxyRequest {
         id: String::from("ID_Status"),
-        order: proxy::ProxyRequestData::Status,
+        order: proxy::ProxyRequestOrder::Status,
     });
 
     // wait for sozu to start and answer
@@ -89,7 +89,7 @@ fn test() {
 
     command.write_message(&proxy::ProxyRequest {
         id: String::from("ID_ABCD"),
-        order: proxy::ProxyRequestData::AddHttpFrontend(http_frontend),
+        order: proxy::ProxyRequestOrder::AddHttpFrontend(http_frontend),
     });
     println!("HTTP -> {:?}", command.read_message());
 
@@ -112,7 +112,7 @@ fn test() {
 
     command.write_message(&proxy::ProxyRequest {
         id: String::from("ID_EFGH"),
-        order: proxy::ProxyRequestData::AddBackend(http_backend),
+        order: proxy::ProxyRequestOrder::AddBackend(http_backend),
     });
 
     println!("HTTP -> {:?}", command.read_message());
@@ -168,7 +168,7 @@ fn test() {
 
     command.write_message(&proxy::ProxyRequest {
         id: String::from("ID_EFGH-2"),
-        order: proxy::ProxyRequestData::RemoveBackend(proxy::RemoveBackend {
+        order: proxy::ProxyRequestOrder::RemoveBackend(proxy::RemoveBackend {
             cluster_id: String::from("test"),
             backend_id: String::from("test-0"),
             address: "127.0.0.1:2048".parse().unwrap(),
@@ -186,7 +186,7 @@ fn test() {
 
     command.write_message(&proxy::ProxyRequest {
         id: String::from("ID_EFGH-3"),
-        order: proxy::ProxyRequestData::AddBackend(http_backend),
+        order: proxy::ProxyRequestOrder::AddBackend(http_backend),
     });
 
     let barrier2 = barrier.clone();
@@ -245,7 +245,7 @@ fn test() {
 
     command.write_message(&proxy::ProxyRequest {
         id: String::from("ID_EFGH-2"),
-        order: proxy::ProxyRequestData::RemoveBackend(proxy::RemoveBackend {
+        order: proxy::ProxyRequestOrder::RemoveBackend(proxy::RemoveBackend {
             cluster_id: String::from("test"),
             backend_id: String::from("test-0"),
             address: "127.0.0.1:2048".parse().unwrap(),
@@ -263,7 +263,7 @@ fn test() {
 
     command.write_message(&proxy::ProxyRequest {
         id: String::from("ID_EFGH-3"),
-        order: proxy::ProxyRequestData::AddBackend(http_backend),
+        order: proxy::ProxyRequestOrder::AddBackend(http_backend),
     });
 
     let barrier2 = barrier.clone();


### PR DESCRIPTION
Instead of writing the worker id within a request id, concatenated with other stuff as a suffix, we should keep track of which worker we sent a request to, inside the `in_flight` map of the command server.

The ideal way would be to keep a worker's id within a proxy instance:

- #798 

But we could also track requests in a `RequestSummary`, accross the Command Server.

This is highly experimental at this moment.