### PR TITLE
Replace RouteKey with string

### DIFF
--- a/command/src/request.rs
+++ b/command/src/request.rs
@@ -1,4 +1,10 @@
-use std::{collections::BTreeMap, error, fmt, net::SocketAddr, str::FromStr};
+use std::{
+    collections::BTreeMap,
+    error,
+    fmt::{self, Display},
+    net::SocketAddr,
+    str::FromStr,
+};
 
 use anyhow::Context;
 
@@ -7,7 +13,7 @@ use crate::{
     config::ProxyProtocolConfig,
     response::{
         is_default_path_rule, HttpFrontend, HttpListenerConfig, HttpsListenerConfig, MessageId,
-        PathRule, RulePosition, TcpListenerConfig, PathRuleKind,
+        PathRule, PathRuleKind, RulePosition, TcpListenerConfig,
     },
     state::ClusterId,
 };
@@ -345,10 +351,12 @@ impl RequestHttpFrontend {
             tags: self.tags,
         })
     }
+}
 
+impl Display for RequestHttpFrontend {
     /// Used to create a unique summary of the frontend, used as a key in maps
-    pub fn to_string(&self) -> String {
-        let mut s = match &self.path.kind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match &self.path.kind {
             PathRuleKind::Prefix => {
                 format!("{};{};P{}", self.address, self.hostname, self.path.value)
             }
@@ -360,11 +368,10 @@ impl RequestHttpFrontend {
             }
         };
 
-        if let Some(method) = &self.method {
-            s = format!("{s};{method}");
+        match &self.method {
+            Some(method) => write!(f, "{s};{method}"),
+            None => write!(f, "{s}"),
         }
-
-        s
     }
 }
 


### PR DESCRIPTION
HTTP and HTTPS Frontends are stored in `ConfigState` using `RouteKey` as a key in BTreeMaps. RouteKey is a sum-up of what makes a frontend unique: address, hostname, path rule. Thus we avoid collisions in the BTreeMap.

```rust
struct ConfigState {
     // ...
     pub http_fronts: BTreeMap<RouteKey, HttpFrontend>
}
```

```rust
pub struct RouteKey {
    pub address: String,
    hostname: String,
    pub path_rule: PathRule,
    pub method: Option<String>,
}
```

Using a struct as key in a map is difficult to translate and serialize in protobuf though, so instead of using RouteKey I rewrote the maps to use a String as key, and this string is the exact same thing RouteKey was serialized to.

Since they are no more uses for RouteKey, I removed it.

Also, ConfigState has a `https_fronts` field but it is never populated. The HTTPS frontends are stored in `http_fronts`. So I removed the `https_fronts` field altogether, and then decided to populate it instead.
