### PR TITLE
TCP over TLS

### DIFF
--- a/bin/config.toml
+++ b/bin/config.toml
@@ -200,19 +200,19 @@ tls_versions = ["TLSv1.2", "TLSv1.3"]
 # * Sets the lists of availables ciphers (TLSv1.2 and TLSv1.3). Supported ciphers names are specified at
 #   https://docs.rs/rustls/latest/rustls/static.ALL_CIPHER_SUITES.html
 #
-cipher_list = [
-    # TLS 1.3 cipher suites
-    "TLS13_AES_256_GCM_SHA384",
-    "TLS13_AES_128_GCM_SHA256",
-    "TLS13_CHACHA20_POLY1305_SHA256",
-    # TLS 1.2 cipher suites
-    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-]
+#cipher_list = [
+#    # TLS 1.3 cipher suites
+#    "TLS13_AES_256_GCM_SHA384",
+#    "TLS13_AES_128_GCM_SHA256",
+#    "TLS13_CHACHA20_POLY1305_SHA256",
+#    # TLS 1.2 cipher suites
+#    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+#    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+#    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+#    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+#    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+#    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+#]
 #
 # When using `OpenSSL` TLS provider:
 # * Sets the list of available ciphers (TLSv1.2 and below) for ctx using the control string str. The format of the string
@@ -300,7 +300,7 @@ groups_list = ["P-521", "P-384", "P-256", "x25519"]
 # expect_proxy = false
 
 [[listeners]]
-protocol = "tcp"
+protocol = "tcps"
 # listening address
 address = "0.0.0.0:8043"
 tls_versions = ["TLSv1.3"]
@@ -375,7 +375,7 @@ backends = [
 protocol = "tcp"
 
 frontends = [
-  { address = "0.0.0.0:8043", tags = { key = "value" }},
+  { address = "0.0.0.0:8043", tags = { key = "value" }, hostname = "yolo", certificate = "../lib/assets/certificate.pem", key = "../lib/assets/key.pem", certificate_chain = "../lib/assets/certificate_chain.pem"},
 ]
 
 backends = [

--- a/bin/config.toml
+++ b/bin/config.toml
@@ -299,6 +299,15 @@ groups_list = ["P-521", "P-384", "P-256", "x25519"]
 # this option is incompatible with public_address
 # expect_proxy = false
 
+[[listeners]]
+protocol = "tcp"
+# listening address
+address = "0.0.0.0:8043"
+tls_versions = ["TLSv1.3"]
+certificate = "../lib/assets/cert_test.pem"
+key = "../lib/assets/key_test.pem"
+certificate_chain = "../lib/assets/certificate_chain.pem"
+
 # static configuration for cluster
 #
 # A cluster is a set of frontends, routing rules, and backends.
@@ -360,4 +369,15 @@ frontends = [
 backends = [
     { address = "127.0.0.1:4000", weight = 100 },
     { address = "127.0.0.1:4001", weight = 50 }
+]
+
+[clusters.TcpTls]
+protocol = "tcp"
+
+frontends = [
+  { address = "0.0.0.0:8043", tags = { key = "value" }},
+]
+
+backends = [
+  { address = "127.0.0.1:4000" },
 ]

--- a/bin/config.toml
+++ b/bin/config.toml
@@ -371,13 +371,24 @@ backends = [
     { address = "127.0.0.1:4001", weight = 50 }
 ]
 
-[clusters.TcpTls]
+[clusters.TcpTls1]
 protocol = "tcp"
 
 frontends = [
-  { address = "0.0.0.0:8043", tags = { key = "value" }, hostname = "yolo", certificate = "../lib/assets/certificate.pem", key = "../lib/assets/key.pem", certificate_chain = "../lib/assets/certificate_chain.pem"},
+  { address = "0.0.0.0:8043", tags = { key = "value" }, hostname = "yolo1", certificate = "../lib/assets/certificate.pem", key = "../lib/assets/key.pem", certificate_chain = "../lib/assets/certificate_chain.pem"},
 ]
 
 backends = [
   { address = "127.0.0.1:4000" },
+]
+
+[clusters.TcpTls2]
+protocol = "tcp"
+
+frontends = [
+  { address = "0.0.0.0:8043", tags = { key = "value" }, hostname = "yolo2", certificate = "../lib/assets/certificate.pem", key = "../lib/assets/key.pem", certificate_chain = "../lib/assets/certificate_chain.pem"},
+]
+
+backends = [
+  { address = "127.0.0.1:4001" },
 ]

--- a/bin/src/command/orders.rs
+++ b/bin/src/command/orders.rs
@@ -1235,6 +1235,7 @@ impl CommandServer {
                     ProxyRequestOrder::RemoveTcpFrontend(TcpFrontend {
                         ref cluster_id,
                         ref address,
+                        hostname: _,
                         ref tags,
                     }) => {
                         bail!(format!(

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -298,6 +298,7 @@ impl CommandManager {
                 front_timeout: 60,
                 back_timeout: 30,
                 connect_timeout: 3,
+                tls: None,
             })),
             TcpListenerCmd::Remove { address } => self.remove_listener(address, ListenerType::TCP),
             TcpListenerCmd::Activate { address } => {

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -88,6 +88,7 @@ impl CommandManager {
                 self.order_command(ProxyRequestOrder::AddTcpFrontend(TcpFrontend {
                     cluster_id: id,
                     address,
+                    hostname: None,
                     tags,
                 }))
             }
@@ -95,6 +96,7 @@ impl CommandManager {
                 self.order_command(ProxyRequestOrder::RemoveTcpFrontend(TcpFrontend {
                     cluster_id: id,
                     address,
+                    hostname: None,
                     tags: None,
                 }))
             }
@@ -220,6 +222,7 @@ impl CommandManager {
                 listener.groups_list = groups_list;
                 let https_listener = listener
                     .to_tls(
+                        None,
                         front_timeout,
                         back_timeout,
                         connect_timeout,

--- a/command/src/proxy.rs
+++ b/command/src/proxy.rs
@@ -467,6 +467,7 @@ pub struct ReplaceCertificate {
 pub struct TcpFrontend {
     pub cluster_id: String,
     pub address: SocketAddr,
+    pub hostname: Option<String>,
     pub tags: Option<BTreeMap<String, String>>,
 }
 
@@ -718,8 +719,8 @@ pub struct HttpsListener {
     pub signature_algorithms: Vec<String>,
     #[serde(default)]
     pub groups_list: Vec<String>,
-    #[serde(skip, default)]
-    pub tls_provider: TlsProvider,
+    // #[serde(skip, default)]
+    // pub tls_provider: TlsProvider,
     #[serde(default)]
     pub expect_proxy: bool,
     #[serde(default = "default_sticky_name")]
@@ -757,7 +758,7 @@ impl Default for HttpsListener {
           .map(String::from)
           .collect(),
       versions:            vec!(TlsVersion::TLSv1_2),
-      tls_provider:        TlsProvider::Rustls,
+    //   tls_provider:        TlsProvider::Rustls,
       expect_proxy:        false,
       sticky_name:         String::from("SOZUBALANCEID"),
       certificate:         None,
@@ -797,7 +798,7 @@ pub struct TcpTlsConfig {
     pub signature_algorithms: Vec<String>,
     #[serde(default)]
     pub groups_list: Vec<String>,
-    #[serde(skip, default)]
+    #[serde(default)]
     pub tls_provider: TlsProvider,
 
     #[serde(default)]
@@ -926,13 +927,22 @@ impl ProxyRequestOrder {
                 [Topic::HttpsProxyConfig].iter().cloned().collect()
             }
             ProxyRequestOrder::AddCertificate(_) => {
-                [Topic::HttpsProxyConfig].iter().cloned().collect()
+                [Topic::HttpsProxyConfig, Topic::TcpProxyConfig]
+                    .iter()
+                    .cloned()
+                    .collect()
             }
             ProxyRequestOrder::ReplaceCertificate(_) => {
-                [Topic::HttpsProxyConfig].iter().cloned().collect()
+                [Topic::HttpsProxyConfig, Topic::TcpProxyConfig]
+                    .iter()
+                    .cloned()
+                    .collect()
             }
             ProxyRequestOrder::RemoveCertificate(_) => {
-                [Topic::HttpsProxyConfig].iter().cloned().collect()
+                [Topic::HttpsProxyConfig, Topic::TcpProxyConfig]
+                    .iter()
+                    .cloned()
+                    .collect()
             }
             ProxyRequestOrder::AddTcpFrontend(_) => {
                 [Topic::TcpProxyConfig].iter().cloned().collect()

--- a/command/src/proxy.rs
+++ b/command/src/proxy.rs
@@ -780,9 +780,32 @@ pub struct TcpListener {
     #[serde(default)]
     #[serde(skip_serializing_if = "is_false")]
     pub expect_proxy: bool,
+    pub tls: Option<TcpTlsConfig>,
     pub front_timeout: u32,
     pub back_timeout: u32,
     pub connect_timeout: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TcpTlsConfig {
+    pub versions: Vec<TlsVersion>,
+
+    pub cipher_list: Vec<String>,
+    #[serde(default)]
+    pub cipher_suites: Vec<String>,
+    #[serde(default)]
+    pub signature_algorithms: Vec<String>,
+    #[serde(default)]
+    pub groups_list: Vec<String>,
+    #[serde(skip, default)]
+    pub tls_provider: TlsProvider,
+
+    #[serde(default)]
+    pub certificate: Option<String>,
+    #[serde(default)]
+    pub certificate_chain: Vec<String>,
+    #[serde(default)]
+    pub key: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -1410,6 +1410,7 @@ mod tests {
             front_timeout: 60,
             back_timeout: 30,
             connect_timeout: 3,
+            tls: None,
         }));
         state.handle_order(&ProxyRequestOrder::ActivateListener(ActivateListener {
             address: "0.0.0.0:1234".parse().unwrap(),
@@ -1463,6 +1464,7 @@ mod tests {
             front_timeout: 60,
             back_timeout: 30,
             connect_timeout: 3,
+            tls: None,
         }));
         state2.handle_order(&ProxyRequestOrder::AddHttpListener(HttpListener {
             address: "0.0.0.0:8080".parse().unwrap(),
@@ -1520,6 +1522,7 @@ mod tests {
                 front_timeout: 60,
                 back_timeout: 30,
                 connect_timeout: 3,
+                tls: None,
             }),
             ProxyRequestOrder::DeactivateListener(DeactivateListener {
                 address: "0.0.0.0:1234".parse().unwrap(),

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -1052,7 +1052,7 @@ mod tests {
     use super::*;
     use crate::proxy::{
         Backend, HttpFrontend, LoadBalancingAlgorithms, LoadBalancingParams, PathRule,
-        ProxyRequestOrder, Route, RulePosition, TlsProvider,
+        ProxyRequestOrder, Route, RulePosition,
     };
 
     #[test]
@@ -1441,7 +1441,7 @@ mod tests {
             cipher_suites: vec![],
             signature_algorithms: vec![],
             groups_list: vec![],
-            tls_provider: TlsProvider::Openssl,
+            // tls_provider: TlsProvider::Openssl,
             certificate: None,
             certificate_chain: vec![],
             key: None,
@@ -1495,7 +1495,7 @@ mod tests {
             cipher_suites: vec![],
             signature_algorithms: vec![],
             groups_list: vec![],
-            tls_provider: TlsProvider::Openssl,
+            // tls_provider: TlsProvider::Openssl,
             certificate: None,
             certificate_chain: vec![],
             key: None,
@@ -1566,7 +1566,7 @@ mod tests {
                 cipher_suites: vec![],
                 signature_algorithms: vec![],
                 groups_list: vec![],
-                tls_provider: TlsProvider::Openssl,
+                // tls_provider: TlsProvider::Openssl,
                 certificate: None,
                 certificate_chain: vec![],
                 key: None,

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -68,7 +68,7 @@ tiny_http = "^0.12.0"
 ureq = "^2.5.0"
 
 [features]
-default = []
+default = ["use-openssl"]
 splice = []
 unstable = []
 logs-debug = []

--- a/lib/examples/tcp.rs
+++ b/lib/examples/tcp.rs
@@ -61,6 +61,7 @@ fn main() -> anyhow::Result<()> {
         address: "127.0.0.1:8080"
             .parse()
             .with_context(|| "could not parse address")?,
+        hostname: None,
         tags: None,
     };
     let tcp_backend = proxy::Backend {

--- a/lib/examples/tcp.rs
+++ b/lib/examples/tcp.rs
@@ -45,6 +45,7 @@ fn main() -> anyhow::Result<()> {
             front_timeout: 60,
             back_timeout: 30,
             connect_timeout: 3,
+            tls: None,
         };
         Logger::init(
             "TCP".to_string(),

--- a/lib/src/https_openssl.rs
+++ b/lib/src/https_openssl.rs
@@ -1771,6 +1771,7 @@ impl Listener {
 
         if let Err(e) = context.set_cipher_list(&cipher_list.join(":")) {
             error!("could not set context cipher list: {:?}", e);
+            // verify the cipher_list and tls_provider are compatible
             return Err(ListenerError::BuildOpenSslError(e.to_string()));
         }
 

--- a/lib/src/https_openssl.rs
+++ b/lib/src/https_openssl.rs
@@ -1782,8 +1782,10 @@ impl Listener {
             }
 
             if let Err(e) = context.set_groups_list(&groups_list.join(":")) {
-                error!("could not set context groups list: {:?}", e);
-                return Err(ListenerError::BuildOpenSslError(e.to_string()));
+                if !e.errors().is_empty() {
+                    error!("could not set context groups list: {:?}", e);
+                    return Err(ListenerError::BuildOpenSslError(e.to_string()));
+                }
             }
         }
 

--- a/lib/src/protocol/h2/stream.rs
+++ b/lib/src/protocol/h2/stream.rs
@@ -11,13 +11,6 @@ use super::{
 };
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum St {
-    Init,
-    ClientPrefaceReceived,
-    ServerPrefaceSent,
-}
-
-#[derive(Clone, Debug, PartialEq)]
 pub struct Stream {
     pub id: u32,
     pub state: StreamState,

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -1276,6 +1276,8 @@ impl Server {
                         .tcp
                         .borrow_mut()
                         .add_listener(listener, self.pool.clone(), token)
+                        .ok()
+                        .flatten()
                         .is_some()
                     {
                         entry.insert(Rc::new(RefCell::new(ListenSession {

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -521,6 +521,10 @@ impl Session {
                 //     incr!(ciphersuite_str(cipher));
                 // };
 
+                println!(
+                    "Finished handshake with SNI: {:?}",
+                    handshake.session.sni_hostname()
+                );
                 let front_stream = FrontRustls {
                     stream: handshake.stream,
                     session: handshake.session,
@@ -1680,7 +1684,9 @@ impl Proxy {
             .insert(front.cluster_id.to_string(), listener.token);
 
         listener.set_tags(front.address.to_string(), front.tags);
-        listener.cluster_id = Some(front.cluster_id.to_string());
+        if !listener.flavor.has_tls() {
+            listener.cluster_id = Some(front.cluster_id.to_string());
+        }
         Ok(())
     }
 

--- a/lib/src/tls.rs
+++ b/lib/src/tls.rs
@@ -562,7 +562,7 @@ impl ResolvesServerCert for MutexWrappedCertificateResolver {
             sigschemes
         );
         if let Ok(ref mut resolver) = self.0.try_lock() {
-            //resolver.domains.print();
+            resolver.domains.print();
             if let Some((_, fingerprint)) = resolver.domains.domain_lookup(name.as_bytes(), true) {
                 trace!(
                     "looking for certificate for {:?} with fingerprint {:?}",


### PR DESCRIPTION
TODO:
- [ ] create specific "tcptls" protocol for Frontend
- [x] add hostname (for SNI) and certificates for each TCP-TLS listener
- [x] implement a CertificateResolver on TCP-TLS Frontend
- [ ] potentially add validation steps:
  - [ ] only 1 cluster/listener per TCP Frontend
  - [x] N TCP-TLS clusters/listeners per TCP-TLS Frontend
  - [x] mandatory hostname for TCP-TLS Frontends
- [ ] support openssl

Signed-off-by: Eloi DEMOLIS <eloi.demolis@clever-cloud.com>