### PR TITLE
add thiserror to sozu-command-lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,6 @@ dependencies = [
 name = "sozu-command-lib"
 version = "0.15.2"
 dependencies = [
- "anyhow",
  "hex",
  "libc",
  "log 0.4.19",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,6 +1885,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "thiserror",
  "time",
  "toml",
  "trailer",

--- a/bin/src/util.rs
+++ b/bin/src/util.rs
@@ -48,12 +48,12 @@ pub fn setup_logging(config: &Config, tag: &str) {
 
 pub fn setup_metrics(config: &Config) -> anyhow::Result<()> {
     if let Some(metrics) = config.metrics.as_ref() {
-        return metrics::setup(
+        return Ok(metrics::setup(
             &metrics.address,
             "MAIN",
             metrics.tagged_metrics,
             metrics.prefix.clone(),
-        );
+        )?);
     }
     Ok(())
 }

--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -27,7 +27,6 @@ include = [
 ]
 
 [dependencies]
-anyhow = "^1.0.72"
 hex = "^0.4.3"
 libc = "^0.2.147"
 log = "^0.4.19"

--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -46,6 +46,7 @@ sha2 = "^0.10.7"
 trailer = "^0.1.2"
 pool = "^0.1.4"
 poule = "^0.3.2"
+thiserror = "^1.0.43"
 
 [features]
 unstable = []

--- a/command/src/certificate.rs
+++ b/command/src/certificate.rs
@@ -10,7 +10,7 @@ use crate::proto::command::TlsVersion;
 #[derive(thiserror::Error, Debug)]
 pub enum CertificateError {
     #[error("Could not parse PEM certificate from bytes: {0}")]
-    ParseError(String),
+    InvalidCertificate(String),
 }
 
 #[derive(Debug)]
@@ -104,7 +104,7 @@ impl<'de> serde::Deserialize<'de> for Fingerprint {
 
 pub fn calculate_fingerprint(certificate: &[u8]) -> Result<Vec<u8>, CertificateError> {
     let parsed_certificate = parse(certificate)
-        .map_err(|parse_error| CertificateError::ParseError(parse_error.to_string()))?;
+        .map_err(|parse_error| CertificateError::InvalidCertificate(parse_error.to_string()))?;
     let fingerprint = Sha256::digest(parsed_certificate.contents())
         .iter()
         .cloned()

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -1392,7 +1392,9 @@ impl ConfigBuilder {
         let command_socket_path = self.file.command_socket.clone().unwrap_or({
             let mut path = env::current_dir().map_err(|e| ConfigError::EnvError(e.to_string()))?;
             path.push("sozu.sock");
-            let verified_path = path.to_str().ok_or(ConfigError::InvalidPath(path.clone()))?;
+            let verified_path = path
+                .to_str()
+                .ok_or(ConfigError::InvalidPath(path.clone()))?;
             verified_path.to_owned()
         });
 

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -51,13 +51,12 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     env,
     fs::{create_dir_all, metadata, File},
-    io::{self, ErrorKind, Read},
+    io::{ErrorKind, Read},
     net::SocketAddr,
     ops::Range,
     path::PathBuf,
 };
 
-use anyhow::{bail, Context};
 use toml;
 
 use crate::{
@@ -154,6 +153,55 @@ pub const DEFAULT_COMMAND_BUFFER_SIZE: usize = 1_000_000;
 
 /// maximum size of the buffer for the channels, in bytes. (2 MB)
 pub const DEFAULT_MAX_COMMAND_BUFFER_SIZE: usize = 2_000_000;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ConfigError {
+    #[error("Could not parse socket address {address}: {error}")]
+    AddressParsingError { address: String, error: String },
+    #[error("env path not found: {0}")]
+    EnvError(String),
+    #[error("Could not open file {path_to_open}: {io_error}")]
+    FileOpenError {
+        path_to_open: String,
+        io_error: String,
+    },
+    #[error("Could not read file {path_to_read}: {io_error}")]
+    FileReadError {
+        path_to_read: String,
+        io_error: String,
+    },
+    #[error("the listener on {0} has incompatible options: it cannot use the expect proxy protocol and have a public_address field at the same time",)]
+    IncompatiblePublicAddress(String),
+    #[error("all the listeners for cluster {0} should have the same expect_proxy option")]
+    InconsistentExpectProxyOption(String),
+    #[error("Invalid '{0}' field for a TCP frontend")]
+    InvalidField(String),
+    #[error("invalid path {0:?}")]
+    InvalidPath(PathBuf),
+    #[error("listening address {0} is already used in the configuration")]
+    ListenerAddressAlreadyInUse(String),
+    #[error("Invalid '{0}' field to create a frontend")]
+    MissingField(String),
+    #[error("missing field 'protocol' to create a listener")]
+    MissingProtocol,
+    #[error("cannot activate automatic state save if the 'saved_state` option is not set")]
+    MissingSavedState,
+    #[error("could not get parent directory for file {0}")]
+    NoFileParent(String),
+    #[error("Could not get the path of the saved state")]
+    SaveStatePath(String),
+    #[error("Can not determine path to sozu socket: {0}")]
+    SocketPathError(String),
+    #[error("toml decoding error: {0}")]
+    TomlDeserialization(String),
+    #[error("Can not set this frontend on a {0:?} listener")]
+    WrongFrontendProtocol(ListenerProtocol),
+    #[error("Can not build a {expected:?} listener from a {found:?} config")]
+    WrongListenerProtocol {
+        expected: ListenerProtocol,
+        found: Option<ListenerProtocol>,
+    },
+}
 
 /// An HTTP, HTTPS or TCP listener as parsed from the `Listeners` section in the toml
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Default, Deserialize)]
@@ -333,18 +381,13 @@ impl ListenerBuilder {
         self
     }
 
-    pub fn parse_address(&self) -> anyhow::Result<SocketAddr> {
-        self.address.parse().with_context(|| "wrong socket address")
+    pub fn parse_address(&self) -> Result<SocketAddr, ConfigError> {
+        parse_socket_address(&self.address)
     }
 
-    pub fn parse_public_address(&self) -> anyhow::Result<Option<SocketAddr>> {
+    pub fn parse_public_address(&self) -> Result<Option<SocketAddr>, ConfigError> {
         match &self.public_address {
-            Some(a) => {
-                let parsed = a
-                    .parse::<SocketAddr>()
-                    .with_context(|| "wrong socket address")?;
-                Ok(Some(parsed))
-            }
+            Some(a) => Ok(Some(parse_socket_address(a)?)),
             None => Ok(None),
         }
     }
@@ -358,29 +401,23 @@ impl ListenerBuilder {
     }
 
     /// build an HTTP listener with config timeouts, using defaults if no config is provided
-    pub fn to_http(&mut self, config: Option<&Config>) -> anyhow::Result<HttpListenerConfig> {
+    pub fn to_http(&mut self, config: Option<&Config>) -> Result<HttpListenerConfig, ConfigError> {
         if self.protocol != Some(ListenerProtocol::Http) {
-            bail!(format!(
-                "Can not build an HTTP listener from a {:?} config",
-                self.protocol
-            ));
+            return Err(ConfigError::WrongListenerProtocol {
+                expected: ListenerProtocol::Http,
+                found: self.protocol.to_owned(),
+            });
         }
 
         if let Some(config) = config {
             self.assign_config_timeouts(config);
         }
 
-        let (answer_404, answer_503) = self
-            .get_404_503_answers()
-            .with_context(|| "Could not get 404 and 503 answers from file system")?;
+        let (answer_404, answer_503) = self.get_404_503_answers()?;
 
-        let _address = self
-            .parse_address()
-            .with_context(|| "wrong socket address")?;
+        let _address = self.parse_address()?;
 
-        let _public_address = self
-            .parse_public_address()
-            .with_context(|| "wrong public address")?;
+        let _public_address = self.parse_public_address()?;
 
         let configuration = HttpListenerConfig {
             address: self.address.clone(),
@@ -400,12 +437,12 @@ impl ListenerBuilder {
     }
 
     /// build an HTTPS listener using defaults if no config or values were provided upstream
-    pub fn to_tls(&mut self, config: Option<&Config>) -> anyhow::Result<HttpsListenerConfig> {
+    pub fn to_tls(&mut self, config: Option<&Config>) -> Result<HttpsListenerConfig, ConfigError> {
         if self.protocol != Some(ListenerProtocol::Https) {
-            bail!(format!(
-                "Can not build an HTTPS listener from a {:?} config",
-                self.protocol
-            ));
+            return Err(ConfigError::WrongListenerProtocol {
+                expected: ListenerProtocol::Https,
+                found: self.protocol.to_owned(),
+            });
         }
 
         let default_cipher_list = DEFAULT_RUSTLS_CIPHER_LIST
@@ -466,15 +503,12 @@ impl ListenerBuilder {
 
         let (answer_404, answer_503) = self
             .get_404_503_answers()
-            .with_context(|| "Could not get 404 and 503 answers from file system")?;
+            //.with_context(|| "Could not get 404 and 503 answers from file system")
+            ?;
 
-        let _address = self
-            .parse_address()
-            .with_context(|| "wrong socket address")?;
+        let _address = self.parse_address()?;
 
-        let _public_address = self
-            .parse_public_address()
-            .with_context(|| "wrong public address")?;
+        let _public_address = self.parse_public_address()?;
 
         if let Some(config) = config {
             self.assign_config_timeouts(config);
@@ -506,21 +540,17 @@ impl ListenerBuilder {
     }
 
     /// build an HTTPS listener using defaults if no config or values were provided upstream
-    pub fn to_tcp(&mut self, config: Option<&Config>) -> anyhow::Result<TcpListenerConfig> {
+    pub fn to_tcp(&mut self, config: Option<&Config>) -> Result<TcpListenerConfig, ConfigError> {
         if self.protocol != Some(ListenerProtocol::Tcp) {
-            bail!(format!(
-                "Can not build a TCP listener from a {:?} config",
-                self.protocol
-            ));
+            return Err(ConfigError::WrongListenerProtocol {
+                expected: ListenerProtocol::Tcp,
+                found: self.protocol.to_owned(),
+            });
         }
 
-        let _address = self
-            .parse_address()
-            .with_context(|| "wrong socket address")?;
+        let _address = self.parse_address()?;
 
-        let _public_address = self
-            .parse_public_address()
-            .with_context(|| "wrong public address")?;
+        let _public_address = self.parse_public_address()?;
 
         if let Some(config) = config {
             self.assign_config_timeouts(config);
@@ -539,46 +569,43 @@ impl ListenerBuilder {
 
     /// Get the 404 and 503 answers from the file system using the provided paths,
     /// if none, defaults to HTML files in the sozu assets
-    fn get_404_503_answers(&self) -> anyhow::Result<(String, String)> {
+    fn get_404_503_answers(&self) -> Result<(String, String), ConfigError> {
         let answer_404 = match &self.answer_404 {
-            Some(a_404_path) => {
-                let mut a_404 = String::new();
-                let mut file = File::open(a_404_path).with_context(|| {
-                    format!(
-                        "Could not open 404 answer file on path {}, current dir {:?}",
-                        a_404_path,
-                        std::env::current_dir().ok()
-                    )
-                })?;
-
-                file.read_to_string(&mut a_404).with_context(|| {
-                    format!(
-                        "Could not read 404 answer file on path {}, current dir {:?}",
-                        a_404_path,
-                        std::env::current_dir().ok()
-                    )
-                })?;
-                a_404
-            }
+            Some(a_404_path) => open_and_read_file(a_404_path)?,
             None => String::from(include_str!("../assets/404.html")),
         };
 
         let answer_503 = match &self.answer_503 {
-            Some(a_503_path) => {
-                let mut a_503 = String::new();
-                let mut file = File::open(a_503_path).with_context(|| {
-                    format!("Could not open 503 answer file on path {a_503_path}")
-                })?;
-
-                file.read_to_string(&mut a_503).with_context(|| {
-                    format!("Could not read 503 answer file on path {a_503_path}")
-                })?;
-                a_503
-            }
+            Some(a_503_path) => open_and_read_file(a_503_path)?,
             None => String::from(include_str!("../assets/503.html")),
         };
         Ok((answer_404, answer_503))
     }
+}
+
+fn parse_socket_address(address: &str) -> Result<SocketAddr, ConfigError> {
+    address
+        .parse::<SocketAddr>()
+        .map_err(|parse_error| ConfigError::AddressParsingError {
+            error: parse_error.to_string(),
+            address: address.to_owned(),
+        })
+}
+
+fn open_and_read_file(path: &str) -> Result<String, ConfigError> {
+    let mut content = String::new();
+    let mut file = File::open(path).map_err(|io_error| ConfigError::FileOpenError {
+        path_to_open: path.to_owned(),
+        io_error: io_error.to_string(),
+    })?;
+
+    file.read_to_string(&mut content)
+        .map_err(|io_error| ConfigError::FileReadError {
+            path_to_read: path.to_owned(),
+            io_error: io_error.to_string(),
+        })?;
+
+    Ok(content)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -621,21 +648,21 @@ pub struct FileClusterFrontendConfig {
 }
 
 impl FileClusterFrontendConfig {
-    pub fn to_tcp_front(&self) -> anyhow::Result<TcpFrontendConfig> {
+    pub fn to_tcp_front(&self) -> Result<TcpFrontendConfig, ConfigError> {
         if self.hostname.is_some() {
-            bail!("invalid 'hostname' field for TCP frontend");
+            return Err(ConfigError::InvalidField("hostname".to_string()));
         }
         if self.path.is_some() {
-            bail!("invalid 'path_prefix' field for TCP frontend");
+            return Err(ConfigError::InvalidField("path_prefix".to_string()));
         }
         if self.certificate.is_some() {
-            bail!("invalid 'certificate' field for TCP frontend");
+            return Err(ConfigError::InvalidField("certificate".to_string()));
         }
         if self.hostname.is_some() {
-            bail!("invalid 'key' field for TCP frontend");
+            return Err(ConfigError::InvalidField("hostname".to_string()));
         }
         if self.certificate_chain.is_some() {
-            bail!("invalid 'certificate_chain' field for TCP frontend",);
+            return Err(ConfigError::InvalidField("certificate_chain".to_string()));
         }
 
         Ok(TcpFrontendConfig {
@@ -644,17 +671,16 @@ impl FileClusterFrontendConfig {
         })
     }
 
-    pub fn to_http_front(&self, _cluster_id: &str) -> anyhow::Result<HttpFrontendConfig> {
+    pub fn to_http_front(&self, _cluster_id: &str) -> Result<HttpFrontendConfig, ConfigError> {
         let hostname = match &self.hostname {
             Some(hostname) => hostname.to_owned(),
-            None => bail!("HTTP frontend should have a 'hostname' field"),
+            None => return Err(ConfigError::MissingField("hostname".to_string())),
         };
 
         let key_opt = match self.key.as_ref() {
             None => None,
             Some(path) => {
-                let key = Config::load_file(path)
-                    .with_context(|| format!("cannot load key at path '{path}'"))?;
+                let key = Config::load_file(path)?;
                 Some(key)
             }
         };
@@ -662,8 +688,7 @@ impl FileClusterFrontendConfig {
         let certificate_opt = match self.certificate.as_ref() {
             None => None,
             Some(path) => {
-                let certificate = Config::load_file(path)
-                    .with_context(|| format!("cannot load certificate at path '{path}'"))?;
+                let certificate = Config::load_file(path)?;
                 Some(certificate)
             }
         };
@@ -671,8 +696,7 @@ impl FileClusterFrontendConfig {
         let chain_opt = match self.certificate_chain.as_ref() {
             None => None,
             Some(path) => {
-                let certificate_chain = Config::load_file(path)
-                    .with_context(|| format!("cannot load certificate chain at path {path}"))?;
+                let certificate_chain = Config::load_file(path)?;
                 Some(split_certificate_chain(certificate_chain))
             }
         };
@@ -747,7 +771,7 @@ impl FileClusterConfig {
         self,
         cluster_id: &str,
         expect_proxy: &HashSet<SocketAddr>,
-    ) -> anyhow::Result<ClusterConfig> {
+    ) -> Result<ClusterConfig, ConfigError> {
         match self.protocol {
             FileClusterProtocolConfig::Tcp => {
                 let mut has_expect_proxy = None;
@@ -755,18 +779,22 @@ impl FileClusterConfig {
                 for f in self.frontends {
                     if expect_proxy.contains(&f.address) {
                         match has_expect_proxy {
-                            Some(true) => {},
-                            Some(false) => bail!(format!(
-                                "all the listeners for cluster {cluster_id} should have the same expect_proxy option"
-                            )),
+                            Some(true) => {}
+                            Some(false) => {
+                                return Err(ConfigError::InconsistentExpectProxyOption(
+                                    cluster_id.to_owned(),
+                                ))
+                            }
                             None => has_expect_proxy = Some(true),
                         }
                     } else {
                         match has_expect_proxy {
-                            Some(false) => {},
-                            Some(true) => bail!(format!(
-                                "all the listeners for cluster {cluster_id} should have the same expect_proxy option"
-                            )),
+                            Some(false) => {}
+                            Some(true) => {
+                                return Err(ConfigError::InconsistentExpectProxyOption(
+                                    cluster_id.to_owned(),
+                                ))
+                            }
                             None => has_expect_proxy = Some(false),
                         }
                     }
@@ -795,9 +823,7 @@ impl FileClusterConfig {
             FileClusterProtocolConfig::Http => {
                 let mut frontends = Vec::new();
                 for frontend in self.frontends {
-                    let http_frontend = frontend
-                        .to_http_front(cluster_id)
-                        .with_context(|| "Could not convert frontend config to http frontend")?;
+                    let http_frontend = frontend.to_http_front(cluster_id)?;
                     frontends.push(http_frontend);
                 }
 
@@ -913,7 +939,7 @@ pub struct HttpClusterConfig {
 }
 
 impl HttpClusterConfig {
-    pub fn generate_requests(&self) -> anyhow::Result<Vec<Request>> {
+    pub fn generate_requests(&self) -> Result<Vec<Request>, ConfigError> {
         let mut v = vec![RequestType::AddCluster(Cluster {
             cluster_id: self.cluster_id.clone(),
             sticky_session: self.sticky_session,
@@ -972,7 +998,7 @@ pub struct TcpClusterConfig {
 }
 
 impl TcpClusterConfig {
-    pub fn generate_requests(&self) -> anyhow::Result<Vec<Request>> {
+    pub fn generate_requests(&self) -> Result<Vec<Request>, ConfigError> {
         let mut v = vec![RequestType::AddCluster(Cluster {
             cluster_id: self.cluster_id.clone(),
             sticky_session: false,
@@ -1026,7 +1052,7 @@ pub enum ClusterConfig {
 }
 
 impl ClusterConfig {
-    pub fn generate_requests(&self) -> anyhow::Result<Vec<Request>> {
+    pub fn generate_requests(&self) -> Result<Vec<Request>, ConfigError> {
         match *self {
             ClusterConfig::Http(ref http) => http.generate_requests(),
             ClusterConfig::Tcp(ref tcp) => tcp.generate_requests(),
@@ -1075,14 +1101,14 @@ pub struct FileConfig {
 }
 
 impl FileConfig {
-    pub fn load_from_path(path: &str) -> anyhow::Result<FileConfig> {
+    pub fn load_from_path(path: &str) -> Result<FileConfig, ConfigError> {
         let data = Config::load_file(path)?;
 
         let config: FileConfig = match toml::from_str(&data) {
             Ok(config) => config,
             Err(e) => {
                 display_toml_error(&data, &e);
-                bail!(format!("toml decoding error: {e}"));
+                return Err(ConfigError::TomlDeserialization(e.to_string()));
             }
         };
 
@@ -1091,9 +1117,8 @@ impl FileConfig {
         if let Some(listeners) = config.listeners.as_ref() {
             for listener in listeners.iter() {
                 if reserved_address.contains(&listener.parse_address()?) {
-                    bail!(format!(
-                        "listening address {:?} is already used in the configuration",
-                        listener.address
+                    return Err(ConfigError::ListenerAddressAlreadyInUse(
+                        listener.address.to_string(),
                     ));
                 }
                 reserved_address.insert(listener.parse_address()?);
@@ -1205,43 +1230,34 @@ impl ConfigBuilder {
         }
     }
 
-    fn push_tls_listener(&mut self, mut listener: ListenerBuilder) -> anyhow::Result<()> {
-        let listener = listener
-            .to_tls(Some(&self.built))
-            .with_context(|| "Cannot convert listener to TLS")?;
+    fn push_tls_listener(&mut self, mut listener: ListenerBuilder) -> Result<(), ConfigError> {
+        let listener = listener.to_tls(Some(&self.built))?;
         self.built.https_listeners.push(listener);
         Ok(())
     }
 
-    fn push_http_listener(&mut self, mut listener: ListenerBuilder) -> anyhow::Result<()> {
-        let listener = listener
-            .to_http(Some(&self.built))
-            .with_context(|| "Cannot convert listener to HTTP")?;
+    fn push_http_listener(&mut self, mut listener: ListenerBuilder) -> Result<(), ConfigError> {
+        let listener = listener.to_http(Some(&self.built))?;
         self.built.http_listeners.push(listener);
         Ok(())
     }
 
-    fn push_tcp_listener(&mut self, mut listener: ListenerBuilder) -> anyhow::Result<()> {
-        let listener = listener
-            .to_tcp(Some(&self.built))
-            .with_context(|| "Cannot convert listener to TCP")?;
+    fn push_tcp_listener(&mut self, mut listener: ListenerBuilder) -> Result<(), ConfigError> {
+        let listener = listener.to_tcp(Some(&self.built))?;
         self.built.tcp_listeners.push(listener);
         Ok(())
     }
 
-    fn populate_listeners(&mut self, listeners: Vec<ListenerBuilder>) -> anyhow::Result<()> {
+    fn populate_listeners(&mut self, listeners: Vec<ListenerBuilder>) -> Result<(), ConfigError> {
         for listener in listeners.iter() {
             let address = listener.parse_address()?;
             if self.known_addresses.contains_key(&address) {
-                bail!(format!(
-                    "there's already a listener for address {:?}",
-                    listener.address
+                return Err(ConfigError::ListenerAddressAlreadyInUse(
+                    listener.address.to_string(),
                 ));
             }
 
-            let protocol = listener
-                .protocol
-                .with_context(|| "No protocol defined for this listener")?;
+            let protocol = listener.protocol.ok_or(ConfigError::MissingProtocol)?;
 
             self.known_addresses.insert(address, protocol);
             if listener.expect_proxy == Some(true) {
@@ -1249,10 +1265,9 @@ impl ConfigBuilder {
             }
 
             if listener.public_address.is_some() && listener.expect_proxy == Some(true) {
-                bail!(format!(
-                        "the listener on {} has incompatible options: it cannot use the expect proxy protocol and have a public_address field at the same time",
-                        &listener.address
-                    ));
+                return Err(ConfigError::IncompatiblePublicAddress(
+                    listener.address.to_string(),
+                ));
             }
 
             match protocol {
@@ -1267,22 +1282,26 @@ impl ConfigBuilder {
     fn populate_clusters(
         &mut self,
         mut file_cluster_configs: HashMap<String, FileClusterConfig>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), ConfigError> {
         for (id, file_cluster_config) in file_cluster_configs.drain() {
-            let mut cluster_config = file_cluster_config
-                .to_cluster_config(id.as_str(), &self.expect_proxy_addresses)
-                .with_context(|| format!("error parsing cluster configuration for cluster {id}"))?;
+            let mut cluster_config =
+                file_cluster_config.to_cluster_config(id.as_str(), &self.expect_proxy_addresses)?;
+            // .with_context(|| format!("error parsing cluster configuration for cluster {id}"))?;
 
             match cluster_config {
                 ClusterConfig::Http(ref mut http) => {
                     for frontend in http.frontends.iter_mut() {
                         match self.known_addresses.get(&frontend.address) {
                             Some(ListenerProtocol::Tcp) => {
-                                bail!("cannot set up a HTTP or HTTPS frontend on a TCP listener");
+                                return Err(ConfigError::WrongFrontendProtocol(
+                                    ListenerProtocol::Tcp,
+                                ));
                             }
                             Some(ListenerProtocol::Http) => {
                                 if frontend.certificate.is_some() {
-                                    bail!("cannot set up a HTTPS frontend on a HTTP listener");
+                                    return Err(ConfigError::WrongFrontendProtocol(
+                                        ListenerProtocol::Http,
+                                    ));
                                 }
                             }
                             Some(ListenerProtocol::Https) => {
@@ -1302,7 +1321,9 @@ impl ConfigBuilder {
                                     if frontend.certificate.is_none() {
                                         debug!("known addresses: {:#?}", self.known_addresses);
                                         debug!("frontend: {:#?}", frontend);
-                                        bail!("cannot set up a HTTP frontend on a HTTPS listener");
+                                        return Err(ConfigError::WrongFrontendProtocol(
+                                            ListenerProtocol::Https,
+                                        ));
                                     }
                                 }
                             }
@@ -1334,7 +1355,9 @@ impl ConfigBuilder {
                     for frontend in &tcp.frontends {
                         match self.known_addresses.get(&frontend.address) {
                             Some(ListenerProtocol::Http) | Some(ListenerProtocol::Https) => {
-                                bail!("cannot set up a TCP frontend on a HTTP listener");
+                                return Err(ConfigError::WrongFrontendProtocol(
+                                    ListenerProtocol::Http,
+                                ));
                             }
                             Some(ListenerProtocol::Tcp) => {}
                             None => {
@@ -1357,7 +1380,7 @@ impl ConfigBuilder {
     }
 
     /// Builds a [`Config`], populated with listeners and clusters
-    pub fn into_config(&mut self) -> anyhow::Result<Config> {
+    pub fn into_config(&mut self) -> Result<Config, ConfigError> {
         if let Some(listeners) = &self.file.listeners {
             self.populate_listeners(listeners.clone())?;
         }
@@ -1367,16 +1390,14 @@ impl ConfigBuilder {
         }
 
         let command_socket_path = self.file.command_socket.clone().unwrap_or({
-            let mut path = env::current_dir().with_context(|| "env path not found")?;
+            let mut path = env::current_dir().map_err(|e| ConfigError::EnvError(e.to_string()))?;
             path.push("sozu.sock");
-            let verified_path = path
-                .to_str()
-                .with_context(|| "command socket path not valid")?;
+            let verified_path = path.to_str().ok_or(ConfigError::InvalidPath(path.clone()))?;
             verified_path.to_owned()
         });
 
         if let (None, Some(true)) = (&self.file.saved_state, &self.file.automatic_state_save) {
-            bail!("cannot activate automatic state save if the 'saved_state` option is not set");
+            return Err(ConfigError::MissingSavedState);
         }
 
         Ok(Config {
@@ -1457,24 +1478,19 @@ fn default_accept_queue_timeout() -> u32 {
 
 impl Config {
     /// Parse a TOML file and build a config out of it
-    pub fn load_from_path(path: &str) -> anyhow::Result<Config> {
-        let file_config =
-            FileConfig::load_from_path(path).with_context(|| "Could not load the config file")?;
+    pub fn load_from_path(path: &str) -> Result<Config, ConfigError> {
+        let file_config = FileConfig::load_from_path(path)?;
 
-        let mut config = ConfigBuilder::new(file_config, path)
-            .into_config()
-            .with_context(|| "Could not build config from file")?;
+        let mut config = ConfigBuilder::new(file_config, path).into_config()?;
 
         // replace saved_state with a verified path
-        config.saved_state = config
-            .saved_state_path()
-            .with_context(|| "Invalid saved_state in the config. Check your config file")?;
+        config.saved_state = config.saved_state_path()?;
 
         Ok(config)
     }
 
     /// yields requests intended to recreate a proxy that match the config
-    pub fn generate_config_messages(&self) -> anyhow::Result<Vec<WorkerRequest>> {
+    pub fn generate_config_messages(&self) -> Result<Vec<WorkerRequest>, ConfigError> {
         let mut v = Vec::new();
         let mut count = 0u8;
 
@@ -1558,63 +1574,86 @@ impl Config {
     }
 
     /// Get the path of the UNIX socket used to communicate with Sōzu
-    pub fn command_socket_path(&self) -> anyhow::Result<String> {
+    pub fn command_socket_path(&self) -> Result<String, ConfigError> {
         let config_path_buf = PathBuf::from(self.config_path.clone());
-        let mut config_folder = match config_path_buf.parent() {
-            Some(path) => path.to_path_buf(),
-            None => bail!("could not get parent folder of configuration file"),
-        };
+        let mut config_dir = config_path_buf
+            .parent()
+            .ok_or(ConfigError::NoFileParent(
+                config_path_buf.to_string_lossy().to_string(),
+            ))?
+            .to_path_buf();
 
         let socket_path = PathBuf::from(self.command_socket.clone());
-        let mut parent = match socket_path.parent() {
-            None => config_folder,
+
+        let mut socket_parent_dir = match socket_path.parent() {
+            // if the socket path is of the form "./sozu.sock",
+            // then the parent is the directory where config.toml is situated
+            None => config_dir,
             Some(path) => {
-                config_folder.push(path);
-                config_folder.canonicalize().with_context(|| {
-                    format!("could not get command socket folder path: {path:?}")
+                // concatenate the config directory and the relative path of the socket
+                config_dir.push(path);
+                // canonicalize to remove double dots like /path/to/config/directory/../../path/to/socket/directory/
+                config_dir.canonicalize().map_err(|io_error| {
+                    ConfigError::SocketPathError(format!(
+                        "Could not canonicalize path {:?}: {}",
+                        config_dir,
+                        io_error.to_string()
+                    ))
                 })?
             }
         };
 
-        let path = match socket_path.file_name() {
-            None => bail!("could not get command socket file name"),
-            Some(f) => {
-                parent.push(f);
-                parent
-            }
-        };
+        let socket_name = socket_path
+            .file_name()
+            .ok_or(ConfigError::SocketPathError(format!(
+                "could not get command socket file name from {:?}",
+                socket_path
+            )))?;
 
-        path.to_str()
-            .map(|s| s.to_string())
-            .with_context(|| "could not parse command socket path")
+        // concatenate parent directory and socket file name
+        socket_parent_dir.push(socket_name);
+
+        let command_socket_path = socket_parent_dir
+            .to_str()
+            .ok_or(ConfigError::SocketPathError(format!(
+                "Invalid socket path {:?}",
+                socket_parent_dir
+            )))?
+            .to_string();
+
+        Ok(command_socket_path)
     }
 
     /// Get the path of where the state will be saved
-    fn saved_state_path(&self) -> anyhow::Result<Option<String>> {
+    fn saved_state_path(&self) -> Result<Option<String>, ConfigError> {
         let path = match self.saved_state.as_ref() {
             Some(path) => path,
             None => return Ok(None),
         };
 
         debug!("saved_stated path in the config: {}", path);
-        let config_path_buf = PathBuf::from(self.config_path.clone());
+        let config_path = PathBuf::from(self.config_path.clone());
 
-        debug!("Config path buffer: {:?}", config_path_buf);
-        let config_folder = config_path_buf
+        debug!("Config path buffer: {:?}", config_path);
+        let config_dir = config_path
             .parent()
-            .with_context(|| "could not get parent folder of configuration file")?;
+            .ok_or(ConfigError::SaveStatePath(format!(
+                "Could get parent directory of config file {:?}",
+                config_path,
+            )))?;
 
-        debug!("Config folder: {:?}", config_folder);
-        if !config_folder.exists() {
-            create_dir_all(config_folder).with_context(|| {
-                format!(
-                    "failed to create state parent directory '{}'",
-                    config_folder.display()
-                )
+        debug!("Config folder: {:?}", config_dir);
+        if !config_dir.exists() {
+            create_dir_all(config_dir).map_err(|io_error| {
+                ConfigError::SaveStatePath(format!(
+                    "failed to create state parent directory '{}': {}",
+                    config_dir.display(),
+                    io_error.to_string()
+                ))
             })?;
         }
 
-        let mut saved_state_path_raw = config_folder.to_path_buf();
+        let mut saved_state_path_raw = config_dir.to_path_buf();
         saved_state_path_raw.push(path);
         debug!(
             "Looking for saved state on the path {:?}",
@@ -1624,32 +1663,49 @@ impl Config {
         match metadata(path) {
             Err(err) if matches!(err.kind(), ErrorKind::NotFound) => {
                 info!("Create an empty state file at '{}'", path);
-                File::create(path)
-                    .with_context(|| format!("fail to create state file at '{path}'"))?;
+                File::create(path).map_err(|io_error| {
+                    ConfigError::SaveStatePath(format!(
+                        "failed to create state file '{:?}': {}",
+                        path,
+                        io_error.to_string()
+                    ))
+                })?;
             }
             _ => {}
         }
 
-        saved_state_path_raw.canonicalize().with_context(|| {
-            format!("could not get saved state path from config file input {path:?}")
+        saved_state_path_raw.canonicalize().map_err(|io_error| {
+            ConfigError::SaveStatePath(format!(
+                "could not get saved state path from config file input {path:?}: {}",
+                io_error
+            ))
         })?;
 
         let stringified_path = saved_state_path_raw
             .to_str()
-            .ok_or_else(|| anyhow::Error::msg("Invalid character format, expected UTF8"))?
+            .ok_or(ConfigError::SaveStatePath(format!(
+                "Invalid path {:?}",
+                saved_state_path_raw
+            )))?
             .to_string();
 
         Ok(Some(stringified_path))
     }
 
     /// read any file to a string
-    pub fn load_file(path: &str) -> io::Result<String> {
-        std::fs::read_to_string(path)
+    pub fn load_file(path: &str) -> Result<String, ConfigError> {
+        std::fs::read_to_string(path).map_err(|io_error| ConfigError::FileReadError {
+            path_to_read: path.to_owned(),
+            io_error: io_error.to_string(),
+        })
     }
 
     /// read any file to bytes
-    pub fn load_file_bytes(path: &str) -> io::Result<Vec<u8>> {
-        std::fs::read(path)
+    pub fn load_file_bytes(path: &str) -> Result<Vec<u8>, ConfigError> {
+        std::fs::read(path).map_err(|io_error| ConfigError::FileReadError {
+            path_to_read: path.to_owned(),
+            io_error: io_error.to_string(),
+        })
     }
 }
 

--- a/command/src/lib.rs
+++ b/command/src/lib.rs
@@ -71,3 +71,19 @@ pub mod scm_socket;
 pub mod state;
 /// A writer used for logging
 pub mod writer;
+
+/// Used only when returning errors
+#[derive(Debug)]
+pub enum ObjectKind {
+    Backend,
+    Certificate,
+    Cluster,
+    HttpFrontend,
+    HttpsFrontend,
+    HttpListener,
+    HttpsListener,
+    Listener,
+    TcpCluster,
+    TcpListener,
+    TcpFrontend,
+}

--- a/command/src/request.rs
+++ b/command/src/request.rs
@@ -5,8 +5,6 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::Context;
-
 use crate::{
     proto::command::{
         request::RequestType, LoadBalancingAlgorithms, PathRuleKind, Request, RequestHttpFrontend,
@@ -14,6 +12,14 @@ use crate::{
     },
     response::{HttpFrontend, MessageId},
 };
+
+#[derive(thiserror::Error, Debug)]
+pub enum RequestError {
+    #[error("Could not parse socket address {address}: {error}")]
+    WrongAddress { address: String, error: String },
+    #[error("wrong value {value} for field '{name}'")]
+    WrongFieldValue { name: String, value: i32 },
+}
 
 impl Request {
     /// determine to which of the three proxies (HTTP, HTTPS, TCP) a request is destined
@@ -126,18 +132,24 @@ pub struct ProxyDestinations {
 
 impl RequestHttpFrontend {
     /// convert a requested frontend to a usable one by parsing its address
-    pub fn to_frontend(self) -> anyhow::Result<HttpFrontend> {
+    pub fn to_frontend(self) -> Result<HttpFrontend, RequestError> {
         Ok(HttpFrontend {
-            address: self
-                .address
-                .parse::<SocketAddr>()
-                .with_context(|| "wrong socket address")?,
+            address: self.address.parse::<SocketAddr>().map_err(|parse_error| {
+                RequestError::WrongAddress {
+                    address: self.address.clone(),
+                    error: parse_error.to_string(),
+                }
+            })?,
             cluster_id: self.cluster_id,
             hostname: self.hostname,
             path: self.path,
             method: self.method,
-            position: RulePosition::from_i32(self.position)
-                .with_context(|| "wrong i32 value for RulePosition")?,
+            position: RulePosition::from_i32(self.position).ok_or(
+                RequestError::WrongFieldValue {
+                    name: "position".to_string(),
+                    value: self.position.clone(),
+                },
+            )?,
             tags: Some(self.tags),
         })
     }

--- a/command/src/request.rs
+++ b/command/src/request.rs
@@ -15,10 +15,10 @@ use crate::{
 
 #[derive(thiserror::Error, Debug)]
 pub enum RequestError {
-    #[error("Could not parse socket address {address}: {error}")]
-    WrongAddress { address: String, error: String },
-    #[error("wrong value {value} for field '{name}'")]
-    WrongFieldValue { name: String, value: i32 },
+    #[error("Invalid address {address}: {error}")]
+    InvalidSocketAddress { address: String, error: String },
+    #[error("invalid value {value} for field '{name}'")]
+    InvalidValue { name: String, value: i32 },
 }
 
 impl Request {
@@ -135,7 +135,7 @@ impl RequestHttpFrontend {
     pub fn to_frontend(self) -> Result<HttpFrontend, RequestError> {
         Ok(HttpFrontend {
             address: self.address.parse::<SocketAddr>().map_err(|parse_error| {
-                RequestError::WrongAddress {
+                RequestError::InvalidSocketAddress {
                     address: self.address.clone(),
                     error: parse_error.to_string(),
                 }
@@ -144,12 +144,10 @@ impl RequestHttpFrontend {
             hostname: self.hostname,
             path: self.path,
             method: self.method,
-            position: RulePosition::from_i32(self.position).ok_or(
-                RequestError::WrongFieldValue {
-                    name: "position".to_string(),
-                    value: self.position.clone(),
-                },
-            )?,
+            position: RulePosition::from_i32(self.position).ok_or(RequestError::InvalidValue {
+                name: "position".to_string(),
+                value: self.position.clone(),
+            })?,
             tags: Some(self.tags),
         })
     }

--- a/command/src/scm_socket.rs
+++ b/command/src/scm_socket.rs
@@ -8,13 +8,26 @@ use std::{
     str::from_utf8,
 };
 
-use anyhow::Context;
 use mio::net::TcpListener;
 use nix::{cmsg_space, sys::socket};
 use serde_json;
 
 pub const MAX_FDS_OUT: usize = 200;
 pub const MAX_BYTES_OUT: usize = 4096;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ScmSocketError {
+    #[error("could not set the blocking status of the unix stream to {blocking}: {error}")]
+    SetBlocking { blocking: bool, error: String },
+    #[error("could not send message per SCM socket: {0}")]
+    SendError(String),
+    #[error("could not send message per SCM socket: {0}")]
+    ReceiveError(String),
+    #[error("could not parse utf8 from buffer: {0}")]
+    Utf8Error(String),
+    #[error("Could not deserialize utf8 string into listeners: {0}")]
+    ListenerParseError(String),
+}
 
 /// A unix socket specialized for file descriptor passing
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -25,12 +38,15 @@ pub struct ScmSocket {
 
 impl ScmSocket {
     /// Create a blocking SCM socket from a raw file descriptor (unsafe)
-    pub fn new(fd: RawFd) -> anyhow::Result<Self> {
+    pub fn new(fd: RawFd) -> Result<Self, ScmSocketError> {
         unsafe {
             let stream = StdUnixStream::from_raw_fd(fd);
             stream
                 .set_nonblocking(false)
-                .with_context(|| "could not change blocking status for stream")?;
+                .map_err(|io_error| ScmSocketError::SetBlocking {
+                    blocking: false,
+                    error: io_error.to_string(),
+                })?;
             let _dropped_fd = stream.into_raw_fd();
         }
 
@@ -43,7 +59,7 @@ impl ScmSocket {
     }
 
     /// Use the standard library (unsafe) to set the socket to blocking / unblocking
-    pub fn set_blocking(&mut self, blocking: bool) -> anyhow::Result<()> {
+    pub fn set_blocking(&mut self, blocking: bool) -> Result<(), ScmSocketError> {
         if self.blocking == blocking {
             return Ok(());
         }
@@ -51,7 +67,10 @@ impl ScmSocket {
             let stream = StdUnixStream::from_raw_fd(self.fd);
             stream
                 .set_nonblocking(!blocking)
-                .with_context(|| "could not change blocking status for stream")?;
+                .map_err(|io_error| ScmSocketError::SetBlocking {
+                    blocking,
+                    error: io_error.to_string(),
+                })?;
             let _dropped_fd = stream.into_raw_fd();
         }
         self.blocking = blocking;
@@ -59,7 +78,7 @@ impl ScmSocket {
     }
 
     /// Send listeners (socket addresses and file descriptors) via an scm socket
-    pub fn send_listeners(&self, listeners: &Listeners) -> anyhow::Result<()> {
+    pub fn send_listeners(&self, listeners: &Listeners) -> Result<(), ScmSocketError> {
         let listeners_count = ListenersCount {
             http: listeners.http.iter().map(|t| t.0).collect(),
             tls: listeners.tls.iter().map(|t| t.0).collect(),
@@ -80,22 +99,21 @@ impl ScmSocket {
     }
 
     /// Receive and parse listeners (socket addresses and file descriptors) via an scm socket
-    pub fn receive_listeners(&self) -> anyhow::Result<Listeners> {
+    pub fn receive_listeners(&self) -> Result<Listeners, ScmSocketError> {
         let mut buf = vec![0; MAX_BYTES_OUT];
 
         let mut received_fds: [RawFd; MAX_FDS_OUT] = [0; MAX_FDS_OUT];
 
-        let (size, file_descriptor_length) = self
-            .receive_msg_and_fds(&mut buf, &mut received_fds)
-            .with_context(|| "could not receive listeners")?;
+        let (size, file_descriptor_length) =
+            self.receive_msg_and_fds(&mut buf, &mut received_fds)?;
 
         debug!("{} received :{:?}", self.fd, (size, file_descriptor_length));
 
-        let raw_listener_list =
-            from_utf8(&buf[..size]).with_context(|| "Could not parse utf8 string from buffer")?;
+        let raw_listener_list = from_utf8(&buf[..size])
+            .map_err(|utf8_error| ScmSocketError::Utf8Error(utf8_error.to_string()))?;
 
         let mut listeners_count = serde_json::from_str::<ListenersCount>(raw_listener_list)
-            .with_context(|| "Could not deserialize utf8 string into listeners")?;
+            .map_err(|error| ScmSocketError::ListenerParseError(error.to_string()))?;
 
         let mut index = 0;
         let len = listeners_count.http.len();
@@ -131,7 +149,7 @@ impl ScmSocket {
 
     /// Sends message and file descriptors separately. The file descriptors are summed up
     /// in a ControlMessage.
-    fn send_msg_and_fds(&self, message: &[u8], fds: &[RawFd]) -> anyhow::Result<()> {
+    fn send_msg_and_fds(&self, message: &[u8], fds: &[RawFd]) -> Result<(), ScmSocketError> {
         let iov = [IoSlice::new(message)];
         let flags = if self.blocking {
             socket::MsgFlags::empty()
@@ -142,14 +160,14 @@ impl ScmSocket {
         if fds.is_empty() {
             debug!("{} send empty", self.fd);
             socket::sendmsg::<()>(self.fd, &iov, &[], flags, None)
-                .with_context(|| "Could not send empty message per socket")?;
+                .map_err(|error| ScmSocketError::SendError(error.to_string()))?;
             return Ok(());
         };
 
         let control_message = [socket::ControlMessage::ScmRights(fds)];
         debug!("{} send with data", self.fd);
         socket::sendmsg::<()>(self.fd, &iov, &control_message, flags, None)
-            .with_context(|| "Could not send message per socket")?;
+            .map_err(|error| ScmSocketError::SendError(error.to_string()))?;
         Ok(())
     }
 
@@ -158,7 +176,7 @@ impl ScmSocket {
         &self,
         message: &mut [u8],
         fds: &mut [RawFd],
-    ) -> anyhow::Result<(usize, usize)> {
+    ) -> Result<(usize, usize), ScmSocketError> {
         let mut cmsg = cmsg_space!([RawFd; MAX_FDS_OUT]);
         let mut iov = [IoSliceMut::new(message)];
 
@@ -169,7 +187,7 @@ impl ScmSocket {
         };
 
         let msg = socket::recvmsg::<()>(self.fd, &mut iov[..], Some(&mut cmsg), flags)
-            .with_context(|| "Could not receive message per socket")?;
+            .map_err(|error| ScmSocketError::ReceiveError(error.to_string()))?;
 
         let mut fd_count = 0;
         let received_fds = msg

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -9,7 +9,7 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::{bail, Context};
+use anyhow::Context;
 use mio::{
     net::{TcpListener as MioTcpListener, TcpStream as MioTcpStream},
     unix::SourceFd,
@@ -62,14 +62,11 @@ use crate::{
     server::{ListenSession, ListenToken, ProxyChannel, Server, SessionManager, SessionToken},
     socket::{server_bind, FrontRustls},
     timer::TimeoutContainer,
-    tls::{
-        CertificateResolver, GenericCertificateResolverError, MutexWrappedCertificateResolver,
-        ParsedCertificateAndKey,
-    },
+    tls::{CertificateResolver, MutexWrappedCertificateResolver, ParsedCertificateAndKey},
     util::UnwrapLog,
-    AcceptError, CachedTags, FrontendFromRequestError, L7ListenerHandler, L7Proxy, ListenerHandler,
-    Protocol, ProxyConfiguration, ProxySession, Readiness, SessionIsToBeClosed, SessionMetrics,
-    SessionResult, StateMachineBuilder, StateResult,
+    AcceptError, CachedTags, FrontendFromRequestError, L7ListenerHandler, L7Proxy, ListenerError,
+    ListenerHandler, Protocol, ProxyConfiguration, ProxyError, ProxySession, Readiness,
+    SessionIsToBeClosed, SessionMetrics, SessionResult, StateMachineBuilder, StateResult,
 };
 
 // const SERVER_PROTOS: &[&str] = &["http/1.1", "h2"];
@@ -520,20 +517,6 @@ impl ProxySession for HttpsSession {
 pub type HostName = String;
 pub type PathBegin = String;
 
-#[derive(thiserror::Error, Debug)]
-pub enum ListenerError {
-    #[error("failed to acquire the lock, {0}")]
-    LockError(String),
-    #[error("failed to handle certificate request, got a resolver error, {0}")]
-    ResolverError(GenericCertificateResolverError),
-    #[error("failed to parse pem, {0}")]
-    PemParseError(String),
-    #[error("failed to build rustls context, {0}")]
-    BuildRustlsError(String),
-    #[error("Wrong socket address")]
-    WrongSocketAddress,
-}
-
 pub struct HttpsListener {
     active: bool,
     address: StdSocketAddr,
@@ -655,10 +638,13 @@ impl HttpsListener {
 
         let server_config = Arc::new(Self::create_rustls_context(&config, resolver.to_owned())?);
 
-        let address: StdSocketAddr = config
+        let address = config
             .address
-            .parse()
-            .map_err(|_| ListenerError::WrongSocketAddress)?;
+            .parse::<StdSocketAddr>()
+            .map_err(|parse_error| ListenerError::SocketParseError {
+                address: config.address.clone(),
+                error: parse_error.to_string(),
+            })?;
 
         Ok(HttpsListener {
             listener: None,
@@ -681,20 +667,24 @@ impl HttpsListener {
         &mut self,
         registry: &Registry,
         tcp_listener: Option<MioTcpListener>,
-    ) -> anyhow::Result<Token> {
+    ) -> Result<Token, ListenerError> {
         if self.active {
             return Ok(self.token);
         }
 
         let mut listener = match tcp_listener {
             Some(tcp_listener) => tcp_listener,
-            None => server_bind(self.config.address.clone())
-                .with_context(|| format!("could not create listener {:?}", self.config.address))?,
+            None => server_bind(self.config.address.clone()).map_err(|server_bind_error| {
+                ListenerError::ActivationError {
+                    address: self.config.address.clone(),
+                    error: server_bind_error.to_string(),
+                }
+            })?,
         };
 
         registry
             .register(&mut listener, self.token, Interest::READABLE)
-            .with_context(|| format!("Could not register listener socket {listener:?}"))?;
+            .map_err(|io_error| ListenerError::SocketRegistrationFailure(io_error.to_string()))?;
 
         self.listener = Some(listener);
         self.active = true;
@@ -765,17 +755,17 @@ impl HttpsListener {
         Ok(server_config)
     }
 
-    pub fn add_https_front(&mut self, tls_front: HttpFrontend) -> anyhow::Result<()> {
+    pub fn add_https_front(&mut self, tls_front: HttpFrontend) -> Result<(), ListenerError> {
         self.fronts
             .add_http_front(&tls_front)
-            .with_context(|| "Could not add https frontend")
+            .map_err(|router_error| ListenerError::AddFrontendError(router_error))
     }
 
-    pub fn remove_https_front(&mut self, tls_front: HttpFrontend) -> anyhow::Result<()> {
+    pub fn remove_https_front(&mut self, tls_front: HttpFrontend) -> Result<(), ListenerError> {
         debug!("removing tls_front {:?}", tls_front);
         self.fronts
             .remove_http_front(&tls_front)
-            .with_context(|| "Could not remove https frontend")
+            .map_err(|router_error| ListenerError::RemoveFrontendError(router_error))
     }
 
     fn accept(&mut self) -> Result<MioTcpStream, AcceptError> {
@@ -837,7 +827,7 @@ impl HttpsProxy {
     pub fn remove_listener(
         &mut self,
         remove: RemoveListener,
-    ) -> anyhow::Result<Option<ResponseContent>> {
+    ) -> Result<Option<ResponseContent>, ProxyError> {
         let len = self.listeners.len();
 
         self.listeners
@@ -852,7 +842,7 @@ impl HttpsProxy {
         Ok(None)
     }
 
-    pub fn soft_stop(&mut self) -> anyhow::Result<()> {
+    pub fn soft_stop(&mut self) -> Result<(), ProxyError> {
         let listeners: HashMap<_, _> = self.listeners.drain().collect();
         let mut socket_errors = vec![];
         for (_, l) in listeners.iter() {
@@ -866,13 +856,16 @@ impl HttpsProxy {
         }
 
         if !socket_errors.is_empty() {
-            bail!("Error deregistering listen sockets: {:?}", socket_errors);
+            return Err(ProxyError::SoftStopError {
+                proxy_protocol: "HTTPS".to_string(),
+                error: format!("Error deregistering listen sockets: {:?}", socket_errors),
+            });
         }
 
         Ok(())
     }
 
-    pub fn hard_stop(&mut self) -> anyhow::Result<()> {
+    pub fn hard_stop(&mut self) -> Result<(), ProxyError> {
         let mut listeners: HashMap<_, _> = self.listeners.drain().collect();
         let mut socket_errors = vec![];
         for (_, l) in listeners.drain() {
@@ -886,13 +879,19 @@ impl HttpsProxy {
         }
 
         if !socket_errors.is_empty() {
-            bail!("Error deregistering listen sockets: {:?}", socket_errors);
+            return Err(ProxyError::HardStopError {
+                proxy_protocol: "HTTPS".to_string(),
+                error: format!("Error deregistering listen sockets: {:?}", socket_errors),
+            });
         }
 
         Ok(())
     }
 
-    pub fn logging(&mut self, logging_filter: String) -> anyhow::Result<Option<ResponseContent>> {
+    pub fn logging(
+        &mut self,
+        logging_filter: String,
+    ) -> Result<Option<ResponseContent>, ProxyError> {
         logging::LOGGER.with(|l| {
             let directives = logging::parse_logging_spec(&logging_filter);
             l.borrow_mut().set_directives(directives);
@@ -900,7 +899,7 @@ impl HttpsProxy {
         Ok(None)
     }
 
-    pub fn query_all_certificates(&mut self) -> anyhow::Result<Option<ResponseContent>> {
+    pub fn query_all_certificates(&mut self) -> Result<Option<ResponseContent>, ProxyError> {
         let certificates = self
             .listeners
             .values()
@@ -937,7 +936,7 @@ impl HttpsProxy {
     pub fn query_certificate_for_domain(
         &mut self,
         domain: String,
-    ) -> anyhow::Result<Option<ResponseContent>> {
+    ) -> Result<Option<ResponseContent>, ProxyError> {
         let certificates = self
             .listeners
             .values()
@@ -973,17 +972,20 @@ impl HttpsProxy {
         &mut self,
         addr: &StdSocketAddr,
         tcp_listener: Option<MioTcpListener>,
-    ) -> anyhow::Result<Token> {
+    ) -> Result<Token, ProxyError> {
         let listener = self
             .listeners
             .values()
             .find(|listener| listener.borrow().address == *addr)
-            .with_context(|| format!("No listener found for address {addr}"))?;
+            .ok_or(ProxyError::NoListenerFound(addr.to_owned()))?;
 
         listener
             .borrow_mut()
             .activate(&self.registry, tcp_listener)
-            .with_context(|| "Failed to activate listener")
+            .map_err(|listener_error| ProxyError::ListenerActivationFailure {
+                address: addr.clone(),
+                listener_error,
+            })
     }
 
     pub fn give_back_listeners(&mut self) -> Vec<(StdSocketAddr, MioTcpListener)> {
@@ -1000,7 +1002,7 @@ impl HttpsProxy {
             .collect()
     }
 
-    // TODO: return Result with context
+    // TODO: return <Result, ProxyError>
     pub fn give_back_listener(
         &mut self,
         address: StdSocketAddr,
@@ -1018,7 +1020,10 @@ impl HttpsProxy {
             })
     }
 
-    pub fn add_cluster(&mut self, mut cluster: Cluster) -> anyhow::Result<Option<ResponseContent>> {
+    pub fn add_cluster(
+        &mut self,
+        mut cluster: Cluster,
+    ) -> Result<Option<ResponseContent>, ProxyError> {
         if let Some(answer_503) = cluster.answer_503.take() {
             for listener in self.listeners.values() {
                 listener
@@ -1032,7 +1037,10 @@ impl HttpsProxy {
         Ok(None)
     }
 
-    pub fn remove_cluster(&mut self, cluster_id: &str) -> anyhow::Result<Option<ResponseContent>> {
+    pub fn remove_cluster(
+        &mut self,
+        cluster_id: &str,
+    ) -> Result<Option<ResponseContent>, ProxyError> {
         self.clusters.remove(cluster_id);
         for listener in self.listeners.values() {
             listener
@@ -1048,65 +1056,75 @@ impl HttpsProxy {
     pub fn add_https_frontend(
         &mut self,
         front: RequestHttpFrontend,
-    ) -> anyhow::Result<Option<ResponseContent>> {
-        let front = front.to_frontend()?;
+    ) -> Result<Option<ResponseContent>, ProxyError> {
+        let front = front.clone().to_frontend().map_err(|request_error| {
+            ProxyError::WrongInputFrontend {
+                front,
+                error: request_error.to_string(),
+            }
+        })?;
 
-        match self
+        let mut listener = self
             .listeners
             .values()
             .find(|l| l.borrow().address == front.address)
-        {
-            Some(listener) => {
-                let mut owned = listener.borrow_mut();
-                owned.set_tags(front.hostname.to_owned(), front.tags.to_owned());
-                owned
-                    .add_https_front(front)
-                    .with_context(|| "Could not add https frontend")?;
-                Ok(None)
-            }
-            None => bail!("adding front {:?} to unknown listener", front),
-        }
+            .ok_or(ProxyError::NoListenerFound(front.address))?
+            .borrow_mut();
+
+        listener.set_tags(front.hostname.to_owned(), front.tags.to_owned());
+        listener
+            .add_https_front(front)
+            .map_err(|listener_error| ProxyError::AddFrontendError(listener_error))?;
+        Ok(None)
     }
 
     pub fn remove_https_frontend(
         &mut self,
         front: RequestHttpFrontend,
-    ) -> anyhow::Result<Option<ResponseContent>> {
-        let front = front.to_frontend()?;
+    ) -> Result<Option<ResponseContent>, ProxyError> {
+        let front = front.clone().to_frontend().map_err(|request_error| {
+            ProxyError::WrongInputFrontend {
+                front,
+                error: request_error.to_string(),
+            }
+        })?;
 
-        if let Some(listener) = self
+        let mut listener = self
             .listeners
             .values()
-            .find(|l| l.borrow_mut().address == front.address)
-        {
-            let mut owned = listener.borrow_mut();
-            owned.set_tags(front.hostname.to_owned(), None);
-            owned
-                .remove_https_front(front)
-                .with_context(|| "Could not remove https frontend")?;
-        }
+            .find(|l| l.borrow().address == front.address)
+            .ok_or(ProxyError::NoListenerFound(front.address))?
+            .borrow_mut();
+
+        listener.set_tags(front.hostname.to_owned(), None);
+        listener
+            .remove_https_front(front)
+            .map_err(|listener_error| ProxyError::RemoveFrontendError(listener_error))?;
         Ok(None)
     }
 
     pub fn add_certificate(
         &mut self,
         add_certificate: AddCertificate,
-    ) -> anyhow::Result<Option<ResponseContent>> {
-        let address = add_certificate.address.parse()?;
-        match self
+    ) -> Result<Option<ResponseContent>, ProxyError> {
+        let address = add_certificate
+            .address
+            .parse::<StdSocketAddr>()
+            .map_err(|parse_error| ProxyError::SocketParseError {
+                address: add_certificate.address.clone(),
+                error: parse_error.to_string(),
+            })?;
+
+        let listener = self
             .listeners
             .values()
             .find(|l| l.borrow().address == address)
-        {
-            Some(listener) => listener
-                .borrow_mut()
-                .add_certificate(&add_certificate)
-                .with_context(|| "Could not add certificate to listener")?,
-            None => bail!(
-                "adding certificate to unknown listener {}",
-                add_certificate.address
-            ),
-        };
+            .ok_or(ProxyError::NoListenerFound(address))?;
+
+        listener
+            .borrow_mut()
+            .add_certificate(&add_certificate)
+            .map_err(|listener_error| ProxyError::AddCertificateError(listener_error))?;
 
         Ok(None)
     }
@@ -1115,26 +1133,30 @@ impl HttpsProxy {
     pub fn remove_certificate(
         &mut self,
         remove_certificate: RemoveCertificate,
-    ) -> anyhow::Result<Option<ResponseContent>> {
-        let address = remove_certificate.address.parse()?;
+    ) -> Result<Option<ResponseContent>, ProxyError> {
+        let address = remove_certificate
+            .address
+            .parse::<StdSocketAddr>()
+            .map_err(|parse_error| ProxyError::SocketParseError {
+                address: remove_certificate.address,
+                error: parse_error.to_string(),
+            })?;
+
         let fingerprint = Fingerprint(
             hex::decode(&remove_certificate.fingerprint)
-                .with_context(|| "Failed at decoding the string (expected hexadecimal data)")?,
+                .map_err(|e| ProxyError::WrongCertificateFingerprint(e.to_string()))?,
         );
-        match self
+
+        let listener = self
             .listeners
             .values()
             .find(|l| l.borrow().address == address)
-        {
-            Some(listener) => listener
-                .borrow_mut()
-                .remove_certificate(&fingerprint)
-                .with_context(|| "Could not remove certificate from listener")?,
-            None => bail!(
-                "removing certificate from unknown listener {}",
-                remove_certificate.address
-            ),
-        };
+            .ok_or(ProxyError::NoListenerFound(address))?;
+
+        listener
+            .borrow_mut()
+            .remove_certificate(&fingerprint)
+            .map_err(|listener_error| ProxyError::AddCertificateError(listener_error))?;
 
         Ok(None)
     }
@@ -1143,22 +1165,25 @@ impl HttpsProxy {
     pub fn replace_certificate(
         &mut self,
         replace_certificate: ReplaceCertificate,
-    ) -> anyhow::Result<Option<ResponseContent>> {
-        let address = replace_certificate.address.parse()?;
-        match self
+    ) -> Result<Option<ResponseContent>, ProxyError> {
+        let address = replace_certificate
+            .address
+            .parse::<StdSocketAddr>()
+            .map_err(|parse_error| ProxyError::SocketParseError {
+                address: replace_certificate.address.clone(),
+                error: parse_error.to_string(),
+            })?;
+
+        let listener = self
             .listeners
             .values()
             .find(|l| l.borrow().address == address)
-        {
-            Some(listener) => listener
-                .borrow_mut()
-                .replace_certificate(&replace_certificate)
-                .with_context(|| "Could not replace certificate on listener")?,
-            None => bail!(
-                "replacing certificate on unknown listener {}",
-                replace_certificate.address
-            ),
-        };
+            .ok_or(ProxyError::NoListenerFound(address))?;
+
+        listener
+            .borrow_mut()
+            .replace_certificate(&replace_certificate)
+            .map_err(|listener_error| ProxyError::ReplaceCertificateError(listener_error))?;
 
         Ok(None)
     }
@@ -1256,27 +1281,22 @@ impl ProxyConfiguration for HttpsProxy {
             RequestType::AddCluster(cluster) => {
                 debug!("{} add cluster {:?}", request_id, cluster);
                 self.add_cluster(cluster.clone())
-                    .with_context(|| format!("Could not add cluster {}", cluster.cluster_id))
             }
             RequestType::RemoveCluster(cluster_id) => {
                 debug!("{} remove cluster {:?}", request_id, cluster_id);
                 self.remove_cluster(&cluster_id)
-                    .with_context(|| format!("Could not remove cluster {cluster_id}"))
             }
             RequestType::AddHttpsFrontend(front) => {
                 debug!("{} add https front {:?}", request_id, front);
                 self.add_https_frontend(front)
-                    .with_context(|| "Could not add https frontend")
             }
             RequestType::RemoveHttpsFrontend(front) => {
                 debug!("{} remove https front {:?}", request_id, front);
                 self.remove_https_frontend(front)
-                    .with_context(|| "Could not remove https frontend")
             }
             RequestType::AddCertificate(add_certificate) => {
                 debug!("{} add certificate: {:?}", request_id, add_certificate);
                 self.add_certificate(add_certificate)
-                    .with_context(|| "Could not add certificate")
             }
             RequestType::RemoveCertificate(remove_certificate) => {
                 debug!(
@@ -1284,7 +1304,6 @@ impl ProxyConfiguration for HttpsProxy {
                     request_id, remove_certificate
                 );
                 self.remove_certificate(remove_certificate)
-                    .with_context(|| "Could not remove certificate")
             }
             RequestType::ReplaceCertificate(replace_certificate) => {
                 debug!(
@@ -1292,20 +1311,14 @@ impl ProxyConfiguration for HttpsProxy {
                     request_id, replace_certificate
                 );
                 self.replace_certificate(replace_certificate)
-                    .with_context(|| "Could not replace certificate")
             }
             RequestType::RemoveListener(remove) => {
                 debug!("removing HTTPS listener at address {:?}", remove.address);
-                self.remove_listener(remove.clone()).with_context(|| {
-                    format!("Could not remove listener at address {:?}", remove.address)
-                })
+                self.remove_listener(remove.clone())
             }
             RequestType::SoftStop(_) => {
                 debug!("{} processing soft shutdown", request_id);
-                match self
-                    .soft_stop()
-                    .with_context(|| "Could not perform soft stop")
-                {
+                match self.soft_stop() {
                     Ok(_) => {
                         info!("{} soft stop successful", request_id);
                         return WorkerResponse::processing(request.id);
@@ -1315,10 +1328,7 @@ impl ProxyConfiguration for HttpsProxy {
             }
             RequestType::HardStop(_) => {
                 debug!("{} processing hard shutdown", request_id);
-                match self
-                    .hard_stop()
-                    .with_context(|| "Could not perform hard stop")
-                {
+                match self.hard_stop() {
                     Ok(_) => {
                         debug!("{} hard stop successful", request_id);
                         return WorkerResponse::processing(request.id);
@@ -1336,17 +1346,14 @@ impl ProxyConfiguration for HttpsProxy {
                     request_id, logging_filter
                 );
                 self.logging(logging_filter.clone())
-                    .with_context(|| format!("Could not set logging level to {logging_filter}"))
             }
             RequestType::QueryCertificatesFromWorkers(filters) => {
                 if let Some(domain) = filters.domain {
                     debug!("{} query certificate for domain {}", request_id, domain);
                     self.query_certificate_for_domain(domain.clone())
-                        .with_context(|| format!("Could not query certificate for domain {domain}"))
                 } else {
                     debug!("{} query all certificates", request_id);
                     self.query_all_certificates()
-                        .with_context(|| "Could not query all certificates")
                 }
             }
             other_request => {
@@ -1354,7 +1361,7 @@ impl ProxyConfiguration for HttpsProxy {
                     "{} unsupported request for HTTPS proxy, ignoring {:?}",
                     request.id, other_request
                 );
-                Err(anyhow::Error::msg("unsupported message"))
+                Err(ProxyError::UnsupportedMessage)
             }
         };
 
@@ -1366,9 +1373,9 @@ impl ProxyConfiguration for HttpsProxy {
                     None => WorkerResponse::ok(request_id),
                 }
             }
-            Err(error_message) => {
-                debug!("{} unsuccessful: {:#}", request_id, error_message);
-                WorkerResponse::error(request_id, format!("{error_message:#}"))
+            Err(proxy_error) => {
+                debug!("{} unsuccessful: {:#}", request_id, proxy_error);
+                WorkerResponse::error(request_id, format!("{proxy_error}"))
             }
         }
     }

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -67,8 +67,8 @@ use crate::{
         ParsedCertificateAndKey,
     },
     util::UnwrapLog,
-    AcceptError, CachedTags, L7ListenerHandler, L7Proxy, ListenerHandler, Protocol,
-    ProxyConfiguration, ProxySession, Readiness, SessionIsToBeClosed, SessionMetrics,
+    AcceptError, CachedTags, FrontendFromRequestError, L7ListenerHandler, L7Proxy, ListenerHandler,
+    Protocol, ProxyConfiguration, ProxySession, Readiness, SessionIsToBeClosed, SessionMetrics,
     SessionResult, StateMachineBuilder, StateResult,
 };
 
@@ -578,17 +578,22 @@ impl L7ListenerHandler for HttpsListener {
         host: &str,
         uri: &str,
         method: &Method,
-    ) -> anyhow::Result<Route> {
+    ) -> Result<Route, FrontendFromRequestError> {
         let (remaining_input, (hostname, _)) = match hostname_and_port(host.as_bytes()) {
             Ok(tuple) => tuple,
             Err(parse_error) => {
                 // parse_error contains a slice of given_host, which should NOT escape this scope
-                bail!("Hostname parsing failed for host {host}: {parse_error}");
+                return Err(FrontendFromRequestError::HostParsingFailure {
+                    host: host.to_owned(),
+                    error: parse_error.to_string(),
+                });
             }
         };
 
         if remaining_input != &b""[..] {
-            bail!("frontend_from_request: invalid remaining chars after hostname. Host: {host}");
+            return Err(FrontendFromRequestError::InvalidCharsAfterHost(
+                host.to_owned(),
+            ));
         }
 
         // it is alright to call from_utf8_unchecked,
@@ -598,7 +603,7 @@ impl L7ListenerHandler for HttpsListener {
 
         self.fronts
             .lookup(host.as_bytes(), uri.as_bytes(), method)
-            .with_context(|| "No cluster found")
+            .ok_or(FrontendFromRequestError::NoClusterFound)
     }
 }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -391,20 +391,16 @@ use std::{
     str,
 };
 
-use anyhow::{bail, Context};
 use mio::{net::TcpStream, Interest, Token};
 use protocol::http::parser::Method;
 use sozu_command::proto::command::ListenerType;
 use sozu_command_lib::{
-    proto::command::{Cluster, Event, EventKind, LoadBalancingParams},
-    ready::Ready,
-    request::WorkerRequest,
-    response::WorkerResponse,
+    proto::command::Cluster, ready::Ready, request::WorkerRequest, response::WorkerResponse,
     state::ClusterId,
 };
 use time::{Duration, Instant};
 
-use self::{backends::BackendMap, retry::RetryPolicy, router::Route};
+use self::{backends::BackendMap, router::Route};
 
 /// Anything that can be registered in mio (subscribe to kernel events)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -786,148 +782,7 @@ pub enum SocketType {
     FrontClient,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum BackendStatus {
-    Normal,
-    Closing,
-    Closed,
-}
-
 type SessionIsToBeClosed = bool;
-
-#[derive(Debug, PartialEq, Clone)]
-pub struct Backend {
-    pub sticky_id: Option<String>,
-    pub backend_id: String,
-    pub address: SocketAddr,
-    pub status: BackendStatus,
-    pub retry_policy: retry::RetryPolicyWrapper,
-    pub active_connections: usize,
-    pub active_requests: usize,
-    pub failures: usize,
-    pub load_balancing_parameters: Option<LoadBalancingParams>,
-    pub backup: bool,
-    pub connection_time: PeakEWMA,
-}
-
-impl Backend {
-    pub fn new(
-        backend_id: &str,
-        address: SocketAddr,
-        sticky_id: Option<String>,
-        load_balancing_parameters: Option<LoadBalancingParams>,
-        backup: Option<bool>,
-    ) -> Backend {
-        let desired_policy = retry::ExponentialBackoffPolicy::new(6);
-        Backend {
-            sticky_id,
-            backend_id: backend_id.to_string(),
-            address,
-            status: BackendStatus::Normal,
-            retry_policy: desired_policy.into(),
-            active_connections: 0,
-            active_requests: 0,
-            failures: 0,
-            load_balancing_parameters,
-            backup: backup.unwrap_or(false),
-            connection_time: PeakEWMA::new(),
-        }
-    }
-
-    pub fn set_closing(&mut self) {
-        self.status = BackendStatus::Closing;
-    }
-
-    pub fn retry_policy(&mut self) -> &mut retry::RetryPolicyWrapper {
-        &mut self.retry_policy
-    }
-
-    pub fn can_open(&self) -> bool {
-        if let Some(action) = self.retry_policy.can_try() {
-            self.status == BackendStatus::Normal && action == retry::RetryAction::OKAY
-        } else {
-            false
-        }
-    }
-
-    pub fn inc_connections(&mut self) -> Option<usize> {
-        if self.status == BackendStatus::Normal {
-            self.active_connections += 1;
-            Some(self.active_connections)
-        } else {
-            None
-        }
-    }
-
-    /// TODO: normalize with saturating_sub()
-    pub fn dec_connections(&mut self) -> Option<usize> {
-        match self.status {
-            BackendStatus::Normal => {
-                if self.active_connections > 0 {
-                    self.active_connections -= 1;
-                }
-                Some(self.active_connections)
-            }
-            BackendStatus::Closed => None,
-            BackendStatus::Closing => {
-                if self.active_connections > 0 {
-                    self.active_connections -= 1;
-                }
-                if self.active_connections == 0 {
-                    self.status = BackendStatus::Closed;
-                    None
-                } else {
-                    Some(self.active_connections)
-                }
-            }
-        }
-    }
-
-    pub fn set_connection_time(&mut self, dur: Duration) {
-        self.connection_time.observe(dur.whole_nanoseconds() as f64);
-    }
-
-    pub fn peak_ewma_connection(&mut self) -> f64 {
-        self.connection_time.get(self.active_connections)
-    }
-
-    pub fn try_connect(&mut self) -> anyhow::Result<mio::net::TcpStream> {
-        if self.status != BackendStatus::Normal {
-            bail!("This backend is not in a normal status");
-        }
-
-        match mio::net::TcpStream::connect(self.address) {
-            Ok(tcp_stream) => {
-                //self.retry_policy.succeed();
-                self.inc_connections();
-                Ok(tcp_stream)
-            }
-            Err(mio_error) => {
-                self.retry_policy.fail();
-                self.failures += 1;
-                // TODO: handle EINPROGRESS. It is difficult. It is discussed here:
-                // https://docs.rs/mio/latest/mio/net/struct.TcpStream.html#method.connect
-                // with an example code here:
-                // https://github.com/Thomasdezeeuw/heph/blob/0c4f1ab3eaf08bea1d65776528bfd6114c9f8374/src/net/tcp/stream.rs#L560-L622
-                Err(mio_error).with_context(|| "Failed to connect to socket with MIO")
-            }
-        }
-    }
-}
-
-// when a backend has been removed from configuration and the last connection to
-// it has stopped, it will be dropped, so we can notify that the backend server
-// can be safely stopped
-impl std::ops::Drop for Backend {
-    fn drop(&mut self) {
-        server::push_event(Event {
-            kind: EventKind::RemovedBackendHasNoConnections as i32,
-            backend_id: Some(self.backend_id.clone()),
-            address: Some(self.address.to_string()),
-            cluster_id: None,
-        });
-    }
-}
 
 #[derive(Clone)]
 pub struct Readiness {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -592,17 +592,28 @@ pub trait ListenerHandler {
     fn set_tags(&mut self, key: String, tags: Option<BTreeMap<String, String>>);
 }
 
+#[derive(thiserror::Error, Debug)]
+pub enum FrontendFromRequestError {
+    #[error("Could not parse hostname from '{host}': {error}")]
+    HostParsingFailure { host: String, error: String },
+    #[error("invalid remaining chars after hostname. Host: {0}")]
+    InvalidCharsAfterHost(String),
+    #[error("no cluster found")]
+    NoClusterFound,
+}
+
 pub trait L7ListenerHandler {
     fn get_sticky_name(&self) -> &str;
 
     fn get_connect_timeout(&self) -> u32;
 
+    /// retrieve a frontend by parsing a request's hostname, uri and method
     fn frontend_from_request(
         &self,
         host: &str,
         uri: &str,
         method: &Method,
-    ) -> anyhow::Result<Route>;
+    ) -> Result<Route, FrontendFromRequestError>;
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/lib/src/load_balancing.rs
+++ b/lib/src/load_balancing.rs
@@ -6,7 +6,7 @@ use rand::{
     thread_rng, Rng,
 };
 
-use crate::{sozu_command::proto::command::LoadMetric, Backend};
+use crate::{backends::Backend, sozu_command::proto::command::LoadMetric};
 
 pub trait LoadBalancingAlgorithm: Debug {
     fn next_available_backend(
@@ -177,7 +177,7 @@ mod test {
     use super::*;
     use crate::retry::{ExponentialBackoffPolicy, RetryPolicyWrapper};
     use crate::sozu_command::proto::command::LoadMetric;
-    use crate::{BackendStatus, PeakEWMA};
+    use crate::{backends::BackendStatus, PeakEWMA};
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
     fn create_backend(id: String, connections: Option<usize>) -> Backend {

--- a/lib/src/metrics/local_drain.rs
+++ b/lib/src/metrics/local_drain.rs
@@ -271,7 +271,7 @@ impl LocalDrain {
         let raw_metrics = self
             .cluster_metrics
             .get(cluster_id)
-            .ok_or(MetricError::NoMetricsForCluster(cluster_id.to_owned()))?;
+            .ok_or(MetricError::NoMetrics(cluster_id.to_owned()))?;
 
         let cluster: BTreeMap<String, FilteredMetrics> = raw_metrics
             .iter()
@@ -301,7 +301,7 @@ impl LocalDrain {
         let backend_metrics = self
             .cluster_metrics
             .get(backend_id)
-            .ok_or(MetricError::NoMetricsForBackend(backend_id.to_owned()))?;
+            .ok_or(MetricError::NoMetrics(backend_id.to_owned()))?;
 
         let filtered_backend_metrics = backend_metrics
             .iter()
@@ -354,7 +354,7 @@ impl LocalDrain {
             let cluster_id = self
                 .backend_to_cluster
                 .get(backend_id)
-                .ok_or(MetricError::NoMetricsForBackend(backend_id.to_owned()))?
+                .ok_or(MetricError::NoMetrics(backend_id.to_owned()))?
                 .to_owned();
 
             let backends = vec![self.metrics_of_one_backend(backend_id, metric_names)?];

--- a/lib/src/metrics/mod.rs
+++ b/lib/src/metrics/mod.rs
@@ -27,11 +27,9 @@ pub enum MetricError {
     #[error("Could not parse udp address {address}: {error}")]
     WrongUdpAddress { address: String, error: String },
     #[error("Could not bind to udp address {address}: {error}")]
-    UdpBindError { address: String, error: String },
-    #[error("No metrics found for backend with id {0}")]
-    NoMetricsForBackend(String),
-    #[error("No metrics found for cluster with id {0}")]
-    NoMetricsForCluster(String),
+    UdpBind { address: String, error: String },
+    #[error("No metrics found for object with id {0}")]
+    NoMetrics(String),
     #[error("Could not create histogram for time metric {time_metric:?}: {error}")]
     HistogramCreation {
         time_metric: MetricValue,
@@ -301,7 +299,7 @@ pub fn udp_bind() -> Result<UdpSocket, MetricError> {
                 error: parse_error.to_string(),
             })?;
 
-    UdpSocket::bind(udp_address).map_err(|parse_error| MetricError::UdpBindError {
+    UdpSocket::bind(udp_address).map_err(|parse_error| MetricError::UdpBind {
         address: udp_address.to_string(),
         error: parse_error.to_string(),
     })

--- a/lib/src/metrics/mod.rs
+++ b/lib/src/metrics/mod.rs
@@ -11,7 +11,6 @@ use std::{
     time::Instant,
 };
 
-use anyhow::Context;
 use mio::net::UdpSocket;
 use sozu_command::proto::command::{
     FilteredMetrics, MetricsConfiguration, QueryMetricsOptions, ResponseContent,
@@ -21,6 +20,28 @@ use self::{local_drain::LocalDrain, network_drain::NetworkDrain};
 
 thread_local! {
   pub static METRICS: RefCell<Aggregator> = RefCell::new(Aggregator::new(String::from("sozu")));
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum MetricError {
+    #[error("Could not parse udp address {address}: {error}")]
+    WrongUdpAddress { address: String, error: String },
+    #[error("Could not bind to udp address {address}: {error}")]
+    UdpBindError { address: String, error: String },
+    #[error("No metrics found for backend with id {0}")]
+    NoMetricsForBackend(String),
+    #[error("No metrics found for cluster with id {0}")]
+    NoMetricsForCluster(String),
+    #[error("Could not create histogram for time metric {time_metric:?}: {error}")]
+    HistogramCreation {
+        time_metric: MetricValue,
+        error: String,
+    },
+    #[error("could not record time metric {time_metric:?}: {error}")]
+    TimeMetricRecordingError {
+        time_metric: MetricValue,
+        error: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -111,7 +132,7 @@ pub fn setup<O: Into<String>>(
     origin: O,
     use_tagged_metrics: bool,
     prefix: Option<String>,
-) -> anyhow::Result<()> {
+) -> Result<(), MetricError> {
     let metrics_socket = udp_bind()?;
 
     debug!(
@@ -216,7 +237,7 @@ impl Aggregator {
         self.local.dump_proxy_metrics(&Vec::new())
     }
 
-    pub fn query(&mut self, q: &QueryMetricsOptions) -> anyhow::Result<ResponseContent> {
+    pub fn query(&mut self, q: &QueryMetricsOptions) -> Result<ResponseContent, MetricError> {
         self.local.query(q)
     }
 
@@ -269,11 +290,21 @@ impl Write for MetricSocket {
     }
 }
 
-pub fn udp_bind() -> anyhow::Result<UdpSocket> {
-    let address = "0.0.0.0:0"
-        .parse()
-        .with_context(|| "could not parse 0.0.0.0:0")?;
-    UdpSocket::bind(address).with_context(|| "Could not bind to 0.0.0.0:0 udp socket")
+pub fn udp_bind() -> Result<UdpSocket, MetricError> {
+    let address = "0.0.0.0:0";
+
+    let udp_address =
+        address
+            .parse::<SocketAddr>()
+            .map_err(|parse_error| MetricError::WrongUdpAddress {
+                address: address.to_owned(),
+                error: parse_error.to_string(),
+            })?;
+
+    UdpSocket::bind(udp_address).map_err(|parse_error| MetricError::UdpBindError {
+        address: udp_address.to_string(),
+        error: parse_error.to_string(),
+    })
 }
 
 /// adds a value to a counter

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -977,7 +977,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         if self.connection_attempts >= CONN_RETRIES {
             error!("{} max connection attempt reached", self.log_context());
             self.set_answer(DefaultAnswerStatus::Answer503, None);
-            return Err(BackendConnectionError::TooManyAttempts);
+            return Err(BackendConnectionError::MaxConnectionRetries(None));
         }
         Ok(())
     }
@@ -1041,9 +1041,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             Ok(route) => route,
             Err(frontend_error) => {
                 self.set_answer(DefaultAnswerStatus::Answer404, None);
-                return Err(RetrieveClusterError::FrontendFromRequestError(
-                    frontend_error,
-                ));
+                return Err(RetrieveClusterError::RetrieveFrontend(frontend_error));
             }
         };
 
@@ -1091,7 +1089,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             )
             .map_err(|backend_error| {
                 self.set_answer(DefaultAnswerStatus::Answer503, None);
-                BackendConnectionError::BackendError(backend_error)
+                BackendConnectionError::Backend(backend_error)
             })?;
 
         if frontend_should_stick {
@@ -1424,7 +1422,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
                         return SessionResult::Continue;
                     }
                     Err(connection_error) => {
-                        error!("Error connecting to backend: {:#}", connection_error)
+                        error!("Error connecting to backend: {}", connection_error)
                     }
                 }
             } else {
@@ -1479,7 +1477,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
                                 return SessionResult::Continue;
                             }
                             Err(connection_error) => {
-                                error!("Error connecting to backend: {:#}", connection_error)
+                                error!("Error connecting to backend: {}", connection_error)
                             }
                         }
                     }

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -17,6 +17,7 @@ use sozu_command::proto::command::{Event, EventKind, ListenerType};
 use time::{Duration, Instant};
 
 use crate::{
+    backends::Backend,
     logs::{Endpoint, LogContext, RequestRecord},
     pool::{Checkout, Pool},
     protocol::{
@@ -29,9 +30,9 @@ use crate::{
     socket::{stats::socket_rtt, SocketHandler, SocketResult, TransportProtocol},
     sozu_command::ready::Ready,
     timer::TimeoutContainer,
-    AcceptError, Backend, BackendConnectAction, BackendConnectionStatus, L7ListenerHandler,
-    L7Proxy, ListenerHandler, Protocol, ProxySession, Readiness, SessionIsToBeClosed,
-    SessionMetrics, SessionResult, StateResult,
+    AcceptError, BackendConnectAction, BackendConnectionStatus, L7ListenerHandler, L7Proxy,
+    ListenerHandler, Protocol, ProxySession, Readiness, SessionIsToBeClosed, SessionMetrics,
+    SessionResult, StateResult,
 };
 
 /// Generic Http representation using the Kawa crate using the Checkout of Sozu as buffer
@@ -1131,11 +1132,11 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
                         "Couldn't find a backend corresponding to sticky_session {sticky_session} for cluster {cluster_id}"
                     )
                 }),
-            _ => proxy
+            _ => Ok(proxy
                 .borrow()
                 .backends()
                 .borrow_mut()
-                .backend_from_cluster_id(cluster_id),
+                .backend_from_cluster_id(cluster_id)?),
         }
     }
 

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -9,7 +9,6 @@ use std::{
     rc::{Rc, Weak},
 };
 
-use anyhow::{bail, Context};
 use kawa;
 use mio::{net::TcpStream, *};
 use rusty_ulid::Ulid;
@@ -17,7 +16,7 @@ use sozu_command::proto::command::{Event, EventKind, ListenerType};
 use time::{Duration, Instant};
 
 use crate::{
-    backends::Backend,
+    backends::{Backend, BackendError},
     logs::{Endpoint, LogContext, RequestRecord},
     pool::{Checkout, Pool},
     protocol::{
@@ -30,9 +29,9 @@ use crate::{
     socket::{stats::socket_rtt, SocketHandler, SocketResult, TransportProtocol},
     sozu_command::ready::Ready,
     timer::TimeoutContainer,
-    AcceptError, BackendConnectAction, BackendConnectionStatus, L7ListenerHandler, L7Proxy,
-    ListenerHandler, Protocol, ProxySession, Readiness, SessionIsToBeClosed, SessionMetrics,
-    SessionResult, StateResult,
+    AcceptError, BackendConnectAction, BackendConnectionError, BackendConnectionStatus,
+    L7ListenerHandler, L7Proxy, ListenerHandler, Protocol, ProxySession, Readiness,
+    RetrieveClusterError, SessionIsToBeClosed, SessionMetrics, SessionResult, StateResult,
 };
 
 /// Generic Http representation using the Kawa crate using the Checkout of Sozu as buffer
@@ -108,6 +107,7 @@ pub struct Http<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> {
     configured_connect_timeout: Duration,
     configured_frontend_timeout: Duration,
     pub cluster_id: Option<String>,
+    /// attempts to connect to the backends during the session
     connection_attempts: u8,
     pub frontend_readiness: Readiness,
     pub frontend_socket: Front,
@@ -973,11 +973,11 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
     }
 
     /// Check the number of connection attempts against authorized connection retries
-    fn check_circuit_breaker(&mut self) -> anyhow::Result<()> {
+    fn check_circuit_breaker(&mut self) -> Result<(), BackendConnectionError> {
         if self.connection_attempts >= CONN_RETRIES {
             error!("{} max connection attempt reached", self.log_context());
             self.set_answer(DefaultAnswerStatus::Answer503, None);
-            bail!("Maximum connection attempt reached");
+            return Err(BackendConnectionError::TooManyAttempts);
         }
         Ok(())
     }
@@ -1000,22 +1000,22 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
     }
 
     // -> host, path, method
-    pub fn extract_route(&self) -> anyhow::Result<(&str, &str, &Method)> {
+    pub fn extract_route(&self) -> Result<(&str, &str, &Method), RetrieveClusterError> {
         let given_method = self
             .context
             .method
             .as_ref()
-            .with_context(|| "No method given")?;
+            .ok_or(RetrieveClusterError::NoMethod)?;
         let given_authority = self
             .context
             .authority
             .as_deref()
-            .with_context(|| "No host given")?;
+            .ok_or(RetrieveClusterError::NoHost)?;
         let given_path = self
             .context
             .path
             .as_deref()
-            .with_context(|| "No path given")?;
+            .ok_or(RetrieveClusterError::NoPath)?;
 
         Ok((given_authority, given_path, given_method))
     }
@@ -1023,32 +1023,35 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
     fn cluster_id_from_request(
         &mut self,
         proxy: Rc<RefCell<dyn L7Proxy>>,
-    ) -> anyhow::Result<String> {
+    ) -> Result<String, RetrieveClusterError> {
         let (host, uri, method) = match self.extract_route() {
             Ok(tuple) => tuple,
-            Err(e) => {
+            Err(cluster_error) => {
                 self.set_answer(DefaultAnswerStatus::Answer400, None);
-                return Err(e).with_context(|| "Could not extract route from request");
+                return Err(cluster_error);
             }
         };
 
-        let cluster_id_res = self
+        let route_result = self
             .listener
             .borrow()
             .frontend_from_request(host, uri, method);
 
-        let cluster_id = match cluster_id_res {
-            Ok(route) => match route {
-                Route::ClusterId(cluster_id) => cluster_id,
-                Route::Deny => {
-                    self.set_answer(DefaultAnswerStatus::Answer401, None);
-                    bail!("Unauthorized route");
-                }
-            },
-            Err(e) => {
-                let no_host_error = format!("Host not found: {host}: {e:#}");
+        let route = match route_result {
+            Ok(route) => route,
+            Err(frontend_error) => {
                 self.set_answer(DefaultAnswerStatus::Answer404, None);
-                bail!(no_host_error);
+                return Err(RetrieveClusterError::FrontendFromRequestError(
+                    frontend_error,
+                ));
+            }
+        };
+
+        let cluster_id = match route {
+            Route::ClusterId(cluster_id) => cluster_id,
+            Route::Deny => {
+                self.set_answer(DefaultAnswerStatus::Answer401, None);
+                return Err(RetrieveClusterError::UnauthorizedRoute);
             }
         };
 
@@ -1066,7 +1069,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
                 DefaultAnswerStatus::Answer301,
                 Some(Rc::new(answer.into_bytes())),
             );
-            bail!("Route is unauthorized");
+            return Err(RetrieveClusterError::UnauthorizedRoute);
         }
 
         Ok(cluster_id)
@@ -1078,20 +1081,18 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         frontend_should_stick: bool,
         proxy: Rc<RefCell<dyn L7Proxy>>,
         metrics: &mut SessionMetrics,
-    ) -> anyhow::Result<TcpStream> {
-        let (backend, conn) = match self.get_backend_for_sticky_session(
-            frontend_should_stick,
-            self.context.sticky_session_found.as_deref(),
-            cluster_id,
-            proxy,
-        ) {
-            Ok(tuple) => tuple,
-            Err(e) => {
+    ) -> Result<TcpStream, BackendConnectionError> {
+        let (backend, conn) = self
+            .get_backend_for_sticky_session(
+                frontend_should_stick,
+                self.context.sticky_session_found.as_deref(),
+                cluster_id,
+                proxy,
+            )
+            .map_err(|backend_error| {
                 self.set_answer(DefaultAnswerStatus::Answer503, None);
-                return Err(e)
-                    .with_context(|| format!("Could not find a backend for cluster {cluster_id}"));
-            }
-        };
+                BackendConnectionError::BackendError(backend_error)
+            })?;
 
         if frontend_should_stick {
             // update sticky name in case it changed I guess?
@@ -1120,23 +1121,18 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         sticky_session: Option<&str>,
         cluster_id: &str,
         proxy: Rc<RefCell<dyn L7Proxy>>,
-    ) -> anyhow::Result<(Rc<RefCell<Backend>>, TcpStream)> {
+    ) -> Result<(Rc<RefCell<Backend>>, TcpStream), BackendError> {
         match (frontend_should_stick, sticky_session) {
             (true, Some(sticky_session)) => proxy
                 .borrow()
                 .backends()
                 .borrow_mut()
-                .backend_from_sticky_session(cluster_id, sticky_session)
-                .with_context(|| {
-                    format!(
-                        "Couldn't find a backend corresponding to sticky_session {sticky_session} for cluster {cluster_id}"
-                    )
-                }),
-            _ => Ok(proxy
+                .backend_from_sticky_session(cluster_id, sticky_session),
+            _ => proxy
                 .borrow()
                 .backends()
                 .borrow_mut()
-                .backend_from_cluster_id(cluster_id)?),
+                .backend_from_cluster_id(cluster_id),
         }
     }
 
@@ -1145,16 +1141,15 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         session_rc: Rc<RefCell<dyn ProxySession>>,
         proxy: Rc<RefCell<dyn L7Proxy>>,
         metrics: &mut SessionMetrics,
-    ) -> anyhow::Result<BackendConnectAction> {
+    ) -> Result<BackendConnectAction, BackendConnectionError> {
         let old_cluster_id = self.cluster_id.clone();
         let old_backend_token = self.backend_token;
 
-        self.check_circuit_breaker()
-            .with_context(|| "Circuit broke")?;
+        self.check_circuit_breaker()?;
 
         let cluster_id = self
             .cluster_id_from_request(proxy.clone())
-            .with_context(|| "Could not get cluster id from request")?;
+            .map_err(|cluster_error| BackendConnectionError::RetrieveClusterError(cluster_error))?;
 
         trace!(
             "connect_to_backend: {:?} {:?} {:?}",

--- a/lib/src/protocol/pipe.rs
+++ b/lib/src/protocol/pipe.rs
@@ -5,14 +5,14 @@ use mio::*;
 use rusty_ulid::Ulid;
 
 use crate::{
+    backends::Backend,
     logs::{Endpoint, LogContext, RequestRecord},
     pool::Checkout,
     protocol::SessionState,
     socket::{stats::socket_rtt, SocketHandler, SocketResult, TransportProtocol},
     sozu_command::ready::Ready,
     timer::TimeoutContainer,
-    Backend, L7Proxy, ListenerHandler, Protocol, Readiness, SessionMetrics, SessionResult,
-    StateResult,
+    L7Proxy, ListenerHandler, Protocol, Readiness, SessionMetrics, SessionResult, StateResult,
 };
 
 #[derive(PartialEq, Eq)]

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -16,13 +16,13 @@ use self::pattern_trie::TrieNode;
 #[derive(thiserror::Error, Debug)]
 pub enum RouterError {
     #[error("Could not parse rule from frontend path {0:?}")]
-    UnparsablePathRule(String),
+    InvalidPathRule(String),
     #[error("parsing hostname {hostname} failed")]
-    UnparsableDomain { hostname: String },
+    InvalidDomain { hostname: String },
     #[error("Could not add route {0}")]
-    AddRouteFailure(String),
+    AddRoute(String),
     #[error("Could not remove route {0}")]
-    RemoveRouteFailure(String),
+    RemoveRoute(String),
 }
 
 pub struct Router {
@@ -111,7 +111,7 @@ impl Router {
 
     pub fn add_http_front(&mut self, front: &HttpFrontend) -> Result<(), RouterError> {
         let path_rule = PathRule::from_config(front.path.clone())
-            .ok_or(RouterError::UnparsablePathRule(front.path.to_string()))?;
+            .ok_or(RouterError::InvalidPathRule(front.path.to_string()))?;
 
         let method_rule = MethodRule::new(front.method.clone());
 
@@ -123,7 +123,7 @@ impl Router {
         let success = match front.position {
             RulePosition::Pre => {
                 let domain = front.hostname.parse::<DomainRule>().map_err(|_| {
-                    RouterError::UnparsableDomain {
+                    RouterError::InvalidDomain {
                         hostname: front.hostname.clone(),
                     }
                 })?;
@@ -132,7 +132,7 @@ impl Router {
             }
             RulePosition::Post => {
                 let domain = front.hostname.parse::<DomainRule>().map_err(|_| {
-                    RouterError::UnparsableDomain {
+                    RouterError::InvalidDomain {
                         hostname: front.hostname.clone(),
                     }
                 })?;
@@ -144,21 +144,21 @@ impl Router {
             }
         };
         if !success {
-            return Err(RouterError::AddRouteFailure(format!("{:?}", front)));
+            return Err(RouterError::AddRoute(format!("{:?}", front)));
         }
         Ok(())
     }
 
     pub fn remove_http_front(&mut self, front: &HttpFrontend) -> Result<(), RouterError> {
         let path_rule = PathRule::from_config(front.path.clone())
-            .ok_or(RouterError::UnparsablePathRule(front.path.to_string()))?;
+            .ok_or(RouterError::InvalidPathRule(front.path.to_string()))?;
 
         let method_rule = MethodRule::new(front.method.clone());
 
         let remove_success = match front.position {
             RulePosition::Pre => {
                 let domain = front.hostname.parse::<DomainRule>().map_err(|_| {
-                    RouterError::UnparsableDomain {
+                    RouterError::InvalidDomain {
                         hostname: front.hostname.clone(),
                     }
                 })?;
@@ -167,7 +167,7 @@ impl Router {
             }
             RulePosition::Post => {
                 let domain = front.hostname.parse::<DomainRule>().map_err(|_| {
-                    RouterError::UnparsableDomain {
+                    RouterError::InvalidDomain {
                         hostname: front.hostname.clone(),
                     }
                 })?;
@@ -179,7 +179,7 @@ impl Router {
             }
         };
         if !remove_success {
-            return Err(RouterError::RemoveRouteFailure(format!("{:?}", front)));
+            return Err(RouterError::RemoveRoute(format!("{:?}", front)));
         }
         Ok(())
     }

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -32,9 +32,14 @@ use sozu_command::{
 use time::{Duration, Instant};
 
 use crate::{
-    backends::BackendMap, features::FEATURES, http, https, metrics::METRICS, pool::Pool, tcp,
-    timer::Timer, AcceptError, Backend, Protocol, ProxyConfiguration, ProxySession,
-    SessionIsToBeClosed,
+    backends::{Backend, BackendMap},
+    features::FEATURES,
+    http, https,
+    metrics::METRICS,
+    pool::Pool,
+    tcp,
+    timer::Timer,
+    AcceptError, Protocol, ProxyConfiguration, ProxySession, SessionIsToBeClosed,
 };
 
 // Number of retries to perform on a server after a connection failure

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -949,7 +949,7 @@ impl Server {
                 METRICS.with(|metrics| {
                     match (*metrics.borrow_mut()).query(query_metrics_options) {
                         Ok(c) => push_queue(WorkerResponse::ok_with_content(message.id.clone(), c)),
-                        Err(e) => error!("Error querying metrics: {:#}", e),
+                        Err(e) => error!("Error querying metrics: {}", e),
                     }
                 });
                 return;
@@ -962,7 +962,7 @@ impl Server {
 
     pub fn notify_proxys(&mut self, request: WorkerRequest) {
         if let Err(e) = self.config_state.dispatch(&request.content) {
-            error!("Could not execute order on config state: {:#}", e);
+            error!("Could not execute order on config state: {}", e);
         }
 
         let req_id = request.id.clone();
@@ -1087,7 +1087,7 @@ impl Server {
                 WorkerResponse::ok(req_id)
             }
             Err(e) => {
-                let error = format!("Couldn't add HTTP listener: {e:#}");
+                let error = format!("Couldn't add HTTP listener: {e}");
                 error!("{}", error);
                 WorkerResponse::error(req_id, error)
             }
@@ -1156,7 +1156,7 @@ impl Server {
                 WorkerResponse::ok(req_id)
             }
             Err(e) => {
-                let error = format!("Couldn't add TCP listener: {e:#}");
+                let error = format!("Couldn't add TCP listener: {e}");
                 error!("{}", error);
                 WorkerResponse::error(req_id, error)
             }
@@ -1193,8 +1193,8 @@ impl Server {
                         WorkerResponse::ok(req_id)
                     }
                     Err(activate_error) => {
-                        error!("Could not activate HTTP listener: {:#}", activate_error);
-                        WorkerResponse::error(req_id, format!("{activate_error:#}"))
+                        error!("Could not activate HTTP listener: {}", activate_error);
+                        WorkerResponse::error(req_id, activate_error)
                     }
                 }
             }
@@ -1215,8 +1215,8 @@ impl Server {
                         WorkerResponse::ok(req_id)
                     }
                     Err(activate_error) => {
-                        error!("Could not activate HTTPS listener: {:#}", activate_error);
-                        WorkerResponse::error(req_id, format!("{activate_error:#}"))
+                        error!("Could not activate HTTPS listener: {}", activate_error);
+                        WorkerResponse::error(req_id, activate_error)
                     }
                 }
             }
@@ -1264,11 +1264,10 @@ impl Server {
                 {
                     Some((token, listener)) => (token, listener),
                     None => {
-                        error!("Couldn't deactivate HTTP listener at address {:?}", address);
-                        return WorkerResponse::error(
-                            req_id,
-                            format!("cannot deactivate HTTP listener at address {address:?}"),
-                        );
+                        let error =
+                            format!("Couldn't deactivate HTTP listener at address {address:?}");
+                        error!("{}", error);
+                        return WorkerResponse::error(req_id, error);
                     }
                 };
 
@@ -1309,14 +1308,12 @@ impl Server {
                         Some((token, listener)) => (token, listener),
 
                         None => {
-                            error!(
+                            let error = format!(
                                 "Couldn't deactivate HTTPS listener at address {:?}",
                                 address
                             );
-                            return WorkerResponse::error(
-                                req_id,
-                                format!("cannot deactivate HTTPS listener at address {address:?}"),
-                            );
+                            error!("{}", error);
+                            return WorkerResponse::error(req_id, error);
                         }
                     };
                 if let Err(e) = self.poll.registry().deregister(&mut listener) {
@@ -1351,11 +1348,10 @@ impl Server {
                 {
                     Some((token, listener)) => (token, listener),
                     None => {
-                        error!("Couldn't deactivate TCP listener at address {:?}", address);
-                        return WorkerResponse::error(
-                            req_id,
-                            format!("cannot deactivate TCP listener at address {address:?}"),
-                        );
+                        let error =
+                            format!("Couldn't deactivate TCP listener at address {:?}", address);
+                        error!("{}", error);
+                        return WorkerResponse::error(req_id, error);
                     }
                 };
 

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -20,7 +20,7 @@ use sozu_command::proto::command::request::RequestType;
 use time::{Duration, Instant};
 
 use crate::{
-    backends::BackendMap,
+    backends::{Backend, BackendMap},
     logs::{Endpoint, LogContext, RequestRecord},
     pool::{Checkout, Pool},
     protocol::{
@@ -47,9 +47,9 @@ use crate::{
         state::ClusterId,
     },
     timer::TimeoutContainer,
-    AcceptError, Backend, BackendConnectAction, BackendConnectionStatus, CachedTags,
-    ListenerHandler, Protocol, ProxyConfiguration, ProxySession, Readiness, SessionIsToBeClosed,
-    SessionMetrics, SessionResult, StateMachineBuilder, StateResult,
+    AcceptError, BackendConnectAction, BackendConnectionStatus, CachedTags, ListenerHandler,
+    Protocol, ProxyConfiguration, ProxySession, Readiness, SessionIsToBeClosed, SessionMetrics,
+    SessionResult, StateMachineBuilder, StateResult,
 };
 
 StateMachineBuilder! {


### PR DESCRIPTION
Using [anyhow](https://docs.rs/anyhow/latest/anyhow/index.html) in Sōzu has proven valuable to concatenate context accross function, and display the whole context all in one line for optimal readability.

This readability is only an advantage to humans, though. 

We aim to make errors more usable for machines, with proper error enums to be pattern-matched and so on.