### PR TITLE
import sozu-acme into the sozu command line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,22 @@
 version = 3
 
 [[package]]
+name = "acme-lib"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "292ac9d513052341a7f5bdae61f31c4dc93c1dce2598508f52709df08cecc8b0"
+dependencies = [
+ "base64",
+ "lazy_static",
+ "log 0.4.17",
+ "openssl",
+ "serde",
+ "serde_json",
+ "time 0.1.45",
+ "ureq 1.5.5",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,7 +67,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time",
+ "time 0.3.17",
 ]
 
 [[package]]
@@ -214,6 +230,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,8 +301,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
+ "time 0.1.45",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -347,10 +372,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
+
+[[package]]
+name = "cookie"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
+dependencies = [
+ "percent-encoding",
+ "time 0.2.27",
+ "version_check",
+]
+
+[[package]]
 name = "cookie-factory"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b"
+
+[[package]]
+name = "cookie_store"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3818dfca4b0cb5211a659bbcbb94225b7127407b2b135e650d717bfb78ab10d3"
+dependencies = [
+ "cookie",
+ "idna 0.2.3",
+ "log 0.4.17",
+ "publicsuffix",
+ "serde",
+ "serde_json",
+ "time 0.2.27",
+ "url",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -501,6 +559,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +641,15 @@ checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -722,7 +795,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -806,6 +879,17 @@ checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
 dependencies = [
  "cxx",
  "cxx-build",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -937,6 +1021,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,7 +1064,7 @@ checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log 0.4.17",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -1064,6 +1154,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
+name = "openssl"
+version = "0.10.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29d971fd5722fec23977260f6e81aa67d2f22cadbdc2aa049f1022d9a3be1566"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5454462c0eced1e97f2ec09036abc8da362e66802f66fd20f86854d9d8cbcbc4"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1257,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "polling"
@@ -1202,12 +1337,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "publicsuffix"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b4ce31ff0a27d93c8de1849cf58162283752f065a90d508f1105fa6c9a213f"
+dependencies = [
+ "idna 0.2.3",
+ "url",
+]
+
+[[package]]
+name = "qstring"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
+dependencies = [
+ "percent-encoding",
 ]
 
 [[package]]
@@ -1331,6 +1491,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,14 +1524,27 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64",
+ "log 0.4.17",
+ "ring",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
 version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
 dependencies = [
  "log 0.4.17",
  "ring",
- "sct",
- "webpki",
+ "sct 0.7.0",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -1406,6 +1588,16 @@ checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
@@ -1413,6 +1605,21 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -1444,6 +1651,21 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "sha1"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
@@ -1524,6 +1746,7 @@ dependencies = [
 name = "sozu"
 version = "0.14.1"
 dependencies = [
+ "acme-lib",
  "anyhow",
  "async-dup",
  "async-io",
@@ -1551,7 +1774,8 @@ dependencies = [
  "sozu-lib",
  "tempfile",
  "termion",
- "time",
+ "time 0.3.17",
+ "tiny_http 0.7.0",
 ]
 
 [[package]]
@@ -1573,7 +1797,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "time",
+ "time 0.3.17",
  "toml",
  "trailer",
 ]
@@ -1587,7 +1811,7 @@ dependencies = [
  "foreign-types-shared",
  "hdrhistogram",
  "hpack",
- "idna",
+ "idna 0.3.0",
  "lazycell",
  "libc",
  "log 0.4.17",
@@ -1599,7 +1823,7 @@ dependencies = [
  "quickcheck",
  "rand",
  "regex",
- "rustls",
+ "rustls 0.20.7",
  "rustls-pemfile",
  "rusty_ulid",
  "sha2",
@@ -1607,11 +1831,11 @@ dependencies = [
  "socket2",
  "sozu-command-lib",
  "thiserror",
- "time",
- "tiny_http",
- "ureq",
+ "time 0.3.17",
+ "tiny_http 0.12.0",
+ "ureq 2.5.0",
  "url",
- "webpki",
+ "webpki 0.22.0",
  "x509-parser",
 ]
 
@@ -1622,10 +1846,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "standback"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
@@ -1724,6 +2006,32 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
+dependencies = [
+ "const_fn",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros 0.1.1",
+ "version_check",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
@@ -1731,7 +2039,7 @@ dependencies = [
  "itoa",
  "serde",
  "time-core",
- "time-macros",
+ "time-macros 0.2.6",
 ]
 
 [[package]]
@@ -1742,11 +2050,47 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
 dependencies = [
  "time-core",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "standback",
+ "syn",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ce4fc3c4cdea1a4399bb1819a539195fb69db4bbe0bde5b7c7f18fed412e02"
+dependencies = [
+ "ascii",
+ "chrono",
+ "chunked_transfer",
+ "log 0.4.17",
+ "url",
 ]
 
 [[package]]
@@ -1838,6 +2182,25 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8b063c2d59218ae09f22b53c42eaad0d53516457905f5235ca4bc9e99daa71"
+dependencies = [
+ "base64",
+ "chunked_transfer",
+ "cookie",
+ "cookie_store",
+ "log 0.4.17",
+ "once_cell",
+ "qstring",
+ "rustls 0.19.1",
+ "url",
+ "webpki 0.21.4",
+ "webpki-roots 0.21.1",
+]
+
+[[package]]
+name = "ureq"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
@@ -1847,10 +2210,10 @@ dependencies = [
  "flate2",
  "log 0.4.17",
  "once_cell",
- "rustls",
+ "rustls 0.20.7",
  "url",
- "webpki",
- "webpki-roots",
+ "webpki 0.22.0",
+ "webpki-roots 0.22.5",
 ]
 
 [[package]]
@@ -1860,9 +2223,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.3.0",
  "percent-encoding",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1875,6 +2244,12 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -1948,6 +2323,16 @@ dependencies = [
 
 [[package]]
 name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
@@ -1958,11 +2343,20 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
 dependencies = [
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -2077,5 +2471,5 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time",
+ "time 0.3.17",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,11 +301,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
- "time 0.1.45",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -1775,7 +1772,7 @@ dependencies = [
  "tempfile",
  "termion",
  "time 0.3.17",
- "tiny_http 0.7.0",
+ "tiny_http",
 ]
 
 [[package]]
@@ -1832,7 +1829,7 @@ dependencies = [
  "sozu-command-lib",
  "thiserror",
  "time 0.3.17",
- "tiny_http 0.12.0",
+ "tiny_http",
  "ureq 2.5.0",
  "url",
  "webpki 0.22.0",
@@ -2078,19 +2075,6 @@ dependencies = [
  "quote",
  "standback",
  "syn",
-]
-
-[[package]]
-name = "tiny_http"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15ce4fc3c4cdea1a4399bb1819a539195fb69db4bbe0bde5b7c7f18fed412e02"
-dependencies = [
- "ascii",
- "chrono",
- "chunked_transfer",
- "log 0.4.17",
- "url",
 ]
 
 [[package]]

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -25,6 +25,7 @@ include = [
 name = "sozu"
 
 [dependencies]
+acme-lib = "^0.8"
 anyhow = "^1.0.66"
 async-dup = "^1.2.2"
 async-io = "^1.12.0"
@@ -48,6 +49,7 @@ rand = "^0.8.5"
 regex = "^1.7.0"
 slab = "^0.4.7"
 smol = "^1.3.0"
+tiny_http = "^0.7"
 tempfile = "^3.3.0"
 termion = "^2.0.1"
 

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -25,7 +25,7 @@ include = [
 name = "sozu"
 
 [dependencies]
-acme-lib = "^0.8"
+acme-lib = "^0.8.2"
 anyhow = "^1.0.66"
 async-dup = "^1.2.2"
 async-io = "^1.12.0"
@@ -49,7 +49,7 @@ rand = "^0.8.5"
 regex = "^1.7.0"
 slab = "^0.4.7"
 smol = "^1.3.0"
-tiny_http = "^0.7"
+tiny_http = "^0.12.0"
 tempfile = "^3.3.0"
 termion = "^2.0.1"
 

--- a/bin/src/acme.rs
+++ b/bin/src/acme.rs
@@ -1,0 +1,448 @@
+use acme_lib::{create_p384_key, persist::FilePersist, Directory, DirectoryUrl};
+use anyhow::{bail, Context};
+use mio::net::UnixStream;
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use sozu_command_lib::{
+    certificate::{calculate_fingerprint, split_certificate_chain},
+    channel::Channel,
+    command::{CommandRequest, CommandRequestOrder, CommandResponse, CommandStatus},
+    config::Config,
+    proxy::{
+        AddCertificate, Backend, CertificateAndKey, CertificateFingerprint, HttpFrontend, PathRule,
+        ProxyRequestOrder, RemoveBackend, ReplaceCertificate, Route, RulePosition, TlsVersion,
+    },
+};
+use std::{fs::File, io::Write, iter, net::SocketAddr, thread, time};
+use tiny_http::{Response, Server};
+
+use crate::util;
+
+/// sozu-acme is a configuration tool for the
+/// [sōzu HTTP reverse proxy](https://github.com/sozu-proxy/sozu)
+/// that automates certificate requests from
+/// [Let's Encrypt](https://letsencrypt.org/) or other
+/// [ACME](https://tools.ietf.org/html/draft-ietf-acme-acme-07) enabled
+/// certificate authorities.
+///
+/// This tool will perform the following actions:
+///
+/// - contact Let's Encrypt
+/// - retrieve the challenge data
+/// - launch a web server for the HTTP challenge
+/// - configure sōzu to redirect the challenge request to that web server
+/// - start the HTTP challenge validation
+/// - if the challenge was successful, write the certificate, chain and key to the specified paths
+/// - remove the challenge web server from sōzu's configuration
+///
+/// This tool is in beta right now, don't hesitate to test it and report issues.
+pub fn main(
+    config_file: String,
+    domain: String,
+    email: String,
+    cluster_id: String,
+    old_certificate_path: Option<String>,
+    new_certificate_path: String,
+    certificate_chain_path: String,
+    key_path: String,
+    http_frontend_address: String,
+    https_frontend_address: String,
+) -> anyhow::Result<()> {
+    let config = Config::load_from_path(&config_file)
+        .with_context(|| "could not parse configuration file")?;
+
+    util::setup_logging(&config, "ACME");
+    info!("starting up");
+
+    let http = http_frontend_address
+        .parse::<SocketAddr>()
+        .with_context(|| "invalid HTTP frontend address format")?;
+    let https = https_frontend_address
+        .parse::<SocketAddr>()
+        .with_context(|| "invalid HTTPS frontend address format")?;
+
+    let old_certificate_file = match old_certificate_path {
+        Some(path) => {
+            let bytes = Config::load_file_bytes(&path)
+                .with_context(|| "Could not load old certificate file")?;
+            Some(bytes)
+        }
+        None => None,
+    };
+
+    let old_fingerprint = match old_certificate_file {
+        Some(bytes) => {
+            let f = calculate_fingerprint(&bytes)
+                .with_context(|| "Could not calculate old fingerprint")?;
+            Some(f)
+        }
+        None => None,
+    };
+
+    let stream = UnixStream::connect(&config.command_socket).with_context(|| {
+        format!(
+            "could not connect to the command unix socket: {}. Are you sure the proxy is up?",
+            config.command_socket
+        )
+    })?;
+
+    let tls_versions = vec![TlsVersion::TLSv1_2, TlsVersion::TLSv1_3];
+
+    let mut channel: Channel<CommandRequest, CommandResponse> = Channel::new(stream, 10000, 20000);
+    channel
+        .blocking()
+        .with_context(|| "Could not block channel")?;
+
+    info!("got channel, connecting to Let's Encrypt");
+
+    // Use DirectoryUrl::LetsEncrypStaging for dev/testing
+    //let url = DirectoryUrl::LetsEncryptStaging;
+    let url = DirectoryUrl::LetsEncrypt;
+
+    let persist = FilePersist::new(".");
+    // Create a directory entrypoint.
+    let dir = Directory::from_url(persist, url)
+        .with_context(|| "Could not create an entrypoint directory")?;
+
+    // Reads the private account key from persistence,
+    // or creates a new one before accessing the API to establish that it's there.
+    let account = dir
+        .account(&email)
+        .with_context(|| "Could not create account")?;
+
+    // Order a new TLS certificate for a domain.
+    let mut new_cert_order = account
+        .new_order(&domain, &[])
+        .with_context(|| "Could not create the order for a new certificate")?;
+
+    // If the ownership of the domain(s) has already been
+    // authorized in a previous order, you might be able to
+    // skip validation. The ACME API provider decides.
+    let csr_order = loop {
+        // are we done?
+        if let Some(csr_order) = new_cert_order.confirm_validations() {
+            break csr_order;
+        }
+
+        // Get the possible authorizations (for a single domain
+        // this will only be one element).
+        let auths = new_cert_order.authorizations().unwrap();
+        let auth = &auths[0];
+        let challenge = auth.http_challenge();
+        let challenge_token = challenge.http_token();
+
+        let path = format!("/.well-known/acme-challenge/{}", challenge_token);
+        let key_authorization = challenge.http_proof();
+        debug!(
+            "HTTP challenge token: {} key: {}",
+            challenge_token, key_authorization
+        );
+
+        let server = match Server::http("127.0.0.1:0") {
+            Ok(srv) => srv,
+            Err(e) => bail!("could not create HTTP server: {}", e.to_string()),
+        };
+
+        let address = server.server_addr();
+        let acme_app_id = generate_app_id(&cluster_id);
+
+        debug!("setting up proxying");
+        set_up_proxying(&mut channel, &http, &acme_app_id, &domain, &path, address)
+            .with_context(|| "could not set up proxying to HTTP challenge server")?;
+
+        let path2 = path.clone();
+        let _server_thread = thread::spawn(move || {
+            info!("HTTP server started");
+            loop {
+                let request = match server.recv() {
+                    Ok(rq) => rq,
+                    Err(e) => {
+                        error!("server error while receiving request: {}", e);
+                        break;
+                    }
+                };
+
+                info!("got request to URL: {}", request.url());
+                if request.url() == path {
+                    if let Err(e) = request.respond(
+                        Response::from_data(key_authorization.as_bytes()).with_status_code(200),
+                    ) {
+                        error!("Error responding with 200 to request: {}", e);
+                    }
+                    info!("challenge request answered");
+                    // the challenge can be called multiple times
+                    //return true;
+                } else {
+                    if let Err(e) = request
+                        .respond(Response::from_data(&b"not found"[..]).with_status_code(404))
+                    {
+                        error!("Error responding with 404 to request: {}", e);
+                    }
+                }
+            }
+
+            false
+        });
+
+        thread::sleep(time::Duration::from_millis(100));
+
+        challenge
+            .validate(2000)
+            .with_context(|| "The ACME API did not validate the proof of the challenge")?;
+        info!("challenge validated");
+
+        new_cert_order
+            .refresh()
+            .with_context(|| "Could not refresh the order for the new certificate")?;
+
+        //let res = server_thread.join().expect("HTTP server thread failed");
+        //if res {
+        remove_proxying(&mut channel, &http, &acme_app_id, &domain, &path2, address)
+            .with_context(|| "could not deactivate proxying")?;
+        //}
+    };
+
+    // Ownership is proven. Create a private key for
+    // the certificate. These are provided for convenience, you
+    // can provide your own keypair instead if you want.
+    let pkey_pri = create_p384_key();
+
+    // Submit the CSR. This causes the ACME provider to enter a
+    // state of "processing" that must be polled until the
+    // certificate is either issued or rejected. Again we poll
+    // for the status change.
+    let ord_cert = csr_order.finalize_pkey(pkey_pri, 5000).unwrap();
+
+    // Now download the certificate. Also stores the cert in
+    // the persistence.
+    let cert_chain = ord_cert.download_and_save_cert().unwrap();
+
+    info!("got cert: \n{}", cert_chain.certificate());
+    let certificates = split_certificate_chain(cert_chain.certificate().to_string());
+
+    let mut new_cert_file = File::create(&new_certificate_path)
+        .with_context(|| "Could not create new certificate file")?;
+    new_cert_file
+        .write_all(certificates[0].as_bytes())
+        .with_context(|| "Could not write certificate chain in the new certificate file")?;
+
+    //FIXME: there may be more than 1 cert in the chain
+    let mut certificate_chain_file = File::create(&certificate_chain_path)
+        .with_context(|| "Could not create certificate chain file")?;
+    certificate_chain_file
+        .write_all(certificates[1].as_bytes())
+        .with_context(|| "Could not write certificate chain in the certificate chain file")?;
+
+    let mut key_file = File::create(&key_path).with_context(|| "Could not create key file")?;
+    key_file
+        .write_all(cert_chain.private_key().as_bytes())
+        .with_context(|| "Could not write certificate chain in the key file")?;
+
+    info!("saved cert and key");
+    add_certificate(
+        &mut channel,
+        &https,
+        &domain,
+        &new_certificate_path,
+        &certificate_chain_path,
+        &key_path,
+        old_fingerprint,
+        &tls_versions,
+    )
+    .with_context(|| "could not add new certificate")?;
+
+    info!("added new certificate");
+
+    info!("DONE");
+    Ok(())
+}
+
+fn generate_id() -> String {
+    let s: String = iter::repeat(())
+        .map(|()| thread_rng().sample(Alphanumeric))
+        .take(6)
+        .map(|c| c as char)
+        .collect();
+    format!("ID-{}", s)
+}
+
+fn generate_app_id(app_id: &str) -> String {
+    let s: String = iter::repeat(())
+        .map(|()| thread_rng().sample(Alphanumeric))
+        .take(6)
+        .map(|c| c as char)
+        .collect();
+    format!("{}-ACME-{}", app_id, s)
+}
+
+fn set_up_proxying(
+    channel: &mut Channel<CommandRequest, CommandResponse>,
+    frontend: &SocketAddr,
+    cluster_id: &str,
+    hostname: &str,
+    path_begin: &str,
+    server_address: SocketAddr,
+) -> anyhow::Result<()> {
+    let add_http_front = ProxyRequestOrder::AddHttpFrontend(HttpFrontend {
+        route: Route::ClusterId(cluster_id.to_owned()),
+        hostname: String::from(hostname),
+        address: frontend.clone(),
+        path: PathRule::Prefix(path_begin.to_owned()),
+        method: None,
+        position: RulePosition::Tree,
+        tags: None,
+    });
+
+    order_command(channel, add_http_front).with_context(|| "Order AddHttpFront failed")?;
+
+    let add_backend = ProxyRequestOrder::AddBackend(Backend {
+        cluster_id: String::from(cluster_id),
+        backend_id: format!("{}-0", cluster_id),
+        address: server_address,
+        load_balancing_parameters: None,
+        sticky_id: None,
+        backup: None,
+    });
+
+    order_command(channel, add_backend).with_context(|| "AddBackend order failed")?;
+    Ok(())
+}
+
+fn remove_proxying(
+    channel: &mut Channel<CommandRequest, CommandResponse>,
+    frontend: &SocketAddr,
+    cluster_id: &str,
+    hostname: &str,
+    path_begin: &str,
+    server_address: SocketAddr,
+) -> anyhow::Result<()> {
+    let remove_http_front_order = ProxyRequestOrder::RemoveHttpFrontend(HttpFrontend {
+        route: Route::ClusterId(cluster_id.to_owned()),
+        address: frontend.clone(),
+        hostname: String::from(hostname),
+        path: PathRule::Prefix(path_begin.to_owned()),
+        method: None,
+        position: RulePosition::Tree,
+        tags: None,
+    });
+    order_command(channel, remove_http_front_order)
+        .with_context(|| "RemoveHttpFront order failed")?;
+
+    let remove_backend_order = ProxyRequestOrder::RemoveBackend(RemoveBackend {
+        cluster_id: String::from(cluster_id),
+        backend_id: format!("{}-0", cluster_id),
+        address: server_address,
+    });
+
+    order_command(channel, remove_backend_order).with_context(|| "RemoveBackend order failed")?;
+    Ok(())
+}
+
+fn add_certificate(
+    channel: &mut Channel<CommandRequest, CommandResponse>,
+    frontend: &SocketAddr,
+    hostname: &str,
+    certificate_path: &str,
+    chain_path: &str,
+    key_path: &str,
+    old_fingerprint: Option<Vec<u8>>,
+    tls_versions: &Vec<TlsVersion>,
+) -> anyhow::Result<()> {
+    let certificate = Config::load_file(certificate_path)
+        .with_context(|| format!("could not load certificate"))?;
+
+    let key = Config::load_file(key_path).with_context(|| format!("could not load key"))?;
+
+    let certificate_chain = Config::load_file(chain_path)
+        .map(split_certificate_chain)
+        .with_context(|| format!("could not load certificate chain"))?;
+
+    let certificate_order = match old_fingerprint {
+        None => ProxyRequestOrder::AddCertificate(AddCertificate {
+            address: frontend.clone(),
+            certificate: CertificateAndKey {
+                certificate,
+                certificate_chain,
+                key,
+                versions: tls_versions.clone(),
+            },
+            names: vec![hostname.to_string()],
+            expired_at: None,
+        }),
+
+        Some(f) => ProxyRequestOrder::ReplaceCertificate(ReplaceCertificate {
+            address: frontend.clone(),
+            new_certificate: CertificateAndKey {
+                certificate,
+                certificate_chain,
+                key,
+                versions: tls_versions.clone(),
+            },
+            old_fingerprint: CertificateFingerprint(f),
+            new_names: vec![hostname.to_string()],
+            new_expired_at: None,
+        }),
+    };
+
+    info!("Sending the certificate order {:?}", certificate_order);
+    order_command(channel, certificate_order)
+        .with_context(|| "Could not send the certificate order")
+}
+
+fn order_command(
+    channel: &mut Channel<CommandRequest, CommandResponse>,
+    order: ProxyRequestOrder,
+) -> anyhow::Result<()> {
+    let id = generate_id();
+    channel
+        .write_message(&CommandRequest::new(
+            id.clone(),
+            CommandRequestOrder::Proxy(Box::new(order.clone())),
+            None,
+        ))
+        .with_context(|| "Could not write message on the channel")?;
+
+    loop {
+        let response = channel
+            .read_message()
+            .with_context(|| "Could not read response on channel")?;
+        if id != response.id {
+            panic!("received message with invalid id: {:?}", response);
+        }
+        match response.status {
+            CommandStatus::Processing => {
+                // do nothing here
+                // for other messages, we would loop over read_message
+                // until an error or ok message was sent
+            }
+            CommandStatus::Error => {
+                bail!("could not execute order: {}", response.message);
+            }
+            CommandStatus::Ok => {
+                match order {
+                    ProxyRequestOrder::AddBackend(_) => {
+                        info!("backend added : {}", response.message)
+                    }
+                    ProxyRequestOrder::RemoveBackend(_) => {
+                        info!("backend removed : {} ", response.message)
+                    }
+                    ProxyRequestOrder::AddCertificate(_) => {
+                        info!("certificate added: {}", response.message)
+                    }
+                    ProxyRequestOrder::RemoveCertificate(_) => {
+                        info!("certificate removed: {}", response.message)
+                    }
+                    ProxyRequestOrder::AddHttpFrontend(_) => {
+                        info!("front added: {}", response.message)
+                    }
+                    ProxyRequestOrder::RemoveHttpFrontend(_) => {
+                        info!("front removed: {}", response.message)
+                    }
+                    _ => {
+                        // do nothing for now
+                    }
+                }
+                return Ok(());
+            }
+        }
+    }
+}

--- a/bin/src/acme.rs
+++ b/bin/src/acme.rs
@@ -142,7 +142,11 @@ pub fn main(
             Err(e) => bail!("could not create HTTP server: {}", e.to_string()),
         };
 
-        let address = server.server_addr();
+        let address = server
+            .server_addr()
+            .to_ip()
+            .with_context(|| "Could not convert server address to IP")?;
+
         let acme_app_id = generate_app_id(&cluster_id);
 
         debug!("setting up proxying");

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -205,6 +205,33 @@ pub enum SubCmd {
     },
     #[clap(name = "events", about = "receive sozu events")]
     Events,
+    #[clap(
+        name = "acme",
+        next_line_help = false,
+        about = "Set up or renew Let's Encrypt certificates for sozu HTTP reverse proxy"
+    )]
+    Acme {
+        #[clap(long = "config", help = "Sets a custom config file")]
+        config: String,
+        #[clap(long = "domain", help = "the application's domain name")]
+        domain: String,
+        #[clap(long = "email", help = "registration email")]
+        email: String,
+        #[clap(long = "id", help = "cluster identifier (usually an application)")]
+        cluster_id: String,
+        #[clap(long = "old-cert", help = "path of the previous certificate (optional)")]
+        old_certificate_path: Option<String>,
+        #[clap(long = "new-cert", help = "where to write the new certificate")]
+        new_certificate_path: String,
+        #[clap(long = "chain", help = "where to write the certificate chain")]
+        certificate_chain_path: String,
+        #[clap(short = 'k', long = "key-path", help = "where to write the key")]
+        key_path: String,
+        #[clap(long = "http", help = "HTTP frontend address, in the format IP:port")]
+        http_frontend_address: String,
+        #[clap(long = "https", help = "HTTPS frontend address, in the format IP:port")]
+        https_frontend_address: String,
+    },
 }
 
 #[derive(Subcommand, PartialEq, Eq, Clone, Debug)]

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -27,7 +27,7 @@ pub fn ctl(args: cli::Args) -> Result<(), anyhow::Error> {
     let config_file_path = get_config_file_path(&args)?;
     let config = load_configuration(config_file_path)?;
 
-    util::setup_logging(&config);
+    util::setup_logging(&config, "CTL");
 
     // If the command is `config check` then exit because if we are here, the configuration is valid
     if let SubCmd::Config {

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -21,6 +21,8 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 #[macro_use]
 mod logging;
 
+/// CLI utility for Let's Encrypt configuration
+mod acme;
 /// the arguments to the sozu command line
 mod cli;
 /// Receives orders from the CLI, transmits to workers
@@ -94,6 +96,29 @@ fn main(args: Args) -> anyhow::Result<()> {
                 max_command_buffer_size,
             )
         }
+        cli::SubCmd::Acme {
+            config,
+            domain,
+            email,
+            cluster_id,
+            old_certificate_path,
+            new_certificate_path,
+            certificate_chain_path,
+            key_path,
+            http_frontend_address,
+            https_frontend_address,
+        } => acme::main(
+            config,
+            domain,
+            email,
+            cluster_id,
+            old_certificate_path,
+            new_certificate_path,
+            certificate_chain_path,
+            key_path,
+            http_frontend_address,
+            https_frontend_address,
+        ),
         _ => ctl::ctl(args),
     }
 }
@@ -102,7 +127,7 @@ fn start(args: &cli::Args) -> Result<(), anyhow::Error> {
     let config_file_path = get_config_file_path(args)?;
     let config = load_configuration(config_file_path)?;
 
-    util::setup_logging(&config);
+    util::setup_logging(&config, "MAIN");
     info!("Starting up");
     util::setup_metrics(&config).with_context(|| "Could not setup metrics")?;
     util::write_pid_file(&config).with_context(|| "PID file is not writeable")?;

--- a/bin/src/upgrade.rs
+++ b/bin/src/upgrade.rs
@@ -152,7 +152,7 @@ pub fn begin_new_main_process(
         serde_json::from_reader(upgrade_file).with_context(|| "could not parse upgrade data")?;
     let config = upgrade_data.config.clone();
 
-    util::setup_logging(&config);
+    util::setup_logging(&config, "MAIN");
     util::setup_metrics(&config).with_context(|| "Could not setup metrics")?;
     //info!("new main got upgrade data: {:?}", upgrade_data);
 

--- a/bin/src/util.rs
+++ b/bin/src/util.rs
@@ -36,10 +36,10 @@ pub fn disable_close_on_exec(fd: RawFd) -> Result<i32, anyhow::Error> {
     fcntl(fd, FcntlArg::F_SETFD(new_flags)).with_context(|| "could not set file descriptor flags")
 }
 
-pub fn setup_logging(config: &Config) {
+pub fn setup_logging(config: &Config, tag: &str) {
     //FIXME: should have an id for the main too
     logging::setup(
-        "MAIN".to_string(),
+        tag.to_owned(),
         &config.log_level,
         &config.log_target,
         config.log_access_target.as_deref(),


### PR DESCRIPTION
[sozu-acme](https://github.com/sozu-proxy/sozu-acme) is a configuration tool por Sōzu, that requests Let's Encrypt (or other ACME enabled authorities) to get certificates.

This PR takes the code of sozu acme and embeds it as a sōzu command line option:

```
sozu --config config.toml acme -h    

Set up or renew Let's Encrypt certificates for sozu HTTP reverse proxy

Usage: sozu acme [OPTIONS] --config <CONFIG> --domain <DOMAIN> --email <EMAIL> --id <CLUSTER_ID> --new-cert <NEW_CERTIFICATE_PATH> --chain <CERTIFICATE_CHAIN_PATH> --key-path <KEY_PATH> --http <HTTP_FRONTEND_ADDRESS> --https <HTTPS_FRONTEND_ADDRESS>

Options:
      --config <CONFIG>
          Sets a custom config file
      --domain <DOMAIN>
          the application's domain name
  -t, --timeout <TIMEOUT>
          Sets a custom timeout for commands (in milliseconds). 0 disables the timeout
      --email <EMAIL>
          registration email
      --id <CLUSTER_ID>
          cluster identifier (usually an application)
      --old-cert <OLD_CERTIFICATE_PATH>
          path of the previous certificate (optional)
      --new-cert <NEW_CERTIFICATE_PATH>
          where to write the new certificate
      --chain <CERTIFICATE_CHAIN_PATH>
          where to write the certificate chain
  -k, --key-path <KEY_PATH>
          where to write the key
      --http <HTTP_FRONTEND_ADDRESS>
          HTTP frontend address, in the format IP:port
      --https <HTTPS_FRONTEND_ADDRESS>
          HTTPS frontend address, in the format IP:port
  -h, --help
          Print help information
```