### PR TITLE
add context to HTTP and HTTPS listener activation

### DIFF
--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -1465,11 +1465,17 @@ impl Proxy {
         &self,
         addr: &SocketAddr,
         tcp_listener: Option<TcpListener>,
-    ) -> Option<Token> {
-        self.listeners
+    ) -> anyhow::Result<Token> {
+        let listener = self
+            .listeners
             .values()
             .find(|listener| listener.borrow().address == *addr)
-            .and_then(|listener| listener.borrow_mut().activate(&self.registry, tcp_listener))
+            .with_context(|| format!("No listener found for address {}", addr))?;
+
+        listener
+            .borrow_mut()
+            .activate(&self.registry, tcp_listener)
+            .with_context(|| "Failed to activate listener")
     }
 
     pub fn give_back_listeners(&mut self) -> Vec<(SocketAddr, TcpListener)> {
@@ -1638,33 +1644,24 @@ impl Listener {
         &mut self,
         registry: &Registry,
         tcp_listener: Option<TcpListener>,
-    ) -> Option<Token> {
+    ) -> anyhow::Result<Token> {
         if self.active {
-            return Some(self.token);
+            return Ok(self.token);
         }
 
-        let mut listener = tcp_listener.or_else(|| {
-            server_bind(self.config.address)
-                .map_err(|e| {
-                    error!(
-                        "could not create listener {:?}: {:?}",
-                        self.config.address, e
-                    );
-                })
-                .ok()
-        });
+        let mut listener = match tcp_listener {
+            Some(tcp_listener) => tcp_listener,
+            None => server_bind(self.config.address)
+                .with_context(|| format!("could not create listener {:?}", self.config.address))?,
+        };
 
-        if let Some(ref mut sock) = listener {
-            if let Err(e) = registry.register(sock, self.token, Interest::READABLE) {
-                error!("error registering listener socket({:?}): {:?}", sock, e);
-            }
-        } else {
-            return None;
-        }
+        registry
+            .register(&mut listener, self.token, Interest::READABLE)
+            .with_context(|| format!("Could not register listener socket {:?}", listener))?;
 
-        self.listener = listener;
+        self.listener = Some(listener);
         self.active = true;
-        Some(self.token)
+        Ok(self.token)
     }
 
     // TODO: return Result with context

--- a/lib/src/socket.rs
+++ b/lib/src/socket.rs
@@ -341,6 +341,7 @@ impl SocketHandler for FrontRustls {
     }
 }
 
+// TODO: Do we want to add context here or is it overkill?
 pub fn server_bind(addr: SocketAddr) -> io::Result<TcpListener> {
     let sock = Socket::new(Domain::for_address(addr), Type::STREAM, Some(Protocol::TCP))?;
 


### PR DESCRIPTION
in the spirit of #825, batching context for listener activation seems better than in-place logs.