### PR TITLE
doc/configure.md: Adapt to match with frontend example below

### DIFF
--- a/doc/configure.md
+++ b/doc/configure.md
@@ -69,7 +69,8 @@ _General parameters:_
 # possible values are http, https or tcp
 protocol = "http"
 # listening address
-address = "127.0.0.1:8080"
+address = "0.0.0.0:8080"
+# address = "[::]:8080"
 
 # specify a different IP than the one the socket sees, for logs and forwarded headers
 # public_address = "1.2.3.4:80


### PR DESCRIPTION
I spent so much time trying to figure out what this error message meant with the example frontend configuration:

```
Error connecting to backend: Could not get cluster id from request: Host not found: lolcatho.st:8080: No cluster found
```