### PR TITLE
Abstract out server functions

### DIFF
--- a/command/src/scm_socket.rs
+++ b/command/src/scm_socket.rs
@@ -20,7 +20,7 @@ pub const MAX_BYTES_OUT: usize = 4096;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ScmSocket {
     pub fd: RawFd,
-    pub blocking: bool,
+    pub blocking: bool, // TODO this is never used anywhere. Use it by updating / checking it
 }
 
 impl ScmSocket {

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -678,10 +678,10 @@ impl Session {
             }
 
             if front_interest.is_readable() {
-                let order = self.readable();
-                trace!("front readable\tinterpreting session order {:?}", order);
+                let session_result = self.readable();
+                trace!("front readable\tinterpreting session order {:?}", session_result);
 
-                match order {
+                match session_result {
                     SessionResult::ConnectBackend => {
                         match self.connect_to_backend(session.clone()) {
                             // reuse connection or send a default answer, we can continue

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -873,10 +873,10 @@ impl Session {
             }
 
             if front_interest.is_readable() {
-                let order = self.readable();
-                trace!("front readable\tinterpreting session order {:?}", order);
+                let session_result = self.readable();
+                trace!("front readable\tinterpreting session order {:?}", session_result);
 
-                match order {
+                match session_result {
                     SessionResult::ConnectBackend => {
                         match self.connect_to_backend(session.clone()) {
                             // reuse connection or send a default answer, we can continue
@@ -1470,6 +1470,7 @@ impl ProxySession for Session {
         Protocol::HTTPS
     }
 
+    // TODO: rename to update_readiness
     fn process_events(&mut self, token: Token, events: Ready) {
         trace!(
             "token {:?} got event {}",


### PR DESCRIPTION
The `Server::run()` functions is 430 lines long! This is is too much and hinders readability, because of nested loops, indentations, and so forth.

This PR abstracts out these functions, naming them at the same time for clarity:

- reset_loop_time_and_get_timeout
- read_channel_messages_and_notify
- zombie_check
- shutting_down_complete

This PR takes `let` statement from the `run()` functions and adds these variables to become fields of `Server`, for more code flexibility and configurability later on:

```rust
    loop_start: Instant,
    last_sessions_len: usize,
    last_zombie_check: Instant,
    last_shutting_down_message: Option<Instant>,
    max_poll_errors: i32, // TODO: make this configurable? this defaults to 10000 for now
    current_poll_errors: i32,
    should_poll_at: Option<Instant>,
    poll_timeout: Option<Duration>, // TODO: make this configurable? this defaults to 1000 milliseconds for now
```

The `Server::run()` method is now 220 lines long, which is way better IMO.