### PR TITLE
Addresses part of #808 and #810

### DIFF
--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -321,7 +321,9 @@ impl ConfigState {
             // This is to avoid the error message
             &ProxyRequestOrder::Logging(_)
             | &ProxyRequestOrder::Status
-            | &ProxyRequestOrder::Query(_) => false,
+            | &ProxyRequestOrder::Query(_)
+            | &ProxyRequestOrder::SoftStop
+            | &ProxyRequestOrder::HardStop => false,
             o => {
                 error!("state cannot handle order message: {:#?}", o);
                 false

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -1322,6 +1322,7 @@ impl ProxySession for Session {
 
         if res == SessionResult::CloseSession {
             self.close();
+            self.proxy.borrow().sessions.borrow_mut().slab.try_remove(self.frontend_token.0);
         }
     }
 

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -1322,7 +1322,12 @@ impl ProxySession for Session {
 
         if res == SessionResult::CloseSession {
             self.close();
-            self.proxy.borrow().sessions.borrow_mut().slab.try_remove(self.frontend_token.0);
+            self.proxy
+                .borrow()
+                .sessions
+                .borrow_mut()
+                .slab
+                .try_remove(self.frontend_token.0);
         }
     }
 
@@ -1753,11 +1758,11 @@ impl ProxyConfiguration<Session> for Proxy {
     }
 
     fn accept(&mut self, token: ListenToken) -> Result<TcpStream, AcceptError> {
-        self.listeners
-            .get(&Token(token.0))
-            .unwrap()
-            .borrow_mut()
-            .accept()
+        if let Some(listener) = self.listeners.get(&Token(token.0)) {
+            listener.borrow_mut().accept()
+        } else {
+            Err(AcceptError::IoError)
+        }
     }
 
     fn create_session(

--- a/lib/src/https_openssl.rs
+++ b/lib/src/https_openssl.rs
@@ -1401,7 +1401,12 @@ impl ProxySession for Session {
 
         if res == SessionResult::CloseSession {
             self.close();
-            self.proxy.borrow().sessions.borrow_mut().slab.try_remove(self.frontend_token.0);
+            self.proxy
+                .borrow()
+                .sessions
+                .borrow_mut()
+                .slab
+                .try_remove(self.frontend_token.0);
         }
     }
 
@@ -2066,11 +2071,11 @@ impl Proxy {
 
 impl ProxyConfiguration<Session> for Proxy {
     fn accept(&mut self, token: ListenToken) -> Result<TcpStream, AcceptError> {
-        self.listeners
-            .get(&Token(token.0))
-            .unwrap()
-            .borrow_mut()
-            .accept()
+        if let Some(listener) = self.listeners.get(&Token(token.0)) {
+            listener.borrow_mut().accept()
+        } else {
+            Err(AcceptError::IoError)
+        }
     }
 
     fn create_session(

--- a/lib/src/https_openssl.rs
+++ b/lib/src/https_openssl.rs
@@ -1401,6 +1401,7 @@ impl ProxySession for Session {
 
         if res == SessionResult::CloseSession {
             self.close();
+            self.proxy.borrow().sessions.borrow_mut().slab.try_remove(self.frontend_token.0);
         }
     }
 

--- a/lib/src/https_rustls/configuration.rs
+++ b/lib/src/https_rustls/configuration.rs
@@ -402,11 +402,11 @@ impl Proxy {
 
 impl ProxyConfiguration<Session> for Proxy {
     fn accept(&mut self, token: ListenToken) -> Result<TcpStream, AcceptError> {
-        self.listeners
-            .get(&Token(token.0))
-            .unwrap()
-            .borrow_mut()
-            .accept()
+        if let Some(listener) = self.listeners.get(&Token(token.0)) {
+            listener.borrow_mut().accept()
+        } else {
+            Err(AcceptError::IoError)
+        }
     }
 
     fn create_session(

--- a/lib/src/https_rustls/session.rs
+++ b/lib/src/https_rustls/session.rs
@@ -1350,6 +1350,7 @@ impl ProxySession for Session {
 
         if res == SessionResult::CloseSession {
             self.close();
+            self.proxy.borrow().sessions.borrow_mut().slab.try_remove(self.frontend_token.0);
         }
     }
 

--- a/lib/src/protocol/http/mod.rs
+++ b/lib/src/protocol/http/mod.rs
@@ -520,8 +520,8 @@ impl<Front: SocketHandler, L: ListenerHandler> Http<Front, L> {
             .as_ref()
             .map(|r| *r == RequestState::Initial)
             .unwrap_or(false)
-            && self.front_buf.as_ref().map(|b| !b.empty()).unwrap_or(false)
-            && self.back_buf.as_ref().map(|b| !b.empty()).unwrap_or(false)
+            && self.front_buf.as_ref().map(|b| !b.empty()).unwrap_or(true)
+            && self.back_buf.as_ref().map(|b| !b.empty()).unwrap_or(true)
         {
             SessionResult::CloseSession
         } else {


### PR DESCRIPTION
Changes for #808:
- inlined `SessionManager::close_session`
- make sure the SessionManager is not already borrowed when calling `ProxySession::close`

Changes for #810:
- removed Soft and Hard stops error logs
- the sessions slab is cloned to iterate over without retaining the borrow_mut lock
- shutting down session was deleting the back entry in the session manager but not the front entry, so a worker couldn't empty its sessions slab. `ProxySession::shutdown` is now responsible for removing its front entry
- back and front buffers set to `None` are considered empty so new and reset sessions properly shutdown
- tcp sessions that try to connect to a backend with an invalid accept token return `ConnectionError::HostNotFound` instead of crashing

Signed-off-by: Eloi DEMOLIS <eloi.demolis@clever-cloud.com>