### PR TITLE
Fix Sessions close

### DIFF
--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -877,7 +877,10 @@ impl Session {
 
             if front_interest.is_readable() {
                 let session_result = self.readable();
-                trace!("front readable\tinterpreting session order {:?}", session_result);
+                trace!(
+                    "front readable\tinterpreting session order {:?}",
+                    session_result
+                );
 
                 match session_result {
                     SessionResult::ConnectBackend => {
@@ -1451,6 +1454,11 @@ impl ProxySession for Session {
             if let Err(e) = proxy.registry.deregister(&mut SourceFd(&fd)) {
                 error!("1error deregistering socket({:?}): {:?}", fd, e);
             }
+            proxy
+                .sessions
+                .borrow_mut()
+                .slab
+                .try_remove(self.frontend_token.0);
         }
     }
 


### PR DESCRIPTION
Following #852, the TCP and HTTPS sessions were indeed left dangling in the `SessionManager`'s slab even though they should have been closed. Turns out their `close` method was properly called, but while the critical part responsible for removing them from the `SessionManager` could be found in the HTTP Session:

https://github.com/sozu-proxy/sozu/blob/a6e072ce81e06f658164de5ca524c15cb4896d74/lib/src/http.rs#L1252-L1257

it was missing for both the TCP and HTTPS session:

https://github.com/sozu-proxy/sozu/blob/a6e072ce81e06f658164de5ca524c15cb4896d74/lib/src/https.rs#L1455
https://github.com/sozu-proxy/sozu/blob/a6e072ce81e06f658164de5ca524c15cb4896d74/lib/src/tcp.rs#L955
