### PR TITLE
list HTTP, HTTPS and TCP listeners in the CLI

### DIFF
--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -219,7 +219,10 @@ pub enum SubCmd {
         email: String,
         #[clap(long = "id", help = "cluster identifier (usually an application)")]
         cluster_id: String,
-        #[clap(long = "old-cert", help = "path of the previous certificate (optional)")]
+        #[clap(
+            long = "old-cert",
+            help = "path of the previous certificate (optional)"
+        )]
         old_certificate_path: Option<String>,
         #[clap(long = "new-cert", help = "where to write the new certificate")]
         new_certificate_path: String,
@@ -561,6 +564,8 @@ pub enum ListenerCmd {
         #[clap(subcommand)]
         cmd: TcpListenerCmd,
     },
+    #[clap(name = "list", about = "List all listeners")]
+    List,
 }
 
 #[derive(Subcommand, PartialEq, Eq, Clone, Debug)]

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -115,6 +115,7 @@ pub enum Success {
     DumpState(CommandResponseContent), // the cloned state
     HandledClientRequest,
     ListFrontends(CommandResponseContent), // the list of frontends
+    ListListeners(CommandResponseContent), // the list of listeners
     ListWorkers(CommandResponseContent),
     LoadState(String, usize, usize), // state path, oks, errors
     Logging(String),                 // new logging level
@@ -149,6 +150,7 @@ impl std::fmt::Display for Success {
             Self::DumpState(_) => write!(f, "Successfully gathered state from the main process"),
             Self::HandledClientRequest => write!(f, "Successfully handled the client request"),
             Self::ListFrontends(_) => write!(f, "Successfully gathered the list of frontends"),
+            Self::ListListeners(_) => write!(f, "Successfully listed all listeners"),
             Self::ListWorkers(_) => write!(f, "Successfully listed all workers"),
             Self::LoadState(path, ok, error) => write!(
                 f,

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -20,7 +20,7 @@ use crate::{
         create_channel,
         display::{
             print_available_metrics, print_certificates, print_frontend_list, print_json_response,
-            print_metrics, print_query_response_data, print_status,
+            print_listeners, print_metrics, print_query_response_data, print_status,
         },
         CommandManager,
     },
@@ -743,6 +743,30 @@ impl CommandManager {
                 }
                 CommandStatus::Ok => {
                     println!("{}", response.message);
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn list_listeners(&mut self) -> anyhow::Result<()> {
+        let id = generate_id();
+
+        self.send_request(&id, CommandRequestOrder::ListListeners)?;
+
+        loop {
+            let response = self.read_channel_message_with_timeout()?;
+            match response.status {
+                CommandStatus::Processing => println!("processing order…"),
+                CommandStatus::Error => {
+                    bail!("could not get the list of listeners: {}", response.message);
+                }
+                CommandStatus::Ok => {
+                    match response.content {
+                        Some(CommandResponseContent::ListenersList(list)) => print_listeners(list),
+                        _ => println!("Received an unexpected response: {:?}", response),
+                    }
                     break;
                 }
             }

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -99,6 +99,7 @@ impl CommandManager {
                 ListenerCmd::Http { cmd } => self.http_listener_command(cmd),
                 ListenerCmd::Https { cmd } => self.https_listener_command(cmd),
                 ListenerCmd::Tcp { cmd } => self.tcp_listener_command(cmd),
+                ListenerCmd::List => self.list_listeners(),
             },
             SubCmd::Certificate { cmd } => match cmd {
                 CertificateCmd::Add {


### PR DESCRIPTION
This was missing in the CLI. Now we can do

```
$ sozu listener list

HTTP LISTENERS
================
┌─────────────────┬──────────────────────────────────┐
│ socket address  │ 0.0.0.0:8080                     │
├─────────────────┼──────────────────────────────────┤
│ public address  │ None                             │
├─────────────────┼──────────────────────────────────┤
│ 404             │ HTTP/1.1 404 Not Found           │
│                 │ Cache-Control: no-cache          │
│                 │ Connection: close                │
│                 │ Content-Length: 0                │
│                 │                                  │
├─────────────────┼──────────────────────────────────┤
│ 503             │ HTTP/1.1 503 Service unavailable │
│                 │ Cache-Control: no-cache          │
│                 │ Connection: close                │
│                 │ Content-Length: 0                │
│                 │                                  │
├─────────────────┼──────────────────────────────────┤
│ expect proxy    │ false                            │
├─────────────────┼──────────────────────────────────┤
│ sticky name     │ SOZUBALANCEID                    │
├─────────────────┼──────────────────────────────────┤
│ front timeout   │ 60                               │
├─────────────────┼──────────────────────────────────┤
│ back timeout    │ 30                               │
├─────────────────┼──────────────────────────────────┤
│ connect timeout │ 3                                │
├─────────────────┼──────────────────────────────────┤
│ request timeout │ 10                               │
├─────────────────┼──────────────────────────────────┤
│ activated       │ true                             │
└─────────────────┴──────────────────────────────────┘

// and so on with HTTPS listeners and TCP listeners
```