### PR TITLE
full error propagation on order handling by the state

### DIFF
--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -577,7 +577,9 @@ impl CommandServer {
         //FIXME: too many loops, this could be cleaner
         for message in self.config.generate_config_messages() {
             if let CommandRequestOrder::Proxy(order) = message.order {
-                self.state.handle_order(&order);
+                if let Err(e) = self.state.handle_order(&order) {
+                    error!("Could not execute order on state: {:#}", e);
+                }
 
                 if let &ProxyRequestOrder::AddCertificate(_) = &*order {
                     debug!("config generated AddCertificate( ... )");

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -761,7 +761,7 @@ impl CommandManager {
             }
             match response.status {
                 CommandStatus::Processing => println!("Proxy is processing: {}", response.message),
-                CommandStatus::Error => bail!("could not execute order: {}", response.message),
+                CommandStatus::Error => bail!("Order failed: {}", response.message),
                 CommandStatus::Ok => {
                     println!("Success: {}", response.message);
                     break;

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -159,7 +159,7 @@ impl SessionManager {
     }
 
     pub fn check_limits(&mut self) -> bool {
-        // this should be self.nb_connections >= self.max_connections 
+        // this should be self.nb_connections >= self.max_connections
         if self.nb_connections == self.max_connections {
             error!("max number of session connection reached, flushing the accept queue");
             gauge!("accept_queue.backpressure", 1);
@@ -933,7 +933,9 @@ impl Server {
     }
 
     pub fn notify_proxys(&mut self, message: ProxyRequest) {
-        self.config_state.handle_order(&message.order);
+        if let Err(e) = self.config_state.handle_order(&message.order) {
+            error!("Could not execute order on config state: {:#}", e);
+        }
 
         match message {
             ProxyRequest {


### PR DESCRIPTION
Until now, the `handle_order` would only return a boolean to notify the CommandServer or the proxy Server about error handling success.

Now the errors are much richer and propagated: 
- with main process logs
- with worker logs
- in the CLI

For instance:

```
Sending request order: Proxy(RemoveBackend(RemoveBackend { cluster_id: "some_id", backend_id: "23", address: 127.0.0.1:8080 }))
Error: could not execute order: Could not execute order on the state: Could not remove backend: cannot remove backend: cluster some_id has no backends 23 at 127.0.0.1:8080
```