### PR TITLE
Error propagation: SCM sockets, channels

### DIFF
--- a/bin/src/command/worker.rs
+++ b/bin/src/command/worker.rs
@@ -21,7 +21,7 @@ pub struct Worker {
     pub pid: pid_t,
     pub run_state: RunState,
     pub queue: VecDeque<ProxyRequest>,
-    /// used to receive listeners
+    /// Used to send and receive listeners (socket addresses and file descriptors)
     pub scm_socket: ScmSocket,
     pub sender: Option<futures::channel::mpsc::Sender<ProxyRequest>>,
 }
@@ -46,6 +46,7 @@ impl Worker {
         }
     }
 
+    /// send proxy request to the worker, via the mpsc sender
     pub async fn send(&mut self, request_id: String, data: ProxyRequestOrder) {
         if let Some(worker_tx) = self.sender.as_mut() {
             if let Err(e) = worker_tx

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -59,10 +59,9 @@ impl CommandManager {
     ) -> anyhow::Result<()> {
         let command_request = CommandRequest::new(id.to_string(), command_request_order, None);
 
-        if !self.channel.write_message(&command_request) {
-            bail!("Could not write the request");
-        }
-        Ok(())
+        self.channel
+            .write_message(&command_request)
+            .with_context(|| "Could not write the request")
     }
 
     fn read_channel_message_with_timeout(&mut self) -> anyhow::Result<CommandResponse> {
@@ -167,11 +166,13 @@ impl CommandManager {
         println!("shutting down proxy");
         let id = generate_id();
 
-        self.channel.write_message(&CommandRequest::new(
-            id.clone(),
-            CommandRequestOrder::Proxy(Box::new(ProxyRequestOrder::SoftStop)),
-            proxy_id,
-        ));
+        self.channel
+            .write_message(&CommandRequest::new(
+                id.clone(),
+                CommandRequestOrder::Proxy(Box::new(ProxyRequestOrder::SoftStop)),
+                proxy_id,
+            ))
+            .with_context(|| "Could not send the request using the channel")?;
 
         loop {
             let response = self.read_channel_message_with_timeout()?;
@@ -200,11 +201,14 @@ impl CommandManager {
     pub fn hard_stop(&mut self, proxy_id: Option<u32>) -> Result<(), anyhow::Error> {
         println!("shutting down proxy");
         let id = generate_id();
-        self.channel.write_message(&CommandRequest::new(
-            id.clone(),
-            CommandRequestOrder::Proxy(Box::new(ProxyRequestOrder::HardStop)),
-            proxy_id,
-        ));
+        self.channel
+            .write_message(&CommandRequest::new(
+                id.clone(),
+                CommandRequestOrder::Proxy(Box::new(ProxyRequestOrder::HardStop)),
+                proxy_id,
+            ))
+            .with_context(|| "Could not send the request using the channel")?;
+
         loop {
             let response = self.read_channel_message_with_timeout()?;
 

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -158,6 +158,8 @@ pub fn create_channel(config: &Config) -> anyhow::Result<Channel<CommandRequest,
     )
     .with_context(|| "Could not create Channel from the given path")?;
 
-    channel.blocking();
+    channel
+        .blocking()
+        .with_context(|| "Could not block the channel used to communicate with Sōzu")?;
     Ok(channel)
 }

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -60,8 +60,8 @@ fn main(args: Args) -> anyhow::Result<()> {
         }
         // this is used only by the CLI when upgrading
         cli::SubCmd::Worker {
-            fd,
-            scm,
+            fd: worker_to_main_channel_fd,
+            scm: worker_to_main_scm_fd,
             configuration_state_fd,
             id,
             command_buffer_size,
@@ -70,8 +70,8 @@ fn main(args: Args) -> anyhow::Result<()> {
             let max_command_buffer_size =
                 max_command_buffer_size.unwrap_or(command_buffer_size * 2);
             worker::begin_worker_process(
-                fd,
-                scm,
+                worker_to_main_channel_fd,
+                worker_to_main_scm_fd,
                 configuration_state_fd,
                 id,
                 command_buffer_size,

--- a/bin/src/util.rs
+++ b/bin/src/util.rs
@@ -21,9 +21,9 @@ pub fn enable_close_on_exec(fd: RawFd) -> Result<i32, anyhow::Error> {
     fcntl(fd, FcntlArg::F_SETFD(new_flags)).with_context(|| "could not set file descriptor flags")
 }
 
-// FD_CLOEXEC is set by default on every fd in Rust standard lib,
-// so we need to remove the flag on the client, otherwise
-// it won't be accessible
+/// FD_CLOEXEC is set by default on every fd in Rust standard lib,
+/// so we need to remove the flag on the client, otherwise
+/// it won't be accessible
 pub fn disable_close_on_exec(fd: RawFd) -> Result<i32, anyhow::Error> {
     let old_flags =
         fcntl(fd, FcntlArg::F_GETFD).with_context(|| "could not get file descriptor flags")?;

--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -11,10 +11,10 @@ authors = [
   "Geoffroy Couprie <geo.couprie@gmail.com>",
   "Eloi Demolis <eloi.demolis@clever-cloud.com>",
   "Emmanuel Bosquet <emmanuel.bosquet@clever-cloud.com>",
-  "Florentin Dubois <florentin.dubois@clever-cloud.com>"
+  "Florentin Dubois <florentin.dubois@clever-cloud.com>",
 ]
 categories = ["network-programming"]
-edition="2021"
+edition = "2021"
 include = [
   "./README.md",
   "Cargo.toml",
@@ -22,7 +22,7 @@ include = [
   "assets/certificate.pem",
   "assets/key.pem",
   "assets/404.html",
-  "assets/503.html"
+  "assets/503.html",
 ]
 
 [dependencies]
@@ -33,7 +33,7 @@ log = "^0.4.17"
 time = "^0.3.15"
 toml = "^0.5.9"
 memchr = "^2.5.0"
-mio = { version = "^0.8.4", features = [ "os-poll", "net" ] }
+mio = { version = "^0.8.4", features = ["os-poll", "net"] }
 nix = "^0.25.0"
 nom = "^7.1.1"
 pem = "^1.1.0"

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -393,7 +393,6 @@ impl FileClusterFrontendConfig {
         })
     }
 
-    // TODO log the error with error! upstream
     pub fn to_http_front(&self, _cluster_id: &str) -> anyhow::Result<HttpFrontendConfig> {
         let hostname = match &self.hostname {
             Some(hostname) => hostname.to_owned(),
@@ -547,7 +546,9 @@ impl FileClusterConfig {
             FileClusterProtocolConfig::Http => {
                 let mut frontends = Vec::new();
                 for frontend in self.frontends {
-                    let http_frontend = frontend.to_http_front(cluster_id)?;
+                    let http_frontend = frontend
+                        .to_http_front(cluster_id)
+                        .with_context(|| "Could not convert frontend config to http frontend")?;
                     frontends.push(http_frontend);
                 }
 

--- a/command/src/scm_socket.rs
+++ b/command/src/scm_socket.rs
@@ -3,19 +3,20 @@ use std::{
     net::SocketAddr,
     os::unix::{
         io::{FromRawFd, IntoRawFd, RawFd},
-        net,
+        net::UnixStream as StdUnixStream,
     },
     str::from_utf8,
 };
 
 use anyhow::Context;
 use mio::net::TcpListener;
-use nix::{cmsg_space, sys::socket, Result as NixResult};
+use nix::{cmsg_space, sys::socket};
 use serde_json;
 
 pub const MAX_FDS_OUT: usize = 200;
 pub const MAX_BYTES_OUT: usize = 4096;
 
+/// A unix socket specialized for file descriptor passing
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ScmSocket {
     pub fd: RawFd,
@@ -23,33 +24,38 @@ pub struct ScmSocket {
 }
 
 impl ScmSocket {
-    pub fn new(fd: RawFd) -> ScmSocket {
+    /// Create a blocking SCM socket from a raw file descriptor (unsafe)
+    pub fn new(fd: RawFd) -> anyhow::Result<Self> {
         unsafe {
-            let stream = net::UnixStream::from_raw_fd(fd);
-            let _ = stream.set_nonblocking(false).map_err(|e| {
-                error!("could not change blocking status for stream: {:?}", e);
-            });
-            let _fd = stream.into_raw_fd();
+            let stream = StdUnixStream::from_raw_fd(fd);
+            stream
+                .set_nonblocking(false)
+                .with_context(|| "could not change blocking status for stream")?;
+            let _dropped_fd = stream.into_raw_fd();
         }
 
-        ScmSocket { fd, blocking: true }
+        Ok(ScmSocket { fd, blocking: true })
     }
 
+    /// Get the raw file descriptor of the scm channel
     pub fn raw_fd(&self) -> i32 {
         self.fd
     }
 
-    pub fn set_blocking(&self, blocking: bool) {
+    /// Use the standard library (unsafe) to set the socket to blocking / unblocking
+    pub fn set_blocking(&self, blocking: bool) -> anyhow::Result<()> {
         unsafe {
-            let stream = net::UnixStream::from_raw_fd(self.fd);
-            let _ = stream.set_nonblocking(!blocking).map_err(|e| {
-                error!("could not change blocking status for stream: {:?}", e);
-            });
-            let _fd = stream.into_raw_fd();
+            let stream = StdUnixStream::from_raw_fd(self.fd);
+            stream
+                .set_nonblocking(!blocking)
+                .with_context(|| "could not change blocking status for stream")?;
+            let _dropped_fd = stream.into_raw_fd();
         }
+        Ok(())
     }
 
-    pub fn send_listeners(&self, listeners: &Listeners) -> NixResult<()> {
+    /// Send listeners (socket addresses and file descriptors) via an scm socket
+    pub fn send_listeners(&self, listeners: &Listeners) -> anyhow::Result<()> {
         let listeners_count = ListenersCount {
             http: listeners.http.iter().map(|t| t.0).collect(),
             tls: listeners.tls.iter().map(|t| t.0).collect(),
@@ -60,22 +66,23 @@ impl ScmSocket {
             .map(|s| s.into_bytes())
             .unwrap_or_else(|_| Vec::new());
 
-        let mut v: Vec<RawFd> = Vec::new();
+        let mut file_descriptors: Vec<RawFd> = Vec::new();
 
-        v.extend(listeners.http.iter().map(|t| t.1));
-        v.extend(listeners.tls.iter().map(|t| t.1));
-        v.extend(listeners.tcp.iter().map(|t| t.1));
+        file_descriptors.extend(listeners.http.iter().map(|t| t.1));
+        file_descriptors.extend(listeners.tls.iter().map(|t| t.1));
+        file_descriptors.extend(listeners.tcp.iter().map(|t| t.1));
 
-        self.send_msg(&message, &v)
+        self.send_msg_and_fds(&message, &file_descriptors)
     }
 
+    /// Receive and parse listeners (socket addresses and file descriptors) via an scm socket
     pub fn receive_listeners(&self) -> anyhow::Result<Listeners> {
         let mut buf = vec![0; MAX_BYTES_OUT];
 
         let mut received_fds: [RawFd; MAX_FDS_OUT] = [0; MAX_FDS_OUT];
 
         let (size, file_descriptor_length) = self
-            .rcv_msg(&mut buf, &mut received_fds)
+            .receive_msg_and_fds(&mut buf, &mut received_fds)
             .with_context(|| "could not receive listeners")?;
 
         debug!("{} received :{:?}", self.fd, (size, file_descriptor_length));
@@ -118,28 +125,38 @@ impl ScmSocket {
         Ok(Listeners { http, tls, tcp })
     }
 
-    pub fn send_msg(&self, buf: &[u8], fds: &[RawFd]) -> NixResult<()> {
-        let iov = [IoSlice::new(buf)];
+    /// Sends message and file descriptors separately. The file descriptors are summed up
+    /// in a ControlMessage.
+    fn send_msg_and_fds(&self, message: &[u8], fds: &[RawFd]) -> anyhow::Result<()> {
+        let iov = [IoSlice::new(message)];
         let flags = if self.blocking {
             socket::MsgFlags::empty()
         } else {
             socket::MsgFlags::MSG_DONTWAIT
         };
 
-        if !fds.is_empty() {
-            let cmsgs = [socket::ControlMessage::ScmRights(fds)];
-            //println!("{} send with data", self.fd);
-            socket::sendmsg::<()>(self.fd, &iov, &cmsgs, flags, None)?;
-        } else {
-            //println!("{} send empty", self.fd);
-            socket::sendmsg::<()>(self.fd, &iov, &[], flags, None)?;
+        if fds.is_empty() {
+            println!("{} send empty", self.fd);
+            socket::sendmsg::<()>(self.fd, &iov, &[], flags, None)
+                .with_context(|| "Could not send empty message per socket")?;
+            return Ok(());
         };
+
+        let control_message = [socket::ControlMessage::ScmRights(fds)];
+        println!("{} send with data", self.fd);
+        socket::sendmsg::<()>(self.fd, &iov, &control_message, flags, None)
+            .with_context(|| "Could not send message per socket")?;
         Ok(())
     }
 
-    pub fn rcv_msg(&self, buf: &mut [u8], fds: &mut [RawFd]) -> NixResult<(usize, usize)> {
+    /// Parse the message and receives file descriptors separately via the ControlMessage
+    fn receive_msg_and_fds(
+        &self,
+        message: &mut [u8],
+        fds: &mut [RawFd],
+    ) -> anyhow::Result<(usize, usize)> {
         let mut cmsg = cmsg_space!([RawFd; MAX_FDS_OUT]);
-        let mut iov = [IoSliceMut::new(buf)];
+        let mut iov = [IoSliceMut::new(message)];
 
         let flags = if self.blocking {
             socket::MsgFlags::empty()
@@ -147,8 +164,8 @@ impl ScmSocket {
             socket::MsgFlags::MSG_DONTWAIT
         };
 
-        //let msg = socket::recvmsg(self.fd, &iov[..], Some(&mut cmsg), socket::MSG_DONTWAIT)?;
-        let msg = socket::recvmsg::<()>(self.fd, &mut iov[..], Some(&mut cmsg), flags)?;
+        let msg = socket::recvmsg::<()>(self.fd, &mut iov[..], Some(&mut cmsg), flags)
+            .with_context(|| "Could not receive message per socket")?;
 
         let mut fd_count = 0;
         let received_fds = msg
@@ -169,7 +186,8 @@ impl ScmSocket {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+/// Socket addresses and file descriptors needed by a Proxy to start listening
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Listeners {
     pub http: Vec<(SocketAddr, RawFd)>,
     pub tls: Vec<(SocketAddr, RawFd)>,
@@ -177,7 +195,7 @@ pub struct Listeners {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ListenersCount {
+struct ListenersCount {
     pub http: Vec<SocketAddr>,
     pub tls: Vec<SocketAddr>,
     pub tcp: Vec<SocketAddr>,
@@ -185,29 +203,27 @@ pub struct ListenersCount {
 
 impl Listeners {
     pub fn get_http(&mut self, addr: &SocketAddr) -> Option<RawFd> {
-        if let Some(pos) = self.http.iter().position(|(front, _)| front == addr) {
-            Some(self.http.remove(pos).1)
-        } else {
-            None
-        }
+        self.http
+            .iter()
+            .position(|(front, _)| front == addr)
+            .and_then(|pos| Some(self.http.remove(pos).1))
     }
 
     pub fn get_https(&mut self, addr: &SocketAddr) -> Option<RawFd> {
-        if let Some(pos) = self.tls.iter().position(|(front, _)| front == addr) {
-            Some(self.tls.remove(pos).1)
-        } else {
-            None
-        }
+        self.tls
+            .iter()
+            .position(|(front, _)| front == addr)
+            .and_then(|pos| Some(self.tls.remove(pos).1))
     }
 
     pub fn get_tcp(&mut self, addr: &SocketAddr) -> Option<RawFd> {
-        if let Some(pos) = self.tcp.iter().position(|(front, _)| front == addr) {
-            Some(self.tcp.remove(pos).1)
-        } else {
-            None
-        }
+        self.tcp
+            .iter()
+            .position(|(front, _)| front == addr)
+            .and_then(|pos| Some(self.tcp.remove(pos).1))
     }
 
+    /// Deactivate all listeners by closing their file descriptors
     pub fn close(&self) {
         for (_, ref fd) in &self.http {
             unsafe {
@@ -226,5 +242,134 @@ impl Listeners {
                 let _ = TcpListener::from_raw_fd(*fd);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use mio::net::UnixStream as MioUnixStream;
+    use std::{net::SocketAddr, os::unix::prelude::AsRawFd, str::FromStr};
+
+    #[test]
+    fn create_block_unblock_an_scm_socket() {
+        let (nonblocking_stream, _) =
+            MioUnixStream::pair().expect("Could not create a pair of unix streams");
+        let raw_file_descriptor = nonblocking_stream.into_raw_fd();
+
+        let scm_socket = ScmSocket::new(raw_file_descriptor);
+        assert!(scm_socket.is_ok());
+
+        let scm_socket = scm_socket.unwrap();
+
+        assert!(scm_socket.set_blocking(true).is_ok());
+        assert!(scm_socket.set_blocking(false).is_ok());
+    }
+
+    fn socket_addr_from_str(str: &str) -> SocketAddr {
+        SocketAddr::from_str(str).expect(&format!(
+            "failed to create socket address from string slice {}",
+            str
+        ))
+    }
+
+    #[test]
+    fn send_and_receive_empty_listeners() {
+        let (stream_1, stream_2) =
+            MioUnixStream::pair().expect("Could not create a pair of mio unix streams");
+
+        let sending_scm_socket =
+            ScmSocket::new(stream_1.into_raw_fd()).expect("Could not create scm socket");
+
+        let receiving_scm_socket =
+            ScmSocket::new(stream_2.as_raw_fd()).expect("Could not create scm socket");
+
+        let listeners = Listeners {
+            http: vec![],
+            tcp: vec![],
+            tls: vec![],
+        };
+
+        sending_scm_socket
+            .send_listeners(&listeners)
+            .expect("Could not send listeners");
+
+        let received_listeners = receiving_scm_socket
+            .receive_listeners()
+            .expect("Could not receive listeners");
+
+        assert_eq!(listeners, received_listeners);
+    }
+
+    #[test]
+    fn send_and_receive_socket_addresses() {
+        let (stream_1, stream_2) =
+            MioUnixStream::pair().expect("Could not create a pair of mio unix streams");
+
+        println!("unix stream pair: {:?} and {:?}", stream_1, stream_2);
+        let sending_scm_socket =
+            ScmSocket::new(stream_1.into_raw_fd()).expect("Could not create scm socket");
+
+        println!("sending socket: {:?}", sending_scm_socket);
+
+        let receiving_scm_socket =
+            ScmSocket::new(stream_2.into_raw_fd()).expect("Could not create scm socket");
+
+        println!("receiving socket: {:?}", receiving_scm_socket);
+
+        // We have to provide actual file descriptors, even if they will all be changed in the takeover
+        let (http_socket1, http_socket2) =
+            MioUnixStream::pair().expect("Could not create a pair of mio unix streams");
+        let (tcp_socket1, tcp_socket2) =
+            MioUnixStream::pair().expect("Could not create a pair of mio unix streams");
+        let (tls_socket1, tls_socket2) =
+            MioUnixStream::pair().expect("Could not create a pair of mio unix streams");
+
+        let listeners = Listeners {
+            http: vec![
+                (
+                    socket_addr_from_str("127.0.1.1:8080"),
+                    http_socket1.as_raw_fd(),
+                ),
+                (
+                    socket_addr_from_str("127.0.1.2:8080"),
+                    http_socket2.as_raw_fd(),
+                ),
+            ],
+            tcp: vec![
+                (
+                    socket_addr_from_str("127.0.2.1:8080"),
+                    tcp_socket1.as_raw_fd(),
+                ),
+                (
+                    socket_addr_from_str("127.0.2.2:8080"),
+                    tcp_socket2.as_raw_fd(),
+                ),
+            ],
+            tls: vec![
+                (
+                    socket_addr_from_str("127.0.3.1:8443"),
+                    tls_socket1.as_raw_fd(),
+                ),
+                (
+                    socket_addr_from_str("127.0.3.2:8443"),
+                    tls_socket2.as_raw_fd(),
+                ),
+            ],
+        };
+
+        println!("self.fd: {}", sending_scm_socket.fd);
+        println!("listeners to send: {:#?}", listeners);
+
+        sending_scm_socket
+            .send_listeners(&listeners)
+            .expect("Could not send listeners");
+
+        let received_listeners = receiving_scm_socket
+            .receive_listeners()
+            .expect("Could not receive listeners");
+
+        assert_eq!(listeners.http[0].0, received_listeners.http[0].0);
     }
 }

--- a/lib/src/backends.rs
+++ b/lib/src/backends.rs
@@ -51,6 +51,7 @@ impl BackendMap {
             .add_backend(backend);
     }
 
+    // TODO: return anyhow::Result with context, log the error downstream
     pub fn remove_backend(&mut self, cluster_id: &str, backend_address: &SocketAddr) {
         if let Some(backends) = self.backends.get_mut(cluster_id) {
             backends.remove_backend(backend_address);
@@ -62,6 +63,7 @@ impl BackendMap {
         }
     }
 
+    // TODO: return anyhow::Result with context, log the error downstream
     pub fn close_backend_connection(&mut self, cluster_id: &str, addr: &SocketAddr) {
         if let Some(cluster_backends) = self.backends.get_mut(cluster_id) {
             if let Some(ref mut backend) = cluster_backends.find_backend(addr) {
@@ -77,6 +79,8 @@ impl BackendMap {
             .unwrap_or(false)
     }
 
+    // TODO: remove if lets
+    // TODO: return anyhow::Result with context, log the error downstream
     pub fn backend_from_cluster_id(
         &mut self,
         cluster_id: &str,
@@ -130,6 +134,7 @@ impl BackendMap {
         }
     }
 
+    // TODO: return anyhow::Result with context, log the error downstream
     pub fn backend_from_sticky_session(
         &mut self,
         cluster_id: &str,

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -1784,6 +1784,7 @@ impl Listener {
         self.fronts.remove_http_front(tls_front)
     }
 
+    // TODO: return Result with context
     // ToDo factor out with http.rs
     pub fn frontend_from_request(&self, host: &str, uri: &str, method: &Method) -> Option<Route> {
         let host: &str = if let Ok((i, (hostname, _))) = hostname_and_port(host.as_bytes()) {
@@ -1896,6 +1897,7 @@ impl Proxy {
             .collect()
     }
 
+    // TODO: return Result with context
     pub fn give_back_listener(
         &mut self,
         address: StdSocketAddr,
@@ -2345,7 +2347,7 @@ pub fn start(
         let mut server = Server::new(
             event_loop,
             channel,
-            ScmSocket::new(scm_server.as_raw_fd()),
+            ScmSocket::new(scm_server.as_raw_fd()).unwrap(),
             sessions,
             pool,
             backends,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -398,6 +398,7 @@ pub enum SessionResult {
     ConnectBackend,
 }
 
+// TODO: enrich with thiserror
 #[derive(Debug, PartialEq, Eq)]
 pub enum ConnectionError {
     NoHostGiven,

--- a/lib/src/protocol/http/parser/mod.rs
+++ b/lib/src/protocol/http/parser/mod.rs
@@ -169,6 +169,7 @@ pub struct RequestLine {
 }
 
 impl RequestLine {
+    // TODO: respond Result<RequestLine, ParseError
     pub fn from_raw_request_line(r: RawRequestLine) -> Option<RequestLine> {
         if let Ok(uri) = str::from_utf8(r.uri) {
             Some(RequestLine {

--- a/lib/src/protocol/proxy_protocol/expect.rs
+++ b/lib/src/protocol/proxy_protocol/expect.rs
@@ -83,6 +83,7 @@ impl<Front: SocketHandler + Read> ExpectProxyProtocol<Front> {
             self.readiness.event.remove(Ready::readable());
         }
 
+        // TODO: rename to socket_result, pattern match
         if res == SocketResult::Error {
             error!("[{:?}] (expect proxy) front socket error, closing the connection(read {}, wrote {})", self.frontend_token, metrics.bin, metrics.bout);
             metrics.service_stop();

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -32,6 +32,7 @@ impl Router {
         }
     }
 
+    // TODO: return Result<Route> with context
     pub fn lookup(&self, hostname: &[u8], path: &[u8], method: &Method) -> Option<Route> {
         for (domain_rule, path_rule, method_rule, cluster_id) in &self.pre {
             if domain_rule.matches(hostname)

--- a/lib/src/timer.rs
+++ b/lib/src/timer.rs
@@ -158,6 +158,7 @@ impl TimeoutContainer {
         }
     }
 
+    // TODO: write a documenting comment
     pub fn reset(&mut self) -> bool {
         match self.timeout.take() {
             None => {
@@ -329,6 +330,7 @@ impl<T> Timer<T> {
             .map(|state| self.set_timeout(delay_from_now, state))
     }
 
+    // TODO: return Result with context
     /// Cancel a timeout.
     ///
     /// If the timeout has not yet occurred, the return value holds the


### PR DESCRIPTION
The idea is that we would rather log errors within the logic that call functions, than within the function themselves, as described in #825 .

We want to avoid this:

    channel could not write to back buffer: <std::io::Error>

And we would want this:

    Could not send confirmation of fork using the channel. Caused by: channel could not write to back buffer. Caused by: <std::io::Error>

This PR:

- makes SCM socket and Channel logic return `anyhow::Result` enriched with Context.
- logs these errors in the upper-level logic
- uses these errors to panic when usefull, when write or read errors would prevent starting up

This PR leaves a number of such comments:

    // DISCUSS: should we propagate the error instead of printing it?

Rephrased, this means: *should we stop doing what we do and return Error instead of going on?*
As a matter of fact, a considerable number of errors in sōzu are not propagated but simply logged, using mostly this syntax:

```rust
if let Err(e) = some_logic_that_returns_result() {
    error!("Could not do stuff: {}", e);
}
```

So the question is: *if we can't do stuff, should we go on doing other stuff at all?*