### PR TITLE
Fix the parsing of the state file

### DIFF
--- a/command/src/parser.rs
+++ b/command/src/parser.rs
@@ -7,12 +7,12 @@ use nom::{
 
 #[derive(Debug)]
 #[allow(dead_code)]
-pub struct CustomError {
+pub struct ParseError {
     kind: ErrorKind,
     serde_json_error: Option<serde_json::Error>,
 }
 
-impl FromExternalError<&[u8], serde_json::Error> for CustomError {
+impl FromExternalError<&[u8], serde_json::Error> for ParseError {
     fn from_external_error(
         _input: &[u8],
         kind: ErrorKind,
@@ -26,7 +26,7 @@ impl FromExternalError<&[u8], serde_json::Error> for CustomError {
     }
 }
 
-impl nom::error::ParseError<&[u8]> for CustomError {
+impl nom::error::ParseError<&[u8]> for ParseError {
     fn from_error_kind(_input: &[u8], kind: ErrorKind) -> Self {
         // println!("input: {:?}, error kind: {:?}", input, kind);
 
@@ -42,7 +42,7 @@ impl nom::error::ParseError<&[u8]> for CustomError {
 }
 
 /// Parse a single Request or WorkerRequest
-pub fn parse_one_request<'a, T>(input: &'a [u8]) -> IResult<&[u8], T, CustomError>
+pub fn parse_one_request<'a, T>(input: &'a [u8]) -> IResult<&[u8], T, ParseError>
 where
     T: serde::de::Deserialize<'a>,
 {
@@ -51,7 +51,7 @@ where
     let command = match serde_json::from_slice::<T>(json_data) {
         Ok(user) => user,
         Err(serde_error) => {
-            return Err(nom::Err::Failure(CustomError::from_external_error(
+            return Err(nom::Err::Failure(ParseError::from_external_error(
                 input,
                 ErrorKind::MapRes,
                 serde_error,
@@ -65,7 +65,7 @@ where
 }
 
 /// Parse a Requests or WorkerRequests using nom
-pub fn parse_several_requests<'a, T>(input: &'a [u8]) -> IResult<&[u8], Vec<T>, CustomError>
+pub fn parse_several_requests<'a, T>(input: &'a [u8]) -> IResult<&[u8], Vec<T>, ParseError>
 where
     T: serde::de::Deserialize<'a>,
 {

--- a/command/src/parser.rs
+++ b/command/src/parser.rs
@@ -1,7 +1,11 @@
 use nom::{
     self,
+    bytes::streaming::is_not,
+    character::complete::char,
+    combinator::map_res,
     error::{ErrorKind, FromExternalError},
     multi::many0,
+    sequence::terminated,
     IResult,
 };
 
@@ -41,35 +45,25 @@ impl nom::error::ParseError<&[u8]> for ParseError {
     }
 }
 
-/// Parse a single Request or WorkerRequest
-pub fn parse_one_request<'a, T>(input: &'a [u8]) -> IResult<&[u8], T, ParseError>
+/// this is to propagate the serde_json error
+pub fn parse_one_request<'a, T>(input: &'a [u8]) -> Result<T, ParseError>
 where
     T: serde::de::Deserialize<'a>,
 {
-    let (next_input, json_data) = nom::bytes::complete::is_not("\0")(input)?;
-
-    let command = match serde_json::from_slice::<T>(json_data) {
-        Ok(user) => user,
-        Err(serde_error) => {
-            return Err(nom::Err::Failure(ParseError::from_external_error(
-                input,
-                ErrorKind::MapRes,
-                serde_error,
-            )))
-        }
-    };
-
-    let (next_input, _) = nom::character::complete::char('\0')(next_input)?;
-
-    Ok((next_input, command))
+    serde_json::from_slice::<T>(input).map_err(|serde_error| {
+        ParseError::from_external_error(input, ErrorKind::MapRes, serde_error)
+    })
 }
 
-/// Parse a Requests or WorkerRequests using nom
-pub fn parse_several_requests<'a, T>(input: &'a [u8]) -> IResult<&[u8], Vec<T>, ParseError>
+pub fn parse_several_requests<'a, T>(input: &'a [u8]) -> IResult<&[u8], Vec<T>>
 where
     T: serde::de::Deserialize<'a>,
 {
-    many0(parse_one_request)(input)
+    // use serde_json::from_slice;
+    many0(nom::combinator::complete(terminated(
+        map_res(is_not("\0"), parse_one_request),
+        char('\0'),
+    )))(input)
 }
 
 #[cfg(test)]
@@ -88,19 +82,15 @@ mod test {
             RequestType::Status(Status {}).into(),
         );
 
-        let mut string = serde_json::ser::to_string(&worker_request).unwrap();
-
-        string.push('\0');
+        let string = serde_json::ser::to_string(&worker_request).unwrap();
 
         println!("string to parse: {string}");
 
         let bytes = &string.as_bytes();
 
-        let empty_vec: Vec<u8> = vec![];
-
         assert_eq!(
-            parse_one_request(bytes).unwrap(),
-            (&empty_vec[..], worker_request)
+            parse_one_request::<WorkerRequest>(bytes).unwrap(),
+            worker_request
         )
     }
 


### PR DESCRIPTION
As described in #971 , loading files bigger than the 200 KB buffer would fail.

Investigating led me to discover that refactoring 5bbde99bc of the function that parses the state file into `WorkerRequests`, was responsible.

This refactoring would propagate `serde_json` parsing errors, but fail when encountering an unexpected EOF (in reality the end of the buffer).

This pull requests reestablishes the old parsing logic, while keeping the propagation of `serde_json` errors.