### PR TITLE
simplify ProxyRequestOrder::get_topics

### DIFF
--- a/command/src/proxy.rs
+++ b/command/src/proxy.rs
@@ -859,144 +859,58 @@ pub enum QueryAnswerMetrics {
 }
 
 impl ProxyRequestOrder {
-    pub fn get_topics(&self) -> HashSet<Topic> {
+    pub fn get_destinations(&self) -> ProxyDestinations {
+        let mut proxy_destination = ProxyDestinations {
+            to_http_proxy: false,
+            to_https_proxy: false,
+            to_tcp_proxy: false,
+        };
+
         match *self {
-            ProxyRequestOrder::AddCluster(_) => [
-                Topic::HttpProxyConfig,
-                Topic::HttpsProxyConfig,
-                Topic::TcpProxyConfig,
-            ]
-            .iter()
-            .cloned()
-            .collect(),
-            ProxyRequestOrder::RemoveCluster { cluster_id: _ } => [
-                Topic::HttpProxyConfig,
-                Topic::HttpsProxyConfig,
-                Topic::TcpProxyConfig,
-            ]
-            .iter()
-            .cloned()
-            .collect(),
-            ProxyRequestOrder::AddHttpFrontend(_) => {
-                [Topic::HttpProxyConfig].iter().cloned().collect()
+            ProxyRequestOrder::AddHttpFrontend(_)
+            | ProxyRequestOrder::AddHttpListener(_)
+            | ProxyRequestOrder::RemoveHttpFrontend(_) => proxy_destination.to_http_proxy = true,
+
+            ProxyRequestOrder::AddHttpsFrontend(_)
+            | ProxyRequestOrder::RemoveHttpsFrontend(_)
+            | ProxyRequestOrder::AddCertificate(_)
+            | ProxyRequestOrder::ReplaceCertificate(_)
+            | ProxyRequestOrder::RemoveCertificate(_)
+            | ProxyRequestOrder::AddHttpsListener(_)
+            | ProxyRequestOrder::Query(_) => proxy_destination.to_https_proxy = true,
+
+            ProxyRequestOrder::AddTcpFrontend(_)
+            | ProxyRequestOrder::RemoveTcpFrontend(_)
+            | ProxyRequestOrder::AddTcpListener(_) => proxy_destination.to_tcp_proxy = true,
+
+            ProxyRequestOrder::AddCluster(_)
+            | ProxyRequestOrder::AddBackend(_)
+            | ProxyRequestOrder::RemoveCluster { cluster_id: _ }
+            | ProxyRequestOrder::RemoveBackend(_)
+            | ProxyRequestOrder::RemoveListener(_)
+            | ProxyRequestOrder::ActivateListener(_)
+            | ProxyRequestOrder::DeactivateListener(_)
+            | ProxyRequestOrder::SoftStop
+            | ProxyRequestOrder::HardStop
+            | ProxyRequestOrder::Status
+            | ProxyRequestOrder::Logging(_) => {
+                proxy_destination.to_http_proxy = true;
+                proxy_destination.to_https_proxy = true;
+                proxy_destination.to_tcp_proxy = true;
             }
-            ProxyRequestOrder::RemoveHttpFrontend(_) => {
-                [Topic::HttpProxyConfig].iter().cloned().collect()
-            }
-            ProxyRequestOrder::AddHttpsFrontend(_) => {
-                [Topic::HttpsProxyConfig].iter().cloned().collect()
-            }
-            ProxyRequestOrder::RemoveHttpsFrontend(_) => {
-                [Topic::HttpsProxyConfig].iter().cloned().collect()
-            }
-            ProxyRequestOrder::AddCertificate(_) => {
-                [Topic::HttpsProxyConfig].iter().cloned().collect()
-            }
-            ProxyRequestOrder::ReplaceCertificate(_) => {
-                [Topic::HttpsProxyConfig].iter().cloned().collect()
-            }
-            ProxyRequestOrder::RemoveCertificate(_) => {
-                [Topic::HttpsProxyConfig].iter().cloned().collect()
-            }
-            ProxyRequestOrder::AddTcpFrontend(_) => {
-                [Topic::TcpProxyConfig].iter().cloned().collect()
-            }
-            ProxyRequestOrder::RemoveTcpFrontend(_) => {
-                [Topic::TcpProxyConfig].iter().cloned().collect()
-            }
-            ProxyRequestOrder::AddBackend(_) => [
-                Topic::HttpProxyConfig,
-                Topic::HttpsProxyConfig,
-                Topic::TcpProxyConfig,
-            ]
-            .iter()
-            .cloned()
-            .collect(),
-            ProxyRequestOrder::RemoveBackend(_) => [
-                Topic::HttpProxyConfig,
-                Topic::HttpsProxyConfig,
-                Topic::TcpProxyConfig,
-            ]
-            .iter()
-            .cloned()
-            .collect(),
-            ProxyRequestOrder::AddHttpListener(_) => {
-                [Topic::HttpProxyConfig].iter().cloned().collect()
-            }
-            ProxyRequestOrder::AddHttpsListener(_) => {
-                [Topic::HttpsProxyConfig].iter().cloned().collect()
-            }
-            ProxyRequestOrder::AddTcpListener(_) => {
-                [Topic::TcpProxyConfig].iter().cloned().collect()
-            }
-            ProxyRequestOrder::RemoveListener(_) => [
-                Topic::HttpProxyConfig,
-                Topic::HttpsProxyConfig,
-                Topic::TcpProxyConfig,
-            ]
-            .iter()
-            .cloned()
-            .collect(),
-            ProxyRequestOrder::ActivateListener(_) => [
-                Topic::HttpProxyConfig,
-                Topic::HttpsProxyConfig,
-                Topic::TcpProxyConfig,
-            ]
-            .iter()
-            .cloned()
-            .collect(),
-            ProxyRequestOrder::DeactivateListener(_) => [
-                Topic::HttpProxyConfig,
-                Topic::HttpsProxyConfig,
-                Topic::TcpProxyConfig,
-            ]
-            .iter()
-            .cloned()
-            .collect(),
-            ProxyRequestOrder::Query(_) => [Topic::HttpsProxyConfig].iter().cloned().collect(),
-            ProxyRequestOrder::SoftStop => [
-                Topic::HttpProxyConfig,
-                Topic::HttpsProxyConfig,
-                Topic::TcpProxyConfig,
-            ]
-            .iter()
-            .cloned()
-            .collect(),
-            ProxyRequestOrder::HardStop => [
-                Topic::HttpProxyConfig,
-                Topic::HttpsProxyConfig,
-                Topic::TcpProxyConfig,
-            ]
-            .iter()
-            .cloned()
-            .collect(),
-            ProxyRequestOrder::Status => [
-                Topic::HttpProxyConfig,
-                Topic::HttpsProxyConfig,
-                Topic::TcpProxyConfig,
-            ]
-            .iter()
-            .cloned()
-            .collect(),
-            ProxyRequestOrder::ConfigureMetrics(_) => HashSet::new(),
-            ProxyRequestOrder::Logging(_) => [
-                Topic::HttpsProxyConfig,
-                Topic::HttpProxyConfig,
-                Topic::TcpProxyConfig,
-            ]
-            .iter()
-            .cloned()
-            .collect(),
-            ProxyRequestOrder::ReturnListenSockets => HashSet::new(),
+
+            ProxyRequestOrder::ConfigureMetrics(_) => {}
+            ProxyRequestOrder::ReturnListenSockets => {}
         }
+        proxy_destination
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Topic {
-    HttpProxyConfig,
-    HttpsProxyConfig,
-    TcpProxyConfig,
+pub struct ProxyDestinations {
+    pub to_http_proxy: bool,
+    pub to_https_proxy: bool,
+    pub to_tcp_proxy: bool,
 }
 
 /*

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -25,7 +25,7 @@ use crate::{
         proxy::{
             ListenerType, MessageId, ProxyEvent, ProxyRequest, ProxyRequestOrder, ProxyResponse,
             ProxyResponseContent, ProxyResponseStatus, Query, QueryAnswer, QueryAnswerCertificate,
-            QueryCertificateType, QueryClusterType, Topic,
+            QueryCertificateType, QueryClusterType,
         },
         ready::Ready,
         scm_socket::{Listeners, ScmSocket},
@@ -1024,9 +1024,9 @@ impl Server {
             _ => {}
         };
 
-        let topics = message.order.get_topics();
+        let proxy_destinations = message.order.get_destinations();
 
-        if topics.contains(&Topic::HttpProxyConfig) {
+        if proxy_destinations.to_http_proxy {
             match message {
                 // special case for AddHttpListener because we need to register a listener
                 ProxyRequest {
@@ -1167,7 +1167,7 @@ impl Server {
                 ref m => push_queue(self.http.borrow_mut().notify(m.clone())),
             }
         }
-        if topics.contains(&Topic::HttpsProxyConfig) {
+        if proxy_destinations.to_https_proxy {
             match message {
                 // special case for AddHttpListener because we need to register a listener
                 ProxyRequest {
@@ -1307,7 +1307,7 @@ impl Server {
                 ref m => push_queue(self.https.borrow_mut().notify(m.clone())),
             }
         }
-        if topics.contains(&Topic::TcpProxyConfig) {
+        if proxy_destinations.to_tcp_proxy {
             match message {
                 // special case for AddTcpFront because we need to register a listener
                 ProxyRequest {


### PR DESCRIPTION
This function is unnecerralily long! Hashset are an overkill data format in this case.

Anyway. Around 90 lines of code are deleted and it's more readable now.