### PR TITLE
0.14 error management

### DIFF
--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -130,7 +130,7 @@ pub enum Success {
     Query(CommandResponseContent),
     ReloadConfiguration(usize, usize), // ok, errors
     SaveState(usize, String),          // amount of written commands, path of the saved state
-    Status(CommandResponseContent),       // Vec<WorkerInfo>
+    Status(CommandResponseContent),    // Vec<WorkerInfo>
     SubscribeEvent(String),
     UpgradeMain(i32),         // pid of the new main process
     UpgradeWorker(u32),       // worker id
@@ -278,7 +278,11 @@ impl CommandServer {
         let state: ConfigState = Default::default();
 
         for worker in workers.iter_mut() {
-            let main_to_worker_channel = worker.worker_channel.take().unwrap().sock;
+            let main_to_worker_channel = worker
+                .worker_channel
+                .take()
+                .with_context(|| format!("No channel present in worker {}", worker.id))?
+                .sock;
             let (worker_tx, worker_rx) = channel(10000);
             worker.sender = Some(worker_tx);
 
@@ -436,19 +440,21 @@ impl CommandServer {
                 */
                 let accept_client = listener.accept();
                 futures::pin_mut!(accept_client);
-                let (stream, _) =
-                    match futures::future::select(accept_cancel_rx.take().unwrap(), accept_client)
-                        .await
-                    {
-                        futures::future::Either::Left((_canceled, _)) => {
-                            info!("stopping listener");
-                            break;
-                        }
-                        futures::future::Either::Right((res, cancel_rx)) => {
-                            accept_cancel_rx = Some(cancel_rx);
-                            res.unwrap()
-                        }
-                    };
+                let (stream, _) = match futures::future::select(
+                    accept_cancel_rx.take().expect("No channel found"),
+                    accept_client,
+                )
+                .await
+                {
+                    futures::future::Either::Left((_canceled, _)) => {
+                        info!("stopping listener");
+                        break;
+                    }
+                    futures::future::Either::Right((res, cancel_rx)) => {
+                        accept_cancel_rx = Some(cancel_rx);
+                        res.map_err(|e| error!("{}", e)).unwrap()
+                    }
+                };
                 debug!("Accepted a client from upgraded");
 
                 let (client_tx, client_rx) = channel(10000);
@@ -465,7 +471,7 @@ impl CommandServer {
                     sender: client_tx,
                 })
                 .await
-                .unwrap();
+                .expect("Could not send ClientNew message");
                 counter += 1;
             }
         })
@@ -695,7 +701,16 @@ impl CommandServer {
         info!("created new worker: {}", new_worker_id);
         self.next_worker_id += 1;
 
-        let sock = new_worker.worker_channel.take().unwrap().sock;
+        let sock = new_worker
+            .worker_channel
+            .take()
+            .with_context(|| {
+                format!(
+                    "the new worker with id {} does not have a channel",
+                    new_worker.id
+                )
+            })? // this used to crash with unwrap(), do we still want to crash?
+            .sock;
         let (worker_tx, worker_rx) = channel(10_000);
         new_worker.sender = Some(worker_tx);
 
@@ -929,7 +944,7 @@ pub fn start_server(
                         sender: client_tx,
                     })
                     .await
-                    .unwrap();
+                    .expect("Failed at sending ClientNew message");
                 counter += 1;
             }
         })

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -452,7 +452,7 @@ impl CommandServer {
                     }
                     futures::future::Either::Right((res, cancel_rx)) => {
                         accept_cancel_rx = Some(cancel_rx);
-                        res.map_err(|e| error!("{}", e)).unwrap()
+                        res.expect("Can not get unix stream to create a client loop.")
                     }
                 };
                 debug!("Accepted a client from upgraded");

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -368,7 +368,7 @@ impl CommandManager {
         let message = self
             .channel
             .read_message_blocking_timeout(Some(self.timeout))
-            .unwrap();
+            .with_context(|| "Can not read response from channel")?;
 
         if id != message.id {
             bail!("received message with invalid id: {:?}", message);

--- a/bin/src/logging.rs
+++ b/bin/src/logging.rs
@@ -51,6 +51,7 @@ macro_rules! log {
     };
 }
 
+// this should return a Result to trickle up errors
 pub fn init(
     tag: String,
     spec: &str,

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -185,7 +185,7 @@ pub fn fork_main_into_worker(
     trace!("parent({})", unsafe { libc::getpid() });
 
     let mut state_file =
-        tempfile().expect("could not create temporary file for configuration state");
+        tempfile().with_context(|| "could not create temporary file for configuration state")?;
     util::disable_close_on_exec(state_file.as_raw_fd())?;
 
     serde_json::to_writer(&mut state_file, state)

--- a/command/src/certificate.rs
+++ b/command/src/certificate.rs
@@ -1,10 +1,14 @@
+use anyhow::{self, Context};
 use pem::parse;
 use sha2::{Digest, Sha256};
 
-pub fn calculate_fingerprint(certificate: &[u8]) -> Option<Vec<u8>> {
-    parse(certificate)
-        .map(|data| Sha256::digest(&data.contents).iter().cloned().collect())
-        .ok()
+pub fn calculate_fingerprint(certificate: &[u8]) -> anyhow::Result<Vec<u8>> {
+    let parsed_certificate = parse(certificate).with_context(|| "Can not parse certificate")?;
+    let fingerprint = Sha256::digest(&parsed_certificate.contents)
+        .iter()
+        .cloned()
+        .collect();
+    Ok(fingerprint)
 }
 
 pub fn calculate_fingerprint_from_der(certificate: &[u8]) -> Vec<u8> {

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -1190,7 +1190,9 @@ impl Config {
                 id: format!("CONFIG-{}", count),
                 version: PROTOCOL_VERSION,
                 worker_id: None,
-                order: CommandRequestOrder::Proxy(ProxyRequestOrder::AddTcpListener(listener.clone())),
+                order: CommandRequestOrder::Proxy(ProxyRequestOrder::AddTcpListener(
+                    listener.clone(),
+                )),
             });
             count += 1;
         }

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -75,10 +75,9 @@ impl Listener {
         front_timeout: Option<u32>,
         back_timeout: Option<u32>,
         connect_timeout: Option<u32>,
-    ) -> Option<HttpListener> {
+    ) -> anyhow::Result<HttpListener> {
         if self.protocol != FileListenerProtocolConfig::Http {
-            error!("cannot convert listener to HTTP");
-            return None;
+            bail!("cannot convert listener to HTTP");
         }
 
         /*FIXME
@@ -94,47 +93,46 @@ impl Listener {
           }
         };
         */
-        let http_proxy_configuration = Some(self.address);
+        // let http_proxy_configuration = Some(self.address);
 
-        http_proxy_configuration.map(|addr| {
-            let mut configuration = HttpListener {
-                address: addr,
-                public_address: self.public_address,
-                expect_proxy: self.expect_proxy.unwrap_or(false),
-                sticky_name: self.sticky_name.clone(),
-                front_timeout: self.front_timeout.or(front_timeout).unwrap_or(60),
-                back_timeout: self.back_timeout.or(back_timeout).unwrap_or(30),
-                connect_timeout: self.connect_timeout.or(connect_timeout).unwrap_or(3),
-                ..Default::default()
-            };
+        let mut configuration = HttpListener {
+            address: self.address,
+            public_address: self.public_address,
+            expect_proxy: self.expect_proxy.unwrap_or(false),
+            sticky_name: self.sticky_name.clone(),
+            front_timeout: self.front_timeout.or(front_timeout).unwrap_or(60),
+            back_timeout: self.back_timeout.or(back_timeout).unwrap_or(30),
+            connect_timeout: self.connect_timeout.or(connect_timeout).unwrap_or(3),
+            ..Default::default()
+        };
 
-            //FIXME: error messages if file not found?
-            let mut answer_404 = String::new();
-            if self
-                .answer_404
-                .as_ref()
-                .and_then(|path| File::open(path).ok())
-                .and_then(|mut file| file.read_to_string(&mut answer_404).ok())
-                .is_some()
-            {
-                configuration.answer_404 = answer_404;
-            } else {
-                configuration.answer_404 = String::from(include_str!("../assets/404.html"));
-            }
-            let mut answer_503 = String::new();
-            if self
-                .answer_503
-                .as_ref()
-                .and_then(|path| File::open(path).ok())
-                .and_then(|mut file| file.read_to_string(&mut answer_503).ok())
-                .is_some()
-            {
-                configuration.answer_503 = answer_503;
-            } else {
-                configuration.answer_503 = String::from(include_str!("../assets/503.html"));
-            }
-            configuration
-        })
+        //FIXME: error messages if file not found?
+        // sure, this sounds good, that's a TODO
+        let mut answer_404 = String::new();
+        if self
+            .answer_404
+            .as_ref()
+            .and_then(|path| File::open(path).ok())
+            .and_then(|mut file| file.read_to_string(&mut answer_404).ok())
+            .is_some()
+        {
+            configuration.answer_404 = answer_404;
+        } else {
+            configuration.answer_404 = String::from(include_str!("../assets/404.html"));
+        }
+        let mut answer_503 = String::new();
+        if self
+            .answer_503
+            .as_ref()
+            .and_then(|path| File::open(path).ok())
+            .and_then(|mut file| file.read_to_string(&mut answer_503).ok())
+            .is_some()
+        {
+            configuration.answer_503 = answer_503;
+        } else {
+            configuration.answer_503 = String::from(include_str!("../assets/503.html"));
+        }
+        Ok(configuration)
     }
 
     pub fn to_tls(
@@ -142,10 +140,9 @@ impl Listener {
         front_timeout: Option<u32>,
         back_timeout: Option<u32>,
         connect_timeout: Option<u32>,
-    ) -> Option<HttpsListener> {
+    ) -> anyhow::Result<HttpsListener> {
         if self.protocol != FileListenerProtocolConfig::Https {
-            error!("cannot convert listener to HTTPS");
-            return None;
+            bail!("cannot convert listener to HTTPS");
         }
 
         let cipher_list: String = self.cipher_list.clone().unwrap_or_else(|| {
@@ -191,8 +188,8 @@ impl Listener {
 
         let rustls_cipher_list = self.rustls_cipher_list.clone().unwrap_or_default();
 
-        //FIXME
-        let tls_proxy_configuration = Some(self.address);
+        //FIXME => done. This seems useless now
+        // let tls_proxy_configuration = Some(self.address);
 
         let versions = match self.tls_versions {
             None => vec![TlsVersion::TLSv1_2, TlsVersion::TLSv1_3],
@@ -231,54 +228,53 @@ impl Listener {
 
         let expect_proxy = self.expect_proxy.unwrap_or(false);
 
-        tls_proxy_configuration.map(|addr| {
-            let mut configuration = HttpsListener {
-                address: addr,
-                sticky_name: self.sticky_name.clone(),
-                public_address: self.public_address,
-                cipher_list,
-                versions,
-                expect_proxy,
-                rustls_cipher_list,
-                key,
-                certificate,
-                certificate_chain,
-                front_timeout: self.front_timeout.or(front_timeout).unwrap_or(60),
-                back_timeout: self.back_timeout.or(back_timeout).unwrap_or(30),
-                connect_timeout: self.connect_timeout.or(connect_timeout).unwrap_or(3),
-                ..Default::default()
-            };
+        let mut configuration = HttpsListener {
+            address: self.address,
+            sticky_name: self.sticky_name.clone(),
+            public_address: self.public_address,
+            cipher_list,
+            versions,
+            expect_proxy,
+            rustls_cipher_list,
+            key,
+            certificate,
+            certificate_chain,
+            front_timeout: self.front_timeout.or(front_timeout).unwrap_or(60),
+            back_timeout: self.back_timeout.or(back_timeout).unwrap_or(30),
+            connect_timeout: self.connect_timeout.or(connect_timeout).unwrap_or(3),
+            ..Default::default()
+        };
 
-            let mut answer_404 = String::new();
-            if self
-                .answer_404
-                .as_ref()
-                .and_then(|path| File::open(path).ok())
-                .and_then(|mut file| file.read_to_string(&mut answer_404).ok())
-                .is_some()
-            {
-                configuration.answer_404 = answer_404;
-            } else {
-                configuration.answer_404 = String::from(include_str!("../assets/404.html"));
-            }
-            let mut answer_503 = String::new();
-            if self
-                .answer_503
-                .as_ref()
-                .and_then(|path| File::open(path).ok())
-                .and_then(|mut file| file.read_to_string(&mut answer_503).ok())
-                .is_some()
-            {
-                configuration.answer_503 = answer_503;
-            } else {
-                configuration.answer_503 = String::from(include_str!("../assets/503.html"));
-            }
-            if let Some(cipher_list) = self.cipher_list.as_ref() {
-                configuration.cipher_list = cipher_list.clone();
-            }
+        let mut answer_404 = String::new();
+        if self
+            .answer_404
+            .as_ref()
+            .and_then(|path| File::open(path).ok())
+            .and_then(|mut file| file.read_to_string(&mut answer_404).ok())
+            .is_some()
+        {
+            configuration.answer_404 = answer_404;
+        } else {
+            configuration.answer_404 = String::from(include_str!("../assets/404.html"));
+        }
 
-            configuration
-        })
+        let mut answer_503 = String::new();
+        if self
+            .answer_503
+            .as_ref()
+            .and_then(|path| File::open(path).ok())
+            .and_then(|mut file| file.read_to_string(&mut answer_503).ok())
+            .is_some()
+        {
+            configuration.answer_503 = answer_503;
+        } else {
+            configuration.answer_503 = String::from(include_str!("../assets/503.html"));
+        }
+        if let Some(cipher_list) = self.cipher_list.as_ref() {
+            configuration.cipher_list = cipher_list.clone();
+        }
+
+        Ok(configuration)
     }
 
     pub fn to_tcp(
@@ -286,7 +282,8 @@ impl Listener {
         front_timeout: Option<u32>,
         back_timeout: Option<u32>,
         connect_timeout: Option<u32>,
-    ) -> Option<TcpListener> {
+    ) -> anyhow::Result<TcpListener> {
+        // what does this code do? should we remove it?
         /*let mut address = self.address.clone();
         address.push(':');
         address.push_str(&self.port.to_string());
@@ -299,11 +296,12 @@ impl Listener {
             None
           }
         };
-        */
-        let addr_parsed = Some(self.address);
 
-        addr_parsed.map(|addr| TcpListener {
-            address: addr,
+        let addr = addr_parsed;
+        */
+
+        Ok(TcpListener {
+            address: self.address,
             public_address: self.public_address,
             expect_proxy: self.expect_proxy.unwrap_or(false),
             front_timeout: self.front_timeout.or(front_timeout).unwrap_or(60),
@@ -851,7 +849,7 @@ impl FileConfig {
         }
     }
 
-    pub fn into(self, config_path: &str) -> Config {
+    pub fn into(self, config_path: &str) -> anyhow::Result<Config> {
         let mut clusters = HashMap::new();
         let mut http_listeners = Vec::new();
         let mut https_listeners = Vec::new();
@@ -862,10 +860,10 @@ impl FileConfig {
         if let Some(listeners) = self.listeners {
             for listener in listeners.iter() {
                 if known_addresses.contains_key(&listener.address) {
-                    panic!(
+                    bail!(format!(
                         "there's already a listener for address {:?}",
                         listener.address
-                    );
+                    ));
                 }
 
                 known_addresses.insert(listener.address, listener.protocol);
@@ -874,42 +872,30 @@ impl FileConfig {
                 }
 
                 if listener.public_address.is_some() && listener.expect_proxy == Some(true) {
-                    panic!("the listener on {} has incompatible options: it cannot use the expect proxy protocol and have a public_address field at the same time", &listener.address);
+                    bail!(format!(
+                        "the listener on {} has incompatible options: it cannot use the expect proxy protocol and have a public_address field at the same time", 
+                        &listener.address
+                    ));
                 }
 
                 match listener.protocol {
                     FileListenerProtocolConfig::Https => {
-                        if let Some(l) = listener.to_tls(
-                            self.front_timeout,
-                            self.back_timeout,
-                            self.connect_timeout,
-                        ) {
-                            https_listeners.push(l);
-                        } else {
-                            panic!("invalid listener");
-                        }
+                        let listener = listener
+                            .to_tls(self.front_timeout, self.back_timeout, self.connect_timeout)
+                            .with_context(|| "invalid listener")?;
+                        https_listeners.push(listener);
                     }
                     FileListenerProtocolConfig::Http => {
-                        if let Some(l) = listener.to_http(
-                            self.front_timeout,
-                            self.back_timeout,
-                            self.connect_timeout,
-                        ) {
-                            http_listeners.push(l);
-                        } else {
-                            panic!("invalid listener");
-                        }
+                        let listener = listener
+                            .to_http(self.front_timeout, self.back_timeout, self.connect_timeout)
+                            .with_context(|| "invalid listener")?;
+                        http_listeners.push(listener);
                     }
                     FileListenerProtocolConfig::Tcp => {
-                        if let Some(l) = listener.to_tcp(
-                            self.front_timeout,
-                            self.back_timeout,
-                            self.connect_timeout,
-                        ) {
-                            tcp_listeners.push(l);
-                        } else {
-                            panic!("invalid listener");
-                        }
+                        let listener = listener
+                            .to_tcp(self.front_timeout, self.back_timeout, self.connect_timeout)
+                            .with_context(|| "invalid listener")?;
+                        tcp_listeners.push(listener);
                     }
                 }
             }
@@ -917,109 +903,111 @@ impl FileConfig {
 
         if let Some(mut file_cluster_configs) = self.clusters {
             for (id, file_cluster_config) in file_cluster_configs.drain() {
-                match file_cluster_config.to_cluster_config(id.as_str(), &expect_proxy) {
-                    Ok(cluster_config) => {
-                        match cluster_config {
-                            ClusterConfig::Http(ref http) => {
-                                for frontend in http.frontends.iter() {
-                                    match known_addresses.get(&frontend.address) {
-                                        Some(FileListenerProtocolConfig::Tcp) => {
-                                            panic!("cannot set up a HTTP or HTTPS frontend on a TCP listener");
-                                        }
-                                        Some(FileListenerProtocolConfig::Http) => {
-                                            if frontend.certificate.is_some() {
-                                                panic!("cannot set up a HTTPS frontend on a HTTP listener");
-                                            }
-                                        }
-                                        Some(FileListenerProtocolConfig::Https) => {
-                                            if frontend.certificate.is_none() {
-                                                println!("known addresses: {:#?}", known_addresses);
-                                                println!("frontend: {:#?}", frontend);
-                                                panic!("cannot set up a HTTP frontend on a HTTPS listener");
-                                            }
-                                        }
-                                        None => {
-                                            // create a default listener for that front
-                                            let p = if frontend.certificate.is_some() {
-                                                let listener = Listener::new(
-                                                    frontend.address,
-                                                    FileListenerProtocolConfig::Https,
-                                                );
-                                                https_listeners.push(
-                                                    listener
-                                                        .to_tls(
-                                                            self.front_timeout,
-                                                            self.back_timeout,
-                                                            self.connect_timeout,
-                                                        )
-                                                        .unwrap(),
-                                                );
+                let cluster_config = file_cluster_config
+                    .to_cluster_config(id.as_str(), &expect_proxy)
+                    .with_context(|| {
+                        format!("error parsing cluster configuration for cluster {}", id)
+                    })?;
 
-                                                FileListenerProtocolConfig::Https
-                                            } else {
-                                                let listener = Listener::new(
-                                                    frontend.address,
-                                                    FileListenerProtocolConfig::Http,
-                                                );
-                                                http_listeners.push(
-                                                    listener
-                                                        .to_http(
-                                                            self.front_timeout,
-                                                            self.back_timeout,
-                                                            self.connect_timeout,
-                                                        )
-                                                        .unwrap(),
-                                                );
-
-                                                FileListenerProtocolConfig::Http
-                                            };
-                                            known_addresses.insert(frontend.address, p);
-                                        }
+                match cluster_config {
+                    ClusterConfig::Http(ref http) => {
+                        for frontend in http.frontends.iter() {
+                            match known_addresses.get(&frontend.address) {
+                                Some(FileListenerProtocolConfig::Tcp) => {
+                                    bail!(
+                                        "cannot set up a HTTP or HTTPS frontend on a TCP listener"
+                                    );
+                                }
+                                Some(FileListenerProtocolConfig::Http) => {
+                                    if frontend.certificate.is_some() {
+                                        bail!("cannot set up a HTTPS frontend on a HTTP listener");
                                     }
                                 }
-                            }
-                            ClusterConfig::Tcp(ref tcp) => {
-                                //FIXME: verify that different TCP clusters do not request the same address
-                                for frontend in &tcp.frontends {
-                                    match known_addresses.get(&frontend.address) {
-                                        Some(FileListenerProtocolConfig::Http)
-                                        | Some(FileListenerProtocolConfig::Https) => {
-                                            panic!(
-                                                "cannot set up a TCP frontend on a HTTP listener"
-                                            );
-                                        }
-                                        Some(FileListenerProtocolConfig::Tcp) => {}
-                                        None => {
-                                            // create a default listener for that front
-                                            let listener = Listener::new(
-                                                frontend.address,
-                                                FileListenerProtocolConfig::Tcp,
-                                            );
-                                            tcp_listeners.push(
-                                                listener
-                                                    .to_tcp(
-                                                        self.front_timeout,
-                                                        self.back_timeout,
-                                                        self.connect_timeout,
-                                                    )
-                                                    .unwrap(),
-                                            );
-                                            known_addresses.insert(
-                                                frontend.address,
-                                                FileListenerProtocolConfig::Tcp,
-                                            );
-                                        }
+                                Some(FileListenerProtocolConfig::Https) => {
+                                    if frontend.certificate.is_none() {
+                                        println!("known addresses: {:#?}", known_addresses);
+                                        println!("frontend: {:#?}", frontend);
+                                        bail!("cannot set up a HTTP frontend on a HTTPS listener");
                                     }
+                                }
+                                None => {
+                                    // create a default listener for that front
+                                    let file_listener_protocol = if frontend.certificate.is_some() {
+                                        let listener = Listener::new(
+                                            frontend.address,
+                                            FileListenerProtocolConfig::Https,
+                                        );
+                                        https_listeners.push(
+                                            listener
+                                                .to_tls(
+                                                    self.front_timeout,
+                                                    self.back_timeout,
+                                                    self.connect_timeout,
+                                                )
+                                                .with_context(|| {
+                                                    "Cannot convert listener to TLS"
+                                                })?,
+                                        );
+
+                                        FileListenerProtocolConfig::Https
+                                    } else {
+                                        let listener = Listener::new(
+                                            frontend.address,
+                                            FileListenerProtocolConfig::Http,
+                                        );
+                                        http_listeners.push(
+                                            listener
+                                                .to_http(
+                                                    self.front_timeout,
+                                                    self.back_timeout,
+                                                    self.connect_timeout,
+                                                )
+                                                .with_context(|| {
+                                                    "Cannot convert listener to HTTP"
+                                                })?,
+                                        );
+
+                                        FileListenerProtocolConfig::Http
+                                    };
+                                    known_addresses
+                                        .insert(frontend.address, file_listener_protocol);
                                 }
                             }
                         }
-
-                        clusters.insert(id, cluster_config);
                     }
-                    Err(s) => {
-                        panic!("error parsing cluster configuration for {}: {}", id, s);
+                    ClusterConfig::Tcp(ref tcp) => {
+                        //FIXME: verify that different TCP clusters do not request the same address
+                        for frontend in &tcp.frontends {
+                            match known_addresses.get(&frontend.address) {
+                                Some(FileListenerProtocolConfig::Http)
+                                | Some(FileListenerProtocolConfig::Https) => {
+                                    bail!("cannot set up a TCP frontend on a HTTP listener");
+                                }
+                                Some(FileListenerProtocolConfig::Tcp) => {}
+                                None => {
+                                    // create a default listener for that front
+                                    let listener = Listener::new(
+                                        frontend.address,
+                                        FileListenerProtocolConfig::Tcp,
+                                    );
+                                    tcp_listeners.push(
+                                        listener
+                                            .to_tcp(
+                                                self.front_timeout,
+                                                self.back_timeout,
+                                                self.connect_timeout,
+                                            )
+                                            .with_context(|| "Cannot convert listener to TCP")?,
+                                    );
+                                    known_addresses
+                                        .insert(frontend.address, FileListenerProtocolConfig::Tcp);
+                                }
+                            }
+                        }
                     }
                 }
+
+                clusters.insert(id, cluster_config);
             }
         }
 
@@ -1030,16 +1018,19 @@ impl FileConfig {
         });
 
         let command_socket_path = self.command_socket.unwrap_or({
-            let mut path = env::current_dir().unwrap();
+            let mut path = env::current_dir().with_context(|| "env path not found")?;
             path.push("sozu.sock");
-            path.to_str().map(|s| s.to_string()).unwrap()
+            let verified_path = path
+                .to_str()
+                .with_context(|| "command socket path not valid")?;
+            verified_path.to_owned()
         });
 
         if let (None, Some(true)) = (&self.saved_state, &self.automatic_state_save) {
-            panic!("cannot activate automatic state save if the 'saved_state` option is not set");
+            bail!("cannot activate automatic state save if the 'saved_state` option is not set");
         }
 
-        Config {
+        Ok(Config {
             config_path: config_path.to_string(),
             command_socket: command_socket_path,
             command_buffer_size: self.command_buffer_size.unwrap_or(1_000_000),
@@ -1076,7 +1067,7 @@ impl FileConfig {
             //defaults to 30mn
             zombie_check_interval: self.zombie_check_interval.unwrap_or(30 * 60),
             accept_queue_timeout: self.accept_queue_timeout.unwrap_or(60),
-        }
+        })
     }
 }
 
@@ -1147,7 +1138,9 @@ impl Config {
         let file_config =
             FileConfig::load_from_path(path).with_context(|| "Could not load the config file")?;
 
-        let mut config = file_config.into(path);
+        let mut config = file_config
+            .into(path)
+            .with_context(|| "Could not parse config from file")?;
 
         // replace saved_state with a verified path
         config.saved_state = config

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -177,9 +177,12 @@ impl ConfigState {
             &ProxyRequestOrder::AddCertificate(ref add) => {
                 let fingerprint =
                     match calculate_fingerprint(add.certificate.certificate.as_bytes()) {
-                        Some(f) => CertificateFingerprint(f),
-                        None => {
-                            error!("cannot obtain the certificate's fingerprint");
+                        Ok(f) => CertificateFingerprint(f),
+                        Err(e) => {
+                            error!(
+                                "cannot obtain the certificate's fingerprint: {}",
+                                e.to_string()
+                            );
                             return false;
                         }
                     };
@@ -216,9 +219,12 @@ impl ConfigState {
 
                 let fingerprint =
                     match calculate_fingerprint(replace.new_certificate.certificate.as_bytes()) {
-                        Some(f) => CertificateFingerprint(f),
-                        None => {
-                            error!("cannot obtain the certificate's fingerprint");
+                        Ok(f) => CertificateFingerprint(f),
+                        Err(e) => {
+                            error!(
+                                "cannot obtain the certificate's fingerprint: {}",
+                                e.to_string()
+                            );
                             return changed;
                         }
                     };

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -399,7 +399,7 @@ impl Session {
         if upgrade == ProtocolResult::Continue {
             return result;
         }
-        
+
         if self.upgrade() {
             return match *unwrap_msg!(self.protocol.as_mut()) {
                 State::WebSocket(ref mut pipe) => pipe.back_readable(&mut self.metrics),
@@ -1826,6 +1826,8 @@ impl ProxyConfiguration<Session> for Proxy {
 
 pub fn start(config: HttpListener, channel: ProxyChannel, max_buffers: usize, buffer_size: usize) {
     use crate::server;
+
+    // we should be able to trickle up this error
     let event_loop = Poll::new().expect("could not create event loop");
 
     let pool = Rc::new(RefCell::new(Pool::with_capacity(

--- a/lib/src/https_openssl.rs
+++ b/lib/src/https_openssl.rs
@@ -2406,6 +2406,7 @@ use crate::server::HttpsProvider;
 pub fn start(config: HttpsListener, channel: ProxyChannel, max_buffers: usize, buffer_size: usize) {
     use crate::server;
 
+    // we should be able to trickle up this error
     let event_loop = Poll::new().expect("could not create event loop");
 
     let pool = Rc::new(RefCell::new(Pool::with_capacity(

--- a/lib/src/https_rustls/configuration.rs
+++ b/lib/src/https_rustls/configuration.rs
@@ -28,9 +28,9 @@ use crate::{
         logging,
         proxy::{
             AddCertificate, CertificateFingerprint, Cluster, HttpFrontend, HttpsListener,
-            ProxyRequest, ProxyRequestOrder, ProxyResponse, ProxyResponseContent, ProxyResponseStatus,
-            Query, QueryAnswer, QueryAnswerCertificate, QueryCertificateType, RemoveCertificate,
-            Route, TlsVersion,
+            ProxyRequest, ProxyRequestOrder, ProxyResponse, ProxyResponseContent,
+            ProxyResponseStatus, Query, QueryAnswer, QueryAnswerCertificate, QueryCertificateType,
+            RemoveCertificate, Route, TlsVersion,
         },
         scm_socket::ScmSocket,
     },
@@ -699,7 +699,7 @@ use crate::server::HttpsProvider;
 pub fn start(config: HttpsListener, channel: ProxyChannel, max_buffers: usize, buffer_size: usize) {
     use crate::server;
 
-    let event_loop = Poll::new().expect("could not create event loop");
+    let event_loop = Poll::new().expect("could not create event loop"); // we should be able to trickle up this error
 
     let pool = Rc::new(RefCell::new(Pool::with_capacity(
         1,
@@ -746,7 +746,7 @@ pub fn start(config: HttpsListener, channel: ProxyChannel, max_buffers: usize, b
     let mut configuration = Proxy::new(registry, sessions.clone(), pool.clone(), backends.clone());
     if configuration
         .add_listener(config, token)
-        .expect("failed to create listener")
+        .expect("failed to create listener") // we should be able to trickle up this error
         .is_some()
         && configuration.activate_listener(&address, None).is_some()
     {

--- a/lib/src/metrics/mod.rs
+++ b/lib/src/metrics/mod.rs
@@ -273,6 +273,7 @@ impl Write for MetricSocket {
     }
 }
 
+// this should return a Result and trickle up the errors
 pub fn udp_bind() -> UdpSocket {
     UdpSocket::bind("0.0.0.0:0".parse().unwrap()).expect("could not parse address")
 }

--- a/lib/src/protocol/http/parser/request.rs
+++ b/lib/src/protocol/http/parser/request.rs
@@ -310,6 +310,7 @@ pub fn validate_request_header(
         HeaderValue::Upgrade(s) => {
             let mut st = state;
             if let Some(conn) = st.get_mut_connection() {
+                // do we really want to crash here?
                 conn.upgrade = Some(str::from_utf8(s).expect("should be ascii").to_string())
             }
             st

--- a/lib/src/protocol/http/parser/response.rs
+++ b/lib/src/protocol/http/parser/response.rs
@@ -227,7 +227,7 @@ pub fn validate_response_header(
         }
         HeaderValue::Upgrade(protocol) => {
             let proto = str::from_utf8(protocol)
-                .expect("the parsed protocol should be a valid utf8 string")
+                .expect("the parsed protocol should be a valid utf8 string") // do we really want to crash here?
                 .to_string();
             trace!("parsed a protocol: {:?}", proto);
             trace!("state is {:?}", state);

--- a/lib/src/protocol/openssl.rs
+++ b/lib/src/protocol/openssl.rs
@@ -56,11 +56,11 @@ impl TlsHandshake {
                 let ssl = self
                     .ssl
                     .take()
-                    .expect("TlsHandshake should have a Ssl backend");
+                    .expect("TlsHandshake should have a Ssl backend"); // do we really want to crash here?
                 let sock = self
                     .front
                     .take()
-                    .expect("TlsHandshake should have a front socket");
+                    .expect("TlsHandshake should have a front socket"); // do we really want to crash here?
                 match ssl.accept(sock) {
                     Ok(stream) => {
                         self.stream = Some(stream);
@@ -137,7 +137,7 @@ impl TlsHandshake {
                 let mid = self
                     .mid
                     .take()
-                    .expect("TlsHandshake should have a MidHandshakeSslStream backend");
+                    .expect("TlsHandshake should have a MidHandshakeSslStream backend"); // do we really want to crash here?
                 match mid.handshake() {
                     Ok(stream) => {
                         self.stream = Some(stream);

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -1466,7 +1466,7 @@ pub fn start(
 ) {
     use crate::server;
 
-    let poll = Poll::new().expect("could not create event loop");
+    let poll = Poll::new().expect("could not create event loop");     // we should be able to trickle up this error
     let pool = Rc::new(RefCell::new(Pool::with_capacity(
         1,
         max_buffers,


### PR DESCRIPTION
A big part of Sōzu performs the Success/Failure logic using Option instead of Result. There are still too many `expect` and `unwrap` statements.

This PR aims at removing `expect` and `unwrap` statements, or at least convert `unwrap`s into more verbose `expect("some message")`.

This changes some function signatures to return `anyhow::Result<Struct>` instead of `Option<Struct>` or `Result<Struct, String>`.

This adds a lot of comments about errors we should trickle up, and `panic!` or `unwrap` or `expect` statement that are never called but could crash Sōzu. It is good practice to avoid those statements. Trickling up errors is better.