### PR TITLE
Abstract out notify functions

### DIFF
--- a/bin/config.toml
+++ b/bin/config.toml
@@ -17,7 +17,7 @@
 # "trace". For performance reasons, the logs at "debug" or "trace" level are
 # not compiled by default. To activate them, pass the "logs-debug" and
 # "logs-trace" compilation options to cargo
-log_level = "info"
+log_level = "debug"
 
 # where the logs will be sent. It defaults to sending the logs on standard output,
 # but they could be written to a UDP address:

--- a/bin/config.toml
+++ b/bin/config.toml
@@ -17,7 +17,7 @@
 # "trace". For performance reasons, the logs at "debug" or "trace" level are
 # not compiled by default. To activate them, pass the "logs-debug" and
 # "logs-trace" compilation options to cargo
-log_level = "debug"
+log_level = "info"
 
 # where the logs will be sent. It defaults to sending the logs on standard output,
 # but they could be written to a UDP address:

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -1547,11 +1547,7 @@ impl Proxy {
                     Err(err) => Err(anyhow::Error::msg(err)),
                 }
             }
-            None => {
-                // let (listener, tokens) = Listener::new(HttpListener::default(), event_loop,
-                //  self.pool.clone(), None, token: Token) -> (Listener,HashSet<Token>
-                bail!("no HTTP listener found for front: {:?}", front)
-            }
+            None => bail!("no HTTP listener found for address: {}", front.address),
         }
     }
 

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -2142,10 +2142,10 @@ impl Proxy {
                 .borrow_mut()
                 .add_certificate(&add_certificate)
                 .with_context(|| "Could not add certificate to listener")?,
-            None => {
-                error!("adding certificate to unknown listener");
-                bail!("unsupported message");
-            }
+            None => bail!(
+                "adding certificate to unknown listener {}",
+                add_certificate.address
+            ),
         };
 
         Ok(None)
@@ -2165,10 +2165,10 @@ impl Proxy {
                 .borrow_mut()
                 .remove_certificate(&remove_certificate)
                 .with_context(|| "Could not remove certificate from listener")?,
-            None => {
-                error!("removing certificate from unknown listener");
-                bail!("unsupported message");
-            }
+            None => bail!(
+                "removing certificate from unknown listener {}",
+                remove_certificate.address
+            ),
         };
 
         Ok(None)
@@ -2188,10 +2188,10 @@ impl Proxy {
                 .borrow_mut()
                 .replace_certificate(&replace_certificate)
                 .with_context(|| "Could not replace certificate on listener")?,
-            None => {
-                error!("replacing certificate on unknown listener");
-                bail!("unsupported message");
-            }
+            None => bail!(
+                "replacing certificate on unknown listener {}",
+                replace_certificate.address
+            ),
         };
 
         Ok(None)

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -2362,12 +2362,18 @@ impl ProxyConfiguration<Session> for Proxy {
         };
 
         match content_result {
-            Ok(content) => ProxyResponse {
-                id: request_id,
-                status: ProxyResponseStatus::Ok,
-                content,
-            },
-            Err(error_message) => ProxyResponse::error(request_id, format!("{:#}", error_message)),
+            Ok(content) => {
+                info!("{} successful", request_id);
+                ProxyResponse {
+                    id: request_id,
+                    status: ProxyResponseStatus::Ok,
+                    content,
+                }
+            }
+            Err(error_message) => {
+                error!("{} unsuccessful: {:#}", request_id, error_message);
+                ProxyResponse::error(request_id, format!("{:#}", error_message))
+            }
         }
     }
 }


### PR DESCRIPTION
The notify() functions of HTTP and HTTPS proxies (and, to a minor extant, that of the TCP proxy) are way too long.

This PR abstracts each arm of the pattern matching of a `ProxyRequest` into its own method, for instance `self.hard_stop()`. It trickles errors and returns `ProxyResponse` in a consistent way.