### PR TITLE
Fix empty interest on expect proxy proto upgrade

### DIFF
--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -124,6 +124,12 @@ pub struct Http<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> {
 }
 
 impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L> {
+    /// Instantiate a new HTTP SessionState with:
+    /// - frontend_interest: READABLE | HUP | ERROR
+    /// - frontend_event: EMPTY
+    /// - backend_interest: EMPTY
+    /// - backend_event: EMPTY
+    /// Remember to set the events from the previous State!
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         answers: Rc<RefCell<answers::HttpAnswers>>,
@@ -167,7 +173,10 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             connection_attempts: 0,
             container_backend_timeout: TimeoutContainer::new_empty(configured_connect_timeout),
             container_frontend_timeout,
-            frontend_readiness: Readiness::new(),
+            frontend_readiness: Readiness {
+                interest: Ready::READABLE | Ready::HUP | Ready::ERROR,
+                event: Ready::EMPTY,
+            },
             frontend_socket,
             frontend_token,
             keepalive_count: 0,

--- a/lib/src/protocol/pipe.rs
+++ b/lib/src/protocol/pipe.rs
@@ -53,6 +53,12 @@ pub struct Pipe<Front: SocketHandler, L: ListenerHandler> {
 }
 
 impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
+    /// Instantiate a new Pipe SessionState with:
+    /// - frontend_interest: READABLE | WRITABLE | HUP | ERROR
+    /// - frontend_event: EMPTY
+    /// - backend_interest: READABLE | WRITABLE | HUP | ERROR
+    /// - backend_event: EMPTY
+    /// Remember to set the events from the previous State!
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         backend_buffer: Checkout,
@@ -82,7 +88,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             backend_buffer,
             backend_id,
             backend_readiness: Readiness {
-                interest: Ready::ALL,
+                interest: Ready::READABLE | Ready::WRITABLE | Ready::HUP | Ready::ERROR,
                 event: Ready::EMPTY,
             },
             backend_socket,
@@ -94,7 +100,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             container_frontend_timeout,
             frontend_buffer,
             frontend_readiness: Readiness {
-                interest: Ready::ALL,
+                interest: Ready::READABLE | Ready::WRITABLE | Ready::HUP | Ready::ERROR,
                 event: Ready::EMPTY,
             },
             frontend_status,

--- a/lib/src/protocol/proxy_protocol/expect.rs
+++ b/lib/src/protocol/proxy_protocol/expect.rs
@@ -38,6 +38,9 @@ pub struct ExpectProxyProtocol<Front: SocketHandler> {
 }
 
 impl<Front: SocketHandler> ExpectProxyProtocol<Front> {
+    /// Instantiate a new ExpectProxyProtocol SessionState with:
+    /// - frontend_interest: READABLE | HUP | ERROR
+    /// - frontend_event: EMPTY
     pub fn new(
         container_frontend_timeout: TimeoutContainer,
         frontend: Front,
@@ -49,7 +52,7 @@ impl<Front: SocketHandler> ExpectProxyProtocol<Front> {
             container_frontend_timeout,
             frontend_buffer: [0; 232],
             frontend_readiness: Readiness {
-                interest: Ready::READABLE,
+                interest: Ready::READABLE | Ready::HUP | Ready::ERROR,
                 event: Ready::EMPTY,
             },
             frontend_token,

--- a/lib/src/protocol/proxy_protocol/relay.rs
+++ b/lib/src/protocol/proxy_protocol/relay.rs
@@ -30,6 +30,9 @@ pub struct RelayProxyProtocol<Front: SocketHandler> {
 }
 
 impl<Front: SocketHandler> RelayProxyProtocol<Front> {
+    /// Instantiate a new RelayProxyProtocol SessionState with:
+    /// - frontend_interest: READABLE | HUP | ERROR
+    /// - frontend_event: EMPTY
     pub fn new(
         frontend: Front,
         frontend_token: Token,

--- a/lib/src/protocol/proxy_protocol/send.rs
+++ b/lib/src/protocol/proxy_protocol/send.rs
@@ -31,6 +31,11 @@ pub struct SendProxyProtocol<Front: SocketHandler> {
 }
 
 impl<Front: SocketHandler> SendProxyProtocol<Front> {
+    /// Instantiate a new SendProxyProtocol SessionState with:
+    /// - frontend_interest: HUP | ERROR
+    /// - frontend_event: EMPTY
+    /// - backend_interest: HUP | ERROR
+    /// - backend_event: EMPTY
     pub fn new(
         frontend: Front,
         frontend_token: Token,

--- a/lib/src/protocol/rustls.rs
+++ b/lib/src/protocol/rustls.rs
@@ -26,6 +26,10 @@ pub struct TlsHandshake {
 }
 
 impl TlsHandshake {
+    /// Instantiate a new TlsHandshake SessionState with:
+    /// - frontend_interest: READABLE | HUP | ERROR
+    /// - frontend_event: EMPTY
+    /// Remember to set the events from the previous State!
     pub fn new(
         container_frontend_timeout: TimeoutContainer,
         session: ServerConnection,


### PR DESCRIPTION
Initialize kawa_h1 State front_readiness with `READABLE | HUP | ERROR` so we don't have to remember to set it each time we initialize it. Add lacking `HUP | ERROR` for the Expect Proxy Protocol.