### PR TITLE
Refactor listeners socket addresses

### DIFF
--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -36,7 +36,7 @@ pub fn print_listeners(listeners_list: ListenersList) {
 
     println!("\nHTTPS LISTENERS\n================");
 
-    for (_, (https_listener, activated)) in listeners_list.https_listeners.iter() {
+    for (_, https_listener) in listeners_list.https_listeners.iter() {
         let mut table = Table::new();
         table.set_format(*prettytable::format::consts::FORMAT_BOX_CHARS);
         let mut tls_versions = String::new();
@@ -78,7 +78,7 @@ pub fn print_listeners(listeners_list: ListenersList) {
         table.add_row(row!["back timeout", https_listener.back_timeout,]);
         table.add_row(row!["connect timeout", https_listener.connect_timeout,]);
         table.add_row(row!["request timeout", https_listener.request_timeout,]);
-        table.add_row(row!["activated", activated]);
+        table.add_row(row!["activated", https_listener.active]);
         table.printstd();
     }
 

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -11,7 +11,7 @@ use sozu_command_lib::response::{
 pub fn print_listeners(listeners_list: ListenersList) {
     println!("\nHTTP LISTENERS\n================");
 
-    for (_, (http_listener, activated)) in listeners_list.http_listeners.iter() {
+    for (_, http_listener) in listeners_list.http_listeners.iter() {
         let mut table = Table::new();
         table.set_format(*prettytable::format::consts::FORMAT_BOX_CHARS);
         table.add_row(row![
@@ -30,7 +30,7 @@ pub fn print_listeners(listeners_list: ListenersList) {
         table.add_row(row!["back timeout", http_listener.back_timeout]);
         table.add_row(row!["connect timeout", http_listener.connect_timeout]);
         table.add_row(row!["request timeout", http_listener.request_timeout]);
-        table.add_row(row!["activated", activated]);
+        table.add_row(row!["activated", http_listener.active]);
         table.printstd();
     }
 

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -97,7 +97,7 @@ pub fn print_listeners(listeners_list: ListenersList) {
             "connect timeout",
             "activated"
         ]);
-        for (_, (tcp_listener, activated)) in listeners_list.tcp_listeners.iter() {
+        for (_, tcp_listener) in listeners_list.tcp_listeners.iter() {
             table.add_row(row![
                 format!("{:?}", tcp_listener.address),
                 format!("{:?}", tcp_listener.public_address),
@@ -105,7 +105,7 @@ pub fn print_listeners(listeners_list: ListenersList) {
                 tcp_listener.front_timeout,
                 tcp_listener.back_timeout,
                 tcp_listener.connect_timeout,
-                activated,
+                tcp_listener.active,
             ]);
         }
         table.printstd();

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -296,6 +296,7 @@ impl ListenerBuilder {
             request_timeout: self.request_timeout.unwrap_or(DEFAULT_REQUEST_TIMEOUT),
             answer_404,
             answer_503,
+            active: false,
         };
 
         Ok(configuration)

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -397,6 +397,7 @@ impl ListenerBuilder {
             cipher_suites,
             signature_algorithms,
             groups_list,
+            active: false,
         };
 
         Ok(https_listener_config)

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -426,6 +426,7 @@ impl ListenerBuilder {
             front_timeout: self.front_timeout.unwrap_or(DEFAULT_FRONT_TIMEOUT),
             back_timeout: self.back_timeout.unwrap_or(DEFAULT_BACK_TIMEOUT),
             connect_timeout: self.connect_timeout.unwrap_or(DEFAULT_CONNECT_TIMEOUT),
+            active: false,
         })
     }
 

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -277,9 +277,17 @@ impl ListenerBuilder {
             .get_404_503_answers()
             .with_context(|| "Could not get 404 and 503 answers from file system")?;
 
+        let _address = self
+            .parse_address()
+            .with_context(|| "wrong socket address")?;
+
+        let _public_address = self
+            .parse_public_address()
+            .with_context(|| "wrong public address")?;
+
         let configuration = HttpListenerConfig {
-            address: self.parse_address()?,
-            public_address: self.parse_public_address()?,
+            address: self.address.clone(),
+            public_address: self.public_address.clone(),
             expect_proxy: self.expect_proxy.unwrap_or(false),
             sticky_name: self.sticky_name.clone(),
             front_timeout: self.front_timeout.unwrap_or(DEFAULT_FRONT_TIMEOUT),
@@ -362,10 +370,18 @@ impl ListenerBuilder {
             .get_404_503_answers()
             .with_context(|| "Could not get 404 and 503 answers from file system")?;
 
+        let _address = self
+            .parse_address()
+            .with_context(|| "wrong socket address")?;
+
+        let _public_address = self
+            .parse_public_address()
+            .with_context(|| "wrong public address")?;
+
         let https_listener_config = HttpsListenerConfig {
-            address: self.parse_address()?,
+            address: self.address.clone(),
             sticky_name: self.sticky_name.clone(),
-            public_address: self.parse_public_address()?,
+            public_address: self.public_address.clone(),
             cipher_list,
             versions,
             expect_proxy: self.expect_proxy.unwrap_or(false),
@@ -395,9 +411,17 @@ impl ListenerBuilder {
             ));
         }
 
+        let _address = self
+            .parse_address()
+            .with_context(|| "wrong socket address")?;
+
+        let _public_address = self
+            .parse_public_address()
+            .with_context(|| "wrong public address")?;
+
         Ok(TcpListenerConfig {
-            address: self.parse_address()?,
-            public_address: self.parse_public_address()?,
+            address: self.address.clone(),
+            public_address: self.public_address.clone(),
             expect_proxy: self.expect_proxy.unwrap_or(false),
             front_timeout: self.front_timeout.unwrap_or(DEFAULT_FRONT_TIMEOUT),
             back_timeout: self.back_timeout.unwrap_or(DEFAULT_BACK_TIMEOUT),
@@ -1078,7 +1102,7 @@ impl ConfigBuilder {
                                 if frontend.certificate.is_none() {
                                     if let Some(https_listener) =
                                         self.built.https_listeners.iter().find(|listener| {
-                                            listener.address == frontend.address
+                                            listener.address == frontend.address.to_string()
                                                 && listener.certificate.is_some()
                                         })
                                     {
@@ -1341,7 +1365,7 @@ impl Config {
                 v.push(WorkerRequest {
                     id: format!("CONFIG-{count}"),
                     content: Request::ActivateListener(ActivateListener {
-                        address: listener.address,
+                        address: listener.address.clone(),
                         proxy: ListenerType::HTTP,
                         from_scm: false,
                     }),
@@ -1353,7 +1377,7 @@ impl Config {
                 v.push(WorkerRequest {
                     id: format!("CONFIG-{count}"),
                     content: Request::ActivateListener(ActivateListener {
-                        address: listener.address,
+                        address: listener.address.clone(),
                         proxy: ListenerType::HTTPS,
                         from_scm: false,
                     }),
@@ -1365,7 +1389,7 @@ impl Config {
                 v.push(WorkerRequest {
                     id: format!("CONFIG-{count}"),
                     content: Request::ActivateListener(ActivateListener {
-                        address: listener.address,
+                        address: listener.address.clone(),
                         proxy: ListenerType::TCP,
                         from_scm: false,
                     }),

--- a/command/src/request.rs
+++ b/command/src/request.rs
@@ -249,20 +249,20 @@ pub enum ListenerType {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct RemoveListener {
-    pub address: SocketAddr,
+    pub address: String,
     pub proxy: ListenerType,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ActivateListener {
-    pub address: SocketAddr,
+    pub address: String,
     pub proxy: ListenerType,
     pub from_scm: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct DeactivateListener {
-    pub address: SocketAddr,
+    pub address: String,
     pub proxy: ListenerType,
     pub to_scm: bool,
 }

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -326,16 +326,17 @@ impl Backend {
 /// the bool indicates if it is active or not
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct ListenersList {
-    pub http_listeners: HashMap<SocketAddr, (HttpListenerConfig, bool)>,
-    pub https_listeners: HashMap<SocketAddr, (HttpsListenerConfig, bool)>,
-    pub tcp_listeners: HashMap<SocketAddr, (TcpListenerConfig, bool)>,
+    /// address -> (listener_config, activated)
+    pub http_listeners: HashMap<String, (HttpListenerConfig, bool)>,
+    pub https_listeners: HashMap<String, (HttpsListenerConfig, bool)>,
+    pub tcp_listeners: HashMap<String, (TcpListenerConfig, bool)>,
 }
 
 /// details of an HTTP listener, sent by the main process to the worker
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HttpListenerConfig {
-    pub address: SocketAddr,
-    pub public_address: Option<SocketAddr>,
+    pub address: String,
+    pub public_address: Option<String>,
     pub answer_404: String,
     pub answer_503: String,
     #[serde(default)]
@@ -357,8 +358,8 @@ pub struct HttpListenerConfig {
 /// details of an HTTPS listener, sent by the main process to the worker
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HttpsListenerConfig {
-    pub address: SocketAddr,
-    pub public_address: Option<SocketAddr>,
+    pub address: String,
+    pub public_address: Option<String>,
     pub answer_404: String,
     pub answer_503: String,
     pub versions: Vec<TlsVersion>,
@@ -389,10 +390,10 @@ pub struct HttpsListenerConfig {
 /// details of an TCP listener, sent by the main process to the worker
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TcpListenerConfig {
-    pub address: SocketAddr,
+    pub address: String,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub public_address: Option<SocketAddr>,
+    pub public_address: Option<String>,
     #[serde(default)]
     #[serde(skip_serializing_if = "is_false")]
     pub expect_proxy: bool,

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -327,7 +327,7 @@ impl Backend {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct ListenersList {
     /// address -> (listener_config, activated)
-    pub http_listeners: HashMap<String, (HttpListenerConfig, bool)>,
+    pub http_listeners: HashMap<String, HttpListenerConfig>,
     pub https_listeners: HashMap<String, HttpsListenerConfig>,
     pub tcp_listeners: HashMap<String, TcpListenerConfig>,
 }
@@ -353,6 +353,8 @@ pub struct HttpListenerConfig {
     pub connect_timeout: u32,
     /// max time to send a complete request
     pub request_timeout: u32,
+    /// should default to false
+    pub active: bool,
 }
 
 /// details of an HTTPS listener, sent by the main process to the worker

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -12,7 +12,7 @@ use crate::{
         default_sticky_name, is_false, AddBackend, Cluster, LoadBalancingParams,
         RequestHttpFrontend, RequestTcpFrontend, PROTOCOL_VERSION,
     },
-    state::{ConfigState, ClusterId},
+    state::{ClusterId, ConfigState},
 };
 
 /// Responses of the main process to the CLI (or other client)
@@ -329,7 +329,7 @@ pub struct ListenersList {
     /// address -> (listener_config, activated)
     pub http_listeners: HashMap<String, (HttpListenerConfig, bool)>,
     pub https_listeners: HashMap<String, (HttpsListenerConfig, bool)>,
-    pub tcp_listeners: HashMap<String, (TcpListenerConfig, bool)>,
+    pub tcp_listeners: HashMap<String, TcpListenerConfig>,
 }
 
 /// details of an HTTP listener, sent by the main process to the worker
@@ -400,6 +400,8 @@ pub struct TcpListenerConfig {
     pub front_timeout: u32,
     pub back_timeout: u32,
     pub connect_timeout: u32,
+    /// should default to false
+    pub active: bool,
 }
 
 /// Runstate of a worker

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -328,7 +328,7 @@ impl Backend {
 pub struct ListenersList {
     /// address -> (listener_config, activated)
     pub http_listeners: HashMap<String, (HttpListenerConfig, bool)>,
-    pub https_listeners: HashMap<String, (HttpsListenerConfig, bool)>,
+    pub https_listeners: HashMap<String, HttpsListenerConfig>,
     pub tcp_listeners: HashMap<String, TcpListenerConfig>,
 }
 
@@ -385,6 +385,8 @@ pub struct HttpsListenerConfig {
     pub connect_timeout: u32,
     /// max time to send a complete request
     pub request_timeout: u32,
+    /// should default to false
+    pub active: bool,
 }
 
 /// details of an TCP listener, sent by the main process to the worker

--- a/e2e/src/tests/mod.rs
+++ b/e2e/src/tests/mod.rs
@@ -47,7 +47,7 @@ pub fn setup_test<S: Into<String>>(
         ListenerBuilder::new_http(front_address).to_http().unwrap(),
     ));
     worker.send_proxy_request(Request::ActivateListener(ActivateListener {
-        address: front_address,
+        address: front_address.to_string(),
         proxy: ListenerType::HTTP,
         from_scm: false,
     }));

--- a/e2e/src/tests/tests.rs
+++ b/e2e/src/tests/tests.rs
@@ -1,5 +1,6 @@
 use std::{
     io::stdout,
+    net::SocketAddr,
     thread,
     time::{Duration, Instant},
 };
@@ -273,7 +274,7 @@ pub fn try_issue_810_timeout() -> State {
 }
 
 pub fn try_issue_810_panic(part2: bool) -> State {
-    let front_address = "127.0.0.1:2001"
+    let front_address: SocketAddr = "127.0.0.1:2001"
         .parse()
         .expect("could not parse front address");
     let back_address = "127.0.0.1:2002"
@@ -287,7 +288,7 @@ pub fn try_issue_810_panic(part2: bool) -> State {
         ListenerBuilder::new_tcp(front_address).to_tcp().unwrap(),
     ));
     worker.send_proxy_request(Request::ActivateListener(ActivateListener {
-        address: front_address,
+        address: front_address.to_string(),
         proxy: ListenerType::TCP,
         from_scm: false,
     }));
@@ -338,7 +339,7 @@ pub fn try_issue_810_panic(part2: bool) -> State {
 }
 
 pub fn try_tls_endpoint() -> State {
-    let front_address = "127.0.0.1:2001"
+    let front_address: SocketAddr = "127.0.0.1:2001"
         .parse()
         .expect("could not parse front address");
     let back_address = "127.0.0.1:2002"
@@ -353,7 +354,7 @@ pub fn try_tls_endpoint() -> State {
     ));
 
     worker.send_proxy_request(Request::ActivateListener(ActivateListener {
-        address: front_address,
+        address: front_address.to_string(),
         proxy: ListenerType::HTTPS,
         from_scm: false,
     }));
@@ -621,7 +622,7 @@ fn try_http_behaviors() -> State {
 
     info!("starting up");
 
-    let front_address = "127.0.0.1:2001"
+    let front_address: SocketAddr = "127.0.0.1:2001"
         .parse()
         .expect("could not parse front address");
 
@@ -632,7 +633,7 @@ fn try_http_behaviors() -> State {
         ListenerBuilder::new_http(front_address).to_http().unwrap(),
     ));
     worker.send_proxy_request(Request::ActivateListener(ActivateListener {
-        address: front_address,
+        address: front_address.to_string(),
         proxy: ListenerType::HTTP,
         from_scm: false,
     }));

--- a/lib/examples/tcp.rs
+++ b/lib/examples/tcp.rs
@@ -45,6 +45,7 @@ fn main() -> anyhow::Result<()> {
             front_timeout: 60,
             back_timeout: 30,
             connect_timeout: 3,
+            active: false,
         };
         Logger::init(
             "TCP".to_string(),

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -434,7 +434,7 @@ pub enum AcceptError {
     TooManySessions,
     WouldBlock,
     RegisterError,
-    WrongSocketAddress
+    WrongSocketAddress,
 }
 
 use self::server::ListenToken;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -434,6 +434,7 @@ pub enum AcceptError {
     TooManySessions,
     WouldBlock,
     RegisterError,
+    WrongSocketAddress
 }
 
 use self::server::ListenToken;

--- a/lib/src/protocol/http/mod.rs
+++ b/lib/src/protocol/http/mod.rs
@@ -22,6 +22,7 @@ use crate::{
     pool::Pool,
     protocol::SessionResult,
     retry::RetryPolicy,
+    router::Route,
     server::{push_event, CONN_RETRIES},
     socket::{SocketHandler, SocketResult, TransportProtocol},
     sozu_command::ready::Ready,
@@ -29,7 +30,7 @@ use crate::{
     util::UnwrapLog,
     Backend, BackendConnectAction, BackendConnectionStatus, L7ListenerHandler, L7Proxy,
     ListenerHandler, LogDuration, ProxySession, SessionIsToBeClosed,
-    {Protocol, Readiness, SessionMetrics, StateResult}, router::Route,
+    {Protocol, Readiness, SessionMetrics, StateResult},
 };
 
 use self::parser::{

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -1805,6 +1805,7 @@ mod tests {
                 front_timeout: 60,
                 back_timeout: 30,
                 connect_timeout: 3,
+                active: false,
             };
 
             {

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -1127,17 +1127,25 @@ impl ListenerHandler for TcpListener {
 }
 
 impl TcpListener {
-    fn new(config: TcpListenerConfig, pool: Rc<RefCell<Pool>>, token: Token) -> TcpListener {
-        TcpListener {
+    fn new(
+        config: TcpListenerConfig,
+        pool: Rc<RefCell<Pool>>,
+        token: Token,
+    ) -> anyhow::Result<TcpListener> {
+        let address = config
+            .address
+            .parse()
+            .with_context(|| "wrong socket address")?;
+        Ok(TcpListener {
             cluster_id: None,
             listener: None,
             token,
-            address: config.address,
+            address,
             pool,
             config,
             active: false,
             tags: BTreeMap::new(),
-        }
+        })
     }
 
     // TODO: return Result with context
@@ -1151,10 +1159,10 @@ impl TcpListener {
         }
 
         let mut listener = tcp_listener.or_else(|| {
-            server_bind(self.config.address)
+            server_bind(self.config.address.clone())
                 .map_err(|e| {
                     error!(
-                        "could not create listener {:?}: {:?}",
+                        "could not create listener {:?}: {:#}",
                         self.config.address, e
                     );
                 })
@@ -1213,13 +1221,15 @@ impl TcpProxy {
         config: TcpListenerConfig,
         pool: Rc<RefCell<Pool>>,
         token: Token,
-    ) -> Option<Token> {
+    ) -> anyhow::Result<Token> {
         match self.listeners.entry(token) {
             Entry::Vacant(entry) => {
-                entry.insert(Rc::new(RefCell::new(TcpListener::new(config, pool, token))));
-                Some(token)
+                let tcp_listener = TcpListener::new(config, pool, token)
+                    .with_context(|| "Could not create TCP listener")?;
+                entry.insert(Rc::new(RefCell::new(tcp_listener)));
+                Ok(token)
             }
-            _ => None,
+            _ => bail!("It seems a listener already exists for this token"),
         }
     }
 
@@ -1383,7 +1393,16 @@ impl ProxyConfiguration for TcpProxy {
                 WorkerResponse::ok(message.id)
             }
             Request::RemoveListener(remove) => {
-                if !self.remove_listener(remove.address) {
+                let address = match remove.address.parse() {
+                    Ok(a) => a,
+                    Err(e) => {
+                        return WorkerResponse::error(
+                            message.id,
+                            format!("Wrong socket address: {}", e),
+                        )
+                    }
+                };
+                if !self.remove_listener(address) {
                     WorkerResponse::error(
                         message.id,
                         format!("no TCP listener to remove at address {:?}", remove.address),
@@ -1562,14 +1581,14 @@ pub fn start_tcp_worker(
     };
 
     let sessions = SessionManager::new(sessions, max_buffers);
-    let address = config.address;
+    let address = config.address.clone();
     let registry = poll
         .registry()
         .try_clone()
         .with_context(|| "Failed at creating a registry")?;
     let mut configuration = TcpProxy::new(registry, sessions.clone(), backends.clone());
     let _ = configuration.add_listener(config, pool.clone(), token);
-    let _ = configuration.activate_listener(&address, None);
+    let _ = configuration.activate_listener(&address.parse().unwrap(), None);
     let (scm_server, _scm_client) =
         UnixStream::pair().with_context(|| "Failed at creating scm stream sockets")?;
     let scm_socket =
@@ -1780,7 +1799,7 @@ mod tests {
             let registry = poll.registry().try_clone().unwrap();
             let mut configuration = TcpProxy::new(registry, sessions.clone(), backends.clone());
             let listener_config = TcpListenerConfig {
-                address: "127.0.0.1:1234".parse().unwrap(),
+                address: "127.0.0.1:1234".to_string(),
                 public_address: None,
                 expect_proxy: false,
                 front_timeout: 60,
@@ -1789,12 +1808,12 @@ mod tests {
             };
 
             {
-                let address = listener_config.address;
+                let address = listener_config.address.clone();
                 let mut s = sessions.borrow_mut();
                 let entry = s.slab.vacant_entry();
                 let _ =
                     configuration.add_listener(listener_config, pool.clone(), Token(entry.key()));
-                let _ = configuration.activate_listener(&address, None);
+                let _ = configuration.activate_listener(&address.parse().unwrap(), None);
                 entry.insert(Rc::new(RefCell::new(ListenSession {
                     protocol: Protocol::TCPListen,
                 })));


### PR DESCRIPTION
In order to write these in protobuf:

- `HttpListenerConfig`
- `HttpsListenerConfig`
- `TcpListenerConfig`

We need to remove the `SocketAddr` types they contain and use `String` instead. Parsing to `SocketAddr` will be done a bit everywhere but only `String` will be passed between processes.

This PR also adds an `active` field on these listener configs. `active` is set to `false` by default, we need an `ActivateListener` request to set them to true.