### PR TITLE
0.14 trickle errors in lib

### DIFF
--- a/bin/src/logging.rs
+++ b/bin/src/logging.rs
@@ -51,7 +51,6 @@ macro_rules! log {
     };
 }
 
-// this should return a Result to trickle up errors
 pub fn init(
     tag: String,
     spec: &str,

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -104,7 +104,7 @@ fn start(args: &cli::Args) -> Result<(), anyhow::Error> {
 
     util::setup_logging(&config);
     info!("Starting up");
-    util::setup_metrics(&config);
+    util::setup_metrics(&config).with_context(|| "Could not setup metrics")?;
     util::write_pid_file(&config).with_context(|| "PID file is not writeable")?;
 
     update_process_limits(&config)?;

--- a/bin/src/upgrade.rs
+++ b/bin/src/upgrade.rs
@@ -139,7 +139,7 @@ pub fn begin_new_main_process(
     let config = upgrade_data.config.clone();
 
     util::setup_logging(&config);
-    util::setup_metrics(&config);
+    util::setup_metrics(&config).with_context(|| "Could not setup metrics")?;
     //info!("new main got upgrade data: {:?}", upgrade_data);
 
     let mut server = CommandServer::from_upgrade_data(upgrade_data)?;

--- a/bin/src/util.rs
+++ b/bin/src/util.rs
@@ -46,15 +46,16 @@ pub fn setup_logging(config: &Config) {
     );
 }
 
-pub fn setup_metrics(config: &Config) {
+pub fn setup_metrics(config: &Config) -> anyhow::Result<()> {
     if let Some(metrics) = config.metrics.as_ref() {
-        metrics::setup(
+        return metrics::setup(
             &metrics.address,
             "MAIN",
             metrics.tagged_metrics,
             metrics.prefix.clone(),
         );
     }
+    Ok(())
 }
 
 pub fn write_pid_file(config: &Config) -> Result<(), anyhow::Error> {

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -162,13 +162,13 @@ pub fn begin_worker_process(
         .with_context(|| "Could not setup metrics")?;
     }
 
-    let mut server = Server::new_from_config(
+    let mut server = Server::try_new_from_config(
         worker_to_main_channel,
         ScmSocket::new(worker_to_main_scm_fd),
         worker_config,
         config_state,
         true,
-    );
+    ).with_context(||"Could not create server from config")?;
 
     info!("starting event loop");
     server.run();

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -158,7 +158,8 @@ pub fn begin_worker_process(
             worker_id,
             metrics.tagged_metrics,
             metrics.prefix.clone(),
-        );
+        )
+        .with_context(|| "Could not setup metrics")?;
     }
 
     let mut server = Server::new_from_config(

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -1825,6 +1825,7 @@ impl ProxyConfiguration<Session> for Proxy {
     }
 }
 
+/// This is not directly used by Sōzu but is available for example and testing purposes
 pub fn start(
     config: HttpListener,
     channel: ProxyChannel,
@@ -1911,7 +1912,8 @@ pub fn start(
         server_config,
         None,
         false,
-    );
+    )
+    .with_context(|| "Failed at creating server")?;
 
     println!("starting event loop");
     server.run();

--- a/lib/src/https_openssl.rs
+++ b/lib/src/https_openssl.rs
@@ -11,6 +11,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use anyhow::Context;
 use foreign_types_shared::{ForeignType, ForeignTypeRef};
 use mio::{net::*, unix::SourceFd, *};
 use nom::HexDisplay;
@@ -2403,7 +2404,7 @@ yD0TrUjkXyjV/zczIYiYSROg9OE5UgYqswIBAg==
 }
 
 use crate::server::HttpsProvider;
-// this function is not used anywhere it seems
+/// this function is not used, but is available for example and testing purposes
 pub fn start(
     config: HttpsListener,
     channel: ProxyChannel,
@@ -2457,7 +2458,7 @@ pub fn start(
     let registry = event_loop
         .registry()
         .try_clone()
-        .with_context("Failed at creating a registry")?;
+        .with_context(|| "Failed at creating a registry")?;
     let mut configuration = Proxy::new(registry, sessions.clone(), pool.clone(), backends.clone());
     let address = config.address;
     if configuration.add_listener(config, token).is_some()
@@ -2480,7 +2481,8 @@ pub fn start(
             server_config,
             None,
             false,
-        );
+        )
+        .with_context(|| "Failed to create server")?;
 
         info!("starting event loop");
         server.run();

--- a/lib/src/https_openssl.rs
+++ b/lib/src/https_openssl.rs
@@ -2403,11 +2403,16 @@ yD0TrUjkXyjV/zczIYiYSROg9OE5UgYqswIBAg==
 }
 
 use crate::server::HttpsProvider;
-pub fn start(config: HttpsListener, channel: ProxyChannel, max_buffers: usize, buffer_size: usize) {
+// this function is not used anywhere it seems
+pub fn start(
+    config: HttpsListener,
+    channel: ProxyChannel,
+    max_buffers: usize,
+    buffer_size: usize,
+) -> anyhow::Result<()> {
     use crate::server;
 
-    // we should be able to trickle up this error
-    let event_loop = Poll::new().expect("could not create event loop");
+    let event_loop = Poll::new().with_context(|| "could not create event loop")?;
 
     let pool = Rc::new(RefCell::new(Pool::with_capacity(
         1,
@@ -2449,13 +2454,17 @@ pub fn start(config: HttpsListener, channel: ProxyChannel, max_buffers: usize, b
     };
 
     let sessions = SessionManager::new(sessions, max_buffers);
-    let registry = event_loop.registry().try_clone().unwrap();
+    let registry = event_loop
+        .registry()
+        .try_clone()
+        .with_context("Failed at creating a registry")?;
     let mut configuration = Proxy::new(registry, sessions.clone(), pool.clone(), backends.clone());
     let address = config.address;
     if configuration.add_listener(config, token).is_some()
         && configuration.activate_listener(&address, None).is_some()
     {
-        let (scm_server, _scm_client) = UnixStream::pair().unwrap();
+        let (scm_server, _scm_client) =
+            UnixStream::pair().with_context(|| "Failed at creating scm stream sockets")?;
         let mut server_config: server::ServerConfig = Default::default();
         server_config.max_connections = max_buffers;
         let mut server = Server::new(
@@ -2477,6 +2486,7 @@ pub fn start(config: HttpsListener, channel: ProxyChannel, max_buffers: usize, b
         server.run();
         info!("ending event loop");
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/lib/src/protocol/http/parser/request.rs
+++ b/lib/src/protocol/http/parser/request.rs
@@ -310,7 +310,7 @@ pub fn validate_request_header(
         HeaderValue::Upgrade(s) => {
             let mut st = state;
             if let Some(conn) = st.get_mut_connection() {
-                // do we really want to crash here?
+                // do we really want to panic here?
                 conn.upgrade = Some(str::from_utf8(s).expect("should be ascii").to_string())
             }
             st

--- a/lib/src/protocol/http/parser/response.rs
+++ b/lib/src/protocol/http/parser/response.rs
@@ -227,7 +227,7 @@ pub fn validate_response_header(
         }
         HeaderValue::Upgrade(protocol) => {
             let proto = str::from_utf8(protocol)
-                .expect("the parsed protocol should be a valid utf8 string") // do we really want to crash here?
+                .expect("the parsed protocol should be a valid utf8 string") // do we really want to panic here?
                 .to_string();
             trace!("parsed a protocol: {:?}", proto);
             trace!("state is {:?}", state);

--- a/lib/src/protocol/openssl.rs
+++ b/lib/src/protocol/openssl.rs
@@ -56,11 +56,11 @@ impl TlsHandshake {
                 let ssl = self
                     .ssl
                     .take()
-                    .expect("TlsHandshake should have a Ssl backend"); // do we really want to crash here?
+                    .expect("TlsHandshake should have a Ssl backend"); // do we really want to panic here?
                 let sock = self
                     .front
                     .take()
-                    .expect("TlsHandshake should have a front socket"); // do we really want to crash here?
+                    .expect("TlsHandshake should have a front socket"); // do we really want to panic here?
                 match ssl.accept(sock) {
                     Ok(stream) => {
                         self.stream = Some(stream);


### PR DESCRIPTION
As in #807 we want to avoid panics in form of `expect` statements in higher level functions of the Sōzu lib: proxy creation and start.

This PR changes the signature of these function to return a Result that will be handled by binaries.