### PR TITLE
Replace logging layer with tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,6 +1018,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,6 +1096,16 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -1194,6 +1213,12 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -1458,6 +1483,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1676,6 +1710,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1711,6 +1754,12 @@ checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smol"
@@ -1773,6 +1822,8 @@ dependencies = [
  "termion",
  "time 0.3.17",
  "tiny_http",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1796,6 +1847,8 @@ dependencies = [
  "sha2",
  "time 0.3.17",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "trailer",
 ]
 
@@ -1830,6 +1883,8 @@ dependencies = [
  "thiserror",
  "time 0.3.17",
  "tiny_http",
+ "tracing",
+ "tracing-subscriber",
  "ureq 2.5.0",
  "url",
  "webpki 0.22.0",
@@ -2002,6 +2057,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2114,6 +2178,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log 0.4.17",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "trailer"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,6 +2336,12 @@ dependencies = [
  "idna 0.3.0",
  "percent-encoding",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -45,6 +45,8 @@ prettytable-rs = { version = "^0.9.0", default-features = false }
 serde = { version = "^1.0.148", features = ["derive"] }
 serde_json = "^1.0.89"
 time = "^0.3.17"
+tracing = "^0.1.37"
+tracing-subscriber = "^0.3.16"
 rand = "^0.8.5"
 regex = "^1.7.0"
 slab = "^0.4.7"

--- a/bin/config.toml
+++ b/bin/config.toml
@@ -17,7 +17,7 @@
 # "trace". For performance reasons, the logs at "debug" or "trace" level are
 # not compiled by default. To activate them, pass the "logs-debug" and
 # "logs-trace" compilation options to cargo
-log_level = "info"
+log_level = "debug"
 
 # where the logs will be sent. It defaults to sending the logs on standard output,
 # but they could be written to a UDP address:

--- a/bin/src/acme.rs
+++ b/bin/src/acme.rs
@@ -14,8 +14,9 @@ use sozu_command_lib::{
 };
 use std::{fs::File, io::Write, iter, net::SocketAddr, thread, time};
 use tiny_http::{Response, Server};
+use tracing::{debug, error, info};
 
-use crate::util;
+// use crate::util;
 
 /// sozu-acme is a configuration tool for the
 /// [sōzu HTTP reverse proxy](https://github.com/sozu-proxy/sozu)
@@ -50,7 +51,8 @@ pub fn main(
     let config = Config::load_from_path(&config_file)
         .with_context(|| "could not parse configuration file")?;
 
-    util::setup_logging(&config, "ACME");
+    crate::sozu_command_lib::logging::setup_tracing_subscriber(&config, "ACME")?;
+
     info!("starting up");
 
     let http = http_frontend_address

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -22,6 +22,7 @@ use nix::{
     unistd::Pid,
 };
 use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info, trace};
 
 use sozu_command_lib::{
     command::{

--- a/bin/src/command/orders.rs
+++ b/bin/src/command/orders.rs
@@ -11,6 +11,7 @@ use anyhow::{bail, Context};
 use async_io::Async;
 use futures::{channel::mpsc::*, SinkExt, StreamExt};
 use nom::{Err, HexDisplay, Offset};
+use tracing::{debug, error, info, trace, warn};
 
 use sozu_command_lib::{
     buffer::fixed::Buffer,
@@ -19,7 +20,7 @@ use sozu_command_lib::{
         CommandStatus, FrontendFilters, ListedFrontends, RunState, WorkerInfo, PROTOCOL_VERSION,
     },
     config::Config,
-    logging,
+    // logging,
     parser::parse_several_commands,
     proxy::{
         AggregatedMetricsData, MetricsConfiguration, ProxyRequest, ProxyRequestOrder,
@@ -1194,10 +1195,15 @@ impl CommandServer {
 
     pub fn set_logging_level(&mut self, logging_filter: String) -> anyhow::Result<Option<Success>> {
         debug!("Changing main process log level to {}", logging_filter);
+
+        /*
+        TODO: replace this with tracing_subscriber
         logging::LOGGER.with(|l| {
             let directives = logging::parse_logging_spec(&logging_filter);
             l.borrow_mut().set_directives(directives);
         });
+        */
+
         // also change / set the content of RUST_LOG so future workers / main thread
         // will have the new logging filter value
         ::std::env::set_var("RUST_LOG", &logging_filter);

--- a/bin/src/command/worker.rs
+++ b/bin/src/command/worker.rs
@@ -3,6 +3,7 @@ use std::{collections::VecDeque, fmt, os::unix::io::AsRawFd};
 use futures::SinkExt;
 use libc::pid_t;
 use nix::{sys::signal::kill, unistd::Pid};
+use tracing::error;
 
 use sozu_command_lib::{
     channel::Channel,

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -2,6 +2,7 @@ use anyhow::{self, bail, Context};
 use prettytable::Table;
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use serde::Serialize;
+use tracing::info;
 
 use sozu_command_lib::{
     command::{

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -5,6 +5,7 @@ use std::{
 
 use anyhow::{self, bail, Context};
 use prettytable::{Row, Table};
+use tracing::trace;
 
 use sozu_command_lib::{
     command::{CommandResponseContent, ListedFrontends, WorkerInfo},

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -27,7 +27,8 @@ pub fn ctl(args: cli::Args) -> Result<(), anyhow::Error> {
     let config_file_path = get_config_file_path(&args)?;
     let config = load_configuration(config_file_path)?;
 
-    util::setup_logging(&config, "CTL");
+    // util::setup_logging(&config, "CTL");
+    tracing_subscriber::fmt::init();
 
     // If the command is `config check` then exit because if we are here, the configuration is valid
     if let SubCmd::Config {

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -1,11 +1,11 @@
 extern crate nom;
-#[macro_use]
+// #[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate prettytable;
 #[macro_use]
 extern crate sozu_lib as sozu;
-#[macro_use]
+// #[macro_use]
 extern crate sozu_command_lib;
 
 #[cfg(target_os = "linux")]
@@ -13,13 +13,14 @@ extern crate num_cpus;
 use cli::Args;
 #[cfg(target_os = "linux")]
 use regex::Regex;
+use tracing::{debug, error, info, warn};
 
 #[cfg(feature = "jemallocator")]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
-#[macro_use]
-mod logging;
+// #[macro_use]
+// mod logging;
 
 /// CLI utility for Let's Encrypt configuration
 mod acme;
@@ -43,7 +44,7 @@ use anyhow::{bail, Context};
 use libc::{cpu_set_t, pid_t};
 
 use sozu::metrics::METRICS;
-use sozu_command_lib::config::Config;
+use sozu_command_lib::{config::Config, logging::setup_tracing_subscriber};
 
 use crate::{
     command::Worker,
@@ -127,7 +128,9 @@ fn start(args: &cli::Args) -> Result<(), anyhow::Error> {
     let config_file_path = get_config_file_path(args)?;
     let config = load_configuration(config_file_path)?;
 
-    util::setup_logging(&config, "MAIN");
+    setup_tracing_subscriber(&config, "MAIN")?;
+    // tracing_subscriber::fmt::i
+
     info!("Starting up");
     util::setup_metrics(&config).with_context(|| "Could not setup metrics")?;
     util::write_pid_file(&config).with_context(|| "PID file is not writeable")?;

--- a/bin/src/util.rs
+++ b/bin/src/util.rs
@@ -2,12 +2,15 @@ use std::{fs::File, io::Write, os::unix::io::RawFd};
 
 use anyhow::Context;
 
+use log::LevelFilter;
 use nix::fcntl::{fcntl, FcntlArg, FdFlag};
+use tracing::{subscriber, Level};
 
 use sozu::metrics;
 use sozu_command_lib::config::Config;
+use tracing_subscriber::{fmt, reload};
 
-use crate::logging;
+// use crate::logging;
 
 pub fn enable_close_on_exec(fd: RawFd) -> Result<i32, anyhow::Error> {
     let file_descriptor =
@@ -36,6 +39,7 @@ pub fn disable_close_on_exec(fd: RawFd) -> Result<i32, anyhow::Error> {
     fcntl(fd, FcntlArg::F_SETFD(new_flags)).with_context(|| "could not set file descriptor flags")
 }
 
+/*
 pub fn setup_logging(config: &Config, tag: &str) {
     //FIXME: should have an id for the main too
     logging::setup(
@@ -45,6 +49,8 @@ pub fn setup_logging(config: &Config, tag: &str) {
         config.log_access_target.as_deref(),
     );
 }
+*/
+
 
 pub fn setup_metrics(config: &Config) -> anyhow::Result<()> {
     if let Some(metrics) = config.metrics.as_ref() {

--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -41,6 +41,8 @@ rand = "^0.8.5"
 serde = { version = "^1.0.148", features = ["derive"] }
 serde_json = "^1.0.89"
 sha2 = "^0.10.6"
+tracing = "^0.1.37"
+tracing-subscriber = { version = "^0.3.16", features = ["std", "env-filter"]}
 trailer = "^0.1.2"
 pool = "^0.1.4"
 poule = "^0.3.2"

--- a/command/src/channel.rs
+++ b/command/src/channel.rs
@@ -16,6 +16,7 @@ use anyhow::{bail, Context};
 use mio::{event::Source, net::UnixStream as MioUnixStream};
 use serde::{de::DeserializeOwned, ser::Serialize};
 use serde_json;
+use tracing::error;
 
 use crate::{buffer::growable::Buffer, ready::Ready};
 

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -10,6 +10,7 @@ use std::{
 
 use anyhow::{bail, Context};
 use toml;
+use tracing::{debug, info, error};
 
 use crate::{
     certificate::split_certificate_chain,
@@ -818,7 +819,7 @@ impl FileConfig {
                 if let Some(l) = config.listeners.as_ref() {
                     for listener in l.iter() {
                         if reserved_address.contains(&listener.address) {
-                            println!(
+                            info!(
                                 "listening address {:?} is already used in the configuration",
                                 listener.address
                             );
@@ -962,8 +963,8 @@ impl FileConfig {
                                             frontend.key = https_listener.key.clone();
                                         }
                                         if frontend.certificate.is_none() {
-                                            println!("known addresses: {:#?}", known_addresses);
-                                            println!("frontend: {:#?}", frontend);
+                                            info!("known addresses: {:#?}", known_addresses);
+                                            info!("frontend: {:#?}", frontend);
                                             bail!(
                                                 "cannot set up a HTTP frontend on a HTTPS listener"
                                             );

--- a/command/src/lib.rs
+++ b/command/src/lib.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate serde;
 
-#[macro_use]
+// #[macro_use]
 pub mod logging;
 pub mod buffer;
 pub mod certificate;

--- a/command/src/logging.rs
+++ b/command/src/logging.rs
@@ -866,7 +866,7 @@ pub fn setup_tracing_subscriber_with_env() {
 pub fn setup_test_logger(test_name: &str) {
     tracing_subscriber::fmt()
         .with_max_level(Level::INFO)
-        .pretty()
+        // .pretty()
         .with_line_number(true)
         .with_span_events(FmtSpan::FULL)
         .init();

--- a/command/src/scm_socket.rs
+++ b/command/src/scm_socket.rs
@@ -12,6 +12,7 @@ use anyhow::Context;
 use mio::net::TcpListener;
 use nix::{cmsg_space, sys::socket};
 use serde_json;
+use tracing::{debug, info};
 
 pub const MAX_FDS_OUT: usize = 200;
 pub const MAX_BYTES_OUT: usize = 4096;
@@ -140,14 +141,14 @@ impl ScmSocket {
         };
 
         if fds.is_empty() {
-            println!("{} send empty", self.fd);
+            info!("SCM socket {} sending an empty message", self.fd);
             socket::sendmsg::<()>(self.fd, &iov, &[], flags, None)
                 .with_context(|| "Could not send empty message per socket")?;
             return Ok(());
         };
 
         let control_message = [socket::ControlMessage::ScmRights(fds)];
-        println!("{} send with data", self.fd);
+        info!("SCM socket {} send with data", self.fd);
         socket::sendmsg::<()>(self.fd, &iov, &control_message, flags, None)
             .with_context(|| "Could not send message per socket")?;
         Ok(())

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -12,6 +12,7 @@ use std::{
 
 use anyhow::{bail, Context};
 use serde::de::{self, Visitor};
+use tracing::info;
 
 use crate::{
     certificate::calculate_fingerprint,

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -54,6 +54,8 @@ rusty_ulid = { version = "^1.0.0", default-features = true, features = [
 ] }
 thiserror = "^1.0.37"
 time = "^0.3.17"
+tracing = "^0.1.37"
+tracing-subscriber = { version = "^0.3.16", features = ["std", "env-filter"]}
 url = "^2.3.1"
 webpki = "^0.22.0"
 x509-parser = "^0.14.0"

--- a/lib/examples/main.rs
+++ b/lib/examples/main.rs
@@ -1,40 +1,27 @@
 #![allow(unused_variables, unused_must_use)]
 #[macro_use]
 extern crate sozu_lib as sozu;
-#[macro_use]
+// #[macro_use]
 extern crate sozu_command_lib as sozu_command;
 extern crate time;
 
-use std::{env, io::stdout, thread};
+use std::thread;
 
 use anyhow::Context;
 use sozu_command::config::DEFAULT_RUSTLS_CIPHER_LIST;
+use tracing::{debug, error, info};
 
 use crate::sozu_command::{
     channel::Channel,
-    logging::{Logger, LoggerBackend},
+    // logging::{Logger, LoggerBackend},
     proxy,
     proxy::{LoadBalancingParams, PathRule, Route, RulePosition},
 };
 
 fn main() -> anyhow::Result<()> {
-    if env::var("RUST_LOG").is_ok() {
-        Logger::init(
-            "EXAMPLE".to_string(),
-            &env::var("RUST_LOG").with_context(|| "could not get the RUST_LOG env var")?,
-            LoggerBackend::Stdout(stdout()),
-            None,
-        );
-    } else {
-        Logger::init(
-            "EXAMPLE".to_string(),
-            "info",
-            LoggerBackend::Stdout(stdout()),
-            None,
-        );
-    }
+    crate::sozu_command::logging::setup_tracing_subscriber_with_env();
 
-    info!("MAIN\tstarting up");
+    error!("MAIN\tstarting up");
 
     sozu::metrics::setup(
         &"127.0.0.1:8125"

--- a/lib/examples/minimal.rs
+++ b/lib/examples/minimal.rs
@@ -1,36 +1,27 @@
 #![allow(unused_variables, unused_must_use)]
 extern crate sozu_lib as sozu;
-#[macro_use]
+// #[macro_use]
 extern crate sozu_command_lib as sozu_command;
 extern crate time;
 
-use std::{collections::BTreeMap, env, io::stdout, thread};
+use std::{
+    collections::BTreeMap,
+    //  env, io::stdout,
+    thread,
+};
+use tracing::info;
 
 use anyhow::Context;
 
 use crate::sozu_command::{
     channel::Channel,
-    logging::{Logger, LoggerBackend},
+    // logging::{Logger, LoggerBackend},
     proxy,
     proxy::{LoadBalancingParams, PathRule, Route, RulePosition},
 };
 
 fn main() -> anyhow::Result<()> {
-    if env::var("RUST_LOG").is_ok() {
-        Logger::init(
-            "EXAMPLE".to_string(),
-            &env::var("RUST_LOG").with_context(|| "could not get the RUST_LOG env var")?,
-            LoggerBackend::Stdout(stdout()),
-            None,
-        );
-    } else {
-        Logger::init(
-            "EXAMPLE".to_string(),
-            "info",
-            LoggerBackend::Stdout(stdout()),
-            None,
-        );
-    }
+    crate::sozu_command::logging::setup_tracing_subscriber_with_env();
 
     info!("starting up");
 
@@ -85,8 +76,8 @@ fn main() -> anyhow::Result<()> {
         order: proxy::ProxyRequestOrder::AddBackend(http_backend),
     });
 
-    println!("HTTP -> {:?}", command.read_message());
-    println!("HTTP -> {:?}", command.read_message());
+    info!("HTTP -> {:?}", command.read_message());
+    info!("HTTP -> {:?}", command.read_message());
 
     let _ = jg.join();
     info!("good bye");

--- a/lib/examples/tcp.rs
+++ b/lib/examples/tcp.rs
@@ -1,33 +1,22 @@
 #![allow(unused_variables, unused_must_use)]
 extern crate sozu_lib as sozu;
-#[macro_use]
+// #[macro_use]
 extern crate sozu_command_lib as sozu_command;
 extern crate time;
 
 use std::{io::stdout, thread};
+use tracing::info;
 
 use anyhow::Context;
 
 use crate::sozu_command::{
     channel::Channel,
-    logging::{Logger, LoggerBackend},
+    // logging::{Logger, LoggerBackend},
     proxy::{self, LoadBalancingParams, TcpListener},
 };
 
 fn main() -> anyhow::Result<()> {
-    /*
-    if env::var("RUST_LOG").is_ok() {
-     Logger::init("EXAMPLE".to_string(), &env::var("RUST_LOG").with_context(|| "could not get the RUST_LOG env var"), LoggerBackend::Stdout(stdout()));
-    } else {
-     Logger::init("EXAMPLE".to_string(), "info", LoggerBackend::Stdout(stdout()));
-    }
-    */
-    Logger::init(
-        "EXAMPLE".to_string(),
-        "debug",
-        LoggerBackend::Stdout(stdout()),
-        None,
-    );
+    crate::sozu_command::logging::setup_tracing_subscriber_with_env();
 
     info!("starting up");
 
@@ -46,12 +35,13 @@ fn main() -> anyhow::Result<()> {
             back_timeout: 30,
             connect_timeout: 3,
         };
-        Logger::init(
-            "TCP".to_string(),
-            "debug",
-            LoggerBackend::Stdout(stdout()),
-            None,
-        );
+
+        // Logger::init(
+        //     "TCP".to_string(),
+        //     "debug",
+        //     LoggerBackend::Stdout(stdout()),
+        //     None,
+        // );
         sozu::tcp::start(listener, max_buffers, buffer_size, channel);
     });
 

--- a/lib/src/backends.rs
+++ b/lib/src/backends.rs
@@ -1,7 +1,8 @@
 use std::{cell::RefCell, collections::HashMap, net::SocketAddr, rc::Rc};
 
 use anyhow::{bail, Context};
-use mio::net::TcpStream;
+use mio::net::TcpStream;use tracing::{debug, error, info, trace};
+
 
 use crate::{
     server::push_event,

--- a/lib/src/features.rs
+++ b/lib/src/features.rs
@@ -1,5 +1,8 @@
 use std::{cell::RefCell, collections::HashMap};
 
+use tracing::{debug, error, info, trace};
+
+
 thread_local! {
   pub static FEATURES: RefCell<FeatureFlags> = RefCell::new(FeatureFlags::new());
 }

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -2180,7 +2180,9 @@ mod tests {
         println!("test received: {:?}", command.read_message());
         println!("test received: {:?}", command.read_message());
 
-        let mut client = TcpStream::connect(("127.0.0.1", 1031)).expect("could not parse address");
+        let mut client = TcpStream::connect(("127.0.0.1", 1031))
+            .expect(&format!("could not connect to address {}", address));
+
         // 5 seconds of timeout
         client.set_read_timeout(Some(Duration::new(5, 0))).unwrap();
 
@@ -2308,7 +2310,8 @@ mod tests {
         info!("test received: {:?}", command.read_message());
         info!("test received: {:?}", command.read_message());
 
-        let mut client = TcpStream::connect(("127.0.0.1", 1041)).expect("could not parse address");
+        let mut client = TcpStream::connect(address)
+            .expect(&format!("could not connect to address {}", address));
         // 5 seconds of timeout
         client.set_read_timeout(Some(Duration::new(5, 0))).unwrap();
 

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -31,6 +31,7 @@ use sozu_command::{
     proxy::{RemoveListener, ReplaceCertificate},
 };
 use time::{Duration, Instant};
+use tracing::{debug, error, info, trace};
 
 use crate::{
     backends::BackendMap,
@@ -55,7 +56,7 @@ use crate::{
     },
     socket::{server_bind, FrontRustls},
     sozu_command::{
-        logging,
+        // logging,
         proxy::{
             AddCertificate, CertificateFingerprint, Cluster, HttpFrontend, HttpsListener,
             ProxyEvent, ProxyRequest, ProxyRequestOrder, ProxyResponse, ProxyResponseContent,
@@ -1963,10 +1964,13 @@ impl Proxy {
         &mut self,
         logging_filter: String,
     ) -> anyhow::Result<Option<ProxyResponseContent>> {
+        /*
+        TODO: replace with tracing_subscriber
         logging::LOGGER.with(|l| {
             let directives = logging::parse_logging_spec(&logging_filter);
             l.borrow_mut().set_directives(directives);
         });
+        */
         Ok(None)
     }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -161,7 +161,7 @@ extern crate slab;
 extern crate socket2;
 extern crate time;
 extern crate url;
-#[macro_use]
+// #[macro_use]
 extern crate sozu_command_lib as sozu_command;
 extern crate cookie_factory;
 extern crate hpack;

--- a/lib/src/metrics/local_drain.rs
+++ b/lib/src/metrics/local_drain.rs
@@ -3,6 +3,7 @@ use std::{collections::BTreeMap, str, time::Instant};
 
 use anyhow::Context;
 use hdrhistogram::Histogram;
+use tracing::{debug, error, trace};
 
 use crate::sozu_command::proxy::{
     ClusterMetricsData, FilteredData, MetricsConfiguration, Percentiles, QueryAnswerMetrics,

--- a/lib/src/metrics/mod.rs
+++ b/lib/src/metrics/mod.rs
@@ -13,6 +13,7 @@ use std::{
 
 use anyhow::Context;
 use mio::net::UdpSocket;
+use tracing::{debug, error};
 
 use crate::sozu_command::proxy::{
     FilteredData, MetricsConfiguration, QueryAnswerMetrics, QueryMetricsOptions,

--- a/lib/src/metrics/network_drain.rs
+++ b/lib/src/metrics/network_drain.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use mio::net::UdpSocket;
+use tracing::error;
 
 use super::{
     writer::{MetricSocket, MetricsWriter},

--- a/lib/src/pool.rs
+++ b/lib/src/pool.rs
@@ -13,6 +13,7 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
+use tracing::{debug, error, info, trace};
 use poule;
 
 static BUFFER_COUNT: AtomicUsize = AtomicUsize::new(0);

--- a/lib/src/protocol/h2/mod.rs
+++ b/lib/src/protocol/h2/mod.rs
@@ -4,6 +4,7 @@ use std::{cell::RefCell, net::SocketAddr, rc::Weak};
 
 use mio::{net::TcpStream, *};
 use rusty_ulid::Ulid;
+use tracing::{debug, error, info, trace};
 
 use crate::{
     pool::{Checkout, Pool},

--- a/lib/src/protocol/h2/parser.rs
+++ b/lib/src/protocol/h2/parser.rs
@@ -1,4 +1,5 @@
 use std::convert::From;
+use tracing::{debug, error, info, trace};
 
 use nom::{
     bytes::streaming::{tag, take},

--- a/lib/src/protocol/h2/state.rs
+++ b/lib/src/protocol/h2/state.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, VecDeque};
 
+use tracing::{debug, error, info, trace};
 use nom::Offset;
 
 use crate::Ready;

--- a/lib/src/protocol/h2/stream.rs
+++ b/lib/src/protocol/h2/stream.rs
@@ -3,7 +3,8 @@ use std::{
     str::from_utf8,
 };
 
-use hpack::Decoder;
+use hpack::Decoder;use tracing::{debug, error, info, trace};
+
 
 use super::{
     parser,

--- a/lib/src/protocol/http/mod.rs
+++ b/lib/src/protocol/http/mod.rs
@@ -12,6 +12,7 @@ use std::{
 use mio::{net::TcpStream, *};
 use rusty_ulid::Ulid;
 use time::{Duration, Instant};
+use tracing::{debug, error, info, trace};
 
 use crate::{
     buffer_queue::BufferQueue,
@@ -653,6 +654,8 @@ impl<Front: SocketHandler, L: ListenerHandler> Http<Front, L> {
             })
         });
 
+        /*
+        TODO: replace with subscriber logic to send it to its distinct target
         info_access!(
             "{}{} -> {}\t{} {} {} {}\t{}\t{} {} {}\t{}",
             self.log_context(),
@@ -668,6 +671,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Http<Front, L> {
             status_line,
             request_line
         );
+        */
     }
 
     pub fn log_default_answer_success(&self, metrics: &SessionMetrics) {
@@ -721,6 +725,8 @@ impl<Front: SocketHandler, L: ListenerHandler> Http<Front, L> {
             })
         });
 
+        /*
+        TODO: replace with subscriber logic to send it to its distinct target
         info_access!(
             "{}{} -> {}\t{} {} {} {}\t{}\t{} {} {}\t{}",
             self.log_context(),
@@ -736,6 +742,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Http<Front, L> {
             status_line,
             request_line
         );
+        */
     }
 
     pub fn log_request_error(&mut self, metrics: &mut SessionMetrics, message: &str) {
@@ -797,6 +804,8 @@ impl<Front: SocketHandler, L: ListenerHandler> Http<Front, L> {
             })
         });
 
+        /*
+        TODO: replace with subscriber logic to send it to its distinct target
         error_access!(
             "{}{} -> {}\t{} {} {} {}\t{} {} {}\t{} | {} {}",
             self.log_context(),
@@ -813,6 +822,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Http<Front, L> {
             message,
             OptionalString::from(tags.as_ref())
         );
+        */
     }
 
     /// Read content from the session

--- a/lib/src/protocol/http/parser/request.rs
+++ b/lib/src/protocol/http/parser/request.rs
@@ -1,6 +1,7 @@
 use std::str;
 
 use nom::{Err, HexDisplay, IResult, Offset};
+use tracing::{debug, error};
 use url::Url;
 
 use crate::{

--- a/lib/src/protocol/http/parser/response.rs
+++ b/lib/src/protocol/http/parser/response.rs
@@ -1,6 +1,7 @@
 use std::{convert::From, str};
 
 use nom::{Err, HexDisplay, IResult, Offset};
+use tracing::{debug, error, trace};
 
 use crate::{buffer_queue::BufferQueue, protocol::http::StickySession};
 

--- a/lib/src/protocol/http/parser/tests.rs
+++ b/lib/src/protocol/http/parser/tests.rs
@@ -4,10 +4,12 @@ use std::{
 };
 
 use nom::{error::ErrorKind, Err, HexDisplay};
+use tracing::{debug, error, info, trace};
 
 use crate::buffer_queue::{buf_with_capacity, OutputElement};
-#[cfg(test)]
 use crate::protocol::http::AddedRequestHeader;
+#[cfg(test)]
+use crate::sozu_command::logging::setup_test_logger;
 
 use super::*;
 
@@ -415,7 +417,7 @@ fn parse_state_content_length_and_chunked_test() {
 
 #[test]
 fn parse_request_without_length() {
-    setup_test_logger!();
+    // setup_test_logger("parse_request_without_length");
     let input = b"GET / HTTP/1.1\r\n\
           Host: localhost:8888\r\n\
           Connection: close\r\n\
@@ -490,7 +492,7 @@ fn parse_request_http_1_0_connection_close() {
 
 #[test]
 fn parse_request_http_1_0_connection_keep_alive() {
-    setup_test_logger!();
+    // setup_test_logger("parse_request_http_1_0_connection_keep_alive");
     let input = b"GET / HTTP/1.0\r\n\
           Host: localhost:8888\r\n\
           Connection: keep-alive\r\n\
@@ -534,7 +536,7 @@ fn parse_request_http_1_0_connection_keep_alive() {
 
 #[test]
 fn parse_request_http_1_1_connection_keep_alive() {
-    setup_test_logger!();
+    // setup_test_logger("parse_request_http_1_1_connection_keep_alive");
     let input = b"GET / HTTP/1.1\r\n\
           Host: localhost:8888\r\n\
           \r\n";
@@ -575,7 +577,7 @@ fn parse_request_http_1_1_connection_keep_alive() {
 
 #[test]
 fn parse_request_http_1_1_connection_close() {
-    setup_test_logger!();
+    // setup_test_logger("parse_request_http_1_1_connection_close");
     let input = b"GET / HTTP/1.1\r\n\
           Connection: close\r\n\
           Host: localhost:8888\r\n\
@@ -618,7 +620,7 @@ fn parse_request_http_1_1_connection_close() {
 
 #[test]
 fn parse_request_add_header_test() {
-    setup_test_logger!();
+    // setup_test_logger("parse_request_add_header_test");
     let input = b"GET /index.html HTTP/1.1\r\n\
           Host: localhost:8888\r\n\
           User-Agent: curl/7.43.0\r\n\
@@ -684,7 +686,7 @@ fn parse_request_add_header_test() {
 
 #[test]
 fn parse_request_delete_forwarded_headers() {
-    setup_test_logger!();
+    // setup_test_logger("parse_request_delete_forwarded_headers");
     let input = b"GET /index.html HTTP/1.1\r\n\
           Host: localhost:8888\r\n\
           Forwarded: proto:https;for=10.0.0.2:1234;by:1.2.3.4\r\n\
@@ -1084,7 +1086,7 @@ fn parse_response_and_chunks_partial_test() {
 
 #[test]
 fn parse_incomplete_chunk_header_test() {
-    setup_test_logger!();
+    // setup_test_logger("parse_incomplete_chunk_header_test");
     let input = b"HTTP/1.1 200 OK\r\n\
           Server: ABCD\r\n\
           Transfer-Encoding: chunked\r\n\

--- a/lib/src/protocol/pipe.rs
+++ b/lib/src/protocol/pipe.rs
@@ -3,6 +3,7 @@ use std::{cell::RefCell, net::SocketAddr, rc::Rc};
 use mio::net::*;
 use mio::*;
 use rusty_ulid::Ulid;
+use tracing::{debug, error, info, trace};
 
 use crate::{
     pool::Checkout,
@@ -294,6 +295,8 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
                     .join(", ")
             });
 
+        /*
+        TODO: replace with subscriber logic to send it to its distinct target
         info_access!(
             "{}{} -> {}\t{} {} {} {}\t{}\t{} {}",
             self.log_ctx,
@@ -307,6 +310,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             proto,
             self.websocket_context.as_deref().unwrap_or("-")
         );
+        */
     }
 
     pub fn log_request_error(&self, metrics: &SessionMetrics, message: &str) {
@@ -347,6 +351,8 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
 
         let proto = self.protocol_string();
 
+        /*
+        TODO: replace with subscriber logic to send it to its distinct target
         error_access!(
             "{}{} -> {}\t{} {} {} {}\t{} {} | {}",
             self.log_ctx,
@@ -360,6 +366,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             self.websocket_context.as_deref().unwrap_or("-"),
             message
         );
+        */
     }
 
     pub fn check_connections(&self) -> bool {

--- a/lib/src/protocol/proxy_protocol/expect.rs
+++ b/lib/src/protocol/proxy_protocol/expect.rs
@@ -3,6 +3,7 @@ use std::{cell::RefCell, io::Read, rc::Rc};
 use mio::{net::TcpStream, *};
 use nom::{Err, HexDisplay};
 use rusty_ulid::Ulid;
+use tracing::{error, trace};
 
 use crate::{
     pool::Checkout,
@@ -206,6 +207,7 @@ mod expect_test {
     };
 
     use crate::protocol::proxy_protocol::header::*;
+    use crate::sozu_command::logging::setup_test_logger;
 
     // Flow diagram of the test below
     //                [connect]   [send proxy protocol]
@@ -214,7 +216,9 @@ mod expect_test {
     //  sozu     ---------v-----------v----X
     #[test]
     fn middleware_should_receive_proxy_protocol_header_from_an_upfront_middleware() {
-        setup_test_logger!();
+        // setup_test_logger(
+        //     "middleware_should_receive_proxy_protocol_header_from_an_upfront_middleware",
+        // );
         let middleware_addr: SocketAddr = "127.0.0.1:3500".parse().expect("parse address error");
         let barrier = Arc::new(Barrier::new(2));
 

--- a/lib/src/protocol/proxy_protocol/relay.rs
+++ b/lib/src/protocol/proxy_protocol/relay.rs
@@ -8,6 +8,7 @@ use mio::net::TcpStream;
 use mio::*;
 use nom::{Err, Offset};
 use rusty_ulid::Ulid;
+use tracing::{debug, error, info};
 
 use crate::{
     pool::Checkout,

--- a/lib/src/protocol/proxy_protocol/send.rs
+++ b/lib/src/protocol/proxy_protocol/send.rs
@@ -6,6 +6,7 @@ use std::{
 
 use mio::{net::TcpStream, *};
 use rusty_ulid::Ulid;
+use tracing::{debug, error};
 
 use crate::{
     pool::Checkout,
@@ -202,6 +203,7 @@ mod send_test {
 
     use super::super::parser::parse_v2_header;
 
+    use crate::sozu_command::logging::setup_test_logger;
     use mio::net::{TcpListener, TcpStream};
     use rusty_ulid::Ulid;
     use std::net::{TcpListener as StdTcpListener, TcpStream as StdTcpStream};
@@ -214,7 +216,7 @@ mod send_test {
 
     #[test]
     fn it_should_send_a_proxy_protocol_header_to_the_upstream_backend() {
-        setup_test_logger!();
+        // setup_test_logger("it_should_send_a_proxy_protocol_header_to_the_upstream_backend");
         let addr_client: SocketAddr = "127.0.0.1:6666".parse().expect("parse address error");
         let addr_backend: SocketAddr = "127.0.0.1:2001".parse().expect("parse address error");
         let barrier = Arc::new(Barrier::new(3));

--- a/lib/src/protocol/rustls.rs
+++ b/lib/src/protocol/rustls.rs
@@ -3,6 +3,7 @@ use std::io::ErrorKind;
 use mio::net::*;
 use rustls::ServerConnection;
 use rusty_ulid::Ulid;
+use tracing::{debug, error, info, trace};
 
 use crate::{protocol::ProtocolResult, Readiness, Ready, SessionResult};
 

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -14,7 +14,8 @@ use mio::{
 };
 use slab::Slab;
 use sozu_command::proxy::{ActivateListener, DeactivateListener, HttpListener, HttpsListener};
-use time::{Duration, Instant};
+use time::{Duration, Instant};use tracing::{debug, error, info, trace};
+
 
 use crate::{
     backends::BackendMap,

--- a/lib/src/socket.rs
+++ b/lib/src/socket.rs
@@ -5,7 +5,8 @@ use std::{
 
 use mio::net::{TcpListener, TcpStream};
 use rustls::{ProtocolVersion, ServerConnection};
-use socket2::{Domain, Protocol, Socket, Type};
+use socket2::{Domain, Protocol, Socket, Type};use tracing::{debug, error, info, trace};
+
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum SocketResult {

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -1597,9 +1597,11 @@ mod tests {
     use std::io::{Read, Write};
     use std::net::{Shutdown, TcpListener, TcpStream};
     use std::os::unix::io::IntoRawFd;
+    use std::str::FromStr;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Barrier};
     use std::{str, thread};
+
     static TEST_FINISHED: AtomicBool = AtomicBool::new(false);
 
     /*
@@ -1623,9 +1625,15 @@ mod tests {
         let _tx = start_proxy().expect("Could not start proxy");
         barrier.wait();
 
-        let mut s1 = TcpStream::connect("127.0.0.1:1234").expect("could not parse address");
-        let s3 = TcpStream::connect("127.0.0.1:1234").expect("could not parse address");
-        let mut s2 = TcpStream::connect("127.0.0.1:1234").expect("could not parse address");
+        let address: SocketAddr =
+            FromStr::from_str("127.0.0.1:1024").expect("could not parse address");
+
+        let mut s1 = TcpStream::connect(address)
+            .expect(&format!("could not connect to address {}", address));
+        let s3 = TcpStream::connect(address)
+            .expect(&format!("could not connect to address {}", address));
+        let mut s2 = TcpStream::connect(address)
+            .expect(&format!("could not connect to address {}", address));
 
         s1.write(&b"hello "[..])
             .map_err(|e| {
@@ -1680,7 +1688,8 @@ mod tests {
     }
 
     fn start_server(barrier: Arc<Barrier>) {
-        let listener = TcpListener::bind("127.0.0.1:5678").expect("could not parse address");
+        let listener = TcpListener::bind("127.0.0.1:5678")
+            .expect("could not connect to address 127.0.0.1:5678");
         fn handle_client(stream: &mut TcpStream, id: u8) {
             let mut buf = [0; 128];
             let _response = b" END";

--- a/lib/src/timer.rs
+++ b/lib/src/timer.rs
@@ -7,6 +7,7 @@ use std::{cmp, iter, u64, usize};
 use mio::Token;
 use slab::Slab;
 use time::{Duration, Instant};
+use tracing::{debug, trace};
 
 use crate::server::TIMER;
 

--- a/lib/src/tls.rs
+++ b/lib/src/tls.rs
@@ -17,6 +17,7 @@ use rustls::{
 };
 use sha2::{Digest, Sha256};
 use sozu_command::proxy::TlsVersion;
+use tracing::{debug, error, info, trace};
 use x509_parser::{
     oid_registry::{OID_X509_COMMON_NAME, OID_X509_EXT_SUBJECT_ALT_NAME},
     pem::{parse_x509_pem, Pem},

--- a/lib/tests/http.rs
+++ b/lib/tests/http.rs
@@ -8,7 +8,7 @@ extern crate ureq;
 
 use std::{
     io::{stdout, Read, Write},
-    net::{TcpListener, TcpStream, ToSocketAddrs},
+    net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs},
     str,
     sync::{Arc, Barrier},
     thread,
@@ -118,7 +118,10 @@ fn main_test() {
     info!("HTTP -> {:?}", command.read_message());
 
     info!("sending invalid request, expecting 400");
-    let mut client = TcpStream::connect(("127.0.0.1", 8080)).expect("could not parse address");
+    let address_8080: SocketAddr =
+        str::FromStr::from_str("127.0.0.1:8080").expect("could not parse address");
+    let mut client = TcpStream::connect(address_8080)
+        .expect(&format!("could not connect to address {}", address_8080));
     // 1 seconds of timeout
     client.set_read_timeout(Some(Duration::new(1, 0)));
 
@@ -149,8 +152,12 @@ fn main_test() {
     let barrier = Arc::new(Barrier::new(2));
     let barrier2 = barrier.clone();
 
+    let address_2048: SocketAddr =
+        str::FromStr::from_str("127.0.0.1:2048").expect("could not parse address");
+
     let _ = thread::spawn(move || {
-        let listener = TcpListener::bind("127.0.0.1:2048").expect("could not parse address");
+        let listener = TcpListener::bind(address_2048)
+            .expect(&format!("could not connect to address {}", address_2048));
         barrier2.wait();
         let mut stream = listener.incoming().next().unwrap().unwrap();
         let response = b"TEST\r\n\r\n";
@@ -191,7 +198,8 @@ fn main_test() {
 
     let barrier2 = barrier.clone();
     let _ = thread::spawn(move || {
-        let listener = TcpListener::bind("127.0.0.1:2048").expect("could not parse address");
+        let listener = TcpListener::bind(address_2048)
+            .expect(&format!("could not connect to address {}", address_2048));
         barrier2.wait();
         let mut stream = listener.incoming().next().unwrap().unwrap();
         let response = b"HTTP/1.1 200 Ok\r\nConnection: close\r\nContent-Length: 5\r\n\r\nHello";
@@ -210,7 +218,8 @@ fn main_test() {
 
     let barrier2 = barrier.clone();
     let _ = thread::spawn(move || {
-        let listener = TcpListener::bind("127.0.0.1:2048").expect("could not parse address");
+        let listener = TcpListener::bind(address_2048)
+            .expect(&format!("could not connect to address {}", address_2048));
         barrier2.wait();
         let mut stream = listener.incoming().next().unwrap().unwrap();
         let response = b"HTTP/1.1 200 Ok\r\nConnection: close\r\n\r\nHello world!";
@@ -227,7 +236,8 @@ fn main_test() {
 
     let barrier2 = barrier.clone();
     let _ = thread::spawn(move || {
-        let listener = TcpListener::bind("127.0.0.1:2048").expect("could not parse address");
+        let listener = TcpListener::bind(address_2048)
+            .expect(&format!("could not connect to address {}", address_2048));
         barrier2.wait();
         let stream = listener.incoming().next().unwrap().unwrap();
         stream.shutdown(std::net::Shutdown::Both).unwrap();
@@ -268,7 +278,8 @@ fn main_test() {
 
     let barrier2 = barrier.clone();
     let _ = thread::spawn(move || {
-        let listener = TcpListener::bind("127.0.0.1:2048").expect("could not parse address");
+        let listener = TcpListener::bind(address_2048)
+            .expect(&format!("could not connect to address {}", address_2048));
         barrier2.wait();
         let mut stream = listener.incoming().next().unwrap().unwrap();
         let response = b"HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: WebSocket\r\n\r\n";


### PR DESCRIPTION
For now, Sōzu implements its own two layers of logging : 

- a set of logging macros (`info!`, `debug!`, etc)
- a `Logger` instantiated in each worker to gather the log events and write them onto 5 possible targets:
  - a UDP address
  - a TCP address
  - a unix socket
  - a file
  - stdout

Since the birth of Sōzu, the [tokio ecosystem](https://tokio.rs/) has grown to become a defining standard in terms of asynchronous software architecture. It contains its own tracing crate, [tracing](https://docs.rs/tracing/latest/tracing/), compatible with a number of loggers.

Switching Sōzu's home-made macros and logger will allow for a lot of enhancements down the way (such as structured logging: #437) and remove a great deal of code that is uneasy to maintain.

This PR aims to perform a drop-in replacement of Sōzu's logging logic, including notably:

- [x] a naive use of `logging-subscriber` to print logs to stdout throughout Sōzu
- [ ] the ability to change the log level during runtime
- [ ] send logs to all 5 targets (udp, tcp, unix socket, file, stdout)
