### PR TITLE
fix(proxy): Add power_of_two and least_loaded to FromStr trait

### DIFF
--- a/command/src/proxy.rs
+++ b/command/src/proxy.rs
@@ -551,8 +551,10 @@ impl FromStr for LoadBalancingAlgorithms {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "roundrobin" => Ok(LoadBalancingAlgorithms::RoundRobin),
+            "round_robin" => Ok(LoadBalancingAlgorithms::RoundRobin),
             "random" => Ok(LoadBalancingAlgorithms::Random),
+            "power_of_two" => Ok(LoadBalancingAlgorithms::PowerOfTwo),
+            "least_loaded" => Ok(LoadBalancingAlgorithms::LeastLoaded),
             _ => Err(ParseErrorLoadBalancing {}),
         }
     }

--- a/command/src/proxy.rs
+++ b/command/src/proxy.rs
@@ -550,7 +550,7 @@ impl FromStr for LoadBalancingAlgorithms {
     type Err = ParseErrorLoadBalancing;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
+        match s.to_lowercase().as_str() {
             "round_robin" => Ok(LoadBalancingAlgorithms::RoundRobin),
             "random" => Ok(LoadBalancingAlgorithms::Random),
             "power_of_two" => Ok(LoadBalancingAlgorithms::PowerOfTwo),


### PR DESCRIPTION
Also adjusted `roundrobin`to `round_robin` as described in `bin/config.toml`

```toml
# per cluster load balancing algorithm. The possible values are
# "round_robin", "random", "least_loaded" and "power_of_two". Defaults to "round_robin"
load_balancing = "round_robin"
```