### PR TITLE
Update lib documentation

### DIFF
--- a/lib/examples/main.rs
+++ b/lib/examples/main.rs
@@ -1,15 +1,15 @@
 #![allow(unused_variables, unused_must_use)]
 #[macro_use]
-extern crate sozu_lib as sozu;
+extern crate sozu_lib;
 #[macro_use]
-extern crate sozu_command_lib as sozu_command;
+extern crate sozu_command_lib;
 extern crate time;
 
 use std::{env, io::stdout, thread};
 
 use anyhow::Context;
 
-use sozu_command::{
+use sozu_command_lib::{
     channel::Channel,
     config::ListenerBuilder,
     logging::{Logger, LoggerBackend},
@@ -39,7 +39,7 @@ fn main() -> anyhow::Result<()> {
 
     info!("MAIN\tstarting up");
 
-    sozu::metrics::setup(
+    sozu_lib::metrics::setup(
         &"127.0.0.1:8125"
             .parse()
             .with_context(|| "Could not parse address for metrics setup")?,
@@ -56,7 +56,7 @@ fn main() -> anyhow::Result<()> {
     let jg = thread::spawn(move || {
         let max_buffers = 500;
         let buffer_size = 16384;
-        sozu::http::start_http_worker(http_listener, channel, max_buffers, buffer_size);
+        sozu_lib::http::start_http_worker(http_listener, channel, max_buffers, buffer_size);
     });
 
     let http_front = RequestHttpFrontend {
@@ -93,14 +93,14 @@ fn main() -> anyhow::Result<()> {
     info!("MAIN\tHTTP -> {:?}", command.read_message());
     info!("MAIN\tHTTP -> {:?}", command.read_message());
 
-    let https_listener = ListenerBuilder::new_tcp("127.0.0.1:8443").to_tls()?;
+    let https_listener = ListenerBuilder::new_https("127.0.0.1:8443").to_tls()?;
 
     let (mut command2, channel2) =
         Channel::generate(1000, 10000).with_context(|| "should create a channel")?;
     let jg2 = thread::spawn(move || {
         let max_buffers = 500;
         let buffer_size = 16384;
-        sozu::https::start_https_worker(https_listener, channel2, max_buffers, buffer_size)
+        sozu_lib::https::start_https_worker(https_listener, channel2, max_buffers, buffer_size)
     });
 
     let cert1 = include_str!("../assets/certificate.pem");

--- a/lib/examples/minimal.rs
+++ b/lib/examples/minimal.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate time;
 
 #[macro_use]
@@ -14,10 +13,11 @@ use sozu_command_lib::{
     info,
     logging::{Logger, LoggerBackend},
     proto::command::{
-        request::RequestType, AddBackend, LoadBalancingParams, PathRule, Request,
-        RequestHttpFrontend, RulePosition,
+        request::RequestType, AddBackend, Cluster, LoadBalancingAlgorithms, LoadBalancingParams,
+        PathRule, Request, RequestHttpFrontend, RulePosition,
     },
     request::WorkerRequest,
+    response::WorkerResponse,
 };
 
 fn main() -> anyhow::Result<()> {
@@ -39,22 +39,35 @@ fn main() -> anyhow::Result<()> {
 
     info!("starting up");
 
-    let http_listener = ListenerBuilder::new_http("127.0.0.1:8080").to_http()?;
+    let http_listener = ListenerBuilder::new_http("127.0.0.1:8080")
+        .to_http()
+        .expect("Could not create HTTP listener");
 
-    let (mut command_channel, proxy_channel) =
-        Channel::generate(1000, 10000).with_context(|| "should create a channel")?;
+    let (mut command_channel, proxy_channel): (
+        Channel<WorkerRequest, WorkerResponse>,
+        Channel<WorkerResponse, WorkerRequest>,
+    ) = Channel::generate(1000, 10000).with_context(|| "should create a channel")?;
 
-    let jg = thread::spawn(move || {
+    let worker_thread_join_handle = thread::spawn(move || {
         let max_buffers = 500;
         let buffer_size = 16384;
         sozu_lib::http::start_http_worker(http_listener, proxy_channel, max_buffers, buffer_size)
             .expect("The worker could not be started, or shut down");
     });
 
+    let cluster = Cluster {
+        cluster_id: "my-cluster".to_string(),
+        sticky_session: false,
+        https_redirect: false,
+        load_balancing: LoadBalancingAlgorithms::RoundRobin as i32,
+        answer_503: Some("A custom forbidden message".to_string()),
+        ..Default::default()
+    };
+
     let http_front = RequestHttpFrontend {
-        cluster_id: Some(String::from("test")),
+        cluster_id: Some("my-cluster".to_string()),
         address: "127.0.0.1:8080".to_string(),
-        hostname: String::from("example.com"),
+        hostname: "example.com".to_string(),
         path: PathRule::prefix(String::from("/")),
         position: RulePosition::Pre.into(),
         tags: BTreeMap::from([
@@ -64,8 +77,8 @@ fn main() -> anyhow::Result<()> {
         ..Default::default()
     };
     let http_backend = AddBackend {
-        cluster_id: String::from("test"),
-        backend_id: String::from("test-0"),
+        cluster_id: "my-cluster".to_string(),
+        backend_id: "test-backend".to_string(),
         address: "127.0.0.1:8000".to_string(),
         load_balancing_parameters: Some(LoadBalancingParams::default()),
         ..Default::default()
@@ -73,7 +86,16 @@ fn main() -> anyhow::Result<()> {
 
     command_channel
         .write_message(&WorkerRequest {
-            id: String::from("ID_ABCD"),
+            id: String::from("add-the-cluster"),
+            content: Request {
+                request_type: Some(RequestType::AddCluster(cluster)),
+            },
+        })
+        .expect("Could not send AddHttpFrontend request");
+
+    command_channel
+        .write_message(&WorkerRequest {
+            id: String::from("add-the-frontend"),
             content: Request {
                 request_type: Some(RequestType::AddHttpFrontend(http_front)),
             },
@@ -82,7 +104,7 @@ fn main() -> anyhow::Result<()> {
 
     command_channel
         .write_message(&WorkerRequest {
-            id: String::from("ID_EFGH"),
+            id: String::from("add-the-backend"),
             content: Request {
                 request_type: Some(RequestType::AddBackend(http_backend)),
             },
@@ -92,7 +114,7 @@ fn main() -> anyhow::Result<()> {
     println!("HTTP -> {:?}", command_channel.read_message());
     println!("HTTP -> {:?}", command_channel.read_message());
 
-    let _ = jg.join();
+    let _ = worker_thread_join_handle.join();
     info!("good bye");
     Ok(())
 }

--- a/lib/examples/tcp.rs
+++ b/lib/examples/tcp.rs
@@ -1,13 +1,13 @@
 #![allow(unused_variables, unused_must_use)]
-extern crate sozu_lib as sozu;
+extern crate sozu_lib;
 #[macro_use]
-extern crate sozu_command_lib as sozu_command;
+extern crate sozu_command_lib;
 extern crate time;
 
 use std::{io::stdout, thread};
 
 use anyhow::Context;
-use sozu_command::{
+use sozu_command_lib::{
     channel::Channel,
     logging::{Logger, LoggerBackend},
     proto::command::{
@@ -51,7 +51,7 @@ fn main() -> anyhow::Result<()> {
             LoggerBackend::Stdout(stdout()),
             None,
         );
-        sozu::tcp::start_tcp_worker(listener, max_buffers, buffer_size, channel);
+        sozu_lib::tcp::start_tcp_worker(listener, max_buffers, buffer_size, channel);
     });
 
     let tcp_front = RequestTcpFrontend {

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -1001,7 +1001,8 @@ impl L7Proxy for HttpProxy {
     }
 }
 
-/// This is not directly used by Sōzu but is available for example and testing purposes
+/// This is starts an HTTP worker with an HTTP listener config.
+/// It activates the Listener automatically.
 pub fn start_http_worker(
     config: HttpListenerConfig,
     channel: ProxyChannel,

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -485,6 +485,7 @@ impl Server {
         Ok(server)
     }
 
+    /// The server runs in a loop until a shutdown is ordered
     pub fn run(&mut self) {
         let mut events = Events::with_capacity(1024); // TODO: make event capacity configurable?
         self.last_sessions_len = self.sessions.borrow().slab.len();


### PR DESCRIPTION
The documentation of `sozu_lib` was completely obsolete, even before introducing protobuf.

I made the documentation more verbose and gave it context too.