### PR TITLE
Write response in protobuf

### DIFF
--- a/bin/src/acme.rs
+++ b/bin/src/acme.rs
@@ -12,10 +12,9 @@ use sozu_command_lib::{
     config::Config,
     proto::command::{
         request::RequestType, AddBackend, AddCertificate, CertificateAndKey, PathRule,
-        RemoveBackend, ReplaceCertificate, Request, RequestHttpFrontend, ResponseStatus,
+        RemoveBackend, ReplaceCertificate, Request, RequestHttpFrontend, Response, ResponseStatus,
         TlsVersion,
     },
-    response::Response,
 };
 
 use crate::util;
@@ -409,7 +408,7 @@ fn order_request(channel: &mut Channel<Request, Response>, request: Request) -> 
             .read_message()
             .with_context(|| "Could not read response on channel")?;
 
-        match response.status {
+        match response.status() {
             ResponseStatus::Processing => {
                 // do nothing here
                 // for other messages, we would loop over read_message

--- a/bin/src/acme.rs
+++ b/bin/src/acme.rs
@@ -12,9 +12,10 @@ use sozu_command_lib::{
     config::Config,
     proto::command::{
         request::RequestType, AddBackend, AddCertificate, CertificateAndKey, PathRule,
-        RemoveBackend, ReplaceCertificate, Request, RequestHttpFrontend, TlsVersion,
+        RemoveBackend, ReplaceCertificate, Request, RequestHttpFrontend, ResponseStatus,
+        TlsVersion,
     },
-    response::{Response, ResponseStatus},
+    response::Response,
 };
 
 use crate::util;

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -309,15 +309,6 @@ pub enum StateCmd {
         #[clap(short = 'f', long = "file")]
         file: String,
     },
-    #[clap(name = "dump", about = "Dump current state to STDOUT")]
-    Dump {
-        #[clap(
-            short = 'j',
-            long = "json",
-            help = "Print the command result in JSON format"
-        )]
-        json: bool,
-    },
 }
 
 #[derive(Subcommand, PartialEq, Eq, Clone, Debug)]

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -82,9 +82,8 @@ pub enum Advancement {
 // in which case Success caries the response data.
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum Success {
-    ClientClose(String),        // the client id
-    ClientNew(String),          // the client id
-    DumpState(ResponseContent), // the cloned state
+    ClientClose(String), // the client id
+    ClientNew(String),   // the client id
     HandledClientRequest,
     ListFrontends(ResponseContent), // the list of frontends
     ListListeners(ResponseContent), // the list of listeners
@@ -119,7 +118,6 @@ impl std::fmt::Display for Success {
         match self {
             Self::ClientClose(id) => write!(f, "Close client: {id}"),
             Self::ClientNew(id) => write!(f, "New client successfully added: {id}"),
-            Self::DumpState(_) => write!(f, "Successfully gathered state from the main process"),
             Self::HandledClientRequest => write!(f, "Successfully handled the client request"),
             Self::ListFrontends(_) => write!(f, "Successfully gathered the list of frontends"),
             Self::ListListeners(_) => write!(f, "Successfully listed all listeners"),

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -27,10 +27,10 @@ use sozu_command_lib::{
     config::Config,
     proto::command::{
         request::RequestType, response_content::ContentType, MetricsConfiguration, Request,
-        ResponseContent, ResponseStatus, RunState, Status,
+        Response, ResponseContent, ResponseStatus, RunState, Status,
     },
     request::WorkerRequest,
-    response::{Response, WorkerResponse},
+    response::WorkerResponse,
     scm_socket::{Listeners, ScmSocket},
     state::ConfigState,
 };

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -25,9 +25,11 @@ use serde::{Deserialize, Serialize};
 
 use sozu_command_lib::{
     config::Config,
-    proto::command::{request::RequestType, MetricsConfiguration, Request, RunState, Status},
+    proto::command::{
+        request::RequestType, MetricsConfiguration, Request, ResponseStatus, RunState, Status,
+    },
     request::WorkerRequest,
-    response::{Response, ResponseContent, ResponseStatus, WorkerResponse},
+    response::{Response, ResponseContent, WorkerResponse},
     scm_socket::{Listeners, ScmSocket},
     state::ConfigState,
 };

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -975,7 +975,7 @@ impl CommandServer {
             return_success(
                 command_tx,
                 thread_client_id,
-                Success::Status(ResponseContent::Status(worker_info_vec)),
+                Success::Status(ResponseContent::Workers(worker_info_vec)),
             )
             .await;
         })

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -19,11 +19,12 @@ use sozu_command_lib::{
     parser::parse_several_commands,
     proto::command::{
         request::RequestType, AggregatedMetrics, AvailableMetrics, ClusterHashes,
-        ClusterInformations, FrontendFilters, ListenersList, MetricsConfiguration, Request,
-        ResponseStatus, ReturnListenSockets, RunState, SoftStop, Status, WorkerInfo, WorkerInfos,
+        ClusterInformations, FrontendFilters, ListedFrontends, ListenersList, MetricsConfiguration,
+        Request, ResponseStatus, ReturnListenSockets, RunState, SoftStop, Status, WorkerInfo,
+        WorkerInfos,
     },
     request::WorkerRequest,
-    response::{ListedFrontends, Response, ResponseContent},
+    response::{Response, ResponseContent},
     scm_socket::Listeners,
     state::get_cluster_ids_by_domain,
 };
@@ -368,7 +369,7 @@ impl CommandServer {
             }) {
                 listed_frontends
                     .http_frontends
-                    .push(http_frontend.1.to_owned());
+                    .push(http_frontend.1.to_owned().into());
             }
         }
 
@@ -382,13 +383,15 @@ impl CommandServer {
             }) {
                 listed_frontends
                     .https_frontends
-                    .push(https_frontend.1.to_owned());
+                    .push(https_frontend.1.to_owned().into());
             }
         }
 
         if (filters.tcp || list_all) && filters.domain.is_none() {
             for tcp_frontend in self.state.tcp_fronts.values().flat_map(|v| v.iter()) {
-                listed_frontends.tcp_frontends.push(tcp_frontend.to_owned())
+                listed_frontends
+                    .tcp_frontends
+                    .push(tcp_frontend.to_owned().into())
             }
         }
 

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -204,20 +204,6 @@ impl CommandServer {
                     }
                     offset = buffer.data().offset(i);
 
-                    /*
-                    TODO: maybe we should put on WorkerRequest the version field we had on CommandRequest: a u32 to track versionning
-                    if requests.iter().any(|o| {
-                        if o.version > PROTOCOL_VERSION {
-                            error!("configuration protocol version mismatch: Sōzu handles up to version {}, the message uses version {}", PROTOCOL_VERSION, o.version);
-                            true
-                        } else {
-                            false
-                        }
-                    }) {
-                        break;
-                    }
-                    */
-
                     for request in requests {
                         message_counter += 1;
 

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -18,9 +18,9 @@ use sozu_command_lib::{
     logging,
     parser::parse_several_commands,
     proto::command::{
-        request::RequestType, AggregatedMetrics, AvailableMetrics, ClusterHashes, FrontendFilters,
-        ListenersList, MetricsConfiguration, Request, ResponseStatus, ReturnListenSockets,
-        RunState, SoftStop, Status, WorkerInfo, WorkerInfos,
+        request::RequestType, AggregatedMetrics, AvailableMetrics, ClusterHashes,
+        ClusterInformations, FrontendFilters, ListenersList, MetricsConfiguration, Request,
+        ResponseStatus, ReturnListenSockets, RunState, SoftStop, Status, WorkerInfo, WorkerInfos,
     },
     request::WorkerRequest,
     response::{ListedFrontends, Response, ResponseContent},
@@ -1082,12 +1082,12 @@ impl CommandServer {
             Some(RequestType::QueryClustersHashes(_)) => {
                 main_response_content = Some(ResponseContent::ClustersHashes(ClusterHashes {
                     map: self.state.hash_state(),
-                }));
+                }))
             }
             Some(RequestType::QueryClusterById(cluster_id)) => {
-                main_response_content = Some(ResponseContent::Clusters(vec![self
-                    .state
-                    .cluster_state(cluster_id)]))
+                main_response_content = Some(ResponseContent::Clusters(ClusterInformations {
+                    vec: vec![self.state.cluster_state(cluster_id)],
+                }))
             }
             Some(RequestType::QueryClustersByDomain(domain)) => {
                 let cluster_ids = get_cluster_ids_by_domain(
@@ -1095,11 +1095,12 @@ impl CommandServer {
                     domain.hostname.clone(),
                     domain.path.clone(),
                 );
-                let clusters = cluster_ids
+                let vec = cluster_ids
                     .iter()
                     .map(|cluster_id| self.state.cluster_state(cluster_id))
                     .collect();
-                main_response_content = Some(ResponseContent::Clusters(clusters));
+                main_response_content =
+                    Some(ResponseContent::Clusters(ClusterInformations { vec }));
             }
             _ => {}
         };

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -20,7 +20,7 @@ use sozu_command_lib::{
     proto::command::{
         request::RequestType, AggregatedMetrics, AvailableMetrics, FrontendFilters, ListenersList,
         MetricsConfiguration, Request, ResponseStatus, ReturnListenSockets, RunState, SoftStop,
-        Status, WorkerInfo,
+        Status, WorkerInfo, WorkerInfos,
     },
     request::WorkerRequest,
     response::{ListedFrontends, Response, ResponseContent},
@@ -431,7 +431,7 @@ impl CommandServer {
         debug!("workers: {:#?}", workers);
 
         Ok(Some(Success::ListWorkers(ResponseContent::Workers(
-            workers,
+            WorkerInfos { vec: workers },
         ))))
     }
 
@@ -965,10 +965,12 @@ impl CommandServer {
                 }
             }
 
-            let worker_info_vec: Vec<WorkerInfo> = worker_info_map
-                .values()
-                .map(|worker_info| worker_info.to_owned())
-                .collect();
+            let worker_info_vec = WorkerInfos {
+                vec: worker_info_map
+                    .values()
+                    .map(|worker_info| worker_info.to_owned())
+                    .collect(),
+            };
 
             return_success(
                 command_tx,

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -20,11 +20,10 @@ use sozu_command_lib::{
     proto::command::{
         request::RequestType, response_content::ContentType, AggregatedMetrics, AvailableMetrics,
         ClusterHashes, ClusterInformations, FrontendFilters, ListedFrontends, ListenersList,
-        MetricsConfiguration, Request, ResponseContent, ResponseStatus, ReturnListenSockets,
-        RunState, SoftStop, Status, WorkerInfo, WorkerInfos, WorkerResponses,
+        MetricsConfiguration, Request, Response, ResponseContent, ResponseStatus,
+        ReturnListenSockets, RunState, SoftStop, Status, WorkerInfo, WorkerInfos, WorkerResponses,
     },
     request::WorkerRequest,
-    response::Response,
     scm_socket::Listeners,
     state::get_cluster_ids_by_domain,
 };

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -49,7 +49,6 @@ impl CommandServer {
 
         let result: anyhow::Result<Option<Success>> = match request.request_type {
             Some(RequestType::SaveState(path)) => self.save_state(&path).await,
-            Some(RequestType::DumpState(_)) => self.dump_state().await,
             Some(RequestType::ListWorkers(_)) => self.list_workers().await,
             Some(RequestType::ListFrontends(filters)) => self.list_frontends(filters).await,
             Some(RequestType::ListListeners(_)) => self.list_listeners(),
@@ -74,7 +73,6 @@ impl CommandServer {
                 self.reload_configuration(client_id, path).await
             }
             Some(RequestType::Status(_)) => self.status(client_id).await,
-
             Some(RequestType::QueryCertificateByFingerprint(_))
             | Some(RequestType::QueryCertificatesByDomain(_))
             | Some(RequestType::QueryAllCertificates(_))
@@ -161,14 +159,6 @@ impl CommandServer {
         })();
 
         result.with_context(|| "Could not write the state onto the state file")
-    }
-
-    pub async fn dump_state(&mut self) -> anyhow::Result<Option<Success>> {
-        let state = self.state.clone();
-
-        Ok(Some(Success::DumpState(ResponseContent::State(Box::new(
-            state,
-        )))))
     }
 
     pub async fn load_state(
@@ -1393,8 +1383,7 @@ impl CommandServer {
 
                 let command_response_data = match success {
                     // should list Success::Metrics(crd) as well
-                    Success::DumpState(crd)
-                    | Success::ListFrontends(crd)
+                    Success::ListFrontends(crd)
                     | Success::ListWorkers(crd)
                     | Success::Query(crd)
                     | Success::ListListeners(crd)

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -19,10 +19,11 @@ use sozu_command_lib::{
     parser::parse_several_commands,
     proto::command::{
         request::RequestType, AggregatedMetrics, AvailableMetrics, FrontendFilters, ListenersList,
-        MetricsConfiguration, Request, ReturnListenSockets, RunState, SoftStop, Status, WorkerInfo,
+        MetricsConfiguration, Request, ResponseStatus, ReturnListenSockets, RunState, SoftStop,
+        Status, WorkerInfo,
     },
     request::WorkerRequest,
-    response::{ListedFrontends, Response, ResponseContent, ResponseStatus},
+    response::{ListedFrontends, Response, ResponseContent},
     scm_socket::Listeners,
     state::get_cluster_ids_by_domain,
 };

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -18,9 +18,9 @@ use sozu_command_lib::{
     logging,
     parser::parse_several_commands,
     proto::command::{
-        request::RequestType, AggregatedMetrics, AvailableMetrics, FrontendFilters, ListenersList,
-        MetricsConfiguration, Request, ResponseStatus, ReturnListenSockets, RunState, SoftStop,
-        Status, WorkerInfo, WorkerInfos,
+        request::RequestType, AggregatedMetrics, AvailableMetrics, ClusterHashes, FrontendFilters,
+        ListenersList, MetricsConfiguration, Request, ResponseStatus, ReturnListenSockets,
+        RunState, SoftStop, Status, WorkerInfo, WorkerInfos,
     },
     request::WorkerRequest,
     response::{ListedFrontends, Response, ResponseContent},
@@ -1080,8 +1080,9 @@ impl CommandServer {
         let mut main_response_content = None;
         match &request.request_type {
             Some(RequestType::QueryClustersHashes(_)) => {
-                main_response_content =
-                    Some(ResponseContent::ClustersHashes(self.state.hash_state()));
+                main_response_content = Some(ResponseContent::ClustersHashes(ClusterHashes {
+                    map: self.state.hash_state(),
+                }));
             }
             Some(RequestType::QueryClusterById(cluster_id)) => {
                 main_response_content = Some(ResponseContent::Clusters(vec![self

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -6,9 +6,10 @@ use serde::Serialize;
 use sozu_command_lib::{
     proto::command::{
         request::RequestType, ListWorkers, QueryAllCertificates, QueryClusterByDomain,
-        QueryClustersHashes, QueryMetricsOptions, Request, RunState, UpgradeMain, WorkerInfo,
+        QueryClustersHashes, QueryMetricsOptions, Request, ResponseStatus, RunState, UpgradeMain,
+        WorkerInfo,
     },
-    response::{Response, ResponseContent, ResponseStatus},
+    response::{Response, ResponseContent},
 };
 
 use crate::ctl::{

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -110,11 +110,11 @@ impl CommandManager {
                             ResponseContent::FrontendList(frontends) => {
                                 print_frontend_list(frontends)
                             }
-                            ResponseContent::Status(worker_info_vec) => {
+                            ResponseContent::Status(worker_infos) => {
                                 if json {
-                                    print_json_response(&worker_info_vec)?;
+                                    print_json_response(&worker_infos)?;
                                 } else {
-                                    print_status(worker_info_vec);
+                                    print_status(worker_infos);
                                 }
                             }
                             ResponseContent::ListenersList(list) => print_listeners(list),
@@ -152,11 +152,11 @@ impl CommandManager {
                     );
                 }
                 ResponseStatus::Ok => {
-                    if let Some(ResponseContent::Workers(ref workers)) = response.content {
+                    if let Some(ResponseContent::Workers(ref worker_infos)) = response.content {
                         let mut table = Table::new();
                         table.set_format(*prettytable::format::consts::FORMAT_BOX_CHARS);
                         table.add_row(row!["Worker", "pid", "run state"]);
-                        for worker in workers.iter() {
+                        for worker in worker_infos.vec.iter() {
                             let run_state = format!("{:?}", worker.run_state);
                             table.add_row(row![worker.id, worker.pid, run_state]);
                         }
@@ -204,7 +204,7 @@ impl CommandManager {
                             .with_context(|| "could not reconnect to the command unix socket")?;
 
                         // Do a rolling restart of the workers
-                        let running_workers = workers
+                        let running_workers = worker_infos.vec
                             .iter()
                             .filter(|worker| worker.run_state == RunState::Running as i32)
                             .collect::<Vec<_>>();

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -102,10 +102,6 @@ impl CommandManager {
                             | ResponseContent::Certificates(_)
                             | ResponseContent::AvailableMetrics(_)
                             | ResponseContent::Event(_) => {}
-                            ResponseContent::State(state) => match json {
-                                true => print_json_response(&state)?,
-                                false => println!("{state:#?}"),
-                            },
                             ResponseContent::FrontendList(frontends) => {
                                 print_frontend_list(frontends)
                             }

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -1,6 +1,5 @@
 use anyhow::{self, bail, Context};
 use prettytable::Table;
-use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use serde::Serialize;
 
 use sozu_command_lib::{
@@ -9,7 +8,7 @@ use sozu_command_lib::{
         QueryClusterByDomain, QueryClustersHashes, QueryMetricsOptions, Request, ResponseContent,
         ResponseStatus, RunState, UpgradeMain, WorkerInfo,
     },
-    response::{Response},
+    response::Response,
 };
 
 use crate::ctl::{
@@ -26,26 +25,6 @@ use crate::ctl::{
 struct WorkerStatus<'a> {
     pub worker: &'a WorkerInfo,
     pub status: &'a String,
-}
-
-/*
-fn generate_id() -> String {
-    let s: String = thread_rng()
-    .sample_iter(&Alphanumeric)
-    .take(6)
-    .map(|c| c as char)
-    .collect();
-format!("ID-{s}")
-}
-*/
-
-fn generate_tagged_id(tag: &str) -> String {
-    let s: String = thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(6)
-        .map(|c| c as char)
-        .collect();
-    format!("{tag}-{s}")
 }
 
 impl CommandManager {
@@ -70,8 +49,6 @@ impl CommandManager {
         request: Request,
         json: bool,
     ) -> Result<(), anyhow::Error> {
-        // let id = generate_id();
-
         println!("Sending request : {request:?}");
 
         self.channel
@@ -154,7 +131,6 @@ impl CommandManager {
                         table.printstd();
                         println!();
 
-                        let id = generate_tagged_id("UPGRADE-MAIN");
                         self.send_request(Request {
                             request_type: Some(RequestType::UpgradeMain(UpgradeMain {})),
                         })?;
@@ -163,10 +139,6 @@ impl CommandManager {
 
                         loop {
                             let response = self.read_channel_message_with_timeout()?;
-
-                            // if id != response.id {
-                            //     bail!("Error: received unexpected message: {:?}", response);
-                            // }
 
                             match response.status {
                                 ResponseStatus::Processing => {

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -2,13 +2,10 @@ use anyhow::{self, bail, Context};
 use prettytable::Table;
 use serde::Serialize;
 
-use sozu_command_lib::{
-    proto::command::{
-        request::RequestType, response_content::ContentType, ListWorkers, QueryAllCertificates,
-        QueryClusterByDomain, QueryClustersHashes, QueryMetricsOptions, Request, ResponseContent,
-        ResponseStatus, RunState, UpgradeMain, WorkerInfo,
-    },
-    response::Response,
+use sozu_command_lib::proto::command::{
+    request::RequestType, response_content::ContentType, ListWorkers, QueryAllCertificates,
+    QueryClusterByDomain, QueryClustersHashes, QueryMetricsOptions, Request, Response,
+    ResponseContent, ResponseStatus, RunState, UpgradeMain, WorkerInfo,
 };
 
 use crate::ctl::{
@@ -58,7 +55,7 @@ impl CommandManager {
         loop {
             let response = self.read_channel_message_with_timeout()?;
 
-            match response.status {
+            match response.status() {
                 ResponseStatus::Processing => println!("Proxy is processing: {}", response.message),
                 ResponseStatus::Failure => bail!("Request failed: {}", response.message),
                 ResponseStatus::Ok => {
@@ -105,7 +102,7 @@ impl CommandManager {
         loop {
             let response = self.read_channel_message_with_timeout()?;
 
-            match response.status {
+            match response.status() {
                 ResponseStatus::Processing => {
                     println!("Processing: {}", response.message);
                 }
@@ -140,7 +137,7 @@ impl CommandManager {
                         loop {
                             let response = self.read_channel_message_with_timeout()?;
 
-                            match response.status {
+                            match response.status() {
                                 ResponseStatus::Processing => {
                                     println!("Main process is upgrading");
                                 }
@@ -207,7 +204,7 @@ impl CommandManager {
         loop {
             let response = self.read_channel_message_with_timeout()?;
 
-            match response.status {
+            match response.status() {
                 ResponseStatus::Processing => info!("Proxy is processing: {}", response.message),
                 ResponseStatus::Failure => bail!(
                     "could not stop the worker {}: {}",
@@ -255,7 +252,7 @@ impl CommandManager {
             loop {
                 let response = self.read_channel_message_with_timeout()?;
 
-                match response.status {
+                match response.status() {
                     ResponseStatus::Processing => {
                         println!("Proxy is processing: {}", response.message);
                     }
@@ -343,7 +340,7 @@ impl CommandManager {
         loop {
             let response = self.read_channel_message_with_timeout()?;
 
-            match response.status {
+            match response.status() {
                 ResponseStatus::Processing => {
                     println!("Proxy is processing: {}", response.message);
                 }
@@ -399,7 +396,7 @@ impl CommandManager {
         loop {
             let response = self.read_channel_message_with_timeout()?;
 
-            match response.status {
+            match response.status() {
                 ResponseStatus::Processing => {
                     println!("Proxy is processing: {}", response.message);
                 }

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -93,8 +93,7 @@ impl CommandManager {
                     }
                     match response.content {
                         Some(response_content) => match response_content {
-                            ResponseContent::Workers(_)
-                            | ResponseContent::Metrics(_)
+                            ResponseContent::Metrics(_)
                             | ResponseContent::WorkerResponses(_)
                             | ResponseContent::WorkerMetrics(_)
                             | ResponseContent::ClustersHashes(_)
@@ -110,7 +109,7 @@ impl CommandManager {
                             ResponseContent::FrontendList(frontends) => {
                                 print_frontend_list(frontends)
                             }
-                            ResponseContent::Status(worker_infos) => {
+                            ResponseContent::Workers(worker_infos) => {
                                 if json {
                                     print_json_response(&worker_infos)?;
                                 } else {
@@ -204,7 +203,8 @@ impl CommandManager {
                             .with_context(|| "could not reconnect to the command unix socket")?;
 
                         // Do a rolling restart of the workers
-                        let running_workers = worker_infos.vec
+                        let running_workers = worker_infos
+                            .vec
                             .iter()
                             .filter(|worker| worker.run_state == RunState::Running as i32)
                             .collect::<Vec<_>>();

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -6,7 +6,7 @@ use prettytable::{Row, Table};
 use sozu_command_lib::{
     proto::command::{
         filtered_metrics, AggregatedMetrics, AvailableMetrics, ClusterMetrics, FilteredMetrics,
-        ListenersList, WorkerInfo, WorkerMetrics,
+        ListenersList, WorkerInfos, WorkerMetrics,
     },
     response::{ListedFrontends, ResponseContent},
 };
@@ -115,12 +115,12 @@ pub fn print_listeners(listeners_list: ListenersList) {
     }
 }
 
-pub fn print_status(worker_info_vec: Vec<WorkerInfo>) {
+pub fn print_status(worker_infos: WorkerInfos) {
     let mut table = Table::new();
     table.set_format(*prettytable::format::consts::FORMAT_BOX_CHARS);
     table.add_row(row!["worker id", "pid", "run state"]);
 
-    for worker_info in worker_info_vec {
+    for worker_info in worker_infos.vec {
         let row = row!(worker_info.id, worker_info.pid, worker_info.run_state);
         table.add_row(row);
     }

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -644,11 +644,11 @@ pub fn print_certificates(
 
     for (_worker_id, response_content) in response_contents.iter() {
         match response_content {
-            ResponseContent::Certificates(h) => {
-                for (addr, h2) in h.iter() {
-                    println!("\t{addr}:");
+            ResponseContent::Certificates(list) => {
+                for certs in list.certificates.iter() {
+                    println!("\t{}:", certs.address);
 
-                    for summary in h2.iter() {
+                    for summary in certs.certificate_summaries.iter() {
                         println!(
                             "\t\t{}:\t{}",
                             summary.domain,

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -659,12 +659,11 @@ pub fn print_certificates(
                     println!();
                 }
             }
-            ResponseContent::CertificateByFingerprint(opt) => {
-                if let Some((s, v)) = opt {
-                    println!("\tfrontends: {v:?}\ncertificate:\n{s}");
-                } else {
-                    println!("\tnot found");
-                }
+            ResponseContent::CertificateByFingerprint(cert) => {
+                println!(
+                    "\tfrontends: {:?}\ncertificate:\n{}",
+                    cert.names, cert.certificate
+                );
             }
             _ => {}
         }

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -440,7 +440,7 @@ pub fn print_query_response_data(
             for (key, metrics) in data.iter() {
                 //let m: u8 = metrics;
                 if let ResponseContent::Clusters(clusters) = metrics {
-                    for cluster in clusters.iter() {
+                    for cluster in clusters.vec.iter() {
                         let entry = cluster_data.entry(cluster).or_insert(Vec::new());
                         entry.push(key.to_owned());
 

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -606,7 +606,7 @@ pub fn print_query_response_data(
         for metrics in data.values() {
             //let m: u8 = metrics;
             if let ResponseContent::ClustersHashes(clusters) = metrics {
-                for (key, value) in clusters.iter() {
+                for (key, value) in clusters.map.iter() {
                     query_data.entry(key).or_insert(Vec::new()).push(value);
                 }
             }

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -6,9 +6,9 @@ use prettytable::{Row, Table};
 use sozu_command_lib::{
     proto::command::{
         filtered_metrics, AggregatedMetrics, AvailableMetrics, ClusterMetrics, FilteredMetrics,
-        ListenersList, WorkerInfos, WorkerMetrics,
+        ListedFrontends, ListenersList, WorkerInfos, WorkerMetrics,
     },
-    response::{ListedFrontends, ResponseContent},
+    response::ResponseContent,
 };
 
 pub fn print_listeners(listeners_list: ListenersList) {
@@ -155,7 +155,7 @@ pub fn print_frontend_list(frontends: ListedFrontends) {
                 format!("{:?}", http_frontend.path),
                 format!("{:?}", http_frontend.method),
                 format!("{:?}", http_frontend.position),
-                format_tags_to_string(http_frontend.tags.as_ref())
+                format_tags_to_string(&http_frontend.tags)
             ));
         }
         table.printstd();
@@ -186,7 +186,7 @@ pub fn print_frontend_list(frontends: ListedFrontends) {
                 format!("{:?}", https_frontend.path),
                 format!("{:?}", https_frontend.method),
                 format!("{:?}", https_frontend.position),
-                format_tags_to_string(https_frontend.tags.as_ref())
+                format_tags_to_string(&https_frontend.tags)
             ));
         }
         table.printstd();
@@ -202,7 +202,7 @@ pub fn print_frontend_list(frontends: ListedFrontends) {
             table.add_row(row!(
                 tcp_frontend.cluster_id,
                 tcp_frontend.address,
-                format_tags_to_string(tcp_frontend.tags.as_ref())
+                format_tags_to_string(&tcp_frontend.tags)
             ));
         }
         table.printstd();
@@ -672,14 +672,11 @@ pub fn print_certificates(
     Ok(())
 }
 
-fn format_tags_to_string(tags: Option<&BTreeMap<String, String>>) -> String {
-    tags.map(|tags| {
-        tags.iter()
-            .map(|(k, v)| format!("{k}={v}"))
-            .collect::<Vec<_>>()
-            .join(", ")
-    })
-    .unwrap_or_default()
+fn format_tags_to_string(tags: &BTreeMap<String, String>) -> String {
+    tags.iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 pub fn print_available_metrics(available_metrics: &AvailableMetrics) -> anyhow::Result<()> {

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -8,7 +8,9 @@ use std::time::Duration;
 use anyhow::Context;
 
 use sozu_command_lib::{
-    channel::Channel, config::Config, proto::command::Request, response::Response,
+    channel::Channel,
+    config::Config,
+    proto::command::{Request, Response},
 };
 
 use crate::{

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -7,7 +7,9 @@ use std::time::Duration;
 
 use anyhow::Context;
 
-use sozu_command_lib::{channel::Channel, config::Config, proto::command::Request, response::Response};
+use sozu_command_lib::{
+    channel::Channel, config::Config, proto::command::Request, response::Response,
+};
 
 use crate::{
     cli::{self, *},

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -80,7 +80,6 @@ impl CommandManager {
             SubCmd::State { cmd } => match cmd {
                 StateCmd::Save { file } => self.save_state(file),
                 StateCmd::Load { file } => self.load_state(file),
-                StateCmd::Dump { json } => self.dump_state(json),
             },
             SubCmd::Reload { file, json } => self.reload_configuration(file, json),
             SubCmd::Cluster { cmd } => self.cluster_command(cmd),

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -7,11 +7,10 @@ use sozu_command_lib::{
     config::{Config, ListenerBuilder},
     proto::command::{
         request::RequestType, ActivateListener, AddBackend, AddCertificate, CertificateAndKey,
-        Cluster, DeactivateListener, DumpState, FrontendFilters, HardStop, ListListeners,
-        ListenerType, LoadBalancingParams, MetricsConfiguration, PathRule, ProxyProtocolConfig,
-        RemoveBackend, RemoveCertificate, RemoveListener, ReplaceCertificate, Request,
-        RequestHttpFrontend, RequestTcpFrontend, RulePosition, SoftStop, Status, SubscribeEvents,
-        TlsVersion,
+        Cluster, DeactivateListener, FrontendFilters, HardStop, ListListeners, ListenerType,
+        LoadBalancingParams, MetricsConfiguration, PathRule, ProxyProtocolConfig, RemoveBackend,
+        RemoveCertificate, RemoveListener, ReplaceCertificate, Request, RequestHttpFrontend,
+        RequestTcpFrontend, RulePosition, SoftStop, Status, SubscribeEvents, TlsVersion,
     },
 };
 
@@ -38,17 +37,6 @@ impl CommandManager {
         self.order_request(Request {
             request_type: Some(RequestType::LoadState(path)),
         })
-    }
-
-    pub fn dump_state(&mut self, json: bool) -> anyhow::Result<()> {
-        println!("Dumping the state, json={json}");
-
-        self.order_request_to_all_workers(
-            Request {
-                request_type: Some(RequestType::DumpState(DumpState {})),
-            },
-            json,
-        )
     }
 
     pub fn soft_stop(&mut self) -> anyhow::Result<()> {

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -38,7 +38,7 @@ use sozu_command_lib::{
     channel::Channel,
     config::Config,
     logging::target_to_backend,
-    proto::command::{Request, RunState, WorkerInfo, request::RequestType, Status},
+    proto::command::{request::RequestType, Request, RunState, Status, WorkerInfo},
     ready::Ready,
     request::WorkerRequest,
     response::WorkerResponse,

--- a/command/assets/answer_metrics.json
+++ b/command/assets/answer_metrics.json
@@ -1,5 +1,4 @@
 {
-  "version": 0,
   "status": "OK",
   "message": "",
   "content": {

--- a/command/assets/answer_metrics.json
+++ b/command/assets/answer_metrics.json
@@ -1,5 +1,5 @@
 {
-  "status": "OK",
+  "status": 0,
   "message": "",
   "content": {
     "content_type": {

--- a/command/assets/answer_metrics.json
+++ b/command/assets/answer_metrics.json
@@ -4,93 +4,94 @@
   "status": "OK",
   "message": "",
   "content": {
-    "type": "METRICS",
-    "data": {
-      "main": {
-        "sozu.count": {
-          "inner": {
-            "COUNT": -2
-          }
-        },
-        "sozu.gauge": {
-          "inner": {
-            "GAUGE": 1
-          }
-        },
-        "sozu.time": {
-          "inner": {
-            "TIME": 1234
-          }
-        }
-      },
-      "workers": {
-        "0": {
-          "proxy": {
-            "sozu.count": {
-              "inner": {
-                "COUNT": -2
-              }
-            },
-            "sozu.gauge": {
-              "inner": {
-                "GAUGE": 1
-              }
-            },
-            "sozu.time": {
-              "inner": {
-                "TIME": 1234
-              }
+    "content_type": {
+      "METRICS": {
+        "main": {
+          "sozu.count": {
+            "inner": {
+              "COUNT": -2
             }
           },
-          "clusters": {
-            "cluster_1": {
-              "cluster": {
-                "request_time": {
-                  "inner": {
-                    "PERCENTILES": {
-                      "samples": 42,
-                      "p_50": 1,
-                      "p_90": 2,
-                      "p_99": 10,
-                      "p_99_9": 12,
-                      "p_99_99": 20,
-                      "p_99_999": 22,
-                      "p_100": 30
-                    }
-                  }
+          "sozu.gauge": {
+            "inner": {
+              "GAUGE": 1
+            }
+          },
+          "sozu.time": {
+            "inner": {
+              "TIME": 1234
+            }
+          }
+        },
+        "workers": {
+          "0": {
+            "proxy": {
+              "sozu.count": {
+                "inner": {
+                  "COUNT": -2
                 }
               },
-              "backends": [
-                {
-                  "backend_id": "cluster_1-0",
-                  "metrics": {
-                    "bytes_in": {
-                      "inner": {
-                        "COUNT": 256
+              "sozu.gauge": {
+                "inner": {
+                  "GAUGE": 1
+                }
+              },
+              "sozu.time": {
+                "inner": {
+                  "TIME": 1234
+                }
+              }
+            },
+            "clusters": {
+              "cluster_1": {
+                "cluster": {
+                  "request_time": {
+                    "inner": {
+                      "PERCENTILES": {
+                        "samples": 42,
+                        "p_50": 1,
+                        "p_90": 2,
+                        "p_99": 10,
+                        "p_99_9": 12,
+                        "p_99_99": 20,
+                        "p_99_999": 22,
+                        "p_100": 30
                       }
-                    },
-                    "bytes_out": {
-                      "inner": {
-                        "COUNT": 128
-                      }
-                    },
-                    "percentiles": {
-                      "inner": {
-                        "PERCENTILES": {
-                          "samples": 42,
-                          "p_50": 1,
-                          "p_90": 2,
-                          "p_99": 10,
-                          "p_99_9": 12,
-                          "p_99_99": 20,
-                          "p_99_999": 22,
-                          "p_100": 30
+                    }
+                  }
+                },
+                "backends": [
+                  {
+                    "backend_id": "cluster_1-0",
+                    "metrics": {
+                      "bytes_in": {
+                        "inner": {
+                          "COUNT": 256
+                        }
+                      },
+                      "bytes_out": {
+                        "inner": {
+                          "COUNT": 128
+                        }
+                      },
+                      "percentiles": {
+                        "inner": {
+                          "PERCENTILES": {
+                            "samples": 42,
+                            "p_50": 1,
+                            "p_90": 2,
+                            "p_99": 10,
+                            "p_99_9": 12,
+                            "p_99_99": 20,
+                            "p_99_999": 22,
+                            "p_100": 30
+                          }
                         }
                       }
                     }
                   }
-                }
-              ]
+                ]
+              }
             }
           }
         }

--- a/command/assets/answer_metrics.json
+++ b/command/assets/answer_metrics.json
@@ -1,5 +1,4 @@
 {
-  "id": "ID_TEST",
   "version": 0,
   "status": "OK",
   "message": "",

--- a/command/assets/answer_workers_status.json
+++ b/command/assets/answer_workers_status.json
@@ -4,20 +4,21 @@
   "status": "OK",
   "message": "",
   "content": {
-    "type": "WORKERS",
-    "data": {
-      "vec": [
-        {
-          "id": 1,
-          "pid": 5678,
-          "run_state": 0
-        },
-        {
-          "id": 0,
-          "pid": 1234,
-          "run_state": 1
-        }
-      ]
+    "content_type": {
+      "WORKERS": {
+        "vec": [
+          {
+            "id": 1,
+            "pid": 5678,
+            "run_state": 0
+          },
+          {
+            "id": 0,
+            "pid": 1234,
+            "run_state": 1
+          }
+        ]
+      }
     }
   }
 }

--- a/command/assets/answer_workers_status.json
+++ b/command/assets/answer_workers_status.json
@@ -1,5 +1,4 @@
 {
-  "version": 0,
   "status": "OK",
   "message": "",
   "content": {

--- a/command/assets/answer_workers_status.json
+++ b/command/assets/answer_workers_status.json
@@ -5,17 +5,19 @@
   "message": "",
   "content": {
     "type": "WORKERS",
-    "data": [
-      {
-        "id": 1,
-        "pid": 5678,
-        "run_state": 0
-      },
-      {
-        "id": 0,
-        "pid": 1234,
-        "run_state": 1
-      }
-    ]
+    "data": {
+      "vec": [
+        {
+          "id": 1,
+          "pid": 5678,
+          "run_state": 0
+        },
+        {
+          "id": 0,
+          "pid": 1234,
+          "run_state": 1
+        }
+      ]
+    }
   }
 }

--- a/command/assets/answer_workers_status.json
+++ b/command/assets/answer_workers_status.json
@@ -1,5 +1,5 @@
 {
-  "status": "OK",
+  "status": 0,
   "message": "",
   "content": {
     "content_type": {

--- a/command/assets/answer_workers_status.json
+++ b/command/assets/answer_workers_status.json
@@ -1,5 +1,4 @@
 {
-  "id": "ID_TEST",
   "version": 0,
   "status": "OK",
   "message": "",

--- a/command/build.rs
+++ b/command/build.rs
@@ -9,6 +9,7 @@ pub fn main() {
         .enum_attribute("Order", "#[derive(Hash, Eq, Ord, PartialOrd)]")
         .enum_attribute("request_type", "#[derive(Hash, Eq, Ord, PartialOrd)]")
         .enum_attribute("inner", "#[derive(Hash, Eq, Ord, PartialOrd)]")
+        .enum_attribute("content_type", "#[derive(Hash, Eq, Ord, PartialOrd)]")
         .out_dir("src/proto")
         .compile_protos(&["command.proto"], &["src"])
         .expect("Could not compile protobuf types in command.proto");

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -387,6 +387,10 @@ enum MetricsConfiguration {
     CLEAR = 2;
 }
 
+message ClusterInformations {
+    repeated ClusterInformation vec = 1;
+}
+
 // Information about a given cluster
 // Contains types usually used in requests, because they are readily available in protobuf
 message ClusterInformation {

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -387,6 +387,16 @@ enum MetricsConfiguration {
     CLEAR = 2;
 }
 
+// Information about a given cluster
+// Contains types usually used in requests, because they are readily available in protobuf
+message ClusterInformation {
+    optional Cluster configuration = 1;
+    repeated RequestHttpFrontend http_frontends = 2;
+    repeated RequestHttpFrontend https_frontends = 3;
+    repeated RequestTcpFrontend tcp_frontends = 4;
+    repeated AddBackend backends = 5;
+}
+
 message Event {
     required EventKind kind = 1;
     optional string cluster_id = 2;

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -295,6 +295,14 @@ message CertificateSummary {
     required string fingerprint = 2;
 }
 
+// A certificate matching a request by fingerprint,
+// and the list of domain names associated
+message CertificateWithNames {
+    required string certificate = 1;
+    // domain names associated to the fingerprint
+    repeated string names = 2;
+}
+
 enum TlsVersion {
     SSL_V2 = 0;
     SSL_V3 = 1;

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -401,6 +401,11 @@ enum EventKind {
     REMOVED_BACKEND_HAS_NO_CONNECTIONS = 3;
 }
 
+message ClusterHashes {
+    // cluster id -> hash of cluster information
+    map<string, uint64> map = 1;
+}
+
 enum ResponseStatus {
     OK = 0;
     PROCESSING = 1;

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -387,12 +387,19 @@ enum MetricsConfiguration {
     CLEAR = 2;
 }
 
+
 enum ResponseStatus {
     OK = 0;
     PROCESSING = 1;
     FAILURE = 2;
 }
 
+// A list of worker infos
+message WorkerInfos {
+    repeated WorkerInfo vec = 1;
+}
+
+// Information about a worker with id, pid, runstate
 message WorkerInfo {
     required uint32 id = 1;
     required int32 pid = 2;

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -404,6 +404,41 @@ enum MetricsConfiguration {
     CLEAR = 2;
 }
 
+// content of a response
+message ResponseContent {
+    oneof content_type {
+        // a list of workers, with ids, pids, statuses
+        WorkerInfos workers = 1;
+        // aggregated metrics of main process and workers
+        AggregatedMetrics metrics = 2;
+        // a collection of worker responses to the same request
+        WorkerResponses worker_responses = 3;
+        // a proxy event
+        Event event = 4;
+        // a filtered list of frontend
+        ListedFrontends frontend_list = 5;
+        // all listeners
+        ListenersList listeners_list = 6;
+        // contains proxy & cluster metrics
+        WorkerMetrics worker_metrics = 7;
+        // Lists of metrics that are available
+        AvailableMetrics available_metrics = 8;
+        // a list of cluster informations
+        ClusterInformations clusters = 9;
+        // collection of hashes of cluster information, 
+        ClusterHashes cluster_hashes = 10;
+        // a list of certificates for each socket address
+        ListOfCertificatesByAddress certificates = 11;
+        // returns the certificate matching a request by fingerprint,
+        // and the list of domain names associated
+        CertificateWithNames certificate_by_fingerprint = 12;
+    }
+}
+
+message WorkerResponses {
+    map<string, ResponseContent> map = 1;
+}
+
 // lists of frontends present in the state
 message ListedFrontends {
     repeated RequestHttpFrontend http_frontends = 1;

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -295,6 +295,15 @@ message CertificateSummary {
     required string fingerprint = 2;
 }
 
+message ListOfCertificatesByAddress {
+    repeated CertificatesByAddress certificates = 1;
+}
+
+message CertificatesByAddress {
+    required string address = 1;
+    repeated CertificateSummary certificate_summaries = 2;
+}
+
 // A certificate matching a request by fingerprint,
 // and the list of domain names associated
 message CertificateWithNames {

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -387,7 +387,6 @@ enum MetricsConfiguration {
     CLEAR = 2;
 }
 
-
 enum ResponseStatus {
     OK = 0;
     PROCESSING = 1;

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -387,6 +387,12 @@ enum MetricsConfiguration {
     CLEAR = 2;
 }
 
+enum ResponseStatus {
+    OK = 0;
+    PROCESSING = 1;
+    FAILURE = 2;
+}
+
 message WorkerInfo {
     required uint32 id = 1;
     required int32 pid = 2;

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -404,6 +404,13 @@ enum MetricsConfiguration {
     CLEAR = 2;
 }
 
+// lists of frontends present in the state
+message ListedFrontends {
+    repeated RequestHttpFrontend http_frontends = 1;
+    repeated RequestHttpFrontend https_frontends = 2;
+    repeated RequestTcpFrontend tcp_frontends = 3;
+}
+
 message ClusterInformations {
     repeated ClusterInformation vec = 1;
 }

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -387,6 +387,20 @@ enum MetricsConfiguration {
     CLEAR = 2;
 }
 
+message Event {
+    required EventKind kind = 1;
+    optional string cluster_id = 2;
+    optional string backend_id = 3;
+    optional string address = 4;
+}
+
+enum EventKind {
+    BACKEND_DOWN = 0;
+    BACKEND_UP = 1;
+    NO_AVAILABLE_BACKENDS = 2;
+    REMOVED_BACKEND_HAS_NO_CONNECTIONS = 3;
+}
+
 enum ResponseStatus {
     OK = 0;
     PROCESSING = 1;

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -404,6 +404,17 @@ enum MetricsConfiguration {
     CLEAR = 2;
 }
 
+// Response to a request
+message Response {
+    // wether the request was a success, a failure, or is processing
+    required ResponseStatus status = 1 [default = FAILURE];
+    // a success or error message
+    required string message = 2;
+    // response data, if any
+    optional ResponseContent content = 3;
+}
+
+
 // content of a response
 message ResponseContent {
     oneof content_type {

--- a/command/src/parser.rs
+++ b/command/src/parser.rs
@@ -75,7 +75,7 @@ mod test {
     use super::*;
 
     use crate::{
-        proto::command::{request::RequestType, DumpState, Request, SubscribeEvents},
+        proto::command::{request::RequestType, Request, Status, SubscribeEvents},
         request::WorkerRequest,
     };
 
@@ -84,7 +84,7 @@ mod test {
         let worker_request = WorkerRequest::new(
             "Some request".to_string(),
             Request {
-                request_type: Some(RequestType::DumpState(DumpState {})),
+                request_type: Some(RequestType::Status(Status {})),
             },
         );
 
@@ -122,7 +122,7 @@ mod test {
             WorkerRequest::new(
                 "Yet another request".to_string(),
                 Request {
-                    request_type: Some(RequestType::DumpState(DumpState {})),
+                    request_type: Some(RequestType::Status(Status {})),
                 },
             ),
         ];

--- a/command/src/request.rs
+++ b/command/src/request.rs
@@ -15,8 +15,6 @@ use crate::{
     response::{HttpFrontend, MessageId},
 };
 
-pub const PROTOCOL_VERSION: u8 = 0;
-
 impl Request {
     /// determine to which of the three proxies (HTTP, HTTPS, TCP) a request is destined
     pub fn get_destinations(&self) -> ProxyDestinations {

--- a/command/src/request.rs
+++ b/command/src/request.rs
@@ -214,9 +214,9 @@ mod tests {
     use crate::{
         certificate::split_certificate_chain,
         proto::command::{
-            AddBackend, AddCertificate, CertificateAndKey, Cluster, DumpState, HardStop,
-            ListWorkers, LoadBalancingParams, PathRule, ProxyProtocolConfig, RemoveBackend,
-            RemoveCertificate, RulePosition, SoftStop, Status, TlsVersion, UpgradeMain,
+            AddBackend, AddCertificate, CertificateAndKey, Cluster, HardStop, ListWorkers,
+            LoadBalancingParams, PathRule, ProxyProtocolConfig, RemoveBackend, RemoveCertificate,
+            RulePosition, SoftStop, Status, TlsVersion, UpgradeMain,
         },
         response::HttpFrontend,
     };
@@ -452,14 +452,6 @@ mod tests {
         "../assets/save_state.json",
         Request {
             request_type: Some(RequestType::SaveState(String::from("./config_dump.json")))
-        }
-    );
-
-    test_message!(
-        dump_state,
-        "../assets/dump_state.json",
-        Request {
-            request_type: Some(RequestType::DumpState(DumpState {}))
         }
     );
 

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -14,7 +14,7 @@ use crate::{
         WorkerInfos, WorkerMetrics,
     },
     request::PROTOCOL_VERSION,
-    state::{ClusterId, ConfigState},
+    state::ClusterId,
 };
 
 /// Responses of the main process to the CLI (or other client)
@@ -54,8 +54,6 @@ pub enum ResponseContent {
     Metrics(AggregatedMetrics),
     /// worker responses to a same query: worker_id -> response_content
     WorkerResponses(BTreeMap<String, ResponseContent>),
-    /// the state of Sōzu: frontends, backends, listeners, etc.
-    State(Box<ConfigState>),
     /// a proxy event
     Event(Event),
     /// a filtered list of frontend

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -10,7 +10,8 @@ use crate::{
     proto::command::{
         AddBackend, AggregatedMetrics, AvailableMetrics, CertificateSummary, Cluster,
         FilteredTimeSerie, ListenersList, LoadBalancingParams, PathRule, PathRuleKind,
-        RequestHttpFrontend, RequestTcpFrontend, RulePosition, RunState, WorkerInfo, WorkerMetrics,
+        RequestHttpFrontend, RequestTcpFrontend, ResponseStatus, RulePosition, RunState,
+        WorkerInfo, WorkerMetrics,
     },
     request::PROTOCOL_VERSION,
     state::{ClusterId, ConfigState},
@@ -41,14 +42,6 @@ impl Response {
             content,
         }
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum ResponseStatus {
-    Ok,
-    Processing,
-    Failure,
 }
 
 /// details of a response sent by the main process to the client

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -13,7 +13,6 @@ use crate::{
 /// Responses of the main process to the CLI (or other client)
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Response {
-    pub id: String,
     pub version: u8,
     pub status: ResponseStatus,
     pub message: String,
@@ -22,14 +21,12 @@ pub struct Response {
 
 impl Response {
     pub fn new(
-        // id: String,
         status: ResponseStatus,
         message: String,
         content: Option<ResponseContent>,
     ) -> Response {
         Response {
             version: PROTOCOL_VERSION,
-            id: "generic-response-id-to-be-removed".to_string(),
             status,
             message,
             content,
@@ -368,7 +365,6 @@ mod tests {
         answer_workers_status,
         "../assets/answer_workers_status.json",
         Response {
-            id: "ID_TEST".to_string(),
             version: 0,
             status: ResponseStatus::Ok,
             message: String::from(""),
@@ -395,7 +391,6 @@ mod tests {
         answer_metrics,
         "../assets/answer_metrics.json",
         Response {
-            id: "ID_TEST".to_string(),
             version: 0,
             status: ResponseStatus::Ok,
             message: String::from(""),

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -9,9 +9,9 @@ use std::{
 use crate::{
     proto::command::{
         AddBackend, AggregatedMetrics, AvailableMetrics, CertificateSummary, ClusterHashes,
-        ClusterInformation, Event, FilteredTimeSerie, ListenersList, LoadBalancingParams, PathRule,
-        PathRuleKind, RequestHttpFrontend, RequestTcpFrontend, ResponseStatus, RulePosition,
-        RunState, WorkerInfos, WorkerMetrics,
+        ClusterInformations, Event, FilteredTimeSerie, ListenersList, LoadBalancingParams,
+        PathRule, PathRuleKind, RequestHttpFrontend, RequestTcpFrontend, ResponseStatus,
+        RulePosition, RunState, WorkerInfos, WorkerMetrics,
     },
     request::PROTOCOL_VERSION,
     state::ClusterId,
@@ -67,7 +67,7 @@ pub enum ResponseContent {
     /// Lists of metrics that are available
     AvailableMetrics(AvailableMetrics),
 
-    Clusters(Vec<ClusterInformation>),
+    Clusters(ClusterInformations),
     /// cluster id -> hash of cluster information
     ClustersHashes(ClusterHashes),
 

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -278,17 +278,21 @@ impl fmt::Display for RunState {
     }
 }
 
-// TODO: remove the SocketAddr type
 /// a backend event that happened on a proxy
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(tag = "type", content = "data", rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum Event {
-    BackendDown(String, SocketAddr),
-    BackendUp(String, SocketAddr),
-    NoAvailableBackends(String),
-    /// indicates a backend that was removed from configuration has no lingering connections
-    /// so it can be safely stopped
-    RemovedBackendHasNoConnections(String, SocketAddr),
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Event {
+    pub kind: EventKind,
+    pub cluster_id: Option<String>,
+    pub backend_id: Option<String>,
+    pub address: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EventKind {
+    BackendDown,
+    BackendUp,
+    NoAvailableBackends,
+    RemovedBackendHasNoConnections,
 }
 
 #[derive(Serialize)]

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -8,8 +8,8 @@ use std::{
 
 use crate::{
     proto::command::{
-        AddBackend, AggregatedMetrics, AvailableMetrics, CertificateSummary, Cluster,
-        ClusterHashes, Event, FilteredTimeSerie, ListenersList, LoadBalancingParams, PathRule,
+        AddBackend, AggregatedMetrics, AvailableMetrics, CertificateSummary, ClusterHashes,
+        ClusterInformation, Event, FilteredTimeSerie, ListenersList, LoadBalancingParams, PathRule,
         PathRuleKind, RequestHttpFrontend, RequestTcpFrontend, ResponseStatus, RulePosition,
         RunState, WorkerInfos, WorkerMetrics,
     },
@@ -79,17 +79,6 @@ pub enum ResponseContent {
     CertificateByFingerprint(Option<(String, Vec<String>)>),
 }
 
-// TODO: the types HttpFrontend, TcpFrontend and Backend are not present,
-// and not meant to be present in proto::command. Find a fix, like using the type HttpRequestFrontend
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct ClusterInformation {
-    pub configuration: Option<Cluster>,
-    pub http_frontends: Vec<HttpFrontend>,
-    pub https_frontends: Vec<HttpFrontend>,
-    pub tcp_frontends: Vec<TcpFrontend>,
-    pub backends: Vec<Backend>,
-}
-
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HttpFrontend {
     /// Send a 401, DENY, if cluster_id is None
@@ -121,6 +110,19 @@ impl Into<RequestHttpFrontend> for HttpFrontend {
             method: self.method,
             position: self.position.into(),
             tags,
+        }
+    }
+}
+
+impl Into<AddBackend> for Backend {
+    fn into(self) -> AddBackend {
+        AddBackend {
+            cluster_id: self.cluster_id,
+            backend_id: self.backend_id,
+            address: self.address.to_string(),
+            sticky_id: self.sticky_id,
+            load_balancing_parameters: self.load_balancing_parameters,
+            backup: self.backup,
         }
     }
 }

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -6,14 +6,12 @@ use crate::{
         RequestHttpFrontend, RequestTcpFrontend, ResponseContent, ResponseStatus, RulePosition,
         RunState,
     },
-    request::PROTOCOL_VERSION,
     state::ClusterId,
 };
 
 /// Responses of the main process to the CLI (or other client)
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Response {
-    pub version: u8,
     pub status: ResponseStatus,
     pub message: String,
     pub content: Option<ResponseContent>,
@@ -26,7 +24,6 @@ impl Response {
         content: Option<ResponseContent>,
     ) -> Response {
         Response {
-            version: PROTOCOL_VERSION,
             status,
             message,
             content,
@@ -328,7 +325,7 @@ fn socketaddr_cmp(a: &SocketAddr, b: &SocketAddr) -> Ordering {
 mod tests {
     use crate::proto::command::{
         filtered_metrics, response_content::ContentType, AggregatedMetrics, BackendMetrics,
-        ClusterMetrics, FilteredMetrics, Percentiles, WorkerInfo, WorkerMetrics, WorkerInfos,
+        ClusterMetrics, FilteredMetrics, Percentiles, WorkerInfo, WorkerInfos, WorkerMetrics,
     };
 
     use super::*;
@@ -365,7 +362,6 @@ mod tests {
         answer_workers_status,
         "../assets/answer_workers_status.json",
         Response {
-            version: 0,
             status: ResponseStatus::Ok,
             message: String::from(""),
             content: Some(ResponseContent {
@@ -391,7 +387,6 @@ mod tests {
         answer_metrics,
         "../assets/answer_metrics.json",
         Response {
-            version: 0,
             status: ResponseStatus::Ok,
             message: String::from(""),
             content: Some(ResponseContent {

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -8,10 +8,10 @@ use std::{
 
 use crate::{
     proto::command::{
-        AddBackend, AggregatedMetrics, AvailableMetrics, CertificateSummary, Cluster, Event,
-        FilteredTimeSerie, ListenersList, LoadBalancingParams, PathRule, PathRuleKind,
-        RequestHttpFrontend, RequestTcpFrontend, ResponseStatus, RulePosition, RunState,
-        WorkerInfos, WorkerMetrics,
+        AddBackend, AggregatedMetrics, AvailableMetrics, CertificateSummary, Cluster,
+        ClusterHashes, Event, FilteredTimeSerie, ListenersList, LoadBalancingParams, PathRule,
+        PathRuleKind, RequestHttpFrontend, RequestTcpFrontend, ResponseStatus, RulePosition,
+        RunState, WorkerInfos, WorkerMetrics,
     },
     request::PROTOCOL_VERSION,
     state::ClusterId,
@@ -69,7 +69,7 @@ pub enum ResponseContent {
 
     Clusters(Vec<ClusterInformation>),
     /// cluster id -> hash of cluster information
-    ClustersHashes(BTreeMap<String, u64>),
+    ClustersHashes(ClusterHashes),
 
     /// a list of certificates for each socket address
     Certificates(HashMap<SocketAddr, Vec<CertificateSummary>>),

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::{
     proto::command::{
-        AddBackend, AggregatedMetrics, AvailableMetrics, CertificateSummary, Cluster,
+        AddBackend, AggregatedMetrics, AvailableMetrics, CertificateSummary, Cluster, Event,
         FilteredTimeSerie, ListenersList, LoadBalancingParams, PathRule, PathRuleKind,
         RequestHttpFrontend, RequestTcpFrontend, ResponseStatus, RulePosition, RunState,
         WorkerInfos, WorkerMetrics,
@@ -276,23 +276,6 @@ impl fmt::Display for RunState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{self:?}")
     }
-}
-
-/// a backend event that happened on a proxy
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Event {
-    pub kind: EventKind,
-    pub cluster_id: Option<String>,
-    pub backend_id: Option<String>,
-    pub address: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum EventKind {
-    BackendDown,
-    BackendUp,
-    NoAvailableBackends,
-    RemovedBackendHasNoConnections,
 }
 
 #[derive(Serialize)]

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -1,17 +1,11 @@
-use std::{
-    cmp::Ordering,
-    collections::{BTreeMap, HashMap},
-    default::Default,
-    fmt,
-    net::SocketAddr,
-};
+use std::{cmp::Ordering, collections::BTreeMap, default::Default, fmt, net::SocketAddr};
 
 use crate::{
     proto::command::{
-        AddBackend, AggregatedMetrics, AvailableMetrics, CertificateSummary, ClusterHashes,
-        ClusterInformations, Event, FilteredTimeSerie, ListenersList, LoadBalancingParams,
-        PathRule, PathRuleKind, RequestHttpFrontend, RequestTcpFrontend, ResponseStatus,
-        RulePosition, RunState, WorkerInfos, WorkerMetrics, CertificateWithNames,
+        AddBackend, AggregatedMetrics, AvailableMetrics, CertificateWithNames, ClusterHashes,
+        ClusterInformations, Event, FilteredTimeSerie, ListOfCertificatesByAddress, ListenersList,
+        LoadBalancingParams, PathRule, PathRuleKind, RequestHttpFrontend, RequestTcpFrontend,
+        ResponseStatus, RulePosition, RunState, WorkerInfos, WorkerMetrics,
     },
     request::PROTOCOL_VERSION,
     state::ClusterId,
@@ -72,7 +66,7 @@ pub enum ResponseContent {
     ClustersHashes(ClusterHashes),
 
     /// a list of certificates for each socket address
-    Certificates(HashMap<SocketAddr, Vec<CertificateSummary>>),
+    Certificates(ListOfCertificatesByAddress),
 
     /// returns the certificate matching a request by fingerprint,
     /// and the list of domain names associated

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -11,7 +11,7 @@ use crate::{
         AddBackend, AggregatedMetrics, AvailableMetrics, CertificateSummary, Cluster,
         FilteredTimeSerie, ListenersList, LoadBalancingParams, PathRule, PathRuleKind,
         RequestHttpFrontend, RequestTcpFrontend, ResponseStatus, RulePosition, RunState,
-        WorkerInfo, WorkerMetrics,
+        WorkerInfos, WorkerMetrics,
     },
     request::PROTOCOL_VERSION,
     state::{ClusterId, ConfigState},
@@ -49,7 +49,7 @@ impl Response {
 #[serde(tag = "type", content = "data", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ResponseContent {
     /// a list of workers, with ids, pids, statuses
-    Workers(Vec<WorkerInfo>),
+    Workers(WorkerInfos),
     /// aggregated metrics of main process and workers
     Metrics(AggregatedMetrics),
     /// worker responses to a same query: worker_id -> response_content
@@ -60,8 +60,8 @@ pub enum ResponseContent {
     Event(Event),
     /// a filtered list of frontend
     FrontendList(ListedFrontends),
-    // this is new
-    Status(Vec<WorkerInfo>),
+    // TODO: remove as it is redundant with the Workers variant
+    Status(WorkerInfos),
     /// all listeners
     ListenersList(ListenersList),
 
@@ -437,18 +437,20 @@ mod tests {
             version: 0,
             status: ResponseStatus::Ok,
             message: String::from(""),
-            content: Some(ResponseContent::Workers(vec!(
-                WorkerInfo {
-                    id: 1,
-                    pid: 5678,
-                    run_state: RunState::Running as i32,
-                },
-                WorkerInfo {
-                    id: 0,
-                    pid: 1234,
-                    run_state: RunState::Stopping as i32,
-                },
-            ))),
+            content: Some(ResponseContent::Workers(WorkerInfos {
+                vec: vec!(
+                    WorkerInfo {
+                        id: 1,
+                        pid: 5678,
+                        run_state: RunState::Running as i32,
+                    },
+                    WorkerInfo {
+                        id: 0,
+                        pid: 1234,
+                        run_state: RunState::Stopping as i32,
+                    },
+                )
+            })),
         }
     );
 

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -3,9 +3,10 @@ use std::{cmp::Ordering, collections::BTreeMap, default::Default, fmt, net::Sock
 use crate::{
     proto::command::{
         AddBackend, AggregatedMetrics, AvailableMetrics, CertificateWithNames, ClusterHashes,
-        ClusterInformations, Event, FilteredTimeSerie, ListOfCertificatesByAddress, ListenersList,
-        LoadBalancingParams, PathRule, PathRuleKind, RequestHttpFrontend, RequestTcpFrontend,
-        ResponseStatus, RulePosition, RunState, WorkerInfos, WorkerMetrics,
+        ClusterInformations, Event, FilteredTimeSerie, ListOfCertificatesByAddress,
+        ListedFrontends, ListenersList, LoadBalancingParams, PathRule, PathRuleKind,
+        RequestHttpFrontend, RequestTcpFrontend, ResponseStatus, RulePosition, RunState,
+        WorkerInfos, WorkerMetrics,
     },
     request::PROTOCOL_VERSION,
     state::ClusterId,
@@ -206,14 +207,6 @@ impl Into<RequestTcpFrontend> for TcpFrontend {
             tags: self.tags.unwrap_or(BTreeMap::new()),
         }
     }
-}
-
-// TODO: should contain HttpFrontendConfig and TcpFrontendConfig, or types written in protobuf
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct ListedFrontends {
-    pub http_frontends: Vec<HttpFrontend>,
-    pub https_frontends: Vec<HttpFrontend>,
-    pub tcp_frontends: Vec<TcpFrontend>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -60,8 +60,6 @@ pub enum ResponseContent {
     Event(Event),
     /// a filtered list of frontend
     FrontendList(ListedFrontends),
-    // TODO: remove as it is redundant with the Workers variant
-    Status(WorkerInfos),
     /// all listeners
     ListenersList(ListenersList),
 

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -3,19 +3,11 @@ use std::{cmp::Ordering, collections::BTreeMap, default::Default, fmt, net::Sock
 use crate::{
     proto::command::{
         AddBackend, FilteredTimeSerie, LoadBalancingParams, PathRule, PathRuleKind,
-        RequestHttpFrontend, RequestTcpFrontend, ResponseContent, ResponseStatus, RulePosition,
-        RunState,
+        RequestHttpFrontend, RequestTcpFrontend, Response, ResponseContent, ResponseStatus,
+        RulePosition, RunState,
     },
     state::ClusterId,
 };
-
-/// Responses of the main process to the CLI (or other client)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Response {
-    pub status: ResponseStatus,
-    pub message: String,
-    pub content: Option<ResponseContent>,
-}
 
 impl Response {
     pub fn new(
@@ -24,7 +16,7 @@ impl Response {
         content: Option<ResponseContent>,
     ) -> Response {
         Response {
-            status,
+            status: status as i32,
             message,
             content,
         }
@@ -362,7 +354,7 @@ mod tests {
         answer_workers_status,
         "../assets/answer_workers_status.json",
         Response {
-            status: ResponseStatus::Ok,
+            status: ResponseStatus::Ok as i32,
             message: String::from(""),
             content: Some(ResponseContent {
                 content_type: Some(ContentType::Workers(WorkerInfos {
@@ -387,7 +379,7 @@ mod tests {
         answer_metrics,
         "../assets/answer_metrics.json",
         Response {
-            status: ResponseStatus::Ok,
+            status: ResponseStatus::Ok as i32,
             message: String::from(""),
             content: Some(ResponseContent {
                 content_type: Some(ContentType::Metrics(AggregatedMetrics {

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -11,7 +11,7 @@ use crate::{
         AddBackend, AggregatedMetrics, AvailableMetrics, CertificateSummary, ClusterHashes,
         ClusterInformations, Event, FilteredTimeSerie, ListenersList, LoadBalancingParams,
         PathRule, PathRuleKind, RequestHttpFrontend, RequestTcpFrontend, ResponseStatus,
-        RulePosition, RunState, WorkerInfos, WorkerMetrics,
+        RulePosition, RunState, WorkerInfos, WorkerMetrics, CertificateWithNames,
     },
     request::PROTOCOL_VERSION,
     state::ClusterId,
@@ -76,7 +76,7 @@ pub enum ResponseContent {
 
     /// returns the certificate matching a request by fingerprint,
     /// and the list of domain names associated
-    CertificateByFingerprint(Option<(String, Vec<String>)>),
+    CertificateByFingerprint(CertificateWithNames),
 }
 
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -14,9 +14,10 @@ use crate::{
     certificate::{calculate_fingerprint, Fingerprint},
     proto::command::{
         request::RequestType, ActivateListener, AddBackend, AddCertificate, CertificateAndKey,
-        Cluster, ClusterInformation, DeactivateListener, HttpListenerConfig, HttpsListenerConfig,
-        ListenerType, PathRule, RemoveBackend, RemoveCertificate, RemoveListener,
-        ReplaceCertificate, Request, RequestHttpFrontend, RequestTcpFrontend, TcpListenerConfig,
+        CertificateWithNames, Cluster, ClusterInformation, DeactivateListener, HttpListenerConfig,
+        HttpsListenerConfig, ListenerType, PathRule, RemoveBackend, RemoveCertificate,
+        RemoveListener, ReplaceCertificate, Request, RequestHttpFrontend, RequestTcpFrontend,
+        TcpListenerConfig,
     },
     response::{Backend, HttpFrontend, TcpFrontend},
 };
@@ -1247,12 +1248,15 @@ pub fn get_cluster_ids_by_domain(
     cluster_ids
 }
 
-pub fn get_certificate(state: &ConfigState, fingerprint: &[u8]) -> Option<(String, Vec<String>)> {
+pub fn get_certificate(state: &ConfigState, fingerprint: &[u8]) -> Option<CertificateWithNames> {
     state
         .certificates
         .values()
         .filter_map(|h| h.get(&Fingerprint(fingerprint.to_vec())))
-        .map(|c| (c.certificate.clone(), c.names.clone()))
+        .map(|c| CertificateWithNames {
+            certificate: c.certificate.clone(),
+            names: c.names.clone(),
+        })
         .next()
 }
 

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -14,11 +14,11 @@ use crate::{
     certificate::{calculate_fingerprint, Fingerprint},
     proto::command::{
         request::RequestType, ActivateListener, AddBackend, AddCertificate, CertificateAndKey,
-        Cluster, DeactivateListener, HttpListenerConfig, HttpsListenerConfig, ListenerType,
-        PathRule, RemoveBackend, RemoveCertificate, RemoveListener, ReplaceCertificate, Request,
-        RequestHttpFrontend, RequestTcpFrontend, TcpListenerConfig,
+        Cluster, ClusterInformation, DeactivateListener, HttpListenerConfig, HttpsListenerConfig,
+        ListenerType, PathRule, RemoveBackend, RemoveCertificate, RemoveListener,
+        ReplaceCertificate, Request, RequestHttpFrontend, RequestTcpFrontend, TcpListenerConfig,
     },
-    response::{Backend, ClusterInformation, HttpFrontend, TcpFrontend},
+    response::{Backend, HttpFrontend, TcpFrontend},
 };
 
 /// To use throughout Sōzu
@@ -1152,41 +1152,44 @@ impl ConfigState {
             .collect()
     }
 
+    /// Gives details about a given cluster.
+    /// Types like `HttpFrontend` are converted into protobuf ones, like `RequestHttpFrontend`
     pub fn cluster_state(&self, cluster_id: &str) -> ClusterInformation {
+        let mut http_frontends = Vec::new();
+        let mut https_frontends = Vec::new();
+        let mut tcp_frontends = Vec::new();
+        let mut backends = Vec::new();
+
+        for (_k, http_frontend) in &self.http_fronts {
+            if let Some(id) = &http_frontend.cluster_id {
+                if id == cluster_id {
+                    http_frontends.push(http_frontend.clone().into());
+                }
+            }
+        }
+
+        for (_k, https_frontend) in &self.https_fronts {
+            if let Some(id) = &https_frontend.cluster_id {
+                if id == cluster_id {
+                    https_frontends.push(https_frontend.clone().into());
+                }
+            }
+        }
+
+        for tcp_f in self.tcp_fronts.get(cluster_id).cloned().unwrap_or_default() {
+            tcp_frontends.push(tcp_f.clone().into());
+        }
+
+        for backend in self.backends.get(cluster_id).cloned().unwrap_or_default() {
+            backends.push(backend.clone().into())
+        }
+
         ClusterInformation {
             configuration: self.clusters.get(cluster_id).cloned(),
-            http_frontends: self
-                .http_fronts
-                .iter()
-                .filter_map(|(_k, v)| match &v.cluster_id {
-                    None => None,
-                    Some(id) => {
-                        if id == cluster_id {
-                            Some(v)
-                        } else {
-                            None
-                        }
-                    }
-                })
-                .cloned()
-                .collect(),
-            https_frontends: self
-                .https_fronts
-                .iter()
-                .filter_map(|(_k, v)| match &v.cluster_id {
-                    None => None,
-                    Some(id) => {
-                        if id == cluster_id {
-                            Some(v)
-                        } else {
-                            None
-                        }
-                    }
-                })
-                .cloned()
-                .collect(),
-            tcp_frontends: self.tcp_fronts.get(cluster_id).cloned().unwrap_or_default(),
-            backends: self.backends.get(cluster_id).cloned().unwrap_or_default(),
+            http_frontends,
+            https_frontends,
+            tcp_frontends,
+            backends,
         }
     }
 

--- a/e2e/src/tests/mod.rs
+++ b/e2e/src/tests/mod.rs
@@ -4,7 +4,7 @@ use std::{io::stdin, net::SocketAddr};
 
 use sozu_command_lib::{
     config::{Config, ListenerBuilder},
-    proto::command::{ActivateListener, ListenerType, Request, request::RequestType},
+    proto::command::{request::RequestType, ActivateListener, ListenerType, Request},
     scm_socket::Listeners,
     state::ConfigState,
 };

--- a/lib/examples/tcp.rs
+++ b/lib/examples/tcp.rs
@@ -11,7 +11,8 @@ use sozu_command::{
     channel::Channel,
     logging::{Logger, LoggerBackend},
     proto::command::{
-        AddBackend, LoadBalancingParams, Request, RequestTcpFrontend, TcpListenerConfig, request::RequestType,
+        request::RequestType, AddBackend, LoadBalancingParams, Request, RequestTcpFrontend,
+        TcpListenerConfig,
     },
     request::WorkerRequest,
 };

--- a/lib/src/backends.rs
+++ b/lib/src/backends.rs
@@ -5,7 +5,7 @@ use mio::net::TcpStream;
 
 use sozu_command::{
     proto::command::{LoadBalancingAlgorithms, LoadMetric},
-    response::Event,
+    response::{Event, EventKind},
     state::ClusterId,
 };
 
@@ -105,7 +105,12 @@ impl BackendMap {
                 if self.available {
                     self.available = false;
 
-                    push_event(Event::NoAvailableBackends(cluster_id.to_string()));
+                    push_event(Event {
+                        kind: EventKind::NoAvailableBackends,
+                        cluster_id: Some(cluster_id.to_owned()),
+                        backend_id: None,
+                        address: None,
+                    });
                 }
                 bail!("No more backend available for cluster {}", cluster_id);
             }

--- a/lib/src/backends.rs
+++ b/lib/src/backends.rs
@@ -4,8 +4,7 @@ use anyhow::{bail, Context};
 use mio::net::TcpStream;
 
 use sozu_command::{
-    proto::command::{LoadBalancingAlgorithms, LoadMetric},
-    response::{Event, EventKind},
+    proto::command::{Event, EventKind, LoadBalancingAlgorithms, LoadMetric},
     state::ClusterId,
 };
 
@@ -106,7 +105,7 @@ impl BackendMap {
                     self.available = false;
 
                     push_event(Event {
-                        kind: EventKind::NoAvailableBackends,
+                        kind: EventKind::NoAvailableBackends as i32,
                         cluster_id: Some(cluster_id.to_owned()),
                         backend_id: None,
                         address: None,

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -33,13 +33,14 @@ use sozu_command::{
     config::DEFAULT_CIPHER_SUITES,
     logging,
     proto::command::{
-        request::RequestType, AddCertificate, CertificateSummary, CertificatesByAddress, Cluster,
-        HttpsListenerConfig, ListOfCertificatesByAddress, RemoveCertificate, RemoveListener,
-        ReplaceCertificate, RequestHttpFrontend, TlsVersion,
+        request::RequestType, response_content::ContentType, AddCertificate, CertificateSummary,
+        CertificatesByAddress, Cluster, HttpsListenerConfig, ListOfCertificatesByAddress,
+        RemoveCertificate, RemoveListener, ReplaceCertificate, RequestHttpFrontend,
+        ResponseContent, TlsVersion,
     },
     ready::Ready,
     request::WorkerRequest,
-    response::{HttpFrontend, ResponseContent, WorkerResponse},
+    response::{HttpFrontend, WorkerResponse},
     scm_socket::ScmSocket,
     state::ClusterId,
 };
@@ -967,9 +968,11 @@ impl HttpsProxy {
             certificates
         );
 
-        Ok(Some(ResponseContent::Certificates(
-            ListOfCertificatesByAddress { certificates },
-        )))
+        Ok(Some(ResponseContent {
+            content_type: Some(ContentType::Certificates(ListOfCertificatesByAddress {
+                certificates,
+            })),
+        }))
     }
 
     pub fn query_certificate_for_domain(
@@ -1004,9 +1007,11 @@ impl HttpsProxy {
             domain, certificates
         );
 
-        Ok(Some(ResponseContent::Certificates(
-            ListOfCertificatesByAddress { certificates },
-        )))
+        Ok(Some(ResponseContent {
+            content_type: Some(ContentType::Certificates(ListOfCertificatesByAddress {
+                certificates,
+            })),
+        }))
     }
 
     pub fn activate_listener(

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -34,8 +34,7 @@ use sozu_command::{
     logging,
     proto::command::{
         request::RequestType, AddCertificate, CertificateSummary, Cluster, HttpsListenerConfig,
-        RemoveCertificate, RemoveListener, ReplaceCertificate, Request, RequestHttpFrontend,
-        TlsVersion,
+        RemoveCertificate, RemoveListener, ReplaceCertificate, RequestHttpFrontend, TlsVersion,
     },
     ready::Ready,
     request::WorkerRequest,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -217,7 +217,7 @@ use sozu_command::{
     proto::command::{Cluster, LoadBalancingParams},
     ready::Ready,
     request::WorkerRequest,
-    response::{Event, WorkerResponse},
+    response::{Event, EventKind, WorkerResponse},
     state::ClusterId,
 };
 use time::{Duration, Instant};
@@ -716,10 +716,12 @@ impl Backend {
 // can be safely stopped
 impl std::ops::Drop for Backend {
     fn drop(&mut self) {
-        server::push_event(Event::RemovedBackendHasNoConnections(
-            self.backend_id.clone(),
-            self.address,
-        ));
+        server::push_event(Event {
+            kind: EventKind::RemovedBackendHasNoConnections,
+            backend_id: Some(self.backend_id.clone()),
+            address: Some(self.address.to_string()),
+            cluster_id: None,
+        });
     }
 }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -214,10 +214,10 @@ use anyhow::{bail, Context};
 use mio::{net::TcpStream, Interest, Token};
 use protocol::http::parser::Method;
 use sozu_command::{
-    proto::command::{Cluster, LoadBalancingParams},
+    proto::command::{Cluster, Event, EventKind, LoadBalancingParams},
     ready::Ready,
     request::WorkerRequest,
-    response::{Event, EventKind, WorkerResponse},
+    response::WorkerResponse,
     state::ClusterId,
 };
 use time::{Duration, Instant};
@@ -717,7 +717,7 @@ impl Backend {
 impl std::ops::Drop for Backend {
     fn drop(&mut self) {
         server::push_event(Event {
-            kind: EventKind::RemovedBackendHasNoConnections,
+            kind: EventKind::RemovedBackendHasNoConnections as i32,
             backend_id: Some(self.backend_id.clone()),
             address: Some(self.address.to_string()),
             cluster_id: None,

--- a/lib/src/metrics/local_drain.rs
+++ b/lib/src/metrics/local_drain.rs
@@ -3,12 +3,10 @@ use std::{collections::BTreeMap, str, time::Instant};
 
 use anyhow::Context;
 use hdrhistogram::Histogram;
-use sozu_command::{
-    proto::command::{
-        filtered_metrics, AvailableMetrics, BackendMetrics, ClusterMetrics, FilteredMetrics,
-        MetricsConfiguration, Percentiles, QueryMetricsOptions, WorkerMetrics,
-    },
-    response::ResponseContent,
+use sozu_command::proto::command::{
+    filtered_metrics, response_content::ContentType, AvailableMetrics, BackendMetrics,
+    ClusterMetrics, FilteredMetrics, MetricsConfiguration, Percentiles, QueryMetricsOptions,
+    ResponseContent, WorkerMetrics,
 };
 
 use super::{MetricData, Subscriber};
@@ -199,7 +197,9 @@ impl LocalDrain {
             (true, true) => self.dump_all_metrics(metric_names)?,
         };
 
-        Ok(ResponseContent::WorkerMetrics(worker_metrics))
+        Ok(ResponseContent {
+            content_type: Some(ContentType::WorkerMetrics(worker_metrics)),
+        })
     }
 
     fn list_all_metric_names(&self) -> anyhow::Result<ResponseContent> {
@@ -212,10 +212,12 @@ impl LocalDrain {
                 cluster_metrics.push(metric_name.to_owned());
             }
         }
-        Ok(ResponseContent::AvailableMetrics(AvailableMetrics {
-            proxy_metrics,
-            cluster_metrics,
-        }))
+        Ok(ResponseContent {
+            content_type: Some(ContentType::AvailableMetrics(AvailableMetrics {
+                proxy_metrics,
+                cluster_metrics,
+            })),
+        })
     }
 
     pub fn dump_all_metrics(

--- a/lib/src/metrics/mod.rs
+++ b/lib/src/metrics/mod.rs
@@ -13,9 +13,8 @@ use std::{
 
 use anyhow::Context;
 use mio::net::UdpSocket;
-use sozu_command::{
-    proto::command::{FilteredMetrics, MetricsConfiguration, QueryMetricsOptions},
-    response::ResponseContent,
+use sozu_command::proto::command::{
+    FilteredMetrics, MetricsConfiguration, QueryMetricsOptions, ResponseContent,
 };
 
 use self::{local_drain::LocalDrain, network_drain::NetworkDrain};

--- a/lib/src/protocol/http/mod.rs
+++ b/lib/src/protocol/http/mod.rs
@@ -14,7 +14,7 @@ use std::{
 use anyhow::{bail, Context};
 use mio::{net::TcpStream, *};
 use rusty_ulid::Ulid;
-use sozu_command::response::Event;
+use sozu_command::response::{Event, EventKind};
 use time::{Duration, Instant};
 
 use crate::{
@@ -2220,10 +2220,12 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
                         backend.backend_id, backend.address
                     );
 
-                    push_event(Event::BackendUp(
-                        backend.backend_id.clone(),
-                        backend.address,
-                    ));
+                    push_event(Event {
+                        kind: EventKind::BackendUp,
+                        backend_id: Some(backend.backend_id.to_owned()),
+                        address: Some(backend.address.to_string()),
+                        cluster_id: None,
+                    });
                 }
 
                 if let BackendConnectionStatus::Connecting(start) = last {
@@ -2261,10 +2263,12 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
                     metrics.backend_id.as_deref()
                 );
 
-                push_event(Event::BackendDown(
-                    backend.backend_id.clone(),
-                    backend.address,
-                ));
+                push_event(Event {
+                    kind: EventKind::BackendDown,
+                    backend_id: Some(backend.backend_id.to_owned()),
+                    address: Some(backend.address.to_string()),
+                    cluster_id: None,
+                });
             }
         }
     }

--- a/lib/src/protocol/http/mod.rs
+++ b/lib/src/protocol/http/mod.rs
@@ -14,7 +14,7 @@ use std::{
 use anyhow::{bail, Context};
 use mio::{net::TcpStream, *};
 use rusty_ulid::Ulid;
-use sozu_command::response::{Event, EventKind};
+use sozu_command::proto::command::{Event, EventKind};
 use time::{Duration, Instant};
 
 use crate::{
@@ -2221,7 +2221,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
                     );
 
                     push_event(Event {
-                        kind: EventKind::BackendUp,
+                        kind: EventKind::BackendUp as i32,
                         backend_id: Some(backend.backend_id.to_owned()),
                         address: Some(backend.address.to_string()),
                         cluster_id: None,
@@ -2264,7 +2264,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
                 );
 
                 push_event(Event {
-                    kind: EventKind::BackendDown,
+                    kind: EventKind::BackendDown as i32,
                     backend_id: Some(backend.backend_id.to_owned()),
                     address: Some(backend.address.to_string()),
                     cluster_id: None,

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -18,9 +18,9 @@ use sozu_command::{
     config::Config,
     proto::command::{
         request::RequestType, ActivateListener, AddBackend, Cluster, ClusterHashes,
-        DeactivateListener, Event, HttpListenerConfig, HttpsListenerConfig, ListenerType,
-        LoadBalancingAlgorithms, LoadMetric, MetricsConfiguration, RemoveBackend, ResponseStatus,
-        TcpListenerConfig as CommandTcpListener,
+        ClusterInformations, DeactivateListener, Event, HttpListenerConfig, HttpsListenerConfig,
+        ListenerType, LoadBalancingAlgorithms, LoadMetric, MetricsConfiguration, RemoveBackend,
+        ResponseStatus, TcpListenerConfig as CommandTcpListener,
     },
     ready::Ready,
     request::WorkerRequest,
@@ -891,7 +891,9 @@ impl Server {
             Some(RequestType::QueryClusterById(cluster_id)) => {
                 push_queue(WorkerResponse::ok_with_content(
                     message.id.clone(),
-                    ResponseContent::Clusters(vec![self.config_state.cluster_state(cluster_id)]),
+                    ResponseContent::Clusters(ClusterInformations {
+                        vec: vec![self.config_state.cluster_state(cluster_id)],
+                    }),
                 ));
             }
             Some(RequestType::QueryClustersByDomain(domain)) => {
@@ -900,14 +902,14 @@ impl Server {
                     domain.hostname.clone(),
                     domain.path.clone(),
                 );
-                let answer = cluster_ids
+                let vec = cluster_ids
                     .iter()
                     .map(|cluster_id| self.config_state.cluster_state(cluster_id))
                     .collect();
 
                 push_queue(WorkerResponse::ok_with_content(
                     message.id.clone(),
-                    ResponseContent::Clusters(answer),
+                    ResponseContent::Clusters(ClusterInformations { vec }),
                 ));
                 return;
             }

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -17,9 +17,9 @@ use sozu_command::{
     channel::Channel,
     config::Config,
     proto::command::{
-        request::RequestType, ActivateListener, AddBackend, Cluster, DeactivateListener, Event,
-        HttpListenerConfig, HttpsListenerConfig, ListenerType, LoadBalancingAlgorithms, LoadMetric,
-        MetricsConfiguration, RemoveBackend, ResponseStatus,
+        request::RequestType, ActivateListener, AddBackend, Cluster, ClusterHashes,
+        DeactivateListener, Event, HttpListenerConfig, HttpsListenerConfig, ListenerType,
+        LoadBalancingAlgorithms, LoadMetric, MetricsConfiguration, RemoveBackend, ResponseStatus,
         TcpListenerConfig as CommandTcpListener,
     },
     ready::Ready,
@@ -882,7 +882,9 @@ impl Server {
             Some(RequestType::QueryClustersHashes(_)) => {
                 push_queue(WorkerResponse::ok_with_content(
                     message.id.clone(),
-                    ResponseContent::ClustersHashes(self.config_state.hash_state()),
+                    ResponseContent::ClustersHashes(ClusterHashes {
+                        map: self.config_state.hash_state(),
+                    }),
                 ));
                 return;
             }

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -17,13 +17,14 @@ use sozu_command::{
     channel::Channel,
     config::Config,
     proto::command::{
-        request::RequestType, ActivateListener, AddBackend, Cluster, DeactivateListener,
+        request::RequestType, ActivateListener, AddBackend, Cluster, DeactivateListener, Event,
         HttpListenerConfig, HttpsListenerConfig, ListenerType, LoadBalancingAlgorithms, LoadMetric,
-        RemoveBackend, ResponseStatus, TcpListenerConfig as CommandTcpListener, MetricsConfiguration,
+        MetricsConfiguration, RemoveBackend, ResponseStatus,
+        TcpListenerConfig as CommandTcpListener,
     },
     ready::Ready,
     request::WorkerRequest,
-    response::{Event, MessageId, ResponseContent, WorkerResponse},
+    response::{MessageId, ResponseContent, WorkerResponse},
     scm_socket::{Listeners, ScmSocket},
     state::{get_certificate, get_cluster_ids_by_domain, ConfigState},
 };

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -19,11 +19,11 @@ use sozu_command::{
     proto::command::{
         request::RequestType, ActivateListener, AddBackend, Cluster, DeactivateListener,
         HttpListenerConfig, HttpsListenerConfig, ListenerType, LoadBalancingAlgorithms, LoadMetric,
-        MetricsConfiguration, RemoveBackend, Request, TcpListenerConfig as CommandTcpListener,
+        RemoveBackend, ResponseStatus, TcpListenerConfig as CommandTcpListener, MetricsConfiguration,
     },
     ready::Ready,
     request::WorkerRequest,
-    response::{Event, MessageId, ResponseContent, ResponseStatus, WorkerResponse},
+    response::{Event, MessageId, ResponseContent, WorkerResponse},
     scm_socket::{Listeners, ScmSocket},
     state::{get_certificate, get_cluster_ids_by_domain, ConfigState},
 };

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -16,6 +16,7 @@ use mio::{
 };
 use rusty_ulid::Ulid;
 use slab::Slab;
+use sozu_command::proto::command::request::RequestType;
 use time::{Duration, Instant};
 
 use crate::{
@@ -36,8 +37,7 @@ use crate::{
     sozu_command::{
         logging,
         proto::command::{
-            request::RequestType, Event, EventKind, ProxyProtocolConfig, RequestTcpFrontend,
-            TcpListenerConfig,
+            Event, EventKind, ProxyProtocolConfig, RequestTcpFrontend, TcpListenerConfig,
         },
         ready::Ready,
         request::WorkerRequest,

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -16,8 +16,9 @@ use mio::{
 };
 use rusty_ulid::Ulid;
 use slab::Slab;
-use sozu_command::proto::command::request::RequestType;
 use time::{Duration, Instant};
+
+use sozu_command::{proto::command::request::RequestType, response::EventKind};
 
 use crate::{
     backends::BackendMap,
@@ -504,10 +505,12 @@ impl TcpSession {
                         "backend server {} at {} is up",
                         backend.backend_id, backend.address
                     );
-                    push_event(Event::BackendUp(
-                        backend.backend_id.clone(),
-                        backend.address,
-                    ));
+                    push_event(Event {
+                        kind: EventKind::BackendUp,
+                        backend_id: Some(backend.backend_id.to_owned()),
+                        address: Some(backend.address.to_string()),
+                        cluster_id: None,
+                    });
                 }
 
                 if let BackendConnectionStatus::Connecting(start) = last {
@@ -556,10 +559,12 @@ impl TcpSession {
                     self.metrics.backend_id.as_deref()
                 );
 
-                push_event(Event::BackendDown(
-                    backend.backend_id.clone(),
-                    backend.address,
-                ));
+                push_event(Event {
+                    kind: EventKind::BackendDown,
+                    backend_id: Some(backend.backend_id.to_owned()),
+                    address: Some(backend.address.to_string()),
+                    cluster_id: None,
+                });
             }
         }
     }

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -18,8 +18,6 @@ use rusty_ulid::Ulid;
 use slab::Slab;
 use time::{Duration, Instant};
 
-use sozu_command::{proto::command::request::RequestType, response::EventKind};
-
 use crate::{
     backends::BackendMap,
     pool::{Checkout, Pool},
@@ -37,10 +35,13 @@ use crate::{
     socket::server_bind,
     sozu_command::{
         logging,
-        proto::command::{ProxyProtocolConfig, RequestTcpFrontend, TcpListenerConfig},
+        proto::command::{
+            request::RequestType, Event, EventKind, ProxyProtocolConfig, RequestTcpFrontend,
+            TcpListenerConfig,
+        },
         ready::Ready,
         request::WorkerRequest,
-        response::{Event, WorkerResponse},
+        response::WorkerResponse,
         scm_socket::ScmSocket,
         state::ClusterId,
     },
@@ -506,7 +507,7 @@ impl TcpSession {
                         backend.backend_id, backend.address
                     );
                     push_event(Event {
-                        kind: EventKind::BackendUp,
+                        kind: EventKind::BackendUp as i32,
                         backend_id: Some(backend.backend_id.to_owned()),
                         address: Some(backend.address.to_string()),
                         cluster_id: None,
@@ -560,7 +561,7 @@ impl TcpSession {
                 );
 
                 push_event(Event {
-                    kind: EventKind::BackendDown,
+                    kind: EventKind::BackendDown as i32,
                     backend_id: Some(backend.backend_id.to_owned()),
                     address: Some(backend.address.to_string()),
                     cluster_id: None,


### PR DESCRIPTION
This writes the big Response type in protobuf, and together with it, embedded types like `ListedFrontends`, that were not already translated in protobuf.

A key aspect is that we have type pairs to fullfill different functions. As an example:
- `HttpFrontend` is used *within* Sōzu to describe an HTTP or HTTPS frontend, with its socket address being of the type `SocketAddr`
- `RequestHttpFrontend` is used *without* Sōzu, to send requests to it, with a socket address being a simple `string`.
 
Types used for requests are used as well in the responses. That means `ListedFrontends` contains a list of `RequestHttpFrontend` because this type is fit for communication to and from Sōzu.

If these "outside" type should be renamed differently, is up for debate.