### PR TITLE
update build scripts with the `--locked` flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,7 @@ addons:
 script:
   - cd $ROOT_PATH/lib     && cargo test  --verbose
   - cd $ROOT_PATH/command && cargo test  --verbose
-  - cd $ROOT_PATH/futures && cargo test  --verbose
   - cd $ROOT_PATH/bin     && cargo build --verbose
-  - cd $ROOT_PATH/ctl     && cargo build --verbose
 
 cache:
   directories:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache openssl-dev \
 
 COPY . /source/
 WORKDIR /source/bin
-RUN cargo build --release
+RUN cargo build --release --locked
 
 
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,8 +41,6 @@ update the version number in `Cargo.toml` files in:
 - `command/`
 - `lib/`
 - `bin/`
-- `ctl/`
-- `futures/`
 
 Run `cargo build` at the root of the project to update the `Cargo.lock` file.
 

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -25,14 +25,17 @@ They will be built and available in the `~/.cargo/bin` folder.
 
 Build the sozu executable:
 
-`cd bin && cargo build --release`
+`cd bin && cargo build --release --locked`
 
 > The `--release` parameter inform cargo to compile sozu with optimizations turned on.
 > Only use `--release` to make a production version.
+>
+> The `--locked` flag tells cargo to stick to dependencies versions as specified in `Cargo.lock`
+> and thus prevent dependencie breaks.
 
 Build the sozuctl executable to manage the reverse proxy:
 
-`cd ctl && cargo build --release`
+`cd ctl && cargo build --release --locked`
 
 This will create the `sozu` executable for the reverse proxy, and `sozuctl` to command it.
 

--- a/doc/how_to_use.md
+++ b/doc/how_to_use.md
@@ -12,7 +12,7 @@ However, if you built the project from source, `sozu` and `sozuctl` are placed i
 
 `./target/release/sozu start -c <path/to/your/config.toml>`
 
-> `cargo build --release` puts the resulting binary in `target/release` instead of `target/debug`.
+> `cargo build --release --locked` puts the resulting binary in `target/release` instead of `target/debug`.
 
 You can find a working `config.toml` example [here][cfg].
 

--- a/os-build/archlinux/PKGBUILD
+++ b/os-build/archlinux/PKGBUILD
@@ -31,7 +31,7 @@ pkgver() {
 build() {
   cd "$srcdir/$_gitname"
 
-  cargo build --release --all
+  cargo build --release --all --locked
 }
 
 package() {

--- a/os-build/linux-rpm/README.md
+++ b/os-build/linux-rpm/README.md
@@ -19,5 +19,5 @@ packages.
 If you're building for production, this option is recommended.
 
 ```
-./rpm_build.sh --release
+./rpm_build.sh --release --locked
 ```

--- a/os-build/linux-rpm/sozu.spec
+++ b/os-build/linux-rpm/sozu.spec
@@ -2,7 +2,7 @@
 
 Summary:	A lightweight, fast, always-up reverse proxy server.
 Name:		sozu
-Version:	0.13.6
+Version:	0.14.1
 Release:	1%{?dist}
 Epoch:		1
 License:	AGPL-3.0
@@ -11,9 +11,6 @@ URL:		https://github.com/sozu-proxy/sozu
 
 Source0:	https://github.com/sozu-proxy/sozu/archive/%{version}.tar.gz
 
-Requires:	openssl >= 1.0.1
-
-BuildRequires:	openssl-devel >= 1.0.1
 BuildRequires:	m4
 BuildRequires:	selinux-policy-devel
 # BuildRequires: 	rust
@@ -40,7 +37,7 @@ Requires:	sozu
 %endif
 
 %build
-cargo build --release --all
+cargo build --release --all --locked
 
 %install
 rm -rf %{buildroot}


### PR DESCRIPTION
We want to avoid this issue from reproducing:

- #835

by adding the `--locked` flag everywhere `cargo build --release` is called.