### PR TITLE
Cluster related metrics, user-agent

### DIFF
--- a/doc/debugging_strategies.md
+++ b/doc/debugging_strategies.md
@@ -139,7 +139,7 @@ The `sozu.http.errors` counter is the sum of failed requests. It contains the fo
 
 Going further, backend connections issues are tracked by the following metrics:
 
-* `sozu.connections.errors`: could not connect to a backend server
+* `sozu.backend.connections.error`: could not connect to a backend server
 * `sozu.down`: the retry policy triggered and marked the backend server as down
 
 The `sozu.http.503.errors` metric is incremented after a request sent back a 503 error, and a 503 error is sent
@@ -243,7 +243,7 @@ sozu -c /etc/config.toml query clusters -i cluster_id
 
 ### Backend server unavailable
 
-`sozu.http.503.errors` increases, lots of `sozu.backend.connections.errors` and a
+`sozu.http.503.errors` increases, lots of `sozu.backend.connections.error` and a
 `sozu.backend.down` record: a backend server is down.
 Check the logs for `error connecting to backend, trying again` and `no more available backends for cluster <cluster_id>`
 to find out which cluster is affected

--- a/doc/debugging_strategies.md
+++ b/doc/debugging_strategies.md
@@ -140,7 +140,7 @@ The `sozu.http.errors` counter is the sum of failed requests. It contains the fo
 Going further, backend connections issues are tracked by the following metrics:
 
 * `sozu.backend.connections.error`: could not connect to a backend server
-* `sozu.down`: the retry policy triggered and marked the backend server as down
+* `sozu.backend.down`: the retry policy triggered and marked the backend server as down
 
 The `sozu.http.503.errors` metric is incremented after a request sent back a 503 error, and a 503 error is sent
 after the circuit breaker triggered (we wait for 3 failed connections to the backend server).

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -420,6 +420,7 @@ impl L7ListenerHandler for HttpListener {
         uri: &str,
         method: &Method,
     ) -> anyhow::Result<Route> {
+        let start = Instant::now();
         let (remaining_input, (hostname, _)) = match hostname_and_port(host.as_bytes()) {
             Ok(tuple) => tuple,
             Err(parse_error) => {
@@ -442,9 +443,26 @@ impl L7ListenerHandler for HttpListener {
         */
         let host = unsafe { from_utf8_unchecked(hostname) };
 
-        self.fronts
+        let res = self
+            .fronts
             .lookup(host.as_bytes(), uri.as_bytes(), method)
-            .with_context(|| "No cluster found")
+            .with_context(|| "No cluster found");
+
+        let now = Instant::now();
+
+        if let Ok(r) = res.as_ref() {
+            if let Route::ClusterId(c) = r {
+                time!(
+                    "frontend_matching_time",
+                    &c,
+                    (now - start).whole_milliseconds()
+                );
+            }
+        } else {
+            incr!("http.failed_backend_matching")
+        }
+
+        res
     }
 }
 

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -448,26 +448,25 @@ impl L7ListenerHandler for HttpListener {
         */
         let host = unsafe { from_utf8_unchecked(hostname) };
 
-        let res = self
+        let route = self
             .fronts
             .lookup(host.as_bytes(), uri.as_bytes(), method)
-            .ok_or(FrontendFromRequestError::NoClusterFound);
+            .ok_or_else(|| {
+                incr!("http.failed_backend_matching");
+                FrontendFromRequestError::NoClusterFound
+            })?;
 
         let now = Instant::now();
 
-        if let Ok(r) = res.as_ref() {
-            if let Route::ClusterId(c) = r {
-                time!(
-                    "frontend_matching_time",
-                    &c,
-                    (now - start).whole_milliseconds()
-                );
-            }
-        } else {
-            incr!("http.failed_backend_matching")
+        if let Route::ClusterId(cluster) = &route {
+            time!(
+                "frontend_matching_time",
+                cluster,
+                (now - start).whole_milliseconds()
+            );
         }
 
-        res
+        Ok(route)
     }
 }
 

--- a/lib/src/logs.rs
+++ b/lib/src/logs.rs
@@ -207,7 +207,11 @@ impl RequestRecord<'_> {
                     protocol,
                     endpoint
                 );
-                incr!("access_logs.count");
+                incr!(
+                    "access_logs.count",
+                    self.context.cluster_id,
+                    self.context.backend_id
+                );
             }
             Some(message) => error_access!(
                 "{}{} -> {} \t{}/{}/{}/{} \t{} -> {} \t {} {} {} | {}",

--- a/lib/src/logs.rs
+++ b/lib/src/logs.rs
@@ -138,6 +138,7 @@ pub struct RequestRecord<'a> {
     pub client_rtt: Option<Duration>,
     pub server_rtt: Option<Duration>,
     pub metrics: &'a SessionMetrics,
+    pub user_agent: Option<&'a str>,
 }
 
 impl RequestRecord<'_> {
@@ -150,6 +151,7 @@ impl RequestRecord<'_> {
         let session_address = self.session_address;
         let backend_address = self.backend_address;
         let endpoint = &self.endpoint;
+        let user_agent = &self.user_agent;
 
         let metrics = self.metrics;
         // let backend_response_time = metrics.backend_response_time();
@@ -193,7 +195,7 @@ impl RequestRecord<'_> {
         match self.error {
             None => {
                 info_access!(
-                    "{}{} -> {} \t{}/{}/{}/{} \t{} -> {} \t {} {} {}",
+                    "{}{} -> {} \t{}/{}/{}/{} \t{} -> {} \t {} {} {} {}",
                     context,
                     session_address.as_str_or("X"),
                     backend_address.as_str_or("X"),
@@ -205,7 +207,8 @@ impl RequestRecord<'_> {
                     metrics.bout,
                     tags.as_str_or("-"),
                     protocol,
-                    endpoint
+                    endpoint,
+                    user_agent.as_str_or("")
                 );
                 incr!(
                     "access_logs.count",
@@ -214,7 +217,7 @@ impl RequestRecord<'_> {
                 );
             }
             Some(message) => error_access!(
-                "{}{} -> {} \t{}/{}/{}/{} \t{} -> {} \t {} {} {} | {}",
+                "{}{} -> {} \t{}/{}/{}/{} \t{} -> {} \t {} {} {} {} | {}",
                 context,
                 session_address.as_str_or("X"),
                 backend_address.as_str_or("X"),
@@ -227,6 +230,7 @@ impl RequestRecord<'_> {
                 tags.as_str_or("-"),
                 protocol,
                 endpoint,
+                user_agent.as_str_or(""),
                 message
             ),
         }

--- a/lib/src/logs.rs
+++ b/lib/src/logs.rs
@@ -195,7 +195,7 @@ impl RequestRecord<'_> {
         match self.error {
             None => {
                 info_access!(
-                    "{}{} -> {} \t{}/{}/{}/{} \t{} -> {} \t {} {} {} {}",
+                    "{}{} -> {} \t{}/{}/{}/{} \t{} -> {} \t {}{} {} {}",
                     context,
                     session_address.as_str_or("X"),
                     backend_address.as_str_or("X"),
@@ -205,10 +205,16 @@ impl RequestRecord<'_> {
                     LogDuration(server_rtt),
                     metrics.bin,
                     metrics.bout,
-                    tags.as_str_or("-"),
+                    match user_agent {
+                        Some(_) => tags.as_str_or(""),
+                        None => tags.as_str_or("-"),
+                    },
+                    match tags {
+                        Some(tags) if !tags.is_empty() => user_agent.map(|ua| format!(", user-agent={ua}")).unwrap_or_default(),
+                        Some(_) | None => user_agent.map(|ua| format!("user-agent={ua}")).unwrap_or_default(),
+                    },
                     protocol,
-                    endpoint,
-                    user_agent.as_str_or("")
+                    endpoint
                 );
                 incr!(
                     "access_logs.count",
@@ -217,7 +223,7 @@ impl RequestRecord<'_> {
                 );
             }
             Some(message) => error_access!(
-                "{}{} -> {} \t{}/{}/{}/{} \t{} -> {} \t {} {} {} {} | {}",
+                "{}{} -> {} \t{}/{}/{}/{} \t{} -> {} \t {}{} {} {} | {}",
                 context,
                 session_address.as_str_or("X"),
                 backend_address.as_str_or("X"),
@@ -227,10 +233,16 @@ impl RequestRecord<'_> {
                 LogDuration(server_rtt),
                 metrics.bin,
                 metrics.bout,
-                tags.as_str_or("-"),
+                match user_agent {
+                    Some(_) => tags.as_str_or(""),
+                    None => tags.as_str_or("-"),
+                },
+                match tags {
+                    Some(tags) if !tags.is_empty() => user_agent.map(|ua| format!(", user-agent={ua}")).unwrap_or_default(),
+                    Some(_) | None => user_agent.map(|ua| format!("user-agent={ua}")).unwrap_or_default(),
+                },
                 protocol,
                 endpoint,
-                user_agent.as_str_or(""),
                 message
             ),
         }

--- a/lib/src/metrics/mod.rs
+++ b/lib/src/metrics/mod.rs
@@ -292,11 +292,13 @@ macro_rules! count (
 macro_rules! incr (
   ($key:expr) => (count!($key, 1));
   ($key:expr, $cluster_id:expr, $backend_id:expr) => {
-    use $crate::metrics::Subscriber;
+    {
+        use $crate::metrics::Subscriber;
 
-    $crate::metrics::METRICS.with(|metrics| {
-      (*metrics.borrow_mut()).receive_metric($key, $cluster_id, $backend_id, $crate::metrics::MetricValue::Count(1));
-    });
+        $crate::metrics::METRICS.with(|metrics| {
+          (*metrics.borrow_mut()).receive_metric($key, $cluster_id, $backend_id, $crate::metrics::MetricValue::Count(1));
+        });
+    }
   }
 );
 
@@ -324,12 +326,14 @@ macro_rules! gauge_add (
     });
   });
   ($key:expr, $value:expr, $cluster_id:expr, $backend_id:expr) => {
-    use $crate::metrics::Subscriber;
-    let v = $value;
+    {
+        use $crate::metrics::Subscriber;
+        let v = $value;
 
-    $crate::metrics::METRICS.with(|metrics| {
-      (*metrics.borrow_mut()).receive_metric($key, $cluster_id, $backend_id, $crate::metrics::MetricValue::GaugeAdd(v));
-    });
+        $crate::metrics::METRICS.with(|metrics| {
+          (*metrics.borrow_mut()).receive_metric($key, $cluster_id, $backend_id, $crate::metrics::MetricValue::GaugeAdd(v));
+        });
+    }
   }
 );
 

--- a/lib/src/pool.rs
+++ b/lib/src/pool.rs
@@ -51,7 +51,7 @@ impl Pool {
             })
             .map(|c| {
                 let old_buffer_count = BUFFER_COUNT.fetch_add(1, Ordering::SeqCst);
-                gauge!("buffer.count", old_buffer_count + 1);
+                gauge!("buffer.number", old_buffer_count + 1);
                 Checkout { inner: c }
             })
     }
@@ -115,7 +115,7 @@ impl ops::DerefMut for Checkout {
 impl Drop for Checkout {
     fn drop(&mut self) {
         let old_buffer_count = BUFFER_COUNT.fetch_sub(1, Ordering::SeqCst);
-        gauge!("buffer.count", old_buffer_count - 1);
+        gauge!("buffer.number", old_buffer_count - 1);
     }
 }
 

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -1292,7 +1292,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
 
                 if backend.retry_policy.is_down() {
                     incr!(
-                        "up",
+                        "backend.up",
                         self.cluster_id.as_deref(),
                         metrics.backend_id.as_deref()
                     );
@@ -1340,7 +1340,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
                     backend.backend_id, backend.address
                 );
                 incr!(
-                    "down",
+                    "backend.down",
                     self.cluster_id.as_deref(),
                     metrics.backend_id.as_deref()
                 );

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -789,49 +789,31 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             );
         } else {
             match answer {
-                DefaultAnswerStatus::Answer301 => {
-                    incr!(
-                        "http.301.redirection",
-                        self.cluster_id.as_deref(),
-                        self.backend_id.as_deref()
-                    )
-                }
-                DefaultAnswerStatus::Answer400 => {
-                    incr!("http.400.errors")
-                }
-                DefaultAnswerStatus::Answer401 => {
-                    incr!("http.401.errors")
-                }
-                DefaultAnswerStatus::Answer404 => {
-                    incr!("http.404.errors")
-                }
-                DefaultAnswerStatus::Answer408 => {
-                    incr!("http.408.errors")
-                }
-                DefaultAnswerStatus::Answer413 => {
-                    incr!("http.413.errors")
-                }
-                DefaultAnswerStatus::Answer502 => {
-                    incr!(
-                        "http.502.errors",
-                        self.cluster_id.as_deref(),
-                        self.backend_id.as_deref()
-                    )
-                }
-                DefaultAnswerStatus::Answer503 => {
-                    incr!(
-                        "http.503.errors",
-                        self.cluster_id.as_deref(),
-                        self.backend_id.as_deref()
-                    )
-                }
-                DefaultAnswerStatus::Answer504 => {
-                    incr!(
-                        "http.504.errors",
-                        self.cluster_id.as_deref(),
-                        self.backend_id.as_deref()
-                    )
-                }
+                DefaultAnswerStatus::Answer301 => incr!(
+                    "http.301.redirection",
+                    self.cluster_id.as_deref(),
+                    self.backend_id.as_deref()
+                ),
+                DefaultAnswerStatus::Answer400 => incr!("http.400.errors"),
+                DefaultAnswerStatus::Answer401 => incr!("http.401.errors"),
+                DefaultAnswerStatus::Answer404 => incr!("http.404.errors"),
+                DefaultAnswerStatus::Answer408 => incr!("http.408.errors"),
+                DefaultAnswerStatus::Answer413 => incr!("http.413.errors"),
+                DefaultAnswerStatus::Answer502 => incr!(
+                    "http.502.errors",
+                    self.cluster_id.as_deref(),
+                    self.backend_id.as_deref()
+                ),
+                DefaultAnswerStatus::Answer503 => incr!(
+                    "http.503.errors",
+                    self.cluster_id.as_deref(),
+                    self.backend_id.as_deref()
+                ),
+                DefaultAnswerStatus::Answer504 => incr!(
+                    "http.504.errors",
+                    self.cluster_id.as_deref(),
+                    self.backend_id.as_deref()
+                ),
             };
         }
 

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -789,7 +789,11 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         } else {
             match answer {
                 DefaultAnswerStatus::Answer301 => {
-                    incr!("http.301.redirection")
+                    incr!(
+                        "http.301.redirection",
+                        self.cluster_id.as_deref(),
+                        self.backend_id.as_deref()
+                    )
                 }
                 DefaultAnswerStatus::Answer400 => {
                     incr!("http.400.errors")

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -795,10 +795,22 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
                     self.backend_id.as_deref()
                 ),
                 DefaultAnswerStatus::Answer400 => incr!("http.400.errors"),
-                DefaultAnswerStatus::Answer401 => incr!("http.401.errors"),
+                DefaultAnswerStatus::Answer401 => incr!(
+                    "http.401.errors",
+                    self.cluster_id.as_deref(),
+                    self.backend_id.as_deref()
+                ),
                 DefaultAnswerStatus::Answer404 => incr!("http.404.errors"),
-                DefaultAnswerStatus::Answer408 => incr!("http.408.errors"),
-                DefaultAnswerStatus::Answer413 => incr!("http.413.errors"),
+                DefaultAnswerStatus::Answer408 => incr!(
+                    "http.408.errors",
+                    self.cluster_id.as_deref(),
+                    self.backend_id.as_deref()
+                ),
+                DefaultAnswerStatus::Answer413 => incr!(
+                    "http.413.errors",
+                    self.cluster_id.as_deref(),
+                    self.backend_id.as_deref()
+                ),
                 DefaultAnswerStatus::Answer502 => incr!(
                     "http.502.errors",
                     self.cluster_id.as_deref(),

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -1350,7 +1350,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             let already_unavailable = backend.retry_policy.is_down();
             backend.retry_policy.fail();
             incr!(
-                "connections.error",
+                "backend.connections.error",
                 self.cluster_id.as_deref(),
                 metrics.backend_id.as_deref()
             );

--- a/lib/src/protocol/pipe.rs
+++ b/lib/src/protocol/pipe.rs
@@ -219,6 +219,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             client_rtt: socket_rtt(self.front_socket()),
             server_rtt: self.backend_socket.as_ref().and_then(socket_rtt),
             metrics,
+            user_agent: None,
         }
         .log();
     }

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -422,10 +422,10 @@ impl DomainRule {
             DomainRule::Exact(s) => s.as_bytes() == hostname,
             DomainRule::Regex(r) => {
                 let start = Instant::now();
-                let res = r.is_match(hostname);
+                let is_a_match = r.is_match(hostname);
                 let now = Instant::now();
                 time!("regex_matching_time", (now - start).whole_milliseconds());
-                res
+                is_a_match
             }
         }
     }
@@ -502,11 +502,11 @@ impl PathRule {
             }
             PathRule::Regex(r) => {
                 let start = Instant::now();
-                let res = r.is_match(path);
+                let is_a_match = r.is_match(path);
                 let now = Instant::now();
                 time!("regex_matching_time", (now - start).whole_milliseconds());
 
-                if res {
+                if is_a_match {
                     PathRuleResult::Regex
                 } else {
                     PathRuleResult::None

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -599,7 +599,7 @@ impl Server {
             }
 
             gauge!("client.connections", self.sessions.borrow().nb_connections);
-            gauge!("slab.count", self.sessions.borrow().slab.len());
+            gauge!("slab.entries", self.sessions.borrow().slab.len());
             METRICS.with(|metrics| {
                 (*metrics.borrow_mut()).send_data();
             });
@@ -1521,7 +1521,7 @@ impl Server {
             _ => panic!("should not call accept() on a HTTP, HTTPS or TCP session"),
         }
 
-        gauge!("accept_queue.count", self.accept_queue.len());
+        gauge!("accept_queue.connections", self.accept_queue.len());
     }
 
     pub fn create_sessions(&mut self) {
@@ -1578,7 +1578,7 @@ impl Server {
             self.sessions.borrow_mut().incr();
         }
 
-        gauge!("accept_queue.count", self.accept_queue.len());
+        gauge!("accept_queue.connections", self.accept_queue.len());
     }
 
     pub fn ready(&mut self, token: Token, events: Ready) {

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -469,7 +469,7 @@ impl TcpSession {
 
                 if backend.retry_policy.is_down() {
                     incr!(
-                        "up",
+                        "backend.up",
                         self.cluster_id.as_deref(),
                         self.metrics.backend_id.as_deref()
                     );
@@ -522,7 +522,7 @@ impl TcpSession {
                     backend.backend_id, backend.address
                 );
                 incr!(
-                    "down",
+                    "backend.down",
                     self.cluster_id.as_deref(),
                     self.metrics.backend_id.as_deref()
                 );

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -210,6 +210,7 @@ impl TcpSession {
             client_rtt: socket_rtt(self.state.front_socket()),
             server_rtt: None,
             metrics: &self.metrics,
+            user_agent: None,
         }
         .log();
     }

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -511,7 +511,7 @@ impl TcpSession {
             let already_unavailable = backend.retry_policy.is_down();
             backend.retry_policy.fail();
             incr!(
-                "connections.error",
+                "backend.connections.error",
                 self.cluster_id.as_deref(),
                 self.metrics.backend_id.as_deref()
             );


### PR DESCRIPTION
- Renaming gauge metrics that contains "count" in their name for consistency
- Make back-end HTTP status metrics,  5.x.x sozu HTTP status metrics and access_logs metric cluster-related (see #937 ).
- Add user agent in access logs (see #937 ).
- Add time metrics related to path rules / domain rules matching (see #804  ).