### PR TITLE
Make the CLI accept processing messages

### DIFF
--- a/bin/config.toml
+++ b/bin/config.toml
@@ -89,7 +89,7 @@ buffer_size = 16393
 
 # how much time (in milliseconds) sozuctl will wait for a command to complete.
 # Defaults to 1000 milliseconds
-#ctl_command_timeout = 1000
+# ctl_command_timeout = 1000
 
 # PID file is a file containing the PID of the main process of sozu.
 # It can be helpful to help systemd or any other service system to keep track

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -102,8 +102,7 @@ impl RequestIdentifier {
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum Response {
     Error(String),
-    // Todo: refactor the CLI, see issue #740
-    // Processing(String),
+    Processing(String),
     Ok(Success),
 }
 
@@ -987,7 +986,7 @@ async fn client_loop(
 
     smol::spawn(async move {
         while let Some(response) = client_rx.next().await {
-            //info!("sending back message to client: {:?}", msg);
+            trace!("sending back message to client: {:?}", response);
             let mut message: Vec<u8> = serde_json::to_string(&response)
                 .map(|string| string.into_bytes())
                 .unwrap_or_else(|_| Vec::new());

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -52,40 +52,47 @@ fn generate_tagged_id(tag: &str) -> String {
 }
 
 impl CommandManager {
-    fn read_channel_message_with_timeout(&mut self) -> anyhow::Result<CommandResponse> {
-        match self
-            .channel
-            .read_message_blocking_timeout(Some(self.timeout))
-        {
-            None => bail!("Command timeout. The proxy didn't send an answer"),
-            Some(payload) => Ok(payload),
+    fn send_request(
+        &mut self,
+        id: &str,
+        command_request_order: CommandRequestOrder,
+    ) -> anyhow::Result<()> {
+        let command_request = CommandRequest::new(id.to_string(), command_request_order, None);
+
+        if !self.channel.write_message(&command_request) {
+            bail!("Could not write the request");
         }
+        Ok(())
+    }
+
+    fn read_channel_message_with_timeout(&mut self) -> anyhow::Result<CommandResponse> {
+        self.channel
+            .read_message_blocking_timeout(Some(self.timeout))
+            .with_context(|| "Command timeout. The proxy didn't send an answer")
     }
 
     pub fn save_state(&mut self, path: String) -> Result<(), anyhow::Error> {
         let id = generate_id();
-        self.channel.write_message(&CommandRequest::new(
-            id.clone(),
-            CommandRequestOrder::SaveState { path },
-            None,
-        ));
 
-        let message = self.read_channel_message_with_timeout()?;
+        self.send_request(&id, CommandRequestOrder::SaveState { path })?;
 
-        if id != message.id {
-            bail!("received message with invalid id: {:?}", message);
-        }
-        match message.status {
-            CommandStatus::Processing => {
-                // do nothing here
-                // for other messages, we would loop over read_message
-                // until an error or ok message was sent
+        loop {
+            let response = self.read_channel_message_with_timeout()?;
+
+            if id != response.id {
+                bail!("received message with invalid id: {:?}", response);
             }
-            CommandStatus::Error => {
-                bail!("could not save proxy state: {}", message.message)
-            }
-            CommandStatus::Ok => {
-                println!("{}", message.message);
+            match response.status {
+                CommandStatus::Processing => {
+                    println!("Proxy is processing: {}", response.message);
+                }
+                CommandStatus::Error => {
+                    bail!("could not save proxy state: {}", response.message)
+                }
+                CommandStatus::Ok => {
+                    println!("{}", response.message);
+                    break;
+                }
             }
         }
 
@@ -94,28 +101,26 @@ impl CommandManager {
 
     pub fn load_state(&mut self, path: String) -> Result<(), anyhow::Error> {
         let id = generate_id();
-        self.channel.write_message(&CommandRequest::new(
-            id.clone(),
-            CommandRequestOrder::LoadState { path: path.clone() },
-            None,
-        ));
 
-        let message = self.read_channel_message_with_timeout()?;
+        self.send_request(&id, CommandRequestOrder::LoadState { path: path.clone() })?;
 
-        if id != message.id {
-            bail!("received message with invalid id: {:?}", message);
-        }
-        match message.status {
-            CommandStatus::Processing => {
-                // do nothing here
-                // for other messages, we would loop over read_message
-                // until an error or ok message was sent
+        loop {
+            let response = self.read_channel_message_with_timeout()?;
+
+            if id != response.id {
+                bail!("received message with invalid id: {:?}", response);
             }
-            CommandStatus::Error => {
-                bail!("could not load proxy state: {}", message.message)
-            }
-            CommandStatus::Ok => {
-                println!("Proxy state loaded successfully from {}", path);
+            match response.status {
+                CommandStatus::Processing => {
+                    println!("Proxy is processing: {}", response.message);
+                }
+                CommandStatus::Error => {
+                    bail!("could not load proxy state: {}", response.message)
+                }
+                CommandStatus::Ok => {
+                    println!("Proxy state loaded successfully from {}", path);
+                    break;
+                }
             }
         }
 
@@ -124,39 +129,35 @@ impl CommandManager {
 
     pub fn dump_state(&mut self, json: bool) -> Result<(), anyhow::Error> {
         let id = generate_id();
-        self.channel.write_message(&CommandRequest::new(
-            id.clone(),
-            CommandRequestOrder::DumpState,
-            None,
-        ));
 
-        let message = self.read_channel_message_with_timeout()?;
+        self.send_request(&id.clone(), CommandRequestOrder::DumpState)?;
 
-        if id != message.id {
-            bail!("received message with invalid id: {:?}", message);
-        }
-        match message.status {
-            CommandStatus::Processing => {
-                // do nothing here
-                // for other messages, we would loop over read_message
-                // until an error or ok message was sent
+        loop {
+            let response = self.read_channel_message_with_timeout()?;
+
+            if id != response.id {
+                bail!("received message with invalid id: {:?}", response);
             }
-            CommandStatus::Error => {
-                if json {
-                    print_json_response(&message.message)?;
+            match response.status {
+                CommandStatus::Processing => {
+                    println!("Proxy is processing: {}", response.message);
                 }
-                bail!("could not dump proxy state: {}", message.message);
-            }
-            CommandStatus::Ok => {
-                if let Some(CommandResponseContent::State(state)) = message.content {
+                CommandStatus::Error => {
                     if json {
-                        print_json_response(&state)?;
-                    } else {
-                        println!("{:#?}", state);
+                        print_json_response(&response.message)?;
                     }
-                    return Ok(());
+                    bail!("could not dump proxy state: {}", response.message);
                 }
-                bail!("state dump was empty");
+                CommandStatus::Ok => match response.content {
+                    Some(CommandResponseContent::State(state)) => {
+                        match json {
+                            true => print_json_response(&state)?,
+                            false => println!("{:#?}", state),
+                        }
+                        break;
+                    }
+                    _ => bail!("state dump was empty"),
+                },
             }
         }
         Ok(())
@@ -165,27 +166,31 @@ impl CommandManager {
     pub fn soft_stop(&mut self, proxy_id: Option<u32>) -> Result<(), anyhow::Error> {
         println!("shutting down proxy");
         let id = generate_id();
+
         self.channel.write_message(&CommandRequest::new(
             id.clone(),
             CommandRequestOrder::Proxy(Box::new(ProxyRequestOrder::SoftStop)),
             proxy_id,
         ));
 
-        let message = self.read_channel_message_with_timeout()?;
+        loop {
+            let response = self.read_channel_message_with_timeout()?;
 
-        if id != message.id {
-            bail!("received message with invalid id: {:?}", message);
-        }
+            if id != response.id {
+                bail!("received message with invalid id: {:?}", response);
+            }
 
-        match message.status {
-            CommandStatus::Processing => {
-                println!("Proxy is processing: {}", message.message);
-            }
-            CommandStatus::Error => {
-                bail!("could not stop the proxy: {}", message.message);
-            }
-            CommandStatus::Ok => {
-                println!("Proxy shut down with message: \"{}\"", message.message);
+            match response.status {
+                CommandStatus::Processing => {
+                    println!("Proxy is processing: {}", response.message);
+                }
+                CommandStatus::Error => {
+                    bail!("could not stop the proxy: {}", response.message);
+                }
+                CommandStatus::Ok => {
+                    println!("Proxy shut down with message: \"{}\"", response.message);
+                    break;
+                }
             }
         }
 
@@ -200,19 +205,21 @@ impl CommandManager {
             CommandRequestOrder::Proxy(Box::new(ProxyRequestOrder::HardStop)),
             proxy_id,
         ));
+        loop {
+            let response = self.read_channel_message_with_timeout()?;
 
-        let message = self.read_channel_message_with_timeout()?;
-
-        match message.status {
-            CommandStatus::Processing => {
-                println!("Proxy is processing: {}", message.message);
-            }
-            CommandStatus::Error => {
-                bail!("could not stop the proxy: {}", message.message);
-            }
-            CommandStatus::Ok => {
-                if id == message.id {
-                    println!("Proxy shut down: {}", message.message);
+            match response.status {
+                CommandStatus::Processing => {
+                    println!("Proxy is processing: {}", response.message);
+                }
+                CommandStatus::Error => {
+                    bail!("could not stop the proxy: {}", response.message);
+                }
+                CommandStatus::Ok => {
+                    if id == response.id {
+                        println!("Proxy shut down: {}", response.message);
+                    }
+                    break;
                 }
             }
         }
@@ -226,94 +233,99 @@ impl CommandManager {
         println!("Preparing to upgrade proxy...");
 
         let id = generate_tagged_id("LIST-WORKERS");
-        self.channel.write_message(&CommandRequest::new(
-            id.clone(),
-            CommandRequestOrder::ListWorkers,
-            None,
-        ));
 
-        let message = self.read_channel_message_with_timeout()?;
+        self.send_request(&id, CommandRequestOrder::ListWorkers)?;
 
-        if id != message.id {
-            bail!("Error: received unexpected message: {:?}", message);
-        }
-        match message.status {
-            CommandStatus::Processing => {
-                error!("Error: the proxy didn't return list of workers immediately");
+        loop {
+            let response = self.read_channel_message_with_timeout()?;
+
+            if id != response.id {
+                bail!("Error: received unexpected message: {:?}", response);
             }
-            CommandStatus::Error => {
-                bail!(
-                    "Error: failed to get the list of worker: {}",
-                    message.message
-                );
-            }
-            CommandStatus::Ok => {
-                if let Some(CommandResponseContent::Workers(ref workers)) = message.content {
-                    let mut table = Table::new();
-                    table.set_format(*prettytable::format::consts::FORMAT_BOX_CHARS);
-                    table.add_row(row!["Worker", "pid", "run state"]);
-                    for worker in workers.iter() {
-                        let run_state = format!("{:?}", worker.run_state);
-                        table.add_row(row![worker.id, worker.pid, run_state]);
-                    }
-                    println!();
-                    table.printstd();
-                    println!();
+            match response.status {
+                CommandStatus::Processing => {
+                    println!("Processing: {}", response.message);
+                }
+                CommandStatus::Error => {
+                    bail!(
+                        "Error: failed to get the list of worker: {}",
+                        response.message
+                    );
+                }
+                CommandStatus::Ok => {
+                    if let Some(CommandResponseContent::Workers(ref workers)) = response.content {
+                        let mut table = Table::new();
+                        table.set_format(*prettytable::format::consts::FORMAT_BOX_CHARS);
+                        table.add_row(row!["Worker", "pid", "run state"]);
+                        for worker in workers.iter() {
+                            let run_state = format!("{:?}", worker.run_state);
+                            table.add_row(row![worker.id, worker.pid, run_state]);
+                        }
+                        println!();
+                        table.printstd();
+                        println!();
 
-                    let id = generate_tagged_id("UPGRADE-MAIN");
-                    self.channel.write_message(&CommandRequest::new(
-                        id.clone(),
-                        CommandRequestOrder::UpgradeMain,
-                        None,
-                    ));
-                    println!("Upgrading main process");
+                        let id = generate_tagged_id("UPGRADE-MAIN");
+                        self.send_request(&id, CommandRequestOrder::UpgradeMain)?;
 
-                    loop {
-                        let message = self.read_channel_message_with_timeout()?;
+                        println!("Upgrading main process");
 
-                        if id != message.id {
-                            bail!("Error: received unexpected message: {:?}", message);
+                        loop {
+                            let response = self.read_channel_message_with_timeout()?;
+
+                            if id != response.id {
+                                bail!("Error: received unexpected message: {:?}", response);
+                            }
+
+                            match response.status {
+                                CommandStatus::Processing => {
+                                    println!("Main process is upgrading");
+                                }
+                                CommandStatus::Error => {
+                                    bail!(
+                                        "Error: failed to upgrade the main: {}",
+                                        response.message
+                                    );
+                                }
+                                CommandStatus::Ok => {
+                                    println!(
+                                        "Main process upgrade succeeded: {}",
+                                        response.message
+                                    );
+                                    break;
+                                }
+                            }
                         }
 
-                        match message.status {
-                            CommandStatus::Processing => {
-                                println!("Main process is upgrading");
-                            }
-                            CommandStatus::Error => {
-                                bail!("Error: failed to upgrade the main: {}", message.message);
-                            }
-                            CommandStatus::Ok => {
-                                println!("Main process upgrade succeeded: {}", message.message);
-                                break;
-                            }
+                        // Reconnect to the new main
+                        println!("Reconnecting to new main process...");
+                        self.channel = create_channel(&self.config)
+                            .with_context(|| "could not reconnect to the command unix socket")?;
+
+                        // Do a rolling restart of the workers
+                        let running_workers = workers
+                            .iter()
+                            .filter(|worker| worker.run_state == RunState::Running)
+                            .collect::<Vec<_>>();
+                        let running_count = running_workers.len();
+                        for (i, worker) in running_workers.iter().enumerate() {
+                            println!(
+                                "Upgrading worker {} (#{} out of {})",
+                                worker.id,
+                                i + 1,
+                                running_count
+                            );
+
+                            self.upgrade_worker(worker.id)
+                                .with_context(|| "Upgrading the worker failed")?;
+                            //thread::sleep(Duration::from_millis(1000));
                         }
+
+                        println!("Proxy successfully upgraded!");
+                    } else {
+                        println!("Received a response of the wrong kind: {:?}", response);
                     }
-
-                    // Reconnect to the new main
-                    println!("Reconnecting to new main process...");
-                    self.channel = create_channel(&self.config)
-                        .with_context(|| "could not reconnect to the command unix socket")?;
-
-                    // Do a rolling restart of the workers
-                    let running_workers = workers
-                        .iter()
-                        .filter(|worker| worker.run_state == RunState::Running)
-                        .collect::<Vec<_>>();
-                    let running_count = running_workers.len();
-                    for (i, worker) in running_workers.iter().enumerate() {
-                        println!(
-                            "Upgrading worker {} (#{} out of {})",
-                            worker.id,
-                            i + 1,
-                            running_count
-                        );
-
-                        self.upgrade_worker(worker.id)
-                            .with_context(|| "Upgrading the worker failed")?;
-                        //thread::sleep(Duration::from_millis(1000));
-                    }
-
-                    println!("Proxy successfully upgraded!");
+                    break;
                 }
             }
         }
@@ -323,78 +335,64 @@ impl CommandManager {
     pub fn upgrade_worker(&mut self, worker_id: u32) -> Result<(), anyhow::Error> {
         println!("upgrading worker {}", worker_id);
         let id = generate_id();
-        self.channel.write_message(&CommandRequest::new(
-            id.clone(),
-            CommandRequestOrder::UpgradeWorker(worker_id),
-            //FIXME: we should be able to soft stop one specific worker
-            None,
-        ));
 
-        let message = self
-            .channel
-            .read_message_blocking_timeout(Some(self.timeout));
+        //FIXME: we should be able to soft stop one specific worker
+        self.send_request(&id, CommandRequestOrder::UpgradeWorker(worker_id))?;
 
-        match message {
-            None => bail!(format!(
-                "No response from the proxy about worker {}",
-                worker_id
-            )),
-            Some(message) => match message.status {
-                CommandStatus::Processing => {
-                    info!("Worker {} is processing: {}", worker_id, message.message);
-                }
+        loop {
+            let response = self.read_channel_message_with_timeout()?;
+
+            match response.status {
+                CommandStatus::Processing => info!("Proxy is processing: {}", response.message),
                 CommandStatus::Error => bail!(
                     "could not stop the worker {}: {}",
                     worker_id,
-                    message.message
+                    response.message
                 ),
                 CommandStatus::Ok => {
-                    if id == message.id {
-                        info!("Worker {} shut down: {}", worker_id, message.message);
+                    if id == response.id {
+                        info!("Worker {} shut down: {}", worker_id, response.message);
                     }
+                    break;
                 }
-            },
+            }
         }
         Ok(())
     }
 
     pub fn status(&mut self, json: bool) -> anyhow::Result<()> {
-        let id = generate_id();
+        let request_id = generate_id();
 
-        self.channel.write_message(&CommandRequest::new(
-            id.clone(),
-            CommandRequestOrder::Status,
-            None,
-        ));
+        self.send_request(&request_id, CommandRequestOrder::Status)?;
 
-        let message = self
-            .channel
-            .read_message_blocking_timeout(Some(self.timeout))
-            .with_context(|| "Can not read response from channel")?;
+        loop {
+            let response = self.read_channel_message_with_timeout()?;
 
-        if id != message.id {
-            bail!("received message with invalid id: {:?}", message);
-        }
-
-        match message.status {
-            CommandStatus::Processing => {
-                bail!("should have obtained an answer immediately");
+            if request_id != response.id {
+                bail!("received message with invalid id: {:?}", response);
             }
-            CommandStatus::Error => {
-                if json {
-                    print_json_response(&message.message)?;
+
+            match response.status {
+                CommandStatus::Processing => {
+                    println!("server is processing: {}", response.message);
                 }
-                bail!("could not get the worker list: {}", message.message);
+                CommandStatus::Error => {
+                    if json {
+                        print_json_response(&response.message)?;
+                    }
+                    bail!("could not get the worker list: {}", response.message);
+                }
+                CommandStatus::Ok => match response.content {
+                    Some(CommandResponseContent::Status(worker_info_vec)) => {
+                        print_status(worker_info_vec);
+                        break;
+                    }
+                    Some(_) => {
+                        bail!("Received the wrong kind of response data from the command server")
+                    }
+                    None => bail!("No data in the response"),
+                },
             }
-            CommandStatus::Ok => match message.content {
-                Some(CommandResponseContent::Status(worker_info_vec)) => {
-                    print_status(worker_info_vec);
-                }
-                Some(_) => {
-                    bail!("Received the wrong kind of response data from the command server")
-                }
-                None => bail!("No data in the response"),
-            },
         }
         Ok(())
     }
@@ -410,26 +408,28 @@ impl CommandManager {
             _ => bail!("The command passed to the configure_metrics function is wrong."),
         };
 
-        self.channel.write_message(&CommandRequest::new(
-            id.clone(),
+        self.send_request(
+            &id,
             CommandRequestOrder::Proxy(Box::new(ProxyRequestOrder::ConfigureMetrics(
                 configuration,
             ))),
-            None,
-        ));
+        )?;
 
-        let message = self.read_channel_message_with_timeout()?;
+        loop {
+            let response = self.read_channel_message_with_timeout()?;
 
-        match message.status {
-            CommandStatus::Processing => {
-                println!("Proxy is processing: {}", message.message);
-            }
-            CommandStatus::Error => {
-                bail!("Error with metrics command: {}", message.message);
-            }
-            CommandStatus::Ok => {
-                if id == message.id {
-                    println!("Successfull metrics command: {}", message.message);
+            match response.status {
+                CommandStatus::Processing => {
+                    println!("Proxy is processing: {}", response.message);
+                }
+                CommandStatus::Error => {
+                    bail!("Error with metrics command: {}", response.message);
+                }
+                CommandStatus::Ok => {
+                    if id == response.id {
+                        println!("Successfull metrics command: {}", response.message);
+                    }
+                    break;
                 }
             }
         }
@@ -457,39 +457,41 @@ impl CommandManager {
         // a loop to reperform the query every refresh time
         loop {
             let id = generate_id();
-            self.channel
-                .write_message(&CommandRequest::new(id.clone(), command.clone(), None));
+            self.send_request(&id, command.clone())?;
+
             print!("{}", termion::cursor::Save);
 
-            // this functions may bail and escape the loop, should we avoid that?
-            let message = self.read_channel_message_with_timeout()?;
+            // a loop to process responses
+            loop {
+                let response = self.read_channel_message_with_timeout()?;
 
-            //println!("received message: {:?}", message);
-            if id != message.id {
-                bail!("received message with invalid id: {:?}", message);
-            }
-            match message.status {
-                CommandStatus::Processing => {
-                    // do nothing here
-                    // for other messages, we would loop over read_message
-                    // until an error or ok message was sent
+                if id != response.id {
+                    bail!("received message with invalid id: {:?}", response);
                 }
-                CommandStatus::Error => {
-                    if json {
-                        return print_json_response(&message.message);
-                    } else {
-                        bail!("could not query proxy state: {}", message.message);
+                match response.status {
+                    CommandStatus::Processing => {
+                        println!("Proxy is processing: {}", response.message);
+                    }
+                    CommandStatus::Error => {
+                        if json {
+                            return print_json_response(&response.message);
+                        } else {
+                            bail!("could not query proxy state: {}", response.message);
+                        }
+                    }
+                    CommandStatus::Ok => {
+                        match response.content {
+                            Some(CommandResponseContent::Metrics(aggregated_metrics_data)) => {
+                                print_metrics(aggregated_metrics_data, json)?
+                            }
+                            Some(CommandResponseContent::Query(lists_of_metrics)) => {
+                                print_available_metrics(&lists_of_metrics)?;
+                            }
+                            _ => println!("Wrong kind of response here"),
+                        }
+                        break;
                     }
                 }
-                CommandStatus::Ok => match message.content {
-                    Some(CommandResponseContent::Metrics(aggregated_metrics_data)) => {
-                        print_metrics(aggregated_metrics_data, json)?
-                    }
-                    Some(CommandResponseContent::Query(lists_of_metrics)) => {
-                        print_available_metrics(&lists_of_metrics)?;
-                    }
-                    _ => println!("Wrong kind of response here"),
-                },
             }
 
             match refresh {
@@ -513,32 +515,31 @@ impl CommandManager {
         json: bool,
     ) -> Result<(), anyhow::Error> {
         let id = generate_id();
-        self.channel.write_message(&CommandRequest::new(
-            id.clone(),
-            CommandRequestOrder::ReloadConfiguration { path },
-            None,
-        ));
 
-        let message = self.read_channel_message_with_timeout()?;
+        self.send_request(&id, CommandRequestOrder::ReloadConfiguration { path })?;
 
-        if id != message.id {
-            bail!("received message with invalid id: {:?}", message);
-        }
-        match message.status {
-            CommandStatus::Processing => {
-                bail!("should have obtained an answer immediately");
+        loop {
+            let response = self.read_channel_message_with_timeout()?;
+
+            if id != response.id {
+                bail!("received message with invalid id: {:?}", response);
             }
-            CommandStatus::Error => {
-                if json {
-                    print_json_response(&message.message)?;
+            match response.status {
+                CommandStatus::Processing => {
+                    println!("Proxy is processing: {}", response.message);
                 }
-                bail!("could not get the worker list: {}", message.message);
-            }
-            CommandStatus::Ok => {
-                if json {
-                    print_json_response(&message.message)?;
-                } else {
-                    println!("Reloaded configuration: {}", message.message);
+                CommandStatus::Error => {
+                    if json {
+                        return print_json_response(&response.message);
+                    }
+                    bail!("could not get the worker list: {}", response.message);
+                }
+                CommandStatus::Ok => {
+                    match json {
+                        true => print_json_response(&response.message)?,
+                        false => println!("Reloaded configuration: {}", response.message),
+                    }
+                    break;
                 }
             }
         }
@@ -561,24 +562,29 @@ impl CommandManager {
         });
 
         let id = generate_id();
-        self.channel
-            .write_message(&CommandRequest::new(id.clone(), command, None));
+        self.send_request(&id, command)?;
 
-        let message = self.read_channel_message_with_timeout()?;
+        loop {
+            let response = self.read_channel_message_with_timeout()?;
 
-        if id != message.id {
-            bail!("received message with invalid id: {:?}", message);
-        }
-        match message.status {
-            CommandStatus::Processing => {}
-            CommandStatus::Error => {
-                println!("could not query proxy state: {}", message.message)
+            if id != response.id {
+                bail!("received message with invalid id: {:?}", response);
             }
-            CommandStatus::Ok => {
-                debug!("We received this response: {:?}", message.content);
-
-                if let Some(CommandResponseContent::FrontendList(frontends)) = message.content {
-                    print_frontend_list(frontends);
+            match response.status {
+                CommandStatus::Processing => {
+                    println!("Proxy is processing: {}", response.message);
+                }
+                CommandStatus::Error => {
+                    println!("could not query proxy state: {}", response.message)
+                }
+                CommandStatus::Ok => {
+                    match response.content {
+                        Some(CommandResponseContent::FrontendList(frontends)) => {
+                            print_frontend_list(frontends)
+                        }
+                        _ => println!("Received a response of the wrong kind: {:?}", response),
+                    }
+                    break;
                 }
             }
         }
@@ -624,31 +630,28 @@ impl CommandManager {
         };
 
         let id = generate_id();
-        self.channel
-            .write_message(&CommandRequest::new(id.clone(), command, None));
+        self.send_request(&id, command)?;
 
-        let message = self.read_channel_message_with_timeout()?;
+        loop {
+            let response = self.read_channel_message_with_timeout()?;
 
-        if id != message.id {
-            bail!("received message with invalid id: {:?}", message);
-        }
-        match message.status {
-            CommandStatus::Processing => {
-                // do nothing here
-                // for other messages, we would loop over read_message
-                // until an error or ok message was sent
-
-                // or maybe just print what the processing has to say?
-                println!("{}", message.message);
+            if id != response.id {
+                bail!("received message with invalid id: {:?}", response);
             }
-            CommandStatus::Error => {
-                if json {
-                    print_json_response(&message.message)?;
+            match response.status {
+                CommandStatus::Processing => {
+                    println!("Proxy is processing: {}", response.message);
                 }
-                bail!("could not query proxy state: {}", message.message);
-            }
-            CommandStatus::Ok => {
-                print_query_response_data(cluster_id, domain, message.content, json)?;
+                CommandStatus::Error => {
+                    if json {
+                        print_json_response(&response.message)?;
+                    }
+                    bail!("could not query proxy state: {}", response.message);
+                }
+                CommandStatus::Ok => {
+                    print_query_response_data(cluster_id, domain, response.content, json)?;
+                    break;
+                }
             }
         }
 
@@ -680,33 +683,35 @@ impl CommandManager {
         )));
 
         let id = generate_id();
-        self.channel
-            .write_message(&CommandRequest::new(id.clone(), command, None));
 
-        let message = self.read_channel_message_with_timeout()?;
+        self.send_request(&id, command)?;
 
-        if id != message.id {
-            bail!("received message with invalid id: {:?}", message);
-        }
-        match message.status {
-            CommandStatus::Processing => {
-                // do nothing here
-                // for other messages, we would loop over read_message
-                // until an error or ok message was sent
+        loop {
+            let response = self.read_channel_message_with_timeout()?;
+
+            if id != response.id {
+                bail!("received message with invalid id: {:?}", response);
             }
-            CommandStatus::Error => {
-                if json {
-                    print_json_response(&message.message)?;
-                    bail!("We received an error message");
-                } else {
-                    bail!("could not query proxy state: {}", message.message);
+            match response.status {
+                CommandStatus::Processing => {
+                    println!("Proxy is processing: {}", response.message);
                 }
-            }
-            CommandStatus::Ok => {
-                if let Some(CommandResponseContent::Query(data)) = message.content {
-                    print_certificates(data, json)?;
-                } else {
-                    bail!("unexpected response: {:?}", message.content);
+                CommandStatus::Error => {
+                    if json {
+                        print_json_response(&response.message)?;
+                        bail!("We received an error message");
+                    } else {
+                        bail!("could not query proxy state: {}", response.message);
+                    }
+                }
+                CommandStatus::Ok => {
+                    match response.content {
+                        Some(CommandResponseContent::Query(data)) => {
+                            print_certificates(data, json)?
+                        }
+                        _ => bail!("unexpected response: {:?}", response.content),
+                    }
+                    break;
                 }
             }
         }
@@ -715,24 +720,27 @@ impl CommandManager {
 
     pub fn events(&mut self) -> Result<(), anyhow::Error> {
         let id = generate_id();
-        self.channel.write_message(&CommandRequest::new(
-            id,
-            CommandRequestOrder::SubscribeEvents,
-            None,
-        ));
 
-        let message = self.read_channel_message_with_timeout()?;
-        match message.status {
-            CommandStatus::Processing => {
-                if let Some(CommandResponseContent::Event(event)) = message.content {
-                    println!("got event from worker({}): {:?}", message.message, event);
+        self.send_request(&id, CommandRequestOrder::SubscribeEvents)?;
+
+        loop {
+            let response = self.read_channel_message_with_timeout()?;
+            match response.status {
+                CommandStatus::Processing => match response.content {
+                    Some(CommandResponseContent::Event(event)) => {
+                        println!("got event from worker({}): {:?}", response.message, event)
+                    }
+                    _ => {
+                        println!("Received an unexpected response: {:?}", response)
+                    }
+                },
+                CommandStatus::Error => {
+                    bail!("could not get proxy events: {}", response.message);
                 }
-            }
-            CommandStatus::Error => {
-                bail!("could not get proxy events: {}", message.message);
-            }
-            CommandStatus::Ok => {
-                println!("{}", message.message);
+                CommandStatus::Ok => {
+                    println!("{}", response.message);
+                    break;
+                }
             }
         }
         Ok(())
@@ -740,41 +748,38 @@ impl CommandManager {
 
     pub fn order_command(&mut self, order: ProxyRequestOrder) -> Result<(), anyhow::Error> {
         let id = generate_id();
-        self.channel.write_message(&CommandRequest::new(
-            id.clone(),
-            CommandRequestOrder::Proxy(Box::new(order)),
-            None,
-        ));
 
-        let message = self.read_channel_message_with_timeout()?;
+        self.send_request(&id, CommandRequestOrder::Proxy(Box::new(order)))?;
 
-        if id != message.id {
-            bail!("received message with invalid id: {:?}", message);
-        }
-        match message.status {
-            CommandStatus::Processing => {
-                // do nothing here
-                // for other messages, we would loop over read_message
-                // until an error or ok message was sent
+        loop {
+            let response = self.read_channel_message_with_timeout()?;
+
+            if id != response.id {
+                bail!("received message with invalid id: {:?}", response);
             }
-            CommandStatus::Error => bail!("could not execute order: {}", message.message),
-            CommandStatus::Ok => {
-                //deactivate success messages for now
-                /*
-                match order {
-                  ProxyRequestOrder::AddCluster(_) => println!("cluster added : {}", message.message),
-                  ProxyRequestOrder::RemoveCluster(_) => println!("cluster removed : {} ", message.message),
-                  ProxyRequestOrder::AddBackend(_) => println!("backend added : {}", message.message),
-                  ProxyRequestOrder::RemoveBackend(_) => println!("backend removed : {} ", message.message),
-                  ProxyRequestOrder::AddCertificate(_) => println!("certificate added: {}", message.message),
-                  ProxyRequestOrder::RemoveCertificate(_) => println!("certificate removed: {}", message.message),
-                  ProxyRequestOrder::AddHttpFrontend(_) => println!("front added: {}", message.message),
-                  ProxyRequestOrder::RemoveHttpFrontend(_) => println!("front removed: {}", message.message),
-                  _ => {
-                    // do nothing for now
-                  }
+            match response.status {
+                CommandStatus::Processing => println!("Proxy is processing: {}", response.message),
+                CommandStatus::Error => bail!("could not execute order: {}", response.message),
+                CommandStatus::Ok => {
+                    println!("Success (but nothing to print)");
+                    break;
+                    // TODO: reactivate success messages
+                    /*
+                    match order {
+                      ProxyRequestOrder::AddCluster(_) => println!("cluster added : {}", message.message),
+                      ProxyRequestOrder::RemoveCluster(_) => println!("cluster removed : {} ", message.message),
+                      ProxyRequestOrder::AddBackend(_) => println!("backend added : {}", message.message),
+                      ProxyRequestOrder::RemoveBackend(_) => println!("backend removed : {} ", message.message),
+                      ProxyRequestOrder::AddCertificate(_) => println!("certificate added: {}", message.message),
+                      ProxyRequestOrder::RemoveCertificate(_) => println!("certificate removed: {}", message.message),
+                      ProxyRequestOrder::AddHttpFrontend(_) => println!("front added: {}", message.message),
+                      ProxyRequestOrder::RemoveHttpFrontend(_) => println!("front removed: {}", message.message),
+                      _ => {
+                        // do nothing for now
+                      }
+                    }
+                    */
                 }
-                */
             }
         }
         Ok(())

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -149,6 +149,7 @@ impl CommandManager {
     }
 }
 
+/// creates a blocking channel
 pub fn create_channel(config: &Config) -> anyhow::Result<Channel<CommandRequest, CommandResponse>> {
     let mut channel = Channel::from_path(
         &config.command_socket_path()?,


### PR DESCRIPTION
In order to solve this issue:

- #740 

This PR decomments the function `return_processing` and calls to it, which makes use of the event-based-ness of the CommandServer to notify the CLI of processing orders.

The CLI now loops while reading responses from Sōzu, and pattern matches the status of the response:

- Error => print the error and break the loop
- OK => print result and break the loop
- Processing => prints the processing message and reads on the channel again. The timeout is renewed each time.


Plus some refactoring on request sending and response receiving.