### PR TITLE
Refactor config

### DIFF
--- a/bin/src/acme.rs
+++ b/bin/src/acme.rs
@@ -13,8 +13,10 @@ use sozu_command_lib::{
     },
     channel::Channel,
     config::Config,
-    request::{AddBackend, AddCertificate, RemoveBackend, ReplaceCertificate, Request},
-    response::{PathRule, RequestHttpFrontend, Response, ResponseStatus, Route, RulePosition},
+    request::{
+        AddBackend, AddCertificate, RemoveBackend, ReplaceCertificate, Request, RequestHttpFrontend,
+    },
+    response::{PathRule, Response, ResponseStatus, Route, RulePosition},
 };
 
 use crate::util;

--- a/bin/src/acme.rs
+++ b/bin/src/acme.rs
@@ -14,7 +14,7 @@ use sozu_command_lib::{
     channel::Channel,
     config::Config,
     request::{AddBackend, AddCertificate, RemoveBackend, ReplaceCertificate, Request},
-    response::{HttpFrontend, PathRule, Response, ResponseStatus, Route, RulePosition},
+    response::{PathRule, RequestHttpFrontend, Response, ResponseStatus, Route, RulePosition},
 };
 
 use crate::util;
@@ -286,10 +286,10 @@ fn set_up_proxying(
     path_begin: &str,
     server_address: &SocketAddr,
 ) -> anyhow::Result<()> {
-    let add_http_front = Request::AddHttpFrontend(HttpFrontend {
+    let add_http_front = Request::AddHttpFrontend(RequestHttpFrontend {
         route: Route::ClusterId(cluster_id.to_owned()),
         hostname: String::from(hostname),
-        address: *frontend,
+        address: frontend.to_string(),
         path: PathRule::Prefix(path_begin.to_owned()),
         method: None,
         position: RulePosition::Tree,
@@ -319,9 +319,9 @@ fn remove_proxying(
     path_begin: &str,
     server_address: SocketAddr,
 ) -> anyhow::Result<()> {
-    let remove_http_front = Request::RemoveHttpFrontend(HttpFrontend {
+    let remove_http_front = Request::RemoveHttpFrontend(RequestHttpFrontend {
         route: Route::ClusterId(cluster_id.to_owned()),
-        address: *frontend,
+        address: frontend.to_string(),
         hostname: String::from(hostname),
         path: PathRule::Prefix(path_begin.to_owned()),
         method: None,

--- a/bin/src/acme.rs
+++ b/bin/src/acme.rs
@@ -58,9 +58,7 @@ pub fn main(
     let http = http_frontend_address
         .parse::<SocketAddr>()
         .with_context(|| "invalid HTTP frontend address format")?;
-    let https = https_frontend_address
-        .parse::<SocketAddr>()
-        .with_context(|| "invalid HTTPS frontend address format")?;
+    let https = https_frontend_address;
 
     let old_certificate_file = match old_certificate_path {
         Some(path) => {
@@ -344,7 +342,7 @@ fn remove_proxying(
 
 fn add_certificate(
     channel: &mut Channel<Request, Response>,
-    frontend: &SocketAddr,
+    frontend: &str,
     hostname: &str,
     certificate_path: &str,
     chain_path: &str,
@@ -363,7 +361,7 @@ fn add_certificate(
 
     let request = match old_fingerprint {
         None => Request::AddCertificate(AddCertificate {
-            address: *frontend,
+            address: frontend.to_owned(),
             certificate: CertificateAndKey {
                 certificate,
                 certificate_chain,
@@ -375,7 +373,7 @@ fn add_certificate(
         }),
 
         Some(f) => Request::ReplaceCertificate(ReplaceCertificate {
-            address: *frontend,
+            address: frontend.to_owned(),
             new_certificate: CertificateAndKey {
                 certificate,
                 certificate_chain,

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -569,12 +569,12 @@ pub enum HttpListenerCmd {
     #[clap(name = "add")]
     Add {
         #[clap(short = 'a')]
-        address: SocketAddr,
+        address: String,
         #[clap(
             long = "public-address",
             help = "a different IP than the one the socket sees, for logs and forwarded headers"
         )]
-        public_address: Option<SocketAddr>,
+        public_address: Option<String>,
         #[clap(
             long = "answer-404",
             help = "path to file of the 404 answer sent to the client when a frontend is not found"
@@ -620,7 +620,7 @@ pub enum HttpListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: SocketAddr,
+        address: String,
     },
     #[clap(name = "activate")]
     Activate {
@@ -629,7 +629,7 @@ pub enum HttpListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: SocketAddr,
+        address: String,
     },
     #[clap(name = "deactivate")]
     Deactivate {
@@ -638,7 +638,7 @@ pub enum HttpListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: SocketAddr,
+        address: String,
     },
 }
 
@@ -647,12 +647,12 @@ pub enum HttpsListenerCmd {
     #[clap(name = "add")]
     Add {
         #[clap(short = 'a')]
-        address: SocketAddr,
+        address: String,
         #[clap(
             long = "public-address",
             help = "a different IP than the one the socket sees, for logs and forwarded headers"
         )]
-        public_address: Option<SocketAddr>,
+        public_address: Option<String>,
         #[clap(
             long = "answer-404",
             help = "path to file of the 404 answer sent to the client when a frontend is not found"
@@ -705,7 +705,7 @@ pub enum HttpsListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: SocketAddr,
+        address: String,
     },
     #[clap(name = "activate")]
     Activate {
@@ -714,7 +714,7 @@ pub enum HttpsListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: SocketAddr,
+        address: String,
     },
     #[clap(name = "deactivate")]
     Deactivate {
@@ -723,7 +723,7 @@ pub enum HttpsListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: SocketAddr,
+        address: String,
     },
 }
 
@@ -736,12 +736,12 @@ pub enum TcpListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: SocketAddr,
+        address: String,
         #[clap(
             long = "public-address",
             help = "a different IP than the one the socket sees, for logs and forwarded headers"
         )]
-        public_address: Option<SocketAddr>,
+        public_address: Option<String>,
         #[clap(
             long = "expect-proxy",
             help = "Configures the client socket to receive a PROXY protocol header"
@@ -755,7 +755,7 @@ pub enum TcpListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: SocketAddr,
+        address: String,
     },
     #[clap(name = "activate")]
     Activate {
@@ -764,7 +764,7 @@ pub enum TcpListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: SocketAddr,
+        address: String,
     },
     #[clap(name = "deactivate")]
     Deactivate {
@@ -773,7 +773,7 @@ pub enum TcpListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: SocketAddr,
+        address: String,
     },
 }
 

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -786,7 +786,7 @@ pub enum CertificateCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: SocketAddr,
+        address: String,
         #[clap(long = "certificate", help = "path to the certificate")]
         certificate: String,
         #[clap(long = "certificate-chain", help = "path to the certificate chain")]
@@ -804,7 +804,7 @@ pub enum CertificateCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: SocketAddr,
+        address: String,
         #[clap(aliases = &["cert"], long = "certificate", help = "path to the certificate")]
         certificate: Option<String>,
         #[clap(short = 'f', long = "fingerprint", help = "certificate fingerprint")]
@@ -817,7 +817,7 @@ pub enum CertificateCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: SocketAddr,
+        address: String,
         #[clap(long = "new-certificate", help = "path to the new certificate")]
         certificate: String,
         #[clap(

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, net::SocketAddr};
 
 use clap::{Parser, Subcommand};
 
@@ -363,7 +363,7 @@ pub enum BackendCmd {
             long = "address",
             help = "server address, format: IP:port"
         )]
-        address: String,
+        address: SocketAddr,
     },
     #[clap(name = "add", about = "Add a backend")]
     Add {
@@ -376,7 +376,7 @@ pub enum BackendCmd {
             long = "address",
             help = "server address, format: IP:port"
         )]
-        address: String,
+        address: SocketAddr,
         #[clap(
             short = 's',
             long = "sticky-id",
@@ -452,7 +452,7 @@ pub enum HttpFrontendCmd {
             long = "address",
             help = "frontend address, format: IP:port"
         )]
-        address: String,
+        address: SocketAddr,
         #[clap(subcommand, name = "route")]
         route: Route,
         #[clap(long = "hostname", aliases = &["host"])]
@@ -481,7 +481,7 @@ pub enum HttpFrontendCmd {
             long = "address",
             help = "frontend address, format: IP:port"
         )]
-        address: String,
+        address: SocketAddr,
         #[clap(subcommand, name = "route")]
         route: Route,
         #[clap(long = "hostname", aliases = &["host"])]
@@ -518,7 +518,7 @@ pub enum TcpFrontendCmd {
             long = "address",
             help = "frontend address, format: IP:port"
         )]
-        address: String,
+        address: SocketAddr,
         #[clap(
             long = "tags",
             help = "Specify tag (key-value pair) to apply on front-end (example: 'key=value, other-key=other-value')",
@@ -539,7 +539,7 @@ pub enum TcpFrontendCmd {
             long = "address",
             help = "frontend address, format: IP:port"
         )]
-        address: String,
+        address: SocketAddr,
     },
 }
 
@@ -569,12 +569,12 @@ pub enum HttpListenerCmd {
     #[clap(name = "add")]
     Add {
         #[clap(short = 'a')]
-        address: String,
+        address: SocketAddr,
         #[clap(
             long = "public-address",
             help = "a different IP than the one the socket sees, for logs and forwarded headers"
         )]
-        public_address: Option<String>,
+        public_address: Option<SocketAddr>,
         #[clap(
             long = "answer-404",
             help = "path to file of the 404 answer sent to the client when a frontend is not found"
@@ -620,7 +620,7 @@ pub enum HttpListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: String,
+        address: SocketAddr,
     },
     #[clap(name = "activate")]
     Activate {
@@ -629,7 +629,7 @@ pub enum HttpListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: String,
+        address: SocketAddr,
     },
     #[clap(name = "deactivate")]
     Deactivate {
@@ -638,7 +638,7 @@ pub enum HttpListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: String,
+        address: SocketAddr,
     },
 }
 
@@ -647,12 +647,12 @@ pub enum HttpsListenerCmd {
     #[clap(name = "add")]
     Add {
         #[clap(short = 'a')]
-        address: String,
+        address: SocketAddr,
         #[clap(
             long = "public-address",
             help = "a different IP than the one the socket sees, for logs and forwarded headers"
         )]
-        public_address: Option<String>,
+        public_address: Option<SocketAddr>,
         #[clap(
             long = "answer-404",
             help = "path to file of the 404 answer sent to the client when a frontend is not found"
@@ -705,7 +705,7 @@ pub enum HttpsListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: String,
+        address: SocketAddr,
     },
     #[clap(name = "activate")]
     Activate {
@@ -714,7 +714,7 @@ pub enum HttpsListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: String,
+        address: SocketAddr,
     },
     #[clap(name = "deactivate")]
     Deactivate {
@@ -723,7 +723,7 @@ pub enum HttpsListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: String,
+        address: SocketAddr,
     },
 }
 
@@ -736,12 +736,12 @@ pub enum TcpListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: String,
+        address: SocketAddr,
         #[clap(
             long = "public-address",
             help = "a different IP than the one the socket sees, for logs and forwarded headers"
         )]
-        public_address: Option<String>,
+        public_address: Option<SocketAddr>,
         #[clap(
             long = "expect-proxy",
             help = "Configures the client socket to receive a PROXY protocol header"
@@ -755,7 +755,7 @@ pub enum TcpListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: String,
+        address: SocketAddr,
     },
     #[clap(name = "activate")]
     Activate {
@@ -764,7 +764,7 @@ pub enum TcpListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: String,
+        address: SocketAddr,
     },
     #[clap(name = "deactivate")]
     Deactivate {
@@ -773,7 +773,7 @@ pub enum TcpListenerCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: String,
+        address: SocketAddr,
     },
 }
 
@@ -786,7 +786,7 @@ pub enum CertificateCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: String,
+        address: SocketAddr,
         #[clap(long = "certificate", help = "path to the certificate")]
         certificate: String,
         #[clap(long = "certificate-chain", help = "path to the certificate chain")]
@@ -804,7 +804,7 @@ pub enum CertificateCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: String,
+        address: SocketAddr,
         #[clap(aliases = &["cert"], long = "certificate", help = "path to the certificate")]
         certificate: Option<String>,
         #[clap(short = 'f', long = "fingerprint", help = "certificate fingerprint")]
@@ -817,7 +817,7 @@ pub enum CertificateCmd {
             long = "address",
             help = "listener address, format: IP:port"
         )]
-        address: String,
+        address: SocketAddr,
         #[clap(long = "new-certificate", help = "path to the new certificate")]
         certificate: String,
         #[clap(

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, net::SocketAddr};
+use std::collections::BTreeMap;
 
 use clap::{Parser, Subcommand};
 
@@ -452,7 +452,7 @@ pub enum HttpFrontendCmd {
             long = "address",
             help = "frontend address, format: IP:port"
         )]
-        address: SocketAddr,
+        address: String,
         #[clap(subcommand, name = "route")]
         route: Route,
         #[clap(long = "hostname", aliases = &["host"])]
@@ -481,7 +481,7 @@ pub enum HttpFrontendCmd {
             long = "address",
             help = "frontend address, format: IP:port"
         )]
-        address: SocketAddr,
+        address: String,
         #[clap(subcommand, name = "route")]
         route: Route,
         #[clap(long = "hostname", aliases = &["host"])]
@@ -518,7 +518,7 @@ pub enum TcpFrontendCmd {
             long = "address",
             help = "frontend address, format: IP:port"
         )]
-        address: SocketAddr,
+        address: String,
         #[clap(
             long = "tags",
             help = "Specify tag (key-value pair) to apply on front-end (example: 'key=value, other-key=other-value')",
@@ -539,7 +539,7 @@ pub enum TcpFrontendCmd {
             long = "address",
             help = "frontend address, format: IP:port"
         )]
-        address: SocketAddr,
+        address: String,
     },
 }
 

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -363,7 +363,7 @@ pub enum BackendCmd {
             long = "address",
             help = "server address, format: IP:port"
         )]
-        address: SocketAddr,
+        address: String,
     },
     #[clap(name = "add", about = "Add a backend")]
     Add {
@@ -376,7 +376,7 @@ pub enum BackendCmd {
             long = "address",
             help = "server address, format: IP:port"
         )]
-        address: SocketAddr,
+        address: String,
         #[clap(
             short = 's',
             long = "sticky-id",

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -839,9 +839,15 @@ pub fn start_server(
             accept_cancel_tx,
         )?;
 
-        let _ = server.load_static_cluster_configuration().await.map_err(|load_error|
-            error!("Error loading static cluster configuration: {:#}", load_error)
-        );
+        let _ = server
+            .load_static_cluster_configuration()
+            .await
+            .map_err(|load_error| {
+                error!(
+                    "Error loading static cluster configuration: {:#}",
+                    load_error
+                )
+            });
 
         if let Some(path) = saved_state_path {
             server

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -781,7 +781,7 @@ impl CommandServer {
         )
         .await;
 
-        for request in new_config.generate_config_messages() {
+        for request in new_config.generate_config_messages()? {
             if self.state.dispatch(&request.content).is_ok() {
                 diff_counter += 1;
 

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -1,4 +1,5 @@
 mod command;
+/// TODO: just create a display() method on sozu_command_lib::Response and put everything in there
 mod display;
 mod request_builder;
 
@@ -106,14 +107,22 @@ impl CommandManager {
                     key,
                     address,
                     tls_versions,
-                } => self.add_certificate(address, &certificate, &chain, &key, tls_versions),
+                } => self.add_certificate(
+                    address.to_string(),
+                    &certificate,
+                    &chain,
+                    &key,
+                    tls_versions,
+                ),
                 CertificateCmd::Remove {
                     certificate,
                     address,
                     fingerprint,
-                } => {
-                    self.remove_certificate(address, certificate.as_deref(), fingerprint.as_deref())
-                }
+                } => self.remove_certificate(
+                    address.to_string(),
+                    certificate.as_deref(),
+                    fingerprint.as_deref(),
+                ),
                 CertificateCmd::Replace {
                     certificate,
                     chain,
@@ -123,7 +132,7 @@ impl CommandManager {
                     old_fingerprint,
                     tls_versions,
                 } => self.replace_certificate(
-                    address,
+                    address.to_string(),
                     &certificate,
                     &chain,
                     &key,

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -1,5 +1,3 @@
-use std::net::SocketAddr;
-
 use anyhow::{bail, Context};
 
 use sozu_command_lib::{
@@ -438,7 +436,7 @@ impl CommandManager {
 
     pub fn add_certificate(
         &mut self,
-        address: SocketAddr,
+        address: String,
         certificate_path: &str,
         certificate_chain_path: &str,
         key_path: &str,
@@ -458,7 +456,7 @@ impl CommandManager {
 
     pub fn replace_certificate(
         &mut self,
-        address: SocketAddr,
+        address: String,
         new_certificate_path: &str,
         new_certificate_chain_path: &str,
         new_key_path: &str,
@@ -500,7 +498,7 @@ impl CommandManager {
 
     pub fn remove_certificate(
         &mut self,
-        address: SocketAddr,
+        address: String,
         certificate_path: Option<&str>,
         fingerprint: Option<&str>,
     ) -> anyhow::Result<()> {

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -9,9 +9,9 @@ use sozu_command_lib::{
     request::{
         ActivateListener, AddCertificate, Cluster, DeactivateListener, FrontendFilters,
         ListenerType, LoadBalancingParams, MetricsConfiguration, RemoveBackend, RemoveCertificate,
-        RemoveListener, ReplaceCertificate, Request,
+        RemoveListener, ReplaceCertificate, Request, AddBackend,
     },
-    response::{Backend, HttpFrontend, PathRule, RulePosition, TcpFrontend},
+    response::{HttpFrontend, PathRule, RulePosition, TcpFrontend},
 };
 
 use crate::{
@@ -118,7 +118,7 @@ impl CommandManager {
                 address,
                 sticky_id,
                 backup,
-            } => self.order_request(Request::AddBackend(Backend {
+            } => self.order_request(Request::AddBackend(AddBackend {
                 cluster_id: id,
                 address,
                 backend_id,

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -120,7 +120,7 @@ impl CommandManager {
                 backup,
             } => self.order_request(Request::AddBackend(AddBackend {
                 cluster_id: id,
-                address,
+                address: address.to_string(),
                 backend_id,
                 load_balancing_parameters: Some(LoadBalancingParams::default()),
                 sticky_id,
@@ -132,7 +132,7 @@ impl CommandManager {
                 address,
             } => self.order_request(Request::RemoveBackend(RemoveBackend {
                 cluster_id: id,
-                address,
+                address: address.to_string(),
                 backend_id,
             })),
         }
@@ -175,14 +175,14 @@ impl CommandManager {
             TcpFrontendCmd::Add { id, address, tags } => {
                 self.order_request(Request::AddTcpFrontend(RequestTcpFrontend {
                     cluster_id: id,
-                    address,
+                    address: address.to_string(),
                     tags,
                 }))
             }
             TcpFrontendCmd::Remove { id, address } => {
                 self.order_request(Request::RemoveTcpFrontend(RequestTcpFrontend {
                     cluster_id: id,
-                    address,
+                    address: address.to_string(),
                     tags: None,
                 }))
             }
@@ -202,7 +202,7 @@ impl CommandManager {
                 tags,
             } => self.order_request(Request::AddHttpFrontend(RequestHttpFrontend {
                 route: route.into(),
-                address,
+                address: address.to_string(),
                 hostname,
                 path: PathRule::from_cli_options(path_prefix, path_regex, path_equals),
                 method: method.map(String::from),
@@ -220,7 +220,7 @@ impl CommandManager {
                 route,
             } => self.order_request(Request::RemoveHttpFrontend(RequestHttpFrontend {
                 route: route.into(),
-                address,
+                address: address.to_string(),
                 hostname,
                 path: PathRule::from_cli_options(path_prefix, path_regex, path_equals),
                 method: method.map(String::from),
@@ -243,7 +243,7 @@ impl CommandManager {
                 tags,
             } => self.order_request(Request::AddHttpsFrontend(RequestHttpFrontend {
                 route: route.into(),
-                address,
+                address: address.to_string(),
                 hostname,
                 path: PathRule::from_cli_options(path_prefix, path_regex, path_equals),
                 method: method.map(String::from),
@@ -260,7 +260,7 @@ impl CommandManager {
                 route,
             } => self.order_request(Request::RemoveHttpsFrontend(RequestHttpFrontend {
                 route: route.into(),
-                address,
+                address: address.to_string(),
                 hostname,
                 path: PathRule::from_cli_options(path_prefix, path_regex, path_equals),
                 method: method.map(String::from),
@@ -304,13 +304,13 @@ impl CommandManager {
                 self.order_request(Request::AddHttpsListener(https_listener))
             }
             HttpsListenerCmd::Remove { address } => {
-                self.remove_listener(address, ListenerType::HTTPS)
+                self.remove_listener(address.to_string(), ListenerType::HTTPS)
             }
             HttpsListenerCmd::Activate { address } => {
-                self.activate_listener(address, ListenerType::HTTPS)
+                self.activate_listener(address.to_string(), ListenerType::HTTPS)
             }
             HttpsListenerCmd::Deactivate { address } => {
-                self.deactivate_listener(address, ListenerType::HTTPS)
+                self.deactivate_listener(address.to_string(), ListenerType::HTTPS)
             }
         }
     }
@@ -344,13 +344,13 @@ impl CommandManager {
                 self.order_request(Request::AddHttpListener(http_listener))
             }
             HttpListenerCmd::Remove { address } => {
-                self.remove_listener(address, ListenerType::HTTP)
+                self.remove_listener(address.to_string(), ListenerType::HTTP)
             }
             HttpListenerCmd::Activate { address } => {
-                self.activate_listener(address, ListenerType::HTTP)
+                self.activate_listener(address.to_string(), ListenerType::HTTP)
             }
             HttpListenerCmd::Deactivate { address } => {
-                self.deactivate_listener(address, ListenerType::HTTP)
+                self.deactivate_listener(address.to_string(), ListenerType::HTTP)
             }
         }
     }
@@ -370,12 +370,14 @@ impl CommandManager {
 
                 self.order_request(Request::AddTcpListener(listener))
             }
-            TcpListenerCmd::Remove { address } => self.remove_listener(address, ListenerType::TCP),
+            TcpListenerCmd::Remove { address } => {
+                self.remove_listener(address.to_string(), ListenerType::TCP)
+            }
             TcpListenerCmd::Activate { address } => {
-                self.activate_listener(address, ListenerType::TCP)
+                self.activate_listener(address.to_string(), ListenerType::TCP)
             }
             TcpListenerCmd::Deactivate { address } => {
-                self.deactivate_listener(address, ListenerType::TCP)
+                self.deactivate_listener(address.to_string(), ListenerType::TCP)
             }
         }
     }

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -9,9 +9,9 @@ use sozu_command_lib::{
     request::{
         ActivateListener, AddBackend, AddCertificate, Cluster, DeactivateListener, FrontendFilters,
         ListenerType, LoadBalancingParams, MetricsConfiguration, RemoveBackend, RemoveCertificate,
-        RemoveListener, ReplaceCertificate, Request,
+        RemoveListener, ReplaceCertificate, Request, RequestHttpFrontend, RequestTcpFrontend,
     },
-    response::{PathRule, RequestHttpFrontend, RequestTcpFrontend, RulePosition},
+    response::{PathRule, RulePosition},
 };
 
 use crate::{

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -7,11 +7,11 @@ use sozu_command_lib::{
     },
     config::{Config, FileListenerProtocolConfig, Listener, ProxyProtocolConfig},
     request::{
-        ActivateListener, AddCertificate, Cluster, DeactivateListener, FrontendFilters,
+        ActivateListener, AddBackend, AddCertificate, Cluster, DeactivateListener, FrontendFilters,
         ListenerType, LoadBalancingParams, MetricsConfiguration, RemoveBackend, RemoveCertificate,
-        RemoveListener, ReplaceCertificate, Request, AddBackend,
+        RemoveListener, ReplaceCertificate, Request,
     },
-    response::{HttpFrontend, PathRule, RulePosition, TcpFrontend},
+    response::{PathRule, RequestHttpFrontend, RequestTcpFrontend, RulePosition},
 };
 
 use crate::{
@@ -173,14 +173,14 @@ impl CommandManager {
     pub fn tcp_frontend_command(&mut self, cmd: TcpFrontendCmd) -> anyhow::Result<()> {
         match cmd {
             TcpFrontendCmd::Add { id, address, tags } => {
-                self.order_request(Request::AddTcpFrontend(TcpFrontend {
+                self.order_request(Request::AddTcpFrontend(RequestTcpFrontend {
                     cluster_id: id,
                     address,
                     tags,
                 }))
             }
             TcpFrontendCmd::Remove { id, address } => {
-                self.order_request(Request::RemoveTcpFrontend(TcpFrontend {
+                self.order_request(Request::RemoveTcpFrontend(RequestTcpFrontend {
                     cluster_id: id,
                     address,
                     tags: None,
@@ -200,7 +200,7 @@ impl CommandManager {
                 method,
                 route,
                 tags,
-            } => self.order_request(Request::AddHttpFrontend(HttpFrontend {
+            } => self.order_request(Request::AddHttpFrontend(RequestHttpFrontend {
                 route: route.into(),
                 address,
                 hostname,
@@ -218,7 +218,7 @@ impl CommandManager {
                 address,
                 method,
                 route,
-            } => self.order_request(Request::RemoveHttpFrontend(HttpFrontend {
+            } => self.order_request(Request::RemoveHttpFrontend(RequestHttpFrontend {
                 route: route.into(),
                 address,
                 hostname,
@@ -241,7 +241,7 @@ impl CommandManager {
                 method,
                 route,
                 tags,
-            } => self.order_request(Request::AddHttpsFrontend(HttpFrontend {
+            } => self.order_request(Request::AddHttpsFrontend(RequestHttpFrontend {
                 route: route.into(),
                 address,
                 hostname,
@@ -258,7 +258,7 @@ impl CommandManager {
                 address,
                 method,
                 route,
-            } => self.order_request(Request::RemoveHttpsFrontend(HttpFrontend {
+            } => self.order_request(Request::RemoveHttpsFrontend(RequestHttpFrontend {
                 route: route.into(),
                 address,
                 hostname,

--- a/command/assets/503.html
+++ b/command/assets/503.html
@@ -1,4 +1,4 @@
-HTTP/1.1 503 Service unavailable
+HTTP/1.1 503 Service Unavailable
 Cache-Control: no-cache
 Connection: close
 Content-Length: 0

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -886,6 +886,7 @@ impl ClusterConfig {
     }
 }
 
+/// Built from the TOML config provided by the user.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Default, Deserialize)]
 pub struct FileConfig {
     pub command_socket: Option<String>,
@@ -1205,9 +1206,9 @@ impl ConfigBuilder {
             ctl_command_timeout: self.file.ctl_command_timeout.unwrap_or(1_000),
             pid_file_path: self.file.pid_file_path.clone(),
             activate_listeners: self.file.activate_listeners.unwrap_or(true),
-            front_timeout: self.file.front_timeout.unwrap_or(60),
-            back_timeout: self.file.front_timeout.unwrap_or(30),
-            connect_timeout: self.file.front_timeout.unwrap_or(3),
+            front_timeout: self.file.front_timeout.unwrap_or(DEFAULT_FRONT_TIMEOUT),
+            back_timeout: self.file.front_timeout.unwrap_or(DEFAULT_BACK_TIMEOUT),
+            connect_timeout: self.file.front_timeout.unwrap_or(DEFAULT_CONNECT_TIMEOUT),
             //defaults to 30mn
             zombie_check_interval: self.file.zombie_check_interval.unwrap_or(30 * 60),
             accept_queue_timeout: self.file.accept_queue_timeout.unwrap_or(60),
@@ -1215,6 +1216,7 @@ impl ConfigBuilder {
     }
 }
 
+/// Sōzu config as parsed from the TOML config, used to create requests
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Default, Deserialize)]
 pub struct Config {
     pub config_path: String,
@@ -1302,7 +1304,6 @@ impl Config {
         for listener in &self.http_listeners {
             v.push(WorkerRequest {
                 id: format!("CONFIG-{count}"),
-
                 content: Request::AddHttpListener(listener.clone()),
             });
             count += 1;
@@ -1311,7 +1312,6 @@ impl Config {
         for listener in &self.https_listeners {
             v.push(WorkerRequest {
                 id: format!("CONFIG-{count}"),
-
                 content: Request::AddHttpsListener(listener.clone()),
             });
             count += 1;
@@ -1320,7 +1320,6 @@ impl Config {
         for listener in &self.tcp_listeners {
             v.push(WorkerRequest {
                 id: format!("CONFIG-{count}"),
-
                 content: Request::AddTcpListener(listener.clone()),
             });
             count += 1;

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -1236,15 +1236,15 @@ pub struct Config {
 }
 
 fn default_front_timeout() -> u32 {
-    60
+    DEFAULT_FRONT_TIMEOUT
 }
 
 fn default_back_timeout() -> u32 {
-    30
+    DEFAULT_BACK_TIMEOUT
 }
 
 fn default_connect_timeout() -> u32 {
-    3
+    DEFAULT_CONNECT_TIMEOUT
 }
 
 //defaults to 30mn

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -68,9 +68,9 @@ pub const DEFAULT_BACK_TIMEOUT: u32 = 30;
 pub const DEFAULT_CONNECT_TIMEOUT: u32 = 3;
 pub const DEFAULT_REQUEST_TIMEOUT: u32 = 10;
 
-// todo: refactor this with a builder pattern for cleanliness
-/// an HTTP, HTTPS or TCP listener as ordered by a client.
-/// This is used to parse the TOML config.
+pub const DEFAULT_STICKY_NAME: &str = "SOZUBALANCEID";
+
+/// An HTTP, HTTPS or TCP listener as parsed from the config
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ListenerBuilder {
@@ -100,8 +100,8 @@ pub struct ListenerBuilder {
     pub request_timeout: Option<u32>,
 }
 
-fn default_sticky_name() -> String {
-    String::from("SOZUBALANCEID")
+pub fn default_sticky_name() -> String {
+    DEFAULT_STICKY_NAME.to_string()
 }
 
 impl ListenerBuilder {
@@ -138,7 +138,7 @@ impl ListenerBuilder {
         ListenerBuilder {
             address: address.to_string(),
             protocol: Some(protocol),
-            sticky_name: String::from("SOZUBALANCEID"),
+            sticky_name: DEFAULT_STICKY_NAME.to_string(),
             front_timeout: Some(DEFAULT_FRONT_TIMEOUT),
             back_timeout: Some(DEFAULT_BACK_TIMEOUT),
             connect_timeout: Some(DEFAULT_CONNECT_TIMEOUT),

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -63,6 +63,7 @@ pub const DEFAULT_SIGNATURE_ALGORITHMS: [&str; 9] = [
 
 pub const DEFAULT_GROUPS_LIST: [&str; 4] = ["P-521", "P-384", "P-256", "x25519"];
 
+// TODO: trickle default values from the config, see #873
 pub const DEFAULT_FRONT_TIMEOUT: u32 = 60;
 pub const DEFAULT_BACK_TIMEOUT: u32 = 30;
 pub const DEFAULT_CONNECT_TIMEOUT: u32 = 3;
@@ -129,7 +130,6 @@ impl ListenerBuilder {
         Self::new(address, ListenerProtocol::Https)
     }
 
-    // TODO: set the default values elsewhere, see #873
     /// starts building a Listener with default values
     fn new<S>(address: S, protocol: ListenerProtocol) -> ListenerBuilder
     where
@@ -265,7 +265,12 @@ impl ListenerBuilder {
     }
 
     pub fn to_http(&mut self) -> anyhow::Result<HttpListenerConfig> {
-        // TODO: reintroduce the protocol check and bail
+        if self.protocol != Some(ListenerProtocol::Http) {
+            bail!(format!(
+                "Can not build an HTTP listener from a {:?} config",
+                self.protocol
+            ));
+        }
 
         let (answer_404, answer_503) = self
             .get_404_503_answers()
@@ -288,7 +293,12 @@ impl ListenerBuilder {
     }
 
     pub fn to_tls(&self) -> anyhow::Result<HttpsListenerConfig> {
-        // TODO: reintroduce the protocol check and bail
+        if self.protocol != Some(ListenerProtocol::Https) {
+            bail!(format!(
+                "Can not build an HTTPS listener from a {:?} config",
+                self.protocol
+            ));
+        }
 
         let default_cipher_list = DEFAULT_RUSTLS_CIPHER_LIST
             .into_iter()
@@ -375,7 +385,12 @@ impl ListenerBuilder {
     }
 
     pub fn to_tcp(&self) -> anyhow::Result<TcpListenerConfig> {
-        // TODO: reintroduce the protocol check and bail
+        if self.protocol != Some(ListenerProtocol::Tcp) {
+            bail!(format!(
+                "Can not build a TCP listener from a {:?} config",
+                self.protocol
+            ));
+        }
 
         Ok(TcpListenerConfig {
             address: self.parse_address()?,

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -19,8 +19,8 @@ use crate::{
         LoadBalancingAlgorithms, LoadBalancingParams, LoadMetric, Request, WorkerRequest,
     },
     response::{
-        HttpFrontend, HttpListenerConfig, HttpsListenerConfig, PathRule, Route, RulePosition,
-        TcpFrontend, TcpListenerConfig,
+        HttpListenerConfig, HttpsListenerConfig, PathRule, RequestHttpFrontend, RequestTcpFrontend,
+        Route, RulePosition, TcpListenerConfig,
     },
 };
 
@@ -599,9 +599,9 @@ impl HttpFrontendConfig {
                 expired_at: None,
             }));
 
-            v.push(Request::AddHttpsFrontend(HttpFrontend {
+            v.push(Request::AddHttpsFrontend(RequestHttpFrontend {
                 route: Route::ClusterId(cluster_id.to_string()),
-                address: self.address,
+                address: self.address.to_string(),
                 hostname: self.hostname.clone(),
                 path: self.path.clone(),
                 method: self.method.clone(),
@@ -610,9 +610,9 @@ impl HttpFrontendConfig {
             }));
         } else {
             //create the front both for HTTP and HTTPS if possible
-            v.push(Request::AddHttpFrontend(HttpFrontend {
+            v.push(Request::AddHttpFrontend(RequestHttpFrontend {
                 route: Route::ClusterId(cluster_id.to_string()),
-                address: self.address,
+                address: self.address.to_string(),
                 hostname: self.hostname.clone(),
                 path: self.path.clone(),
                 method: self.method.clone(),
@@ -706,9 +706,9 @@ impl TcpClusterConfig {
         })];
 
         for frontend in &self.frontends {
-            v.push(Request::AddTcpFrontend(TcpFrontend {
+            v.push(Request::AddTcpFrontend(RequestTcpFrontend {
                 cluster_id: self.cluster_id.clone(),
-                address: frontend.address,
+                address: frontend.address.to_string(),
                 tags: frontend.tags.clone(),
             }));
         }

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -588,8 +588,13 @@ impl HttpFrontendConfig {
         let mut v = Vec::new();
 
         if self.key.is_some() && self.certificate.is_some() {
+            // <<<<<<< HEAD
             v.push(Request::AddCertificate(AddCertificate {
-                address: self.address,
+                // address: self.address,
+                // =======
+                // v.push(ProxyRequestOrder::AddCertificate(AddCertificate {
+                address: self.address.to_string(),
+                // >>>>>>> b5ce4fb8 (replace SocketAddr with String in certificate requests)
                 certificate: CertificateAndKey {
                     key: self.key.clone().unwrap(),
                     certificate: self.certificate.clone().unwrap(),

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -264,6 +264,7 @@ impl ListenerBuilder {
         }
     }
 
+    /// build an HTTP listener using defaults if the values were not provided
     pub fn to_http(&mut self) -> anyhow::Result<HttpListenerConfig> {
         if self.protocol != Some(ListenerProtocol::Http) {
             bail!(format!(
@@ -292,6 +293,7 @@ impl ListenerBuilder {
         Ok(configuration)
     }
 
+    /// build an HTTPS listener using defaults if the values were not provided
     pub fn to_tls(&self) -> anyhow::Result<HttpsListenerConfig> {
         if self.protocol != Some(ListenerProtocol::Https) {
             bail!(format!(
@@ -384,6 +386,7 @@ impl ListenerBuilder {
         Ok(https_listener_config)
     }
 
+    /// build a TCP listener using defaults if the values were not provided
     pub fn to_tcp(&self) -> anyhow::Result<TcpListenerConfig> {
         if self.protocol != Some(ListenerProtocol::Tcp) {
             bail!(format!(
@@ -402,6 +405,8 @@ impl ListenerBuilder {
         })
     }
 
+    /// Get the 404 and 503 answers from the file system using the provided paths,
+    /// if none, defaults to HTML files in the sozu assets
     fn get_404_503_answers(&self) -> anyhow::Result<(String, String)> {
         let answer_404 = match &self.answer_404 {
             Some(a_404_path) => {

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -16,11 +16,11 @@ use crate::{
     certificate::{split_certificate_chain, CertificateAndKey, TlsVersion},
     request::{
         ActivateListener, AddBackend, AddCertificate, Cluster, ListenerType,
-        LoadBalancingAlgorithms, LoadBalancingParams, LoadMetric, Request, WorkerRequest,
+        LoadBalancingAlgorithms, LoadBalancingParams, LoadMetric, Request, RequestHttpFrontend,
+        RequestTcpFrontend, WorkerRequest,
     },
     response::{
-        HttpListenerConfig, HttpsListenerConfig, PathRule, RequestHttpFrontend, RequestTcpFrontend,
-        Route, RulePosition, TcpListenerConfig,
+        HttpListenerConfig, HttpsListenerConfig, PathRule, Route, RulePosition, TcpListenerConfig,
     },
 };
 

--- a/command/src/request.rs
+++ b/command/src/request.rs
@@ -4,8 +4,8 @@ use crate::{
     certificate::{CertificateAndKey, CertificateFingerprint},
     config::ProxyProtocolConfig,
     response::{
-        HttpFrontend, HttpListenerConfig, HttpsListenerConfig, MessageId, TcpFrontend,
-        TcpListenerConfig,
+        HttpListenerConfig, HttpsListenerConfig, MessageId, RequestHttpFrontend,
+        RequestTcpFrontend, TcpListenerConfig,
     },
     state::ClusterId,
 };
@@ -52,18 +52,18 @@ pub enum Request {
         cluster_id: String,
     },
 
-    AddHttpFrontend(HttpFrontend),
-    RemoveHttpFrontend(HttpFrontend),
+    AddHttpFrontend(RequestHttpFrontend),
+    RemoveHttpFrontend(RequestHttpFrontend),
 
-    AddHttpsFrontend(HttpFrontend),
-    RemoveHttpsFrontend(HttpFrontend),
+    AddHttpsFrontend(RequestHttpFrontend),
+    RemoveHttpsFrontend(RequestHttpFrontend),
 
     AddCertificate(AddCertificate),
     ReplaceCertificate(ReplaceCertificate),
     RemoveCertificate(RemoveCertificate),
 
-    AddTcpFrontend(TcpFrontend),
-    RemoveTcpFrontend(TcpFrontend),
+    AddTcpFrontend(RequestTcpFrontend),
+    RemoveTcpFrontend(RequestTcpFrontend),
 
     AddBackend(AddBackend),
     RemoveBackend(RemoveBackend),
@@ -427,12 +427,12 @@ mod tests {
         println!("{message:?}");
         assert_eq!(
             message,
-            Request::AddHttpFrontend(HttpFrontend {
+            Request::AddHttpFrontend(RequestHttpFrontend {
                 route: Route::ClusterId(String::from("xxx")),
                 hostname: String::from("yyy"),
                 path: PathRule::Prefix(String::from("xxx")),
                 method: None,
-                address: "0.0.0.0:8080".parse().unwrap(),
+                address: "0.0.0.0:8080".to_string(),
                 position: RulePosition::Tree,
                 tags: None,
             })
@@ -481,12 +481,12 @@ mod tests {
     test_message!(
         add_http_front,
         "../assets/add_http_front.json",
-        Request::AddHttpFrontend(HttpFrontend {
+        Request::AddHttpFrontend(RequestHttpFrontend {
             route: Route::ClusterId(String::from("xxx")),
             hostname: String::from("yyy"),
             path: PathRule::Prefix(String::from("xxx")),
             method: None,
-            address: "0.0.0.0:8080".parse().unwrap(),
+            address: "0.0.0.0:8080".to_string(),
             position: RulePosition::Tree,
             tags: None,
         })
@@ -495,12 +495,12 @@ mod tests {
     test_message!(
         remove_http_front,
         "../assets/remove_http_front.json",
-        Request::RemoveHttpFrontend(HttpFrontend {
+        Request::RemoveHttpFrontend(RequestHttpFrontend {
             route: Route::ClusterId(String::from("xxx")),
             hostname: String::from("yyy"),
             path: PathRule::Prefix(String::from("xxx")),
             method: None,
-            address: "0.0.0.0:8080".parse().unwrap(),
+            address: "0.0.0.0:8080".to_string(),
             position: RulePosition::Tree,
             tags: Some(BTreeMap::from([
                 ("owner".to_owned(), "John".to_owned()),
@@ -515,12 +515,12 @@ mod tests {
     test_message!(
         add_https_front,
         "../assets/add_https_front.json",
-        Request::AddHttpsFrontend(HttpFrontend {
+        Request::AddHttpsFrontend(RequestHttpFrontend {
             route: Route::ClusterId(String::from("xxx")),
             hostname: String::from("yyy"),
             path: PathRule::Prefix(String::from("xxx")),
             method: None,
-            address: "0.0.0.0:8443".parse().unwrap(),
+            address: "0.0.0.0:8443".to_string(),
             position: RulePosition::Tree,
             tags: None,
         })
@@ -529,12 +529,12 @@ mod tests {
     test_message!(
         remove_https_front,
         "../assets/remove_https_front.json",
-        Request::RemoveHttpsFrontend(HttpFrontend {
+        Request::RemoveHttpsFrontend(RequestHttpFrontend {
             route: Route::ClusterId(String::from("xxx")),
             hostname: String::from("yyy"),
             path: PathRule::Prefix(String::from("xxx")),
             method: None,
-            address: "0.0.0.0:8443".parse().unwrap(),
+            address: "0.0.0.0:8443".to_string(),
             position: RulePosition::Tree,
             tags: Some(BTreeMap::from([
                 ("owner".to_owned(), "John".to_owned()),
@@ -652,12 +652,12 @@ mod tests {
         println!("{command:?}");
         assert!(
             command
-                == Request::AddHttpFrontend(HttpFrontend {
+                == Request::AddHttpFrontend(RequestHttpFrontend {
                     route: Route::ClusterId(String::from("xxx")),
                     hostname: String::from("yyy"),
                     path: PathRule::Prefix(String::from("xxx")),
                     method: None,
-                    address: "127.0.0.1:4242".parse().unwrap(),
+                    address: "127.0.0.1:4242".to_string(),
                     position: RulePosition::Tree,
                     tags: None,
                 })
@@ -671,12 +671,12 @@ mod tests {
         println!("{command:?}");
         assert!(
             command
-                == Request::RemoveHttpFrontend(HttpFrontend {
+                == Request::RemoveHttpFrontend(RequestHttpFrontend {
                     route: Route::ClusterId(String::from("xxx")),
                     hostname: String::from("yyy"),
                     path: PathRule::Prefix(String::from("xxx")),
                     method: None,
-                    address: "127.0.0.1:4242".parse().unwrap(),
+                    address: "127.0.0.1:4242".to_string(),
                     position: RulePosition::Tree,
                     tags: Some(BTreeMap::from([
                         ("owner".to_owned(), "John".to_owned()),
@@ -726,12 +726,12 @@ mod tests {
         println!("{command:?}");
         assert!(
             command
-                == Request::AddHttpFrontend(HttpFrontend {
+                == Request::AddHttpFrontend(RequestHttpFrontend {
                     route: Route::ClusterId(String::from("aa")),
                     hostname: String::from("cltdl.fr"),
                     path: PathRule::Prefix(String::from("")),
                     method: None,
-                    address: "127.0.0.1:4242".parse().unwrap(),
+                    address: "127.0.0.1:4242".to_string(),
                     position: RulePosition::Tree,
                     tags: Some(BTreeMap::from([
                         ("owner".to_owned(), "John".to_owned()),

--- a/command/src/request.rs
+++ b/command/src/request.rs
@@ -268,7 +268,7 @@ pub struct FrontendFilters {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct AddCertificate {
-    pub address: SocketAddr,
+    pub address: String,
     pub certificate: CertificateAndKey,
     #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
     pub names: Vec<String>,
@@ -280,13 +280,13 @@ pub struct AddCertificate {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct RemoveCertificate {
-    pub address: SocketAddr,
+    pub address: String,
     pub fingerprint: CertificateFingerprint,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ReplaceCertificate {
-    pub address: SocketAddr,
+    pub address: String,
     pub new_certificate: CertificateAndKey,
     pub old_fingerprint: CertificateFingerprint,
     #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -1,7 +1,6 @@
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, HashMap},
-    convert::From,
     default::Default,
     fmt,
     net::SocketAddr,
@@ -9,10 +8,6 @@ use std::{
 
 use crate::{
     certificate::TlsVersion,
-    config::{
-        DEFAULT_CIPHER_SUITES, DEFAULT_GROUPS_LIST, DEFAULT_RUSTLS_CIPHER_LIST,
-        DEFAULT_SIGNATURE_ALGORITHMS,
-    },
     request::{
         default_sticky_name, is_false, AddBackend, Cluster, LoadBalancingParams,
         RequestHttpFrontend, RequestTcpFrontend, PROTOCOL_VERSION,
@@ -338,24 +333,6 @@ pub struct HttpListenerConfig {
     pub request_timeout: u32,
 }
 
-// TODO: set the default values elsewhere, see #873
-impl Default for HttpListenerConfig {
-    fn default() -> HttpListenerConfig {
-        HttpListenerConfig {
-            address:           "127.0.0.1:8080".parse().expect("could not parse address"),
-              public_address:  None,
-              answer_404:      String::from("HTTP/1.1 404 Not Found\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"),
-              answer_503:      String::from("HTTP/1.1 503 Service Unavailable\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"),
-              expect_proxy:    false,
-              sticky_name:     String::from("SOZUBALANCEID"),
-              front_timeout:   60,
-              back_timeout:    30,
-              connect_timeout: 3,
-              request_timeout: 10,
-        }
-    }
-}
-
 /// details of an HTTPS listener, sent by the main process to the worker
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HttpsListenerConfig {
@@ -386,39 +363,6 @@ pub struct HttpsListenerConfig {
     pub connect_timeout: u32,
     /// max time to send a complete request
     pub request_timeout: u32,
-}
-
-impl Default for HttpsListenerConfig {
-    fn default() -> HttpsListenerConfig {
-        HttpsListenerConfig {
-      address:         "127.0.0.1:8443".parse().expect("could not parse address"),
-      public_address:  None,
-      answer_404:      String::from("HTTP/1.1 404 Not Found\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"),
-      answer_503:      String::from("HTTP/1.1 503 Service Unavailable\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"),
-      cipher_list:     DEFAULT_RUSTLS_CIPHER_LIST.into_iter()
-          .map(String::from)
-          .collect(),
-      cipher_suites:  DEFAULT_CIPHER_SUITES.into_iter()
-          .map(String::from)
-          .collect(),
-      signature_algorithms: DEFAULT_SIGNATURE_ALGORITHMS.into_iter()
-          .map(String::from)
-          .collect(),
-      groups_list: DEFAULT_GROUPS_LIST.into_iter()
-          .map(String::from)
-          .collect(),
-      versions:            vec!(TlsVersion::TLSv1_2),
-      expect_proxy:        false,
-      sticky_name:         String::from("SOZUBALANCEID"),
-      certificate:         None,
-      certificate_chain:   vec![],
-      key:                 None,
-      front_timeout:   60,
-      back_timeout:    30,
-      connect_timeout: 3,
-      request_timeout: 10,
-    }
-    }
 }
 
 /// details of an TCP listener, sent by the main process to the worker

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -13,7 +13,7 @@ use crate::{
         DEFAULT_CIPHER_SUITES, DEFAULT_GROUPS_LIST, DEFAULT_RUSTLS_CIPHER_LIST,
         DEFAULT_SIGNATURE_ALGORITHMS,
     },
-    request::{default_sticky_name, is_false, Cluster, LoadBalancingParams, PROTOCOL_VERSION},
+    request::{default_sticky_name, is_false, Cluster, LoadBalancingParams, PROTOCOL_VERSION, AddBackend},
     state::{ClusterId, ConfigState, RouteKey},
 };
 
@@ -275,6 +275,19 @@ impl Ord for Backend {
 impl PartialOrd for Backend {
     fn partial_cmp(&self, other: &Backend) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl Backend {
+    pub fn to_add_backend(self) -> AddBackend {
+        AddBackend {
+            cluster_id: self.cluster_id,
+            address: self.address.to_string(),
+            sticky_id: self.sticky_id,
+            backend_id: self.backend_id,
+            load_balancing_parameters: self.load_balancing_parameters,
+            backup: self.backup,
+        }
     }
 }
 

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -60,24 +60,11 @@ pub struct ConfigState {
     /// certificate and names
     pub certificates:
         HashMap<SocketAddr, HashMap<CertificateFingerprint, (CertificateAndKey, Vec<String>)>>,
-    // TODO: delete those lines, they are useless
-    //ip, port
-    pub http_addresses: Vec<SocketAddr>,
-    pub https_addresses: Vec<SocketAddr>,
-    //tcp:
 }
 
 impl ConfigState {
     pub fn new() -> Self {
         Self::default()
-    }
-
-    pub fn add_http_address(&mut self, address: SocketAddr) {
-        self.http_addresses.push(address)
-    }
-
-    pub fn add_https_address(&mut self, address: SocketAddr) {
-        self.https_addresses.push(address)
     }
 
     pub fn dispatch(&mut self, request: &Request) -> anyhow::Result<()> {

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -18,11 +18,11 @@ use crate::{
     request::{
         ActivateListener, AddBackend, AddCertificate, Cluster, DeactivateListener, ListenerType,
         RemoveBackend, RemoveCertificate, RemoveListener, ReplaceCertificate, Request,
+        RequestHttpFrontend, RequestTcpFrontend,
     },
     response::{
         Backend, HttpFrontend, HttpListenerConfig, HttpsListenerConfig, PathRule,
-        QueryAnswerCluster, RequestHttpFrontend, RequestTcpFrontend, Route, TcpFrontend,
-        TcpListenerConfig,
+        QueryAnswerCluster, Route, TcpFrontend, TcpListenerConfig,
     },
 };
 
@@ -60,6 +60,7 @@ pub struct ConfigState {
     /// certificate and names
     pub certificates:
         HashMap<SocketAddr, HashMap<CertificateFingerprint, (CertificateAndKey, Vec<String>)>>,
+    // TODO: delete those lines, they are useless
     //ip, port
     pub http_addresses: Vec<SocketAddr>,
     pub https_addresses: Vec<SocketAddr>,
@@ -539,7 +540,7 @@ impl ConfigState {
         }
 
         for front in self.http_fronts.values() {
-            v.push(Request::AddHttpFrontend(front.clone().to_request()));
+            v.push(Request::AddHttpFrontend(front.clone().into()));
         }
 
         for (front, certs) in self.certificates.iter() {
@@ -554,12 +555,12 @@ impl ConfigState {
         }
 
         for front in self.https_fronts.values() {
-            v.push(Request::AddHttpsFrontend(front.clone().to_request()));
+            v.push(Request::AddHttpsFrontend(front.clone().into()));
         }
 
         for front_list in self.tcp_fronts.values() {
             for front in front_list {
-                v.push(Request::AddTcpFrontend(front.clone().to_request()));
+                v.push(Request::AddTcpFrontend(front.clone().into()));
             }
         }
 
@@ -890,11 +891,11 @@ impl ConfigState {
         let added_http_fronts = their_http_fronts.difference(&my_http_fronts);
 
         for &(_, front) in removed_http_fronts {
-            v.push(Request::RemoveHttpFrontend(front.clone().to_request()));
+            v.push(Request::RemoveHttpFrontend(front.clone().into()));
         }
 
         for &(_, front) in added_http_fronts {
-            v.push(Request::AddHttpFrontend(front.clone().to_request()));
+            v.push(Request::AddHttpFrontend(front.clone().into()));
         }
 
         let mut my_https_fronts: HashSet<(&RouteKey, &HttpFrontend)> = HashSet::new();
@@ -909,11 +910,11 @@ impl ConfigState {
         let added_https_fronts = their_https_fronts.difference(&my_https_fronts);
 
         for &(_, front) in removed_https_fronts {
-            v.push(Request::RemoveHttpsFrontend(front.clone().to_request()));
+            v.push(Request::RemoveHttpsFrontend(front.clone().into()));
         }
 
         for &(_, front) in added_https_fronts {
-            v.push(Request::AddHttpsFrontend(front.clone().to_request()));
+            v.push(Request::AddHttpsFrontend(front.clone().into()));
         }
 
         let mut my_tcp_fronts: HashSet<(&ClusterId, &TcpFrontend)> = HashSet::new();
@@ -933,11 +934,11 @@ impl ConfigState {
         let added_tcp_fronts = their_tcp_fronts.difference(&my_tcp_fronts);
 
         for &(_, front) in removed_tcp_fronts {
-            v.push(Request::RemoveTcpFrontend(front.clone().to_request()));
+            v.push(Request::RemoveTcpFrontend(front.clone().into()));
         }
 
         for &(_, front) in added_tcp_fronts {
-            v.push(Request::AddTcpFrontend(front.clone().to_request()));
+            v.push(Request::AddTcpFrontend(front.clone().into()));
         }
 
         //pub certificates:    HashMap<SocketAddr, HashMap<CertificateFingerprint, (CertificateAndKey, Vec<String>)>>,
@@ -1218,8 +1219,8 @@ impl<
 mod tests {
     use super::*;
     use crate::{
-        request::{LoadBalancingAlgorithms, LoadBalancingParams, Request},
-        response::{RequestHttpFrontend, RulePosition},
+        request::{LoadBalancingAlgorithms, LoadBalancingParams, Request, RequestHttpFrontend},
+        response::RulePosition,
     };
 
     #[test]

--- a/e2e/src/http_utils/mod.rs
+++ b/e2e/src/http_utils/mod.rs
@@ -23,3 +23,15 @@ pub fn http_request<S1: Into<String>, S2: Into<String>, S3: Into<String>, S4: In
         content,
     )
 }
+
+// the default value for the 404 error, as provided in the command lib,
+// used as default for listeners
+pub fn default_404_answer() -> String {
+    String::from(include_str!("../../../command/assets/404.html"))
+}
+
+// the default value for the 503 error, as provided in the command lib,
+// used as default for listeners
+pub fn default_503_answer() -> String {
+    String::from(include_str!("../../../command/assets/503.html"))
+}

--- a/e2e/src/sozu/worker.rs
+++ b/e2e/src/sozu/worker.rs
@@ -14,7 +14,7 @@ use sozu_lib as sozu;
 use sozu::server::Server;
 use sozu_command::{
     channel::Channel,
-    config::{Config, FileConfig},
+    config::{Config, ConfigBuilder, FileConfig},
     logging::{Logger, LoggerBackend},
     request::Request,
     request::{Cluster, LoadBalancingAlgorithms, LoadBalancingParams, WorkerRequest},
@@ -53,35 +53,7 @@ pub fn set_no_close_exec(fd: i32) {
 
 impl Worker {
     pub fn empty_file_config() -> FileConfig {
-        FileConfig {
-            command_socket: None,
-            saved_state: None,
-            automatic_state_save: None,
-            worker_count: None,
-            worker_automatic_restart: Some(false),
-            handle_process_affinity: None,
-            command_buffer_size: None,
-            max_command_buffer_size: None,
-            max_connections: None,
-            min_buffers: None,
-            max_buffers: None,
-            buffer_size: None,
-            log_level: None,
-            log_target: None,
-            log_access_target: None,
-            metrics: None,
-            listeners: None,
-            clusters: None,
-            ctl_command_timeout: None,
-            pid_file_path: None,
-            activate_listeners: None,
-            request_timeout: None,
-            front_timeout: None,
-            back_timeout: None,
-            connect_timeout: None,
-            zombie_check_interval: None,
-            accept_queue_timeout: None,
-        }
+        FileConfig::default()
     }
 
     pub fn empty_listeners() -> Listeners {
@@ -92,8 +64,11 @@ impl Worker {
         }
     }
 
-    pub fn into_config(config: FileConfig) -> Config {
-        config.into("").expect("could not create Config")
+    pub fn into_config(file_config: FileConfig) -> Config {
+        let mut config_builder = ConfigBuilder::new(file_config);
+        config_builder
+            .into_config("")
+            .expect("could not create Config")
     }
 
     pub fn empty_config() -> (Config, Listeners, ConfigState) {

--- a/e2e/src/sozu/worker.rs
+++ b/e2e/src/sozu/worker.rs
@@ -20,8 +20,7 @@ use sozu_command::{
         AddBackend, Cluster, LoadBalancingAlgorithms, LoadBalancingParams, Request, WorkerRequest,
     },
     response::{
-        HttpListenerConfig, HttpsListenerConfig, PathRule, ProxyResponse, RequestHttpFrontend,
-        RequestTcpFrontend, Route, RulePosition, TcpListenerConfig,
+        PathRule, ProxyResponse, RequestHttpFrontend, RequestTcpFrontend, Route, RulePosition,
     },
     scm_socket::{Listeners, ScmSocket},
     state::ConfigState,
@@ -265,41 +264,6 @@ impl Worker {
             UnixStream::from_raw_fd(self.scm_worker_to_main.fd);
         }
         result
-    }
-
-    pub fn default_tcp_listener(address: SocketAddr) -> TcpListenerConfig {
-        TcpListenerConfig {
-            address,
-            public_address: None,
-            expect_proxy: false,
-            front_timeout: 60,
-            back_timeout: 30,
-            connect_timeout: 3,
-        }
-    }
-
-    pub fn default_http_listener(address: SocketAddr) -> HttpListenerConfig {
-        HttpListenerConfig {
-            address,
-            public_address: None,
-            expect_proxy: false,
-            front_timeout: 60,
-            back_timeout: 30,
-            connect_timeout: 3,
-            ..HttpListenerConfig::default()
-        }
-    }
-
-    pub fn default_https_listener(address: SocketAddr) -> HttpsListenerConfig {
-        HttpsListenerConfig {
-            address,
-            public_address: None,
-            expect_proxy: false,
-            front_timeout: 60,
-            back_timeout: 30,
-            connect_timeout: 3,
-            ..HttpsListenerConfig::default()
-        }
     }
 
     pub fn default_cluster<S: Into<String>>(cluster_id: S) -> Cluster {

--- a/e2e/src/sozu/worker.rs
+++ b/e2e/src/sozu/worker.rs
@@ -17,11 +17,10 @@ use sozu_command::{
     config::{Config, ConfigBuilder, FileConfig},
     logging::{Logger, LoggerBackend},
     request::{
-        AddBackend, Cluster, LoadBalancingAlgorithms, LoadBalancingParams, Request, WorkerRequest,
+        AddBackend, Cluster, LoadBalancingAlgorithms, LoadBalancingParams, Request,
+        RequestHttpFrontend, RequestTcpFrontend, WorkerRequest,
     },
-    response::{
-        PathRule, ProxyResponse, RequestHttpFrontend, RequestTcpFrontend, Route, RulePosition,
-    },
+    response::{PathRule, ProxyResponse, Route, RulePosition},
     scm_socket::{Listeners, ScmSocket},
     state::ConfigState,
 };

--- a/e2e/src/sozu/worker.rs
+++ b/e2e/src/sozu/worker.rs
@@ -16,11 +16,12 @@ use sozu_command::{
     channel::Channel,
     config::{Config, ConfigBuilder, FileConfig},
     logging::{Logger, LoggerBackend},
-    request::Request,
-    request::{Cluster, LoadBalancingAlgorithms, LoadBalancingParams, WorkerRequest},
+    request::{
+        AddBackend, Cluster, LoadBalancingAlgorithms, LoadBalancingParams, Request, WorkerRequest,
+    },
     response::{
-        Backend, HttpFrontend, HttpListenerConfig, HttpsListenerConfig, PathRule, ProxyResponse,
-        Route, RulePosition, TcpFrontend, TcpListenerConfig,
+        HttpFrontend, HttpListenerConfig, HttpsListenerConfig, PathRule, ProxyResponse, Route,
+        RulePosition, TcpFrontend, TcpListenerConfig,
     },
     scm_socket::{Listeners, ScmSocket},
     state::ConfigState,
@@ -342,9 +343,9 @@ impl Worker {
     pub fn default_backend<S1: Into<String>, S2: Into<String>>(
         cluster_id: S1,
         backend_id: S2,
-        address: SocketAddr,
-    ) -> Backend {
-        Backend {
+        address: String,
+    ) -> AddBackend {
+        AddBackend {
             cluster_id: cluster_id.into(),
             backend_id: backend_id.into(),
             address,

--- a/e2e/src/sozu/worker.rs
+++ b/e2e/src/sozu/worker.rs
@@ -20,8 +20,8 @@ use sozu_command::{
         AddBackend, Cluster, LoadBalancingAlgorithms, LoadBalancingParams, Request, WorkerRequest,
     },
     response::{
-        HttpFrontend, HttpListenerConfig, HttpsListenerConfig, PathRule, ProxyResponse, Route,
-        RulePosition, TcpFrontend, TcpListenerConfig,
+        HttpListenerConfig, HttpsListenerConfig, PathRule, ProxyResponse, RequestHttpFrontend,
+        RequestTcpFrontend, Route, RulePosition, TcpListenerConfig,
     },
     scm_socket::{Listeners, ScmSocket},
     state::ConfigState,
@@ -316,9 +316,9 @@ impl Worker {
 
     pub fn default_tcp_frontend<S: Into<String>>(
         cluster_id: S,
-        address: SocketAddr,
-    ) -> TcpFrontend {
-        TcpFrontend {
+        address: String,
+    ) -> RequestTcpFrontend {
+        RequestTcpFrontend {
             cluster_id: cluster_id.into(),
             address,
             tags: None,
@@ -328,10 +328,10 @@ impl Worker {
     pub fn default_http_frontend<S: Into<String>>(
         cluster_id: S,
         address: SocketAddr,
-    ) -> HttpFrontend {
-        HttpFrontend {
+    ) -> RequestHttpFrontend {
+        RequestHttpFrontend {
             route: Route::ClusterId(cluster_id.into()),
-            address,
+            address: address.to_string(),
             hostname: String::from("localhost"),
             path: PathRule::Prefix(String::from("/")),
             method: None,

--- a/e2e/src/tests/mod.rs
+++ b/e2e/src/tests/mod.rs
@@ -3,7 +3,7 @@ mod tests;
 use std::{io::stdin, net::SocketAddr};
 
 use sozu_command_lib::{
-    config::Config,
+    config::{Config, ListenerBuilder},
     request::Request,
     request::{ActivateListener, ListenerType},
     scm_socket::Listeners,
@@ -43,9 +43,9 @@ pub fn setup_test<S: Into<String>>(
 ) -> (Worker, Vec<SocketAddr>) {
     let mut worker = Worker::start_new_worker(name, config, &listeners, state);
 
-    worker.send_proxy_request(Request::AddHttpListener(Worker::default_http_listener(
-        front_address,
-    )));
+    worker.send_proxy_request(Request::AddHttpListener(
+        ListenerBuilder::new_http(front_address).to_http().unwrap(),
+    ));
     worker.send_proxy_request(Request::ActivateListener(ActivateListener {
         address: front_address,
         proxy: ListenerType::HTTP,

--- a/e2e/src/tests/mod.rs
+++ b/e2e/src/tests/mod.rs
@@ -59,13 +59,13 @@ pub fn setup_test<S: Into<String>>(
 
     let mut backends = Vec::new();
     for i in 0..nb_backends {
-        let back_address = format!("127.0.0.1:{}", 2002 + i)
+        let back_address: SocketAddr = format!("127.0.0.1:{}", 2002 + i)
             .parse()
             .expect("could not parse back address");
         worker.send_proxy_request(Request::AddBackend(Worker::default_backend(
             "cluster_0",
             format!("cluster_0-{i}"),
-            back_address,
+            back_address.to_string(),
         )));
         backends.push(back_address);
     }

--- a/e2e/src/tests/tests.rs
+++ b/e2e/src/tests/tests.rs
@@ -12,7 +12,7 @@ use sozu_command_lib::{
     info,
     logging::{Logger, LoggerBackend},
     request::{ActivateListener, AddCertificate, ListenerType, RemoveBackend, Request},
-    response::HttpFrontend,
+    response::RequestHttpFrontend,
     state::ConfigState,
 };
 
@@ -293,7 +293,7 @@ pub fn try_issue_810_panic(part2: bool) -> State {
     worker.send_proxy_request(Request::AddCluster(Worker::default_cluster("cluster_0")));
     worker.send_proxy_request(Request::AddTcpFrontend(Worker::default_tcp_frontend(
         "cluster_0",
-        front_address,
+        front_address.to_string(),
     )));
 
     worker.send_proxy_request(Request::AddBackend(Worker::default_backend(
@@ -359,7 +359,7 @@ pub fn try_tls_endpoint() -> State {
     worker.send_proxy_request(Request::AddCluster(Worker::default_cluster("cluster_0")));
 
     let hostname = "localhost".to_string();
-    worker.send_proxy_request(Request::AddHttpsFrontend(HttpFrontend {
+    worker.send_proxy_request(Request::AddHttpsFrontend(RequestHttpFrontend {
         hostname: hostname.to_owned(),
         ..Worker::default_http_frontend("cluster_0", front_address)
     }));
@@ -653,7 +653,7 @@ fn try_http_behaviors() -> State {
     assert_eq!(response, Some(expected_response));
     assert_eq!(client.receive(), None);
 
-    worker.send_proxy_request(Request::AddHttpFrontend(HttpFrontend {
+    worker.send_proxy_request(Request::AddHttpFrontend(RequestHttpFrontend {
         hostname: String::from("example.com"),
         ..Worker::default_http_frontend("cluster_0", front_address)
     }));

--- a/e2e/src/tests/tests.rs
+++ b/e2e/src/tests/tests.rs
@@ -373,7 +373,7 @@ pub fn try_tls_endpoint() -> State {
         versions: vec![],
     };
     let add_certificate = AddCertificate {
-        address: front_address,
+        address: front_address.to_string(),
         certificate: certificate_and_key,
         names: vec![],
         expired_at: None,

--- a/e2e/src/tests/tests.rs
+++ b/e2e/src/tests/tests.rs
@@ -276,8 +276,7 @@ pub fn try_issue_810_panic(part2: bool) -> State {
         .parse()
         .expect("could not parse front address");
     let back_address = "127.0.0.1:2002"
-        .to_string()
-        .parse()
+        .parse::<std::net::SocketAddr>()
         .expect("could not parse back address");
 
     let (config, listeners, state) = Worker::empty_config();
@@ -300,7 +299,7 @@ pub fn try_issue_810_panic(part2: bool) -> State {
     worker.send_proxy_request(Request::AddBackend(Worker::default_backend(
         "cluster_0",
         "cluster_0-0",
-        back_address,
+        back_address.to_string(),
     )));
     worker.read_to_last();
 
@@ -342,8 +341,7 @@ pub fn try_tls_endpoint() -> State {
         .parse()
         .expect("could not parse front address");
     let back_address = "127.0.0.1:2002"
-        .to_string()
-        .parse()
+        .parse::<std::net::SocketAddr>()
         .expect("could not parse back address");
 
     let (config, listeners, state) = Worker::empty_config();
@@ -383,7 +381,7 @@ pub fn try_tls_endpoint() -> State {
     worker.send_proxy_request(Request::AddBackend(Worker::default_backend(
         "cluster_0",
         "cluster_0-0",
-        back_address,
+        back_address.to_string(),
     )));
     worker.read_to_last();
 
@@ -673,12 +671,12 @@ fn try_http_behaviors() -> State {
     assert_eq!(client.receive(), None);
 
     let back_address = "127.0.0.1:2002"
-        .parse()
+        .parse::<std::net::SocketAddr>()
         .expect("could not parse back address");
     worker.send_proxy_request(Request::AddBackend(Worker::default_backend(
         "cluster_0",
         "cluster_0-0".to_string(),
-        back_address,
+        back_address.to_string(),
     )));
     worker.read_to_last();
 
@@ -718,12 +716,12 @@ fn try_http_behaviors() -> State {
     worker.send_proxy_request(Request::RemoveBackend(RemoveBackend {
         cluster_id: String::from("cluster_0"),
         backend_id: String::from("cluster_0-0"),
-        address: back_address,
+        address: back_address.to_string(),
     }));
     worker.send_proxy_request(Request::AddBackend(Worker::default_backend(
         "cluster_0",
         "cluster_0-0".to_string(),
-        back_address,
+        back_address.to_string(),
     )));
     backend.disconnect();
     worker.read_to_last();
@@ -779,12 +777,12 @@ fn try_http_behaviors() -> State {
     worker.send_proxy_request(Request::RemoveBackend(RemoveBackend {
         cluster_id: String::from("cluster_0"),
         backend_id: String::from("cluster_0-0"),
-        address: back_address,
+        address: back_address.to_string(),
     }));
     worker.send_proxy_request(Request::AddBackend(Worker::default_backend(
         "cluster_0",
         "cluster_0-0".to_string(),
-        back_address,
+        back_address.to_string(),
     )));
     backend.disconnect();
     worker.read_to_last();

--- a/e2e/src/tests/tests.rs
+++ b/e2e/src/tests/tests.rs
@@ -11,8 +11,9 @@ use sozu_command_lib::{
     config::{FileConfig, ListenerBuilder},
     info,
     logging::{Logger, LoggerBackend},
-    request::{ActivateListener, AddCertificate, ListenerType, RemoveBackend, Request},
-    response::RequestHttpFrontend,
+    request::{
+        ActivateListener, AddCertificate, ListenerType, RemoveBackend, Request, RequestHttpFrontend,
+    },
     state::ConfigState,
 };
 

--- a/lib/examples/main.rs
+++ b/lib/examples/main.rs
@@ -14,8 +14,11 @@ use sozu_command::{
     certificate::CertificateAndKey,
     channel::Channel,
     logging::{Logger, LoggerBackend},
-    request::{AddBackend, AddCertificate, LoadBalancingParams, Request, WorkerRequest},
-    response::{PathRule, RequestHttpFrontend, Route, RulePosition},
+    request::{
+        AddBackend, AddCertificate, LoadBalancingParams, Request, RequestHttpFrontend,
+        WorkerRequest,
+    },
+    response::{PathRule, Route, RulePosition},
 };
 
 fn main() -> anyhow::Result<()> {

--- a/lib/examples/main.rs
+++ b/lib/examples/main.rs
@@ -14,9 +14,9 @@ use sozu_command::{
     channel::Channel,
     config::DEFAULT_RUSTLS_CIPHER_LIST,
     logging::{Logger, LoggerBackend},
-    request::{AddCertificate, LoadBalancingParams, Request, WorkerRequest},
+    request::{AddCertificate, LoadBalancingParams, AddBackend, Request, WorkerRequest},
     response::{
-        Backend, HttpFrontend, HttpListenerConfig, HttpsListenerConfig, PathRule, Route,
+         HttpFrontend, HttpListenerConfig, HttpsListenerConfig, PathRule, Route,
         RulePosition,
     },
 };
@@ -77,13 +77,11 @@ fn main() -> anyhow::Result<()> {
         tags: None,
     };
 
-    let http_backend = Backend {
+    let http_backend = AddBackend {
         cluster_id: String::from("cluster_1"),
         backend_id: String::from("cluster_1-0"),
         sticky_id: None,
-        address: "127.0.0.1:1026"
-            .parse()
-            .with_context(|| "Could not parse backend address")?,
+        address: "127.0.0.1:1026".to_string(),
         load_balancing_parameters: Some(LoadBalancingParams::default()),
         backup: None,
     };
@@ -157,13 +155,11 @@ fn main() -> anyhow::Result<()> {
         id: String::from("ID_IJKL2"),
         content: Request::AddHttpsFrontend(tls_front),
     });
-    let tls_backend = Backend {
+    let tls_backend = AddBackend {
         cluster_id: String::from("cluster_1"),
         backend_id: String::from("cluster_1-0"),
         sticky_id: None,
-        address: "127.0.0.1:1026"
-            .parse()
-            .with_context(|| "Could not parse backend address")?,
+        address: "127.0.0.1:1026".to_string(),
         load_balancing_parameters: Some(LoadBalancingParams::default()),
         backup: None,
     };
@@ -212,13 +208,11 @@ fn main() -> anyhow::Result<()> {
         content: Request::AddHttpsFrontend(tls_front2),
     });
 
-    let tls_backend2 = Backend {
+    let tls_backend2 = AddBackend {
         cluster_id: String::from("cluster_2"),
         backend_id: String::from("cluster_2-0"),
         sticky_id: None,
-        address: "127.0.0.1:1026"
-            .parse()
-            .with_context(|| "Could not parse backend address")?,
+        address: "127.0.0.1:1026".to_string(),
         load_balancing_parameters: Some(LoadBalancingParams::default()),
         backup: None,
     };

--- a/lib/examples/main.rs
+++ b/lib/examples/main.rs
@@ -14,10 +14,9 @@ use sozu_command::{
     channel::Channel,
     config::DEFAULT_RUSTLS_CIPHER_LIST,
     logging::{Logger, LoggerBackend},
-    request::{AddCertificate, LoadBalancingParams, AddBackend, Request, WorkerRequest},
+    request::{AddBackend, AddCertificate, LoadBalancingParams, Request, WorkerRequest},
     response::{
-         HttpFrontend, HttpListenerConfig, HttpsListenerConfig, PathRule, Route,
-        RulePosition,
+        HttpListenerConfig, HttpsListenerConfig, PathRule, RequestHttpFrontend, Route, RulePosition,
     },
 };
 
@@ -65,11 +64,9 @@ fn main() -> anyhow::Result<()> {
         sozu::http::start_http_worker(config, channel, max_buffers, buffer_size);
     });
 
-    let http_front = HttpFrontend {
+    let http_front = RequestHttpFrontend {
         route: Route::ClusterId(String::from("cluster_1")),
-        address: "127.0.0.1:8080"
-            .parse()
-            .with_context(|| "Could not parse frontend address")?,
+        address: "127.0.0.1:8080".to_string(),
         hostname: String::from("lolcatho.st"),
         path: PathRule::Prefix(String::from("/")),
         method: None,
@@ -139,11 +136,9 @@ fn main() -> anyhow::Result<()> {
         }),
     });
 
-    let tls_front = HttpFrontend {
+    let tls_front = RequestHttpFrontend {
         route: Route::ClusterId(String::from("cluster_1")),
-        address: "127.0.0.1:8443"
-            .parse()
-            .with_context(|| "Could not parse frontend address")?,
+        address: "127.0.0.1:8443".to_string(),
         hostname: String::from("lolcatho.st"),
         path: PathRule::Prefix(String::from("/")),
         method: None,
@@ -191,11 +186,9 @@ fn main() -> anyhow::Result<()> {
         }),
     });
 
-    let tls_front2 = HttpFrontend {
+    let tls_front2 = RequestHttpFrontend {
         route: Route::ClusterId(String::from("cluster_2")),
-        address: "127.0.0.1:8443"
-            .parse()
-            .with_context(|| "Could not parse frontend address")?,
+        address: "127.0.0.1:8443".to_string(),
         hostname: String::from("test.local"),
         path: PathRule::Prefix(String::from("/")),
         method: None,

--- a/lib/examples/minimal.rs
+++ b/lib/examples/minimal.rs
@@ -10,8 +10,8 @@ use anyhow::Context;
 use sozu_command::{
     channel::Channel,
     logging::{Logger, LoggerBackend},
-    request::{LoadBalancingParams, Request, WorkerRequest},
-    response::{Backend, HttpFrontend, HttpListenerConfig, PathRule, Route, RulePosition},
+    request::{LoadBalancingParams, Request, WorkerRequest, AddBackend},
+    response::{ HttpFrontend, HttpListenerConfig, PathRule, Route, RulePosition},
 };
 
 fn main() -> anyhow::Result<()> {
@@ -63,12 +63,10 @@ fn main() -> anyhow::Result<()> {
             ("id".to_owned(), "my-own-http-front".to_owned()),
         ])),
     };
-    let http_backend = Backend {
+    let http_backend = AddBackend {
         cluster_id: String::from("test"),
         backend_id: String::from("test-0"),
-        address: "127.0.0.1:8000"
-            .parse()
-            .with_context(|| "could not parse address")?,
+        address: "127.0.0.1:8000".to_string(),
         load_balancing_parameters: Some(LoadBalancingParams::default()),
         sticky_id: None,
         backup: None,

--- a/lib/examples/minimal.rs
+++ b/lib/examples/minimal.rs
@@ -10,8 +10,8 @@ use anyhow::Context;
 use sozu_command::{
     channel::Channel,
     logging::{Logger, LoggerBackend},
-    request::{LoadBalancingParams, Request, WorkerRequest, AddBackend},
-    response::{ HttpFrontend, HttpListenerConfig, PathRule, Route, RulePosition},
+    request::{AddBackend, LoadBalancingParams, Request, WorkerRequest},
+    response::{HttpListenerConfig, PathRule, RequestHttpFrontend, Route, RulePosition},
 };
 
 fn main() -> anyhow::Result<()> {
@@ -49,11 +49,9 @@ fn main() -> anyhow::Result<()> {
         sozu::http::start_http_worker(config, channel, max_buffers, buffer_size);
     });
 
-    let http_front = HttpFrontend {
+    let http_front = RequestHttpFrontend {
         route: Route::ClusterId(String::from("test")),
-        address: "127.0.0.1:8080"
-            .parse()
-            .with_context(|| "could not parse address")?,
+        address: "127.0.0.1:8080".to_string(),
         hostname: String::from("example.com"),
         path: PathRule::Prefix(String::from("/")),
         method: None,

--- a/lib/examples/minimal.rs
+++ b/lib/examples/minimal.rs
@@ -12,8 +12,8 @@ use crate::sozu_command::{
     channel::Channel,
     config::ListenerBuilder,
     logging::{Logger, LoggerBackend},
-    request::{AddBackend, LoadBalancingParams, Request, WorkerRequest},
-    response::{PathRule, RequestHttpFrontend, Route, RulePosition},
+    request::{AddBackend, LoadBalancingParams, Request, RequestHttpFrontend, WorkerRequest},
+    response::{PathRule, Route, RulePosition},
 };
 
 fn main() -> anyhow::Result<()> {

--- a/lib/examples/tcp.rs
+++ b/lib/examples/tcp.rs
@@ -10,8 +10,8 @@ use anyhow::Context;
 use sozu_command::{
     channel::Channel,
     logging::{Logger, LoggerBackend},
-    request::{LoadBalancingParams, Request, WorkerRequest},
-    response::{Backend, TcpFrontend, TcpListenerConfig},
+    request::{AddBackend, LoadBalancingParams, Request, WorkerRequest},
+    response::{TcpFrontend, TcpListenerConfig},
 };
 
 fn main() -> anyhow::Result<()> {
@@ -62,12 +62,10 @@ fn main() -> anyhow::Result<()> {
             .with_context(|| "could not parse address")?,
         tags: None,
     };
-    let tcp_backend = Backend {
+    let tcp_backend = AddBackend {
         cluster_id: String::from("test"),
         backend_id: String::from("test-0"),
-        address: "127.0.0.1:1026"
-            .parse()
-            .with_context(|| "could not parse address")?,
+        address: "127.0.0.1:1026".to_string(),
         load_balancing_parameters: Some(LoadBalancingParams::default()),
         sticky_id: None,
         backup: None,

--- a/lib/examples/tcp.rs
+++ b/lib/examples/tcp.rs
@@ -10,8 +10,8 @@ use anyhow::Context;
 use sozu_command::{
     channel::Channel,
     logging::{Logger, LoggerBackend},
-    request::{AddBackend, LoadBalancingParams, Request, WorkerRequest},
-    response::{RequestTcpFrontend, TcpListenerConfig},
+    request::{AddBackend, LoadBalancingParams, Request, RequestTcpFrontend, WorkerRequest},
+    response::TcpListenerConfig,
 };
 
 fn main() -> anyhow::Result<()> {

--- a/lib/examples/tcp.rs
+++ b/lib/examples/tcp.rs
@@ -11,7 +11,7 @@ use sozu_command::{
     channel::Channel,
     logging::{Logger, LoggerBackend},
     request::{AddBackend, LoadBalancingParams, Request, WorkerRequest},
-    response::{TcpFrontend, TcpListenerConfig},
+    response::{RequestTcpFrontend, TcpListenerConfig},
 };
 
 fn main() -> anyhow::Result<()> {
@@ -55,11 +55,9 @@ fn main() -> anyhow::Result<()> {
         sozu::tcp::start_tcp_worker(listener, max_buffers, buffer_size, channel);
     });
 
-    let tcp_front = TcpFrontend {
+    let tcp_front = RequestTcpFrontend {
         cluster_id: String::from("test"),
-        address: "127.0.0.1:8080"
-            .parse()
-            .with_context(|| "could not parse address")?,
+        address: "127.0.0.1:8080".to_string(),
         tags: None,
     };
     let tcp_backend = AddBackend {

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -18,7 +18,7 @@ use sozu_command::{
     logging,
     ready::Ready,
     request::{Cluster, RemoveListener, Request, WorkerRequest},
-    response::{HttpFrontend, HttpListenerConfig, ProxyResponse, Route},
+    response::{HttpFrontend, HttpListenerConfig, ProxyResponse, RequestHttpFrontend, Route},
     scm_socket::{Listeners, ScmSocket},
 };
 
@@ -615,7 +615,9 @@ impl HttpProxy {
         Ok(())
     }
 
-    pub fn add_http_frontend(&mut self, front: HttpFrontend) -> anyhow::Result<()> {
+    pub fn add_http_frontend(&mut self, front: RequestHttpFrontend) -> anyhow::Result<()> {
+        let front = front.to_frontend()?;
+
         match self
             .listeners
             .values()
@@ -639,7 +641,9 @@ impl HttpProxy {
         }
     }
 
-    pub fn remove_http_frontend(&mut self, front: HttpFrontend) -> anyhow::Result<()> {
+    pub fn remove_http_frontend(&mut self, front: RequestHttpFrontend) -> anyhow::Result<()> {
+        let front = front.to_frontend()?;
+
         if let Some(listener) = self
             .listeners
             .values()
@@ -1126,9 +1130,9 @@ mod tests {
             start_http_worker(config, channel, 10, 16384).expect("could not start the http server");
         });
 
-        let front = HttpFrontend {
+        let front = RequestHttpFrontend {
             route: Route::ClusterId(String::from("cluster_1")),
-            address: "127.0.0.1:1024".parse().unwrap(),
+            address: "127.0.0.1:1024".to_string(),
             hostname: String::from("localhost"),
             path: PathRule::Prefix(String::from("/")),
             method: None,
@@ -1214,8 +1218,8 @@ mod tests {
             start_http_worker(config, channel, 10, 16384).expect("could not start the http server");
         });
 
-        let front = HttpFrontend {
-            address: "127.0.0.1:1031".parse().unwrap(),
+        let front = RequestHttpFrontend {
+            address: "127.0.0.1:1031".to_string(),
             hostname: String::from("localhost"),
             method: None,
             path: PathRule::Prefix(String::from("/")),
@@ -1342,8 +1346,8 @@ mod tests {
                 content: Request::AddCluster(cluster),
             })
             .unwrap();
-        let front = HttpFrontend {
-            address: "127.0.0.1:1041".parse().unwrap(),
+        let front = RequestHttpFrontend {
+            address: "127.0.0.1:1041".to_string(),
             hostname: String::from("localhost"),
             method: None,
             path: PathRule::Prefix(String::from("/")),

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -17,8 +17,8 @@ use time::{Duration, Instant};
 use sozu_command::{
     logging,
     ready::Ready,
-    request::{Cluster, RemoveListener, Request, WorkerRequest},
-    response::{HttpFrontend, HttpListenerConfig, ProxyResponse, RequestHttpFrontend, Route},
+    request::{Cluster, RemoveListener, Request, RequestHttpFrontend, WorkerRequest},
+    response::{HttpFrontend, HttpListenerConfig, ProxyResponse, Route},
     scm_socket::{Listeners, ScmSocket},
 };
 

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -1081,11 +1081,13 @@ pub fn start_http_worker(
 #[cfg(test)]
 mod tests {
     extern crate tiny_http;
+    use sozu_command::config::ListenerBuilder;
+
     use super::*;
     use crate::sozu_command::{
         channel::Channel,
         request::{LoadBalancingAlgorithms, LoadBalancingParams, Request, WorkerRequest},
-        response::{Backend, HttpFrontend, HttpListenerConfig, PathRule, Route, RulePosition},
+        response::{Backend, HttpFrontend, PathRule, Route, RulePosition},
     };
 
     use std::io::{Read, Write};
@@ -1116,12 +1118,9 @@ mod tests {
         start_server(1025, barrier.clone());
         barrier.wait();
 
-        let address: SocketAddr =
-            FromStr::from_str("127.0.0.1:1024").expect("could not parse address");
-        let config = HttpListenerConfig {
-            address,
-            ..Default::default()
-        };
+        let config = ListenerBuilder::new_http("127.0.0.1:1024")
+            .to_http()
+            .expect("could not create listener config");
 
         let (mut command, channel) =
             Channel::generate(1000, 10000).expect("should create a channel");
@@ -1203,12 +1202,9 @@ mod tests {
         start_server(1028, barrier.clone());
         barrier.wait();
 
-        let address: SocketAddr =
-            FromStr::from_str("127.0.0.1:1031").expect("could not parse address");
-        let config = HttpListenerConfig {
-            address,
-            ..Default::default()
-        };
+        let config = ListenerBuilder::new_http("127.0.0.1:1031")
+            .to_http()
+            .expect("could not create listener config");
 
         let (mut command, channel) =
             Channel::generate(1000, 10000).expect("should create a channel");
@@ -1317,12 +1313,10 @@ mod tests {
     #[test]
     fn https_redirect() {
         setup_test_logger!();
-        let address: SocketAddr =
-            FromStr::from_str("127.0.0.1:1041").expect("could not parse address");
-        let config = HttpListenerConfig {
-            address,
-            ..Default::default()
-        };
+
+        let config = ListenerBuilder::new_http("127.0.0.1:1041")
+            .to_http()
+            .expect("could not create listener config");
 
         let (mut command, channel) =
             Channel::generate(1000, 10000).expect("should create a channel");
@@ -1499,6 +1493,11 @@ mod tests {
 
         let address: SocketAddr =
             FromStr::from_str("127.0.0.1:1030").expect("could not parse address");
+
+        let default_config = ListenerBuilder::new_http(address)
+            .to_http()
+            .expect("Could not create default HTTP listener config");
+
         let listener = HttpListener {
             listener: None,
             address,
@@ -1507,7 +1506,7 @@ mod tests {
                 "HTTP/1.1 404 Not Found\r\n\r\n",
                 "HTTP/1.1 503 Service Unavailable\r\n\r\n",
             ))),
-            config: Default::default(),
+            config: default_config,
             token: Token(0),
             active: true,
             tags: BTreeMap::new(),

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -1152,7 +1152,7 @@ mod tests {
         command
             .write_message(&WorkerRequest {
                 id: String::from("ID_EFGH"),
-                content: Request::AddBackend(backend),
+                content: Request::AddBackend(backend.to_add_backend()),
             })
             .unwrap();
 
@@ -1240,7 +1240,7 @@ mod tests {
         command
             .write_message(&WorkerRequest {
                 id: String::from("ID_EFGH"),
-                content: Request::AddBackend(backend),
+                content: Request::AddBackend(backend.to_add_backend()),
             })
             .unwrap();
 
@@ -1368,7 +1368,7 @@ mod tests {
         command
             .write_message(&WorkerRequest {
                 id: String::from("ID_IJKL"),
-                content: Request::AddBackend(backend),
+                content: Request::AddBackend(backend.to_add_backend()),
             })
             .unwrap();
 

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -1122,10 +1122,11 @@ impl HttpsProxy {
         &mut self,
         add_certificate: AddCertificate,
     ) -> anyhow::Result<Option<ProxyResponseContent>> {
+        let address = add_certificate.address.parse()?;
         match self
             .listeners
             .values()
-            .find(|l| l.borrow().address == add_certificate.address)
+            .find(|l| l.borrow().address == address)
         {
             Some(listener) => listener
                 .borrow_mut()
@@ -1145,10 +1146,11 @@ impl HttpsProxy {
         &mut self,
         remove_certificate: RemoveCertificate,
     ) -> anyhow::Result<Option<ProxyResponseContent>> {
+        let address = remove_certificate.address.parse()?;
         match self
             .listeners
             .values()
-            .find(|l| l.borrow().address == remove_certificate.address)
+            .find(|l| l.borrow().address == address)
         {
             Some(listener) => listener
                 .borrow_mut()
@@ -1168,10 +1170,11 @@ impl HttpsProxy {
         &mut self,
         replace_certificate: ReplaceCertificate,
     ) -> anyhow::Result<Option<ProxyResponseContent>> {
+        let address = replace_certificate.address.parse()?;
         match self
             .listeners
             .values()
-            .find(|l| l.borrow().address == replace_certificate.address)
+            .find(|l| l.borrow().address == address)
         {
             Some(listener) => listener
                 .borrow_mut()

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -1563,6 +1563,8 @@ pub fn start_https_worker(
 mod tests {
     use std::{str::FromStr, sync::Arc};
 
+    use sozu_command::config::ListenerBuilder;
+
     use crate::router::{trie::TrieNode, MethodRule, PathRule, Router};
     use crate::sozu_command::response::Route;
 
@@ -1635,6 +1637,10 @@ mod tests {
 
         let rustls_details = Arc::new(server_config);
 
+        let default_config = ListenerBuilder::new_https(address)
+            .to_tls()
+            .expect("Could not create default HTTPS listener config");
+
         let listener = HttpsListener {
             listener: None,
             address,
@@ -1645,7 +1651,7 @@ mod tests {
                 "HTTP/1.1 404 Not Found\r\n\r\n",
                 "HTTP/1.1 503 Service Unavailable\r\n\r\n",
             ))),
-            config: Default::default(),
+            config: default_config,
             token: Token(0),
             active: true,
             tags: BTreeMap::new(),

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -26,7 +26,7 @@ use rustls::{
 };
 use rusty_ulid::Ulid;
 use slab::Slab;
-use sozu_command::config::DEFAULT_CIPHER_SUITES;
+use sozu_command::{config::DEFAULT_CIPHER_SUITES, response::RequestHttpFrontend};
 use time::{Duration, Instant};
 
 use crate::{
@@ -1081,8 +1081,10 @@ impl HttpsProxy {
 
     pub fn add_https_frontend(
         &mut self,
-        front: HttpFrontend,
+        front: RequestHttpFrontend,
     ) -> anyhow::Result<Option<ProxyResponseContent>> {
+        let front = front.to_frontend()?;
+
         match self
             .listeners
             .values()
@@ -1102,8 +1104,10 @@ impl HttpsProxy {
 
     pub fn remove_https_frontend(
         &mut self,
-        front: HttpFrontend,
+        front: RequestHttpFrontend,
     ) -> anyhow::Result<Option<ProxyResponseContent>> {
+        let front = front.to_frontend()?;
+
         if let Some(listener) = self
             .listeners
             .values()

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -26,7 +26,7 @@ use rustls::{
 };
 use rusty_ulid::Ulid;
 use slab::Slab;
-use sozu_command::{config::DEFAULT_CIPHER_SUITES, response::RequestHttpFrontend};
+use sozu_command::{config::DEFAULT_CIPHER_SUITES, request::RequestHttpFrontend};
 use time::{Duration, Instant};
 
 use crate::{

--- a/lib/src/protocol/http/parser/tests.rs
+++ b/lib/src/protocol/http/parser/tests.rs
@@ -8,6 +8,7 @@ use nom::HexDisplay;
 use crate::buffer_queue::{buf_with_capacity, OutputElement};
 #[cfg(test)]
 use crate::protocol::http::AddedRequestHeader;
+use sozu_command::config::DEFAULT_STICKY_NAME;
 
 use super::*;
 
@@ -113,7 +114,7 @@ fn parse_state_host_in_url_test() {
     println!("buffer input: {:?}", buf.input_queue);
 
     //let result = parse_request(initial, input);
-    let result = parse_request_until_stop(initial, None, &mut buf, None, "SOZUBALANCEID");
+    let result = parse_request_until_stop(initial, None, &mut buf, None, DEFAULT_STICKY_NAME);
     println!("result: {result:?}");
     println!("input length: {}", input.len());
     println!("buffer input: {:?}", buf.input_queue);
@@ -161,7 +162,7 @@ fn parse_state_host_in_url_conflict_test() {
     println!("buffer input: {:?}", buf.input_queue);
 
     //let result = parse_request(initial, input);
-    let result = parse_request_until_stop(initial, None, &mut buf, None, "SOZUBALANCEID");
+    let result = parse_request_until_stop(initial, None, &mut buf, None, DEFAULT_STICKY_NAME);
     println!("result: {result:?}");
     println!("input length: {}", input.len());
     println!("buffer input: {:?}", buf.input_queue);
@@ -204,7 +205,7 @@ fn parse_state_content_length_test() {
     println!("buffer input: {:?}", buf.input_queue);
 
     //let result = parse_request(initial, input);
-    let result = parse_request_until_stop(initial, None, &mut buf, None, "SOZUBALANCEID");
+    let result = parse_request_until_stop(initial, None, &mut buf, None, DEFAULT_STICKY_NAME);
     println!("result: {result:?}");
     println!("input length: {}", input.len());
     println!("buffer input: {:?}", buf.input_queue);
@@ -269,7 +270,7 @@ fn parse_state_content_length_partial() {
     );
     println!("buffer output: {:?}", buf.output_queue);
 
-    let result = parse_request_until_stop(initial, None, &mut buf, None, "SOZUBALANCEID");
+    let result = parse_request_until_stop(initial, None, &mut buf, None, DEFAULT_STICKY_NAME);
     println!(
         "unparsed data after parsing:\n{}",
         buf.unparsed_data().to_hex(16)
@@ -320,7 +321,7 @@ fn parse_state_chunked_test() {
     buf.write(&input[..]).unwrap();
 
     //let result = parse_request(initial, input);
-    let result = parse_request_until_stop(initial, None, &mut buf, None, "SOZUBALANCEID");
+    let result = parse_request_until_stop(initial, None, &mut buf, None, DEFAULT_STICKY_NAME);
     println!("result: {result:?}");
     assert_eq!(buf.start_parsing_position, 116);
     assert_eq!(
@@ -355,7 +356,7 @@ fn parse_state_duplicate_content_length_test() {
     let (_pool, mut buf) = buf_with_capacity(2048);
     buf.write(&input[..]).unwrap();
 
-    let result = parse_request_until_stop(initial, None, &mut buf, None, "SOZUBALANCEID");
+    let result = parse_request_until_stop(initial, None, &mut buf, None, DEFAULT_STICKY_NAME);
     println!("result: {result:?}");
     assert_eq!(buf.start_parsing_position, 128);
     assert_eq!(
@@ -392,7 +393,7 @@ fn parse_state_content_length_and_chunked_test() {
     buf.write(&input[..]).unwrap();
 
     //let result = parse_request(initial, input);
-    let result = parse_request_until_stop(initial, None, &mut buf, None, "SOZUBALANCEID");
+    let result = parse_request_until_stop(initial, None, &mut buf, None, DEFAULT_STICKY_NAME);
     println!("result: {result:?}");
     assert_eq!(buf.start_parsing_position, 136);
     assert_eq!(
@@ -425,7 +426,7 @@ fn parse_request_without_length() {
     buf.write(&input[..]).unwrap();
 
     //let result = parse_request(initial, input);
-    let result = parse_request_until_stop(initial, None, &mut buf, None, "SOZUBALANCEID");
+    let result = parse_request_until_stop(initial, None, &mut buf, None, DEFAULT_STICKY_NAME);
     println!("result: {result:?}");
     println!("input length: {}", input.len());
     println!("buffer output: {:?}", buf.output_queue);
@@ -467,7 +468,7 @@ fn parse_request_http_1_0_connection_close() {
     buf.write(&input[..]).unwrap();
 
     //let result = parse_request(initial, input);
-    let result = parse_request_until_stop(initial, None, &mut buf, None, "SOZUBALANCEID");
+    let result = parse_request_until_stop(initial, None, &mut buf, None, DEFAULT_STICKY_NAME);
     println!("result: {result:?}");
     assert_eq!(buf.start_parsing_position, 40);
     assert_eq!(
@@ -500,7 +501,7 @@ fn parse_request_http_1_0_connection_keep_alive() {
     buf.write(&input[..]).unwrap();
 
     //let result = parse_request(initial, input);
-    let result = parse_request_until_stop(initial, None, &mut buf, None, "SOZUBALANCEID");
+    let result = parse_request_until_stop(initial, None, &mut buf, None, DEFAULT_STICKY_NAME);
     println!("result: {result:?}");
     println!("input length: {}", input.len());
     println!("buffer output: {:?}", buf.output_queue);
@@ -543,7 +544,7 @@ fn parse_request_http_1_1_connection_keep_alive() {
     buf.write(&input[..]).unwrap();
 
     //let result = parse_request(initial, input);
-    let result = parse_request_until_stop(initial, None, &mut buf, None, "SOZUBALANCEID");
+    let result = parse_request_until_stop(initial, None, &mut buf, None, DEFAULT_STICKY_NAME);
     println!("end buf:\n{}", buf.buffer.data().to_hex(16));
     println!("result: {result:?}");
     assert_eq!(
@@ -585,7 +586,7 @@ fn parse_request_http_1_1_connection_close() {
     buf.write(&input[..]).unwrap();
 
     //let result = parse_request(initial, input);
-    let result = parse_request_until_stop(initial, None, &mut buf, None, "SOZUBALANCEID");
+    let result = parse_request_until_stop(initial, None, &mut buf, None, DEFAULT_STICKY_NAME);
     println!("end buf:\n{}", buf.buffer.data().to_hex(16));
     println!("result: {result:?}");
     assert_eq!(
@@ -640,7 +641,8 @@ fn parse_request_add_header_test() {
         closing: false,
     });
 
-    let result = parse_request_until_stop(initial, None, &mut buf, added.as_ref(), "SOZUBALANCEID");
+    let result =
+        parse_request_until_stop(initial, None, &mut buf, added.as_ref(), DEFAULT_STICKY_NAME);
     println!("result: {result:?}");
     println!("input length: {}", input.len());
     println!("buffer output: {:?}", buf.output_queue);
@@ -707,7 +709,8 @@ fn parse_request_delete_forwarded_headers() {
         closing: false,
     });
 
-    let result = parse_request_until_stop(initial, None, &mut buf, added.as_ref(), "SOZUBALANCEID");
+    let result =
+        parse_request_until_stop(initial, None, &mut buf, added.as_ref(), DEFAULT_STICKY_NAME);
     println!("result: {result:?}");
     println!("input length: {}", input.len());
     println!("buffer output: {:?}", buf.output_queue);
@@ -829,7 +832,7 @@ fn parse_requests_and_chunks_test() {
     buf.write(&input[..]).unwrap();
 
     //let result = parse_request(initial, input);
-    let result = parse_request_until_stop(initial, None, &mut buf, None, "SOZUBALANCEID");
+    let result = parse_request_until_stop(initial, None, &mut buf, None, DEFAULT_STICKY_NAME);
     println!("result: {result:?}");
     assert_eq!(buf.start_parsing_position, 160);
     assert_eq!(
@@ -871,7 +874,7 @@ fn parse_requests_and_chunks_partial_test() {
     buf.write(&input[..125]).unwrap();
     println!("parsing\n{}", buf.buffer.data().to_hex(16));
 
-    let result = parse_request_until_stop(initial, None, &mut buf, None, "SOZUBALANCEID");
+    let result = parse_request_until_stop(initial, None, &mut buf, None, DEFAULT_STICKY_NAME);
     println!("result({}): {:?}", line!(), result);
     assert_eq!(buf.start_parsing_position, 124);
     assert_eq!(
@@ -895,7 +898,7 @@ fn parse_requests_and_chunks_partial_test() {
     buf.write(&input[125..140]).unwrap();
     println!("parsing\n{}", buf.buffer.data().to_hex(16));
 
-    let result = parse_request_until_stop(result.0, result.1, &mut buf, None, "SOZUBALANCEID");
+    let result = parse_request_until_stop(result.0, result.1, &mut buf, None, DEFAULT_STICKY_NAME);
     println!("result({}): {:?}", line!(), result);
     assert_eq!(buf.start_parsing_position, 153);
     assert_eq!(
@@ -917,7 +920,7 @@ fn parse_requests_and_chunks_partial_test() {
 
     buf.write(&input[153..]).unwrap();
     println!("parsing\n{}", buf.buffer.data().to_hex(16));
-    let result = parse_request_until_stop(result.0, result.1, &mut buf, None, "SOZUBALANCEID");
+    let result = parse_request_until_stop(result.0, result.1, &mut buf, None, DEFAULT_STICKY_NAME);
     println!("result({}): {:?}", line!(), result);
     assert_eq!(buf.start_parsing_position, 160);
     assert_eq!(
@@ -964,7 +967,7 @@ fn parse_response_and_chunks_partial_test() {
         &mut buf,
         false,
         "",
-        "SOZUBALANCEID",
+        DEFAULT_STICKY_NAME,
         None,
         None,
     );
@@ -996,7 +999,7 @@ fn parse_response_and_chunks_partial_test() {
         &mut buf,
         false,
         "",
-        "SOZUBALANCEID",
+        DEFAULT_STICKY_NAME,
         None,
         None,
     );
@@ -1028,7 +1031,7 @@ fn parse_response_and_chunks_partial_test() {
         &mut buf,
         false,
         "",
-        "SOZUBALANCEID",
+        DEFAULT_STICKY_NAME,
         None,
         None,
     );
@@ -1059,7 +1062,7 @@ fn parse_response_and_chunks_partial_test() {
         &mut buf,
         false,
         "",
-        "SOZUBALANCEID",
+        DEFAULT_STICKY_NAME,
         None,
         None,
     );
@@ -1118,7 +1121,7 @@ fn parse_incomplete_chunk_header_test() {
         &mut buf,
         false,
         "",
-        "SOZUBALANCEID",
+        DEFAULT_STICKY_NAME,
         None,
         None,
     );
@@ -1156,7 +1159,7 @@ fn parse_incomplete_chunk_header_test() {
         &mut buf,
         false,
         "",
-        "SOZUBALANCEID",
+        DEFAULT_STICKY_NAME,
         None,
         None,
     );
@@ -1189,7 +1192,7 @@ fn parse_incomplete_chunk_header_test() {
         &mut buf,
         false,
         "",
-        "SOZUBALANCEID",
+        DEFAULT_STICKY_NAME,
         None,
         None,
     );
@@ -1218,7 +1221,7 @@ fn parse_incomplete_chunk_header_test() {
         &mut buf,
         false,
         "",
-        "SOZUBALANCEID",
+        DEFAULT_STICKY_NAME,
         None,
         None,
     );
@@ -1260,7 +1263,7 @@ fn parse_response_302() {
         &mut buf,
         false,
         "Sozu-Id: 123456789\r\n",
-        "SOZUBALANCEID",
+        DEFAULT_STICKY_NAME,
         None,
         None,
     );
@@ -1318,7 +1321,7 @@ fn parse_response_303() {
         &mut buf,
         false,
         "Sozu-Id: 123456789\r\n",
-        "SOZUBALANCEID",
+        DEFAULT_STICKY_NAME,
         None,
         None,
     );
@@ -1375,7 +1378,7 @@ fn parse_response_304() {
         &mut buf,
         is_head,
         "",
-        "SOZUBALANCEID",
+        DEFAULT_STICKY_NAME,
         None,
         None,
     );
@@ -1475,7 +1478,7 @@ fn parse_state_head_with_content_length_test() {
         &mut buf,
         is_head,
         "",
-        "SOZUBALANCEID",
+        DEFAULT_STICKY_NAME,
         None,
         None,
     );
@@ -1524,7 +1527,7 @@ fn parse_connection_upgrade_test() {
     println!("buffer input: {:?}", buf.input_queue);
 
     //let result = parse_request(initial, input);
-    let result = parse_request_until_stop(initial, None, &mut buf, None, "SOZUBALANCEID");
+    let result = parse_request_until_stop(initial, None, &mut buf, None, DEFAULT_STICKY_NAME);
     println!("result: {result:?}");
     println!("input length: {}", input.len());
     println!("buffer input: {:?}", buf.input_queue);
@@ -1598,12 +1601,21 @@ fn header_cookies_no_sticky() {
         _ => panic!(),
     };
 
-    let moves1 =
-        header1.remove_sticky_cookie_in_request(header_line1, header_line1.len(), "SOZUBALANCEID");
-    let moves2 =
-        header2.remove_sticky_cookie_in_request(header_line2, header_line2.len(), "SOZUBALANCEID");
-    let moves3 =
-        header3.remove_sticky_cookie_in_request(header_line3, header_line3.len(), "SOZUBALANCEID");
+    let moves1 = header1.remove_sticky_cookie_in_request(
+        header_line1,
+        header_line1.len(),
+        DEFAULT_STICKY_NAME,
+    );
+    let moves2 = header2.remove_sticky_cookie_in_request(
+        header_line2,
+        header_line2.len(),
+        DEFAULT_STICKY_NAME,
+    );
+    let moves3 = header3.remove_sticky_cookie_in_request(
+        header_line3,
+        header_line3.len(),
+        DEFAULT_STICKY_NAME,
+    );
     let expected1 = vec![BufferMove::Advance(header_line1.len())];
     let expected2 = vec![BufferMove::Advance(header_line2.len())];
     let expected3 = vec![BufferMove::Advance(header_line3.len())];
@@ -1628,10 +1640,16 @@ fn header_cookies_sticky_only_cookie() {
         _ => panic!(),
     };
 
-    let moves1 =
-        header1.remove_sticky_cookie_in_request(header_line1, header_line1.len(), "SOZUBALANCEID");
-    let moves2 =
-        header2.remove_sticky_cookie_in_request(header_line2, header_line2.len(), "SOZUBALANCEID");
+    let moves1 = header1.remove_sticky_cookie_in_request(
+        header_line1,
+        header_line1.len(),
+        DEFAULT_STICKY_NAME,
+    );
+    let moves2 = header2.remove_sticky_cookie_in_request(
+        header_line2,
+        header_line2.len(),
+        DEFAULT_STICKY_NAME,
+    );
     let expected1 = vec![BufferMove::Delete(header_line1.len())];
     let expected2 = vec![BufferMove::Delete(header_line2.len())];
 
@@ -1660,12 +1678,21 @@ fn header_cookies_sticky_start() {
         _ => panic!(),
     };
 
-    let moves1 =
-        header1.remove_sticky_cookie_in_request(header_line1, header_line1.len(), "SOZUBALANCEID");
-    let moves2 =
-        header2.remove_sticky_cookie_in_request(header_line2, header_line2.len(), "SOZUBALANCEID");
-    let moves3 =
-        header3.remove_sticky_cookie_in_request(header_line3, header_line3.len(), "SOZUBALANCEID");
+    let moves1 = header1.remove_sticky_cookie_in_request(
+        header_line1,
+        header_line1.len(),
+        DEFAULT_STICKY_NAME,
+    );
+    let moves2 = header2.remove_sticky_cookie_in_request(
+        header_line2,
+        header_line2.len(),
+        DEFAULT_STICKY_NAME,
+    );
+    let moves3 = header3.remove_sticky_cookie_in_request(
+        header_line3,
+        header_line3.len(),
+        DEFAULT_STICKY_NAME,
+    );
     let expected1 = vec![
         BufferMove::Advance(7),
         BufferMove::Delete(16),
@@ -1711,12 +1738,21 @@ fn header_cookies_sticky_middle() {
         _ => panic!(),
     };
 
-    let moves1 =
-        header1.remove_sticky_cookie_in_request(header_line1, header_line1.len(), "SOZUBALANCEID");
-    let moves2 =
-        header2.remove_sticky_cookie_in_request(header_line2, header_line2.len(), "SOZUBALANCEID");
-    let moves3 =
-        header3.remove_sticky_cookie_in_request(header_line3, header_line3.len(), "SOZUBALANCEID");
+    let moves1 = header1.remove_sticky_cookie_in_request(
+        header_line1,
+        header_line1.len(),
+        DEFAULT_STICKY_NAME,
+    );
+    let moves2 = header2.remove_sticky_cookie_in_request(
+        header_line2,
+        header_line2.len(),
+        DEFAULT_STICKY_NAME,
+    );
+    let moves3 = header3.remove_sticky_cookie_in_request(
+        header_line3,
+        header_line3.len(),
+        DEFAULT_STICKY_NAME,
+    );
     let expected1 = vec![
         BufferMove::Advance(8),
         BufferMove::Advance(9),
@@ -1771,14 +1807,26 @@ fn header_cookies_sticky_end() {
         _ => panic!(),
     };
 
-    let moves1 =
-        header1.remove_sticky_cookie_in_request(header_line1, header_line1.len(), "SOZUBALANCEID");
-    let moves2 =
-        header2.remove_sticky_cookie_in_request(header_line2, header_line2.len(), "SOZUBALANCEID");
-    let moves3 =
-        header3.remove_sticky_cookie_in_request(header_line3, header_line3.len(), "SOZUBALANCEID");
-    let moves4 =
-        header4.remove_sticky_cookie_in_request(header_line4, header_line4.len(), "SOZUBALANCEID");
+    let moves1 = header1.remove_sticky_cookie_in_request(
+        header_line1,
+        header_line1.len(),
+        DEFAULT_STICKY_NAME,
+    );
+    let moves2 = header2.remove_sticky_cookie_in_request(
+        header_line2,
+        header_line2.len(),
+        DEFAULT_STICKY_NAME,
+    );
+    let moves3 = header3.remove_sticky_cookie_in_request(
+        header_line3,
+        header_line3.len(),
+        DEFAULT_STICKY_NAME,
+    );
+    let moves4 = header4.remove_sticky_cookie_in_request(
+        header_line4,
+        header_line4.len(),
+        DEFAULT_STICKY_NAME,
+    );
     let expected1 = vec![
         BufferMove::Advance(8),
         BufferMove::Advance(7),

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -18,12 +18,12 @@ use sozu_command::{
     config::Config,
     ready::Ready,
     request::{
-        ActivateListener, Cluster, DeactivateListener, ListenerType, QueryCertificateType,
-        QueryClusterType, RemoveBackend, Request, WorkerRequest,
+        ActivateListener, AddBackend, Cluster, DeactivateListener, ListenerType,
+        QueryCertificateType, QueryClusterType, RemoveBackend, Request, WorkerRequest,
     },
     response::{
-        Backend as CommandLibBackend, Event, HttpListenerConfig, HttpsListenerConfig, MessageId,
-        ProxyResponse, ProxyResponseContent, QueryAnswer, QueryAnswerCertificate, ResponseStatus,
+        Event, HttpListenerConfig, HttpsListenerConfig, MessageId, ProxyResponse,
+        ProxyResponseContent, QueryAnswer, QueryAnswerCertificate, ResponseStatus,
         TcpListenerConfig as CommandTcpListener,
     },
     scm_socket::{Listeners, ScmSocket},
@@ -1025,25 +1025,26 @@ impl Server {
             );
     }
 
-    fn add_backend(&mut self, req_id: &str, backend: &CommandLibBackend) -> ProxyResponse {
+    fn add_backend(&mut self, req_id: &str, add_backend: &AddBackend) -> ProxyResponse {
         let new_backend = Backend::new(
-            &backend.backend_id,
-            backend.address,
-            backend.sticky_id.clone(),
-            backend.load_balancing_parameters.clone(),
-            backend.backup,
+            &add_backend.backend_id,
+            add_backend.address.parse().unwrap(),
+            add_backend.sticky_id.clone(),
+            add_backend.load_balancing_parameters.clone(),
+            add_backend.backup,
         );
         self.backends
             .borrow_mut()
-            .add_backend(&backend.cluster_id, new_backend);
+            .add_backend(&add_backend.cluster_id, new_backend);
 
         ProxyResponse::ok(req_id)
     }
 
     fn remove_backend(&mut self, req_id: &str, backend: &RemoveBackend) -> ProxyResponse {
+        let address = backend.address.parse().unwrap();
         self.backends
             .borrow_mut()
-            .remove_backend(&backend.cluster_id, &backend.address);
+            .remove_backend(&backend.cluster_id, &address);
 
         ProxyResponse::ok(req_id)
     }

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -16,7 +16,6 @@ use mio::{
 };
 use rusty_ulid::Ulid;
 use slab::Slab;
-use sozu_command::response::RequestTcpFrontend;
 use time::{Duration, Instant};
 
 use crate::{
@@ -38,7 +37,7 @@ use crate::{
         config::ProxyProtocolConfig,
         logging,
         ready::Ready,
-        request::{Request, WorkerRequest},
+        request::{Request, RequestTcpFrontend, WorkerRequest},
         response::{Event, ProxyResponse, TcpListenerConfig},
         scm_socket::ScmSocket,
         state::ClusterId,

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -1868,7 +1868,7 @@ mod tests {
             command
                 .write_message(&WorkerRequest {
                     id: String::from("ID_YOLO2"),
-                    content: Request::AddBackend(backend),
+                    content: Request::AddBackend(backend.to_add_backend()),
                 })
                 .unwrap();
         }
@@ -1899,7 +1899,7 @@ mod tests {
             command
                 .write_message(&WorkerRequest {
                     id: String::from("ID_YOLO4"),
-                    content: Request::AddBackend(backend),
+                    content: Request::AddBackend(backend.to_add_backend()),
                 })
                 .unwrap();
         }

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -1,7 +1,7 @@
 use std::{
     cell::RefCell,
     collections::{hash_map::Entry, BTreeMap, HashMap},
-    io::{self, ErrorKind},
+    io::ErrorKind,
     net::{Shutdown, SocketAddr},
     os::unix::io::AsRawFd,
     rc::Rc,
@@ -16,6 +16,7 @@ use mio::{
 };
 use rusty_ulid::Ulid;
 use slab::Slab;
+use sozu_command::response::RequestTcpFrontend;
 use time::{Duration, Instant};
 
 use crate::{
@@ -38,7 +39,7 @@ use crate::{
         logging,
         ready::Ready,
         request::{Request, WorkerRequest},
-        response::{Event, ProxyResponse, TcpFrontend, TcpListenerConfig},
+        response::{Event, ProxyResponse, TcpListenerConfig},
         scm_socket::ScmSocket,
         state::ClusterId,
     },
@@ -1271,49 +1272,47 @@ impl TcpProxy {
             })
     }
 
-    pub fn add_tcp_front(&mut self, front: TcpFrontend) -> Result<(), io::Error> {
+    pub fn add_tcp_front(&mut self, front: RequestTcpFrontend) -> anyhow::Result<()> {
+        let address = front
+            .address
+            .parse()
+            .with_context(|| "wrong socket address")?;
+
         let mut listener = match self
             .listeners
             .values()
-            .find(|l| l.borrow().address == front.address)
+            .find(|l| l.borrow().address == address)
         {
             Some(l) => l.borrow_mut(),
-            None => {
-                return Err(io::Error::new(
-                    io::ErrorKind::NotFound,
-                    format!("no such listener for '{}'", front.address),
-                ));
-            }
+            None => bail!(format!("no such listener for '{}'", front.address)),
         };
 
         self.fronts
             .insert(front.cluster_id.to_string(), listener.token);
-
         listener.set_tags(front.address.to_string(), front.tags);
         listener.cluster_id = Some(front.cluster_id.to_string());
         Ok(())
     }
 
-    pub fn remove_tcp_front(&mut self, front: &TcpFrontend) -> Result<(), io::Error> {
+    pub fn remove_tcp_front(&mut self, front: RequestTcpFrontend) -> anyhow::Result<()> {
+        let address = front
+            .address
+            .parse()
+            .with_context(|| "wrong socket address")?;
+
         let mut listener = match self
             .listeners
             .values()
-            .find(|l| l.borrow().address == front.address)
+            .find(|l| l.borrow().address == address)
         {
             Some(l) => l.borrow_mut(),
-            None => {
-                return Err(io::Error::new(
-                    io::ErrorKind::NotFound,
-                    format!("no such listener for '{}'", front.address),
-                ));
-            }
+            None => bail!(format!("no such listener for '{}'", front.address)),
         };
 
         listener.set_tags(front.address.to_string(), None);
         if let Some(cluster_id) = listener.cluster_id.take() {
             self.fronts.remove(&cluster_id);
         }
-
         Ok(())
     }
 }
@@ -1329,7 +1328,7 @@ impl ProxyConfiguration for TcpProxy {
                 ProxyResponse::ok(message.id)
             }
             Request::RemoveTcpFrontend(front) => {
-                if let Err(err) = self.remove_tcp_front(&front) {
+                if let Err(err) = self.remove_tcp_front(front) {
                     return ProxyResponse::error(message.id, err);
                 }
 
@@ -1841,11 +1840,9 @@ mod tests {
 
         command.blocking().unwrap();
         {
-            let front = TcpFrontend {
+            let front = RequestTcpFrontend {
                 cluster_id: String::from("yolo"),
-                address: "127.0.0.1:1234"
-                    .parse()
-                    .with_context(|| "Could not parse address")?,
+                address: "127.0.0.1:1234".to_string(),
                 tags: None,
             };
             let backend = sozu_command_lib::response::Backend {
@@ -1873,11 +1870,9 @@ mod tests {
                 .unwrap();
         }
         {
-            let front = TcpFrontend {
+            let front = RequestTcpFrontend {
                 cluster_id: String::from("yolo"),
-                address: "127.0.0.1:1235"
-                    .parse()
-                    .with_context(|| "Could not parse address")?,
+                address: "127.0.0.1:1235".to_string(),
                 tags: None,
             };
             let backend = sozu_command::response::Backend {

--- a/lib/src/tls.rs
+++ b/lib/src/tls.rs
@@ -661,7 +661,7 @@ mod tests {
 
     #[test]
     fn lifecycle() -> Result<(), Box<dyn Error + Send + Sync>> {
-        let address = "127.0.0.1:8080".parse()?;
+        let address = "127.0.0.1:8080".to_string();
         let mut resolver = GenericCertificateResolver::new();
         let certificate_and_key = CertificateAndKey {
             certificate: String::from(include_str!("../assets/certificate.pem")),
@@ -674,7 +674,7 @@ mod tests {
             .map_err(|err| GenericCertificateResolverError::PemParseError(err.to_string()))?;
 
         let fingerprint = resolver.add_certificate(&AddCertificate {
-            address,
+            address: address.clone(),
             certificate: certificate_and_key,
             names: vec![],
             expired_at: None,
@@ -711,7 +711,7 @@ mod tests {
 
     #[test]
     fn name_override() -> Result<(), Box<dyn Error + Send + Sync>> {
-        let address = "127.0.0.1:8080".parse()?;
+        let address = "127.0.0.1:8080".to_string();
         let mut resolver = GenericCertificateResolver::new();
         let certificate_and_key = CertificateAndKey {
             certificate: String::from(include_str!("../assets/certificate.pem")),
@@ -724,7 +724,7 @@ mod tests {
             .map_err(|err| GenericCertificateResolverError::PemParseError(err.to_string()))?;
 
         let fingerprint = resolver.add_certificate(&AddCertificate {
-            address,
+            address: address.clone(),
             certificate: certificate_and_key,
             names: vec!["localhost".into(), "lolcatho.st".into()],
             expired_at: None,
@@ -772,7 +772,7 @@ mod tests {
 
     #[test]
     fn replacement() -> Result<(), Box<dyn Error + Send + Sync>> {
-        let address = "127.0.0.1:8080".parse()?;
+        let address = "127.0.0.1:8080".to_string();
         let mut resolver = GenericCertificateResolver::new();
 
         // ---------------------------------------------------------------------
@@ -789,7 +789,7 @@ mod tests {
 
         let names_1y = resolver.certificate_names(&pem)?;
         let fingerprint_1y = resolver.add_certificate(&AddCertificate {
-            address,
+            address: address.clone(),
             certificate: certificate_and_key_1y,
             names: vec![],
             expired_at: None,
@@ -843,7 +843,7 @@ mod tests {
 
     #[test]
     fn expiration_override() -> Result<(), Box<dyn Error + Send + Sync>> {
-        let address = "127.0.0.1:8080".parse()?;
+        let address = "127.0.0.1:8080".to_string();
         let mut resolver = GenericCertificateResolver::new();
 
         // ---------------------------------------------------------------------
@@ -860,7 +860,7 @@ mod tests {
 
         let names_1y = resolver.certificate_names(&pem)?;
         let fingerprint_1y = resolver.add_certificate(&AddCertificate {
-            address,
+            address: address.clone(),
             certificate: certificate_and_key_1y,
             names: vec![],
             expired_at: Some(
@@ -972,12 +972,12 @@ mod tests {
 
         // ---------------------------------------------------------------------
         // load certificates in resolver
-        let address = "127.0.0.1:8080".parse()?;
+        let address = "127.0.0.1:8080".to_string();
         let mut resolver = GenericCertificateResolver::default();
 
         for certificate in &certificates {
             resolver.add_certificate(&AddCertificate {
-                address,
+                address: address.clone(),
                 certificate: certificate.to_owned(),
                 names: vec![],
                 expired_at: None,


### PR DESCRIPTION
In order to fit in protobuf, we need to get rid of `SocketAddr` as a type in the requests that Sōzu receives.

This PR:
- rewrites parts of how the TOML config is parsed, using a intermediate struct `ConfigBuilder`
- introduces a builder pattern for `Listener`