### PR TITLE
prevent concurrent testing in the github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      max-parallel: 1 # because concurrent testing bring certain time-based tests to fail
       matrix:
         rust:
           - stable


### PR DESCRIPTION
For now this github stategy here:

```yaml
    strategy:
      matrix:
        rust:
          - stable
          - beta
          - nightly
```

Launches 3 jobs at the same time, that install rust, build sōzu, and run the tests, with a different version of Rust.

The problem is that this concurrent running of tests messes with time-based tests, making random tests fail. (But the same tests succeed perfectly if run separately.) We then have to re-run the jobs manually, which is cumbersome.

This simple line here:

```yaml
    strategy:
      max-parallel: 1 # because concurrent testing bring certain time-based tests to fail
```

makes the tests run one after the other. It takes longer (up to 16 minutes) but at least the outcome is trustworthy.
