### PR TITLE
Channel refactoring and testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "sozu"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-dup",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -11,15 +11,11 @@ authors = [
   "Geoffroy Couprie <geo.couprie@gmail.com>",
   "Eloi Demolis <eloi.demolis@clever-cloud.com>",
   "Emmanuel Bosquet <emmanuel.bosquet@clever-cloud.com>",
-  "Florentin Dubois <florentin.dubois@clever-cloud.com>"
+  "Florentin Dubois <florentin.dubois@clever-cloud.com>",
 ]
 categories = ["network-programming"]
-edition="2021"
-include = [
-  "README.md",
-  "Cargo.toml",
-  "src/**/*",
-]
+edition = "2021"
+include = ["README.md", "Cargo.toml", "src/**/*"]
 
 [[bin]]
 name = "sozu"
@@ -36,8 +32,8 @@ jemallocator = { version = "^0.5.0", optional = true }
 lazy_static = "^1.4.0"
 libc = "^0.2.135"
 log = "^0.4.17"
-mio = { version = "^0.8.4", features = [ "os-poll", "net" ] }
-nix  = "^0.25.0"
+mio = { version = "^0.8.4", features = ["os-poll", "net"] }
+nix = "^0.25.0"
 nom = "^7.1.1"
 paw = "^1.0.0"
 prettytable-rs = { version = "^0.9.0", default-features = false }
@@ -51,14 +47,14 @@ smol = "^1.2.5"
 tempfile = "^3.3.0"
 termion = "^1.5.6"
 
-sozu-command-lib = "^0.14.1"
-sozu-lib = "^0.14.1"
+sozu-command-lib = { path = "../command" }
+sozu-lib = { path = "../lib" }
 
 [target.'cfg(target_os="linux")'.dependencies]
 num_cpus = "^1.13.1"
 
 [features]
-default = [ "jemallocator" ]
+default = ["jemallocator"]
 unstable = []
 logs-debug = ["sozu-lib/logs-debug", "sozu-command-lib/logs-debug"]
 logs-trace = ["sozu-lib/logs-trace", "sozu-command-lib/logs-trace"]

--- a/bin/src/command/orders.rs
+++ b/bin/src/command/orders.rs
@@ -531,7 +531,7 @@ impl CommandServer {
             fork_main_into_new_main(self.executable_path.clone(), upgrade_data)
                 .with_context(|| "Could not start a new main process")?;
 
-        fork_confirmation_channel.set_blocking(true);
+        fork_confirmation_channel.blocking();
         let received_ok_from_new_process = fork_confirmation_channel.read_message();
         debug!("upgrade channel sent {:?}", received_ok_from_new_process);
 

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -157,6 +157,6 @@ pub fn create_channel(config: &Config) -> anyhow::Result<Channel<CommandRequest,
     )
     .with_context(|| "Could not create Channel from the given path")?;
 
-    channel.set_nonblocking(false);
+    channel.blocking();
     Ok(channel)
 }

--- a/bin/src/upgrade.rs
+++ b/bin/src/upgrade.rs
@@ -88,14 +88,14 @@ pub fn fork_main_into_new_main(
         upgrade_data.config.command_buffer_size,
         upgrade_data.config.max_command_buffer_size,
     );
-    fork_confirmation_channel.set_nonblocking(false);
+    fork_confirmation_channel.blocking();
 
     info!("launching new main");
     //FIXME: remove the expect, return a result?
     match unsafe { fork().with_context(|| "fork failed")? } {
         ForkResult::Parent { child } => {
             info!("main launched: {}", child);
-            fork_confirmation_channel.set_nonblocking(true);
+            fork_confirmation_channel.nonblocking();
 
             Ok((child.into(), fork_confirmation_channel))
         }
@@ -131,7 +131,7 @@ pub fn begin_new_main_process(
         max_command_buffer_size,
     );
 
-    fork_confirmation_channel.set_blocking(true);
+    fork_confirmation_channel.blocking();
 
     let upgrade_file = unsafe { File::from_raw_fd(upgrade_file_fd) };
     let upgrade_data: UpgradeData =

--- a/command/src/buffer/growable.rs
+++ b/command/src/buffer/growable.rs
@@ -69,6 +69,7 @@ impl Buffer {
         cnt
     }
 
+    /// displaces the end pointer to the right
     pub fn fill(&mut self, count: usize) -> usize {
         let cnt = cmp::min(count, self.available_space());
         self.end += cnt;

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -12,7 +12,7 @@ authors = [
   "Geoffroy Couprie <geo.couprie@gmail.com>",
   "Eloi Demolis <eloi.demolis@clever-cloud.com>",
   "Emmanuel Bosquet <emmanuel.bosquet@clever-cloud.com>",
-  "Florentin Dubois <florentin.dubois@clever-cloud.com>"
+  "Florentin Dubois <florentin.dubois@clever-cloud.com>",
 ]
 categories = ["network-programming"]
 edition = "2021"
@@ -47,11 +47,13 @@ rand = "^0.8.5"
 sha2 = "^0.10.6"
 slab = "^0.4.7"
 socket2 = { version = "^0.4.7", features = ["all"] }
-sozu-command-lib = "0.14.1"
+sozu-command-lib = { path = "../command" }
 regex = "^1.6.0"
 rustls = "^0.20.6"
 rustls-pemfile = "^1.0.1"
-rusty_ulid = { version = "^1.0.0", default-features = true, features = ["ulid-generation"] }
+rusty_ulid = { version = "^1.0.0", default-features = true, features = [
+  "ulid-generation",
+] }
 thiserror = "^1.0.37"
 time = "^0.3.15"
 url = "^2.3.1"

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -471,7 +471,7 @@ impl Server {
         if expects_initial_status {
             // the main process sends a Status message, so we can notify it
             // when the initial state is loaded
-            server.channel.set_nonblocking(false);
+            server.channel.blocking();
             let msg = server.channel.read_message();
             debug!("got message: {:?}", msg);
 
@@ -480,7 +480,7 @@ impl Server {
             if let Some(msg) = msg {
                 server.channel.write_message(&ProxyResponse::ok(msg.id));
             }
-            server.channel.set_nonblocking(true);
+            server.channel.nonblocking();
         }
 
         info!("will try to receive listeners");
@@ -793,7 +793,7 @@ impl Server {
                 if new_sessions_count <= self.base_sessions_count {
                     info!("last session stopped, shutting down!");
                     self.channel.run();
-                    self.channel.set_blocking(true);
+                    self.channel.blocking();
                     self.channel.write_message(&ProxyResponse {
                         id: self
                             .shutting_down

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -1783,7 +1783,7 @@ mod tests {
             info!("ending event loop");
         });
 
-        command.set_blocking(true);
+        command.blocking();
         {
             let front = TcpFrontend {
                 cluster_id: String::from("yolo"),


### PR DESCRIPTION
In order to solve these issues:

- #740 
- #723 

We need reliable timeouts on `/command/src/channel.rs`. This is the occasion to rewrite some unclear code, change the wording of some methods, and add unit tests.