### PR TITLE
Ignore 107 error on front socket, add 100-continue case in e2e tests

### DIFF
--- a/e2e/src/tests/tests.rs
+++ b/e2e/src/tests/tests.rs
@@ -878,13 +878,41 @@ fn try_http_behaviors() -> State {
     );
 
     backend.set_response("HTTP/1.1 200 OK\r\n\r\n");
-    client.set_request("ping");
+    client.set_request("0123456789");
     client.send();
-    let request = backend.receive(1);
+    let request = backend.receive(1).unwrap();
     backend.send(1);
+
+    let expected_response_start = String::from("HTTP/1.1 200 OK\r\n");
+    let expected_response_end = String::from("\r\n\r\n");
     let response = client.receive().unwrap();
     println!("request: {request:?}");
     println!("response: {response:?}");
+    assert!(
+        response.starts_with(&expected_response_start)
+            && response.ends_with(&expected_response_end)
+    );
+    assert_eq!(request, String::from("0123"));
+
+
+    info!("expecting 100 BAD");
+    backend.set_response("HTTP/1.1 200 Ok\r\n\r\nRESPONSE_BODY_NO_LENGTH");
+    client.set_request("GET /100 HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\nExpect: 100-continue\r\n\r\n");
+    client.connect();
+    client.send();
+    backend.accept(1);
+    let request = backend.receive(1);
+    backend.send(1);
+
+    let expected_response_start = String::from("HTTP/1.1 200 Ok\r\n");
+    let expected_response_end = String::from("RESPONSE_BODY_NO_LENGTH");
+    let response = client.receive().unwrap();
+    println!("request: {request:?}");
+    println!("response: {response:?}");
+    assert!(
+        response.starts_with(&expected_response_start)
+            && response.ends_with(&expected_response_end)
+    );
 
     info!("expecting 103");
     backend.set_response("HTTP/1.1 103 Early Hint\r\nLink: </style.css>; rel=preload; as=style\r\n\r\nHTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\npong");

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -293,10 +293,13 @@ impl ProxySession for HttpSession {
 
         let front_socket = self.state.front_socket();
         if let Err(e) = front_socket.shutdown(Shutdown::Both) {
-            error!(
-                "error shutting down front socket({:?}): {:?}",
-                front_socket, e
-            )
+            // error 107 NotConnected can happen when was never fully connected, or was already disconnected due to error
+            if e.kind() != ErrorKind::NotConnected {
+                error!(
+                    "error shutting down front socket({:?}): {:?}",
+                    front_socket, e
+                )
+            }
         }
 
         // deregister the frontend and remove it

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -439,10 +439,13 @@ impl ProxySession for HttpsSession {
 
         let front_socket = self.state.front_socket();
         if let Err(e) = front_socket.shutdown(Shutdown::Both) {
-            error!(
-                "error shutting down front socket({:?}): {:?}",
-                front_socket, e
-            );
+            // error 107 NotConnected can happen when was never fully connected, or was already disconnected due to error
+            if e.kind() != ErrorKind::NotConnected {
+                error!(
+                    "error shutting down front socket({:?}): {:?}",
+                    front_socket, e
+                );
+            }
         }
 
         // deregister the frontend and remove it

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -928,10 +928,13 @@ impl ProxySession for TcpSession {
 
         let front_socket = self.state.front_socket();
         if let Err(e) = front_socket.shutdown(Shutdown::Both) {
-            error!(
-                "error shutting down front socket({:?}): {:?}",
-                front_socket, e
-            );
+            // error 107 NotConnected can happen when was never fully connected, or was already disconnected due to error
+            if e.kind() != ErrorKind::NotConnected {
+                error!(
+                    "error shutting down front socket({:?}): {:?}",
+                    front_socket, e
+                );
+            }
         }
 
         // deregister the frontend and remove it, in a separate scope to drop proxy when done


### PR DESCRIPTION
Don't log error 107 on socket shutdown as it can be safely ignored.
Add a non-standard 100-continue test case in e2e tests that have been encountered in production.