### PR TITLE
Stats command on request types received

### DIFF
--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -281,6 +281,11 @@ pub enum StateCmd {
         #[clap(short = 'f', long = "file")]
         file: String,
     },
+    #[clap(
+        name = "stats",
+        about = "show the counts of requests that were received since startup"
+    )]
+    Stats,
 }
 
 #[derive(Subcommand, PartialEq, Eq, Clone, Debug)]

--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -102,8 +102,9 @@ pub enum Success {
     PropagatedWorkerEvent,
     Query(ResponseContent),
     ReloadConfiguration(usize, usize), // ok, errors
-    SaveState(usize, String),          // amount of written commands, path of the saved state
-    Status(ResponseContent),           // Vec<WorkerInfo>
+    RequestCounts(ResponseContent),
+    SaveState(usize, String), // amount of written commands, path of the saved state
+    Status(ResponseContent),  // Vec<WorkerInfo>
     SubscribeEvent(String),
     UpgradeMain(i32),    // pid of the new main process
     UpgradeWorker(u32),  // worker id
@@ -150,6 +151,7 @@ impl std::fmt::Display for Success {
                 f,
                 "Successfully reloaded configuration, ok: {ok}, errors: {error}"
             ),
+            Self::RequestCounts(_) => write!(f, "count requests"),
             Self::SaveState(counter, path) => {
                 write!(f, "saved {counter} config messages to {path}")
             }

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -76,6 +76,7 @@ impl CommandServer {
             Some(RequestType::QueryCertificatesFromTheState(filters)) => {
                 self.query_certificates_from_the_state(filters)
             }
+            Some(RequestType::CountRequests(_)) => self.query_request_count(),
             Some(RequestType::QueryClusterById(_))
             | Some(RequestType::QueryCertificatesFromWorkers(_))
             | Some(RequestType::QueryClustersByDomain(_))
@@ -110,6 +111,13 @@ impl CommandServer {
         }
 
         Ok(Success::HandledClientRequest)
+    }
+
+    pub fn query_request_count(&mut self) -> anyhow::Result<Option<Success>> {
+        let request_counts = self.state.get_request_counts();
+        Ok(Some(Success::RequestCounts(
+            ContentType::RequestCounts(request_counts).into(),
+        )))
     }
 
     pub async fn save_state(&mut self, path: &str) -> anyhow::Result<Option<Success>> {
@@ -1354,6 +1362,7 @@ impl CommandServer {
 
                 let command_response_data = match success {
                     Success::ListFrontends(crd)
+                    | Success::RequestCounts(crd)
                     | Success::ListWorkers(crd)
                     | Success::CertificatesFromTheState(crd)
                     | Success::Query(crd)

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -13,7 +13,7 @@ use crate::ctl::{
     display::{
         print_available_metrics, print_certificates_by_worker, print_certificates_with_validity,
         print_cluster_responses, print_frontend_list, print_json_response, print_listeners,
-        print_metrics, print_status,
+        print_metrics, print_request_counts, print_status,
     },
     CommandManager,
 };
@@ -68,6 +68,9 @@ impl CommandManager {
                     }
                     if let Some(response_content) = response.content {
                         match response_content.content_type {
+                            Some(ContentType::RequestCounts(request_counts)) => {
+                                print_request_counts(&request_counts)
+                            }
                             Some(ContentType::FrontendList(frontends)) => {
                                 print_frontend_list(frontends)
                             }

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -8,7 +8,7 @@ use sozu_command_lib::proto::{
         filtered_metrics, response_content::ContentType, AggregatedMetrics, AvailableMetrics,
         CertificateAndKey, CertificatesWithFingerprints, ClusterMetrics, FilteredMetrics,
         ListedFrontends, ListenersList, ResponseContent, WorkerInfos, WorkerMetrics,
-        WorkerResponses,
+        WorkerResponses, RequestCounts,
     },
     display::concatenate_vector,
 };
@@ -743,6 +743,17 @@ pub fn print_certificates_with_validity(
     table.printstd();
 
     Ok(())
+}
+
+pub fn print_request_counts(request_counts: &RequestCounts) {
+    let mut table = Table::new();
+    table.set_format(*prettytable::format::consts::FORMAT_BOX_CHARS);
+    table.add_row(row!["request type", "count"]);
+
+    for (request_type, count) in &request_counts.map {
+        table.add_row(row!(request_type, count));
+    }
+    table.printstd();
 }
 
 // ISO 8601

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -82,6 +82,7 @@ impl CommandManager {
             SubCmd::State { cmd } => match cmd {
                 StateCmd::Save { file } => self.save_state(file),
                 StateCmd::Load { file } => self.load_state(file),
+                StateCmd::Stats => self.count_requests(),
             },
             SubCmd::Reload { file, json } => self.reload_configuration(file, json),
             SubCmd::Cluster { cmd, json } => self.cluster_command(cmd, json),

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -7,9 +7,9 @@ use sozu_command_lib::{
     config::{Config, ListenerBuilder},
     proto::command::{
         request::RequestType, ActivateListener, AddBackend, AddCertificate, CertificateAndKey,
-        Cluster, DeactivateListener, FrontendFilters, HardStop, ListListeners, ListenerType,
-        LoadBalancingParams, MetricsConfiguration, PathRule, ProxyProtocolConfig, RemoveBackend,
-        RemoveCertificate, RemoveListener, ReplaceCertificate, RequestHttpFrontend,
+        Cluster, CountRequests, DeactivateListener, FrontendFilters, HardStop, ListListeners,
+        ListenerType, LoadBalancingParams, MetricsConfiguration, PathRule, ProxyProtocolConfig,
+        RemoveBackend, RemoveCertificate, RemoveListener, ReplaceCertificate, RequestHttpFrontend,
         RequestTcpFrontend, RulePosition, SoftStop, Status, SubscribeEvents, TlsVersion,
     },
 };
@@ -33,6 +33,10 @@ impl CommandManager {
         println!("Loading the state on path {path}");
 
         self.send_request(RequestType::LoadState(path).into())
+    }
+
+    pub fn count_requests(&mut self) -> anyhow::Result<()> {
+        self.send_request(RequestType::CountRequests(CountRequests {}).into())
     }
 
     pub fn soft_stop(&mut self) -> anyhow::Result<()> {

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -93,6 +93,9 @@ message Request {
     QueryCertificatesFilters query_certificates_from_the_state = 44;
     // Get certificates from the workers (rather than from the state)
     QueryCertificatesFilters query_certificates_from_workers = 45;
+    // query the state about how many requests of each type has been received
+    // since startup
+    CountRequests count_requests = 46;
   }
 }
 
@@ -105,6 +108,7 @@ message QueryClustersHashes {}
 message SoftStop {}
 message HardStop {}
 message ReturnListenSockets {}
+message CountRequests {}
 
 // details of an HTTP listener
 message HttpListenerConfig {
@@ -454,6 +458,8 @@ message ResponseContent {
         ListOfCertificatesByAddress certificates_by_address = 11;
         // a map of complete certificates using fingerprints as key
         CertificatesWithFingerprints certificates_with_fingerprints = 12;
+        // a census of the types of requests received since startup,
+        RequestCounts request_counts = 13;
     }
 }
 
@@ -587,4 +593,8 @@ message Percentiles {
     required uint64 p_99_99 = 6;
     required uint64 p_99_999 = 7;
     required uint64 p_100 = 8;
+}
+
+message RequestCounts {
+    map<string, int32> map = 1;
 }

--- a/command/src/proto/display.rs
+++ b/command/src/proto/display.rs
@@ -2,7 +2,9 @@ use std::fmt::{Display, Formatter};
 
 use crate::proto::command::TlsVersion;
 
-use super::command::{CertificateAndKey, CertificateSummary, QueryCertificatesFilters};
+use super::command::{
+    request::RequestType, CertificateAndKey, CertificateSummary, QueryCertificatesFilters,
+};
 
 impl Display for CertificateAndKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -51,4 +53,51 @@ pub fn concatenate_vector(vec: &Vec<String>) -> String {
         concatenated.push_str(", ");
     }
     concatenated
+}
+
+pub fn format_request_type(request_type: &RequestType) -> String {
+    match request_type {
+        RequestType::SaveState(_) => "SaveState".to_owned(),
+        RequestType::LoadState(_) => "LoadState".to_owned(),
+        RequestType::CountRequests(_) => "CountRequests".to_owned(),
+        RequestType::ListWorkers(_) => "ListWorkers".to_owned(),
+        RequestType::ListFrontends(_) => "ListFrontends".to_owned(),
+        RequestType::ListListeners(_) => "ListListeners".to_owned(),
+        RequestType::LaunchWorker(_) => "LaunchWorker".to_owned(),
+        RequestType::UpgradeMain(_) => "UpgradeMain".to_owned(),
+        RequestType::UpgradeWorker(_) => "UpgradeWorker".to_owned(),
+        RequestType::SubscribeEvents(_) => "SubscribeEvents".to_owned(),
+        RequestType::ReloadConfiguration(_) => "ReloadConfiguration".to_owned(),
+        RequestType::Status(_) => "Status".to_owned(),
+        RequestType::AddCluster(_) => "AddCluster".to_owned(),
+        RequestType::RemoveCluster(_) => "RemoveCluster".to_owned(),
+        RequestType::AddHttpFrontend(_) => "AddHttpFrontend".to_owned(),
+        RequestType::RemoveHttpFrontend(_) => "RemoveHttpFrontend".to_owned(),
+        RequestType::AddHttpsFrontend(_) => "AddHttpsFrontend".to_owned(),
+        RequestType::RemoveHttpsFrontend(_) => "RemoveHttpsFrontend".to_owned(),
+        RequestType::AddCertificate(_) => "AddCertificate".to_owned(),
+        RequestType::ReplaceCertificate(_) => "ReplaceCertificate".to_owned(),
+        RequestType::RemoveCertificate(_) => "RemoveCertificate".to_owned(),
+        RequestType::AddTcpFrontend(_) => "AddTcpFrontend".to_owned(),
+        RequestType::RemoveTcpFrontend(_) => "RemoveTcpFrontend".to_owned(),
+        RequestType::AddBackend(_) => "AddBackend".to_owned(),
+        RequestType::RemoveBackend(_) => "RemoveBackend".to_owned(),
+        RequestType::AddHttpListener(_) => "AddHttpListener".to_owned(),
+        RequestType::AddHttpsListener(_) => "AddHttpsListener".to_owned(),
+        RequestType::AddTcpListener(_) => "AddTcpListener".to_owned(),
+        RequestType::RemoveListener(_) => "RemoveListener".to_owned(),
+        RequestType::ActivateListener(_) => "ActivateListener".to_owned(),
+        RequestType::DeactivateListener(_) => "DeactivateListener".to_owned(),
+        RequestType::QueryClusterById(_) => "QueryClusterById".to_owned(),
+        RequestType::QueryClustersByDomain(_) => "QueryClustersByDomain".to_owned(),
+        RequestType::QueryClustersHashes(_) => "QueryClustersHashes".to_owned(),
+        RequestType::QueryMetrics(_) => "QueryMetrics".to_owned(),
+        RequestType::SoftStop(_) => "SoftStop".to_owned(),
+        RequestType::HardStop(_) => "HardStop".to_owned(),
+        RequestType::ConfigureMetrics(_) => "ConfigureMetrics".to_owned(),
+        RequestType::Logging(_) => "Logging".to_owned(),
+        RequestType::ReturnListenSockets(_) => "ReturnListenSockets".to_owned(),
+        RequestType::QueryCertificatesFromTheState(_) => "QueryCertificatesFromTheState".to_owned(),
+        RequestType::QueryCertificatesFromWorkers(_) => "QueryCertificatesFromWorkers".to_owned(),
+    }
 }

--- a/command/src/request.rs
+++ b/command/src/request.rs
@@ -74,6 +74,7 @@ impl Request {
 
             // These won't ever reach a worker anyway
             RequestType::SaveState(_)
+            | RequestType::CountRequests(_)
             | RequestType::QueryCertificatesFromTheState(_)
             | RequestType::LoadState(_)
             | RequestType::ListWorkers(_)


### PR DESCRIPTION
It is usefull, in production, to track wether a reverse proxy has received a disproportionate amount of requests. For instance, the state could have received a lot of `AddCluster` requests, but not nearly as many `RemoveCluster` ones, hinting on something being wrong in the infrastructure.

```
sozu state stats     

initializing logger
Sending request : Request { request_type: Some(CountRequests(CountRequests)) }
Success: count requests
┌──────────────────┬───────┐
│ request type     │ count │
├──────────────────┼───────┤
│ ActivateListener │ 4     │
├──────────────────┼───────┤
│ AddBackend       │ 4     │
├──────────────────┼───────┤
│ AddCertificate   │ 2     │
├──────────────────┼───────┤
│ AddCluster       │ 3     │
├──────────────────┼───────┤
│ AddHttpFrontend  │ 2     │
├──────────────────┼───────┤
│ AddHttpListener  │ 2     │
├──────────────────┼───────┤
│ AddHttpsFrontend │ 2     │
├──────────────────┼───────┤
│ AddHttpsListener │ 2     │
├──────────────────┼───────┤
│ AddTcpFrontend   │ 2     │
├──────────────────┼───────┤
│ AddTcpListener   │ 2     │
├──────────────────┼───────┤
│ RemoveCluster    │ 3     │
└──────────────────┴───────┘
```