### PR TITLE
Fix links in how to use

### DIFF
--- a/doc/how_to_use.md
+++ b/doc/how_to_use.md
@@ -87,7 +87,7 @@ To change the path of the saved state file, modify the `saved_state` option in t
 
 ## Systemd integration
 
-The repository provides a unit file [here][un]. You can copy it to `/etc/systemd/system/` and invoke `systemctl daemon-reload`.
+The repository provides a unit file [here][unit-file]. You can copy it to `/etc/systemd/system/` and invoke `systemctl daemon-reload`.
 
 This will make systemd take notice of it, and now you can start the service with `systemctl start sozu.service`. Furthermore, you can enable it, so that it is activated by default on future boots with `systemctl enable sozu.service`.
 
@@ -104,5 +104,5 @@ Here is an example of those variables:
 | `__DATADIR__` | `/var/lib/sozu` |
 | `__RUNDIR__` | `/run` |
 
-[un]: ../os-build/systemd/sozu.service.in
+[unit-file]: ../os-build/systemd/sozu.service
 [gen]: ../os-build/exherbo/generate.sh

--- a/doc/how_to_use.md
+++ b/doc/how_to_use.md
@@ -91,18 +91,4 @@ The repository provides a unit file [here][unit-file]. You can copy it to `/etc/
 
 This will make systemd take notice of it, and now you can start the service with `systemctl start sozu.service`. Furthermore, you can enable it, so that it is activated by default on future boots with `systemctl enable sozu.service`.
 
-You can use a `bash` script and call `sed` to automate this part. e.g.: [generate.sh][gen].
-
-This script will generate `sozu.service`, `sozu.conf` and `config.toml` files into a `generated` folder at the root of `os-build` directory. You will have to set your own `__BINDIR__`, `__SYSCONFDIR__`, `__DATADIR__` and `__RUNDIR__` variables.
-
-Here is an example of those variables:
-
-| variable | value |
-| :--- | :--- |
-| `__BINDIR__` | `/usr/local/bin` |
-| `__SYSCONFDIR__` | `/etc` |
-| `__DATADIR__` | `/var/lib/sozu` |
-| `__RUNDIR__` | `/run` |
-
 [unit-file]: ../os-build/systemd/sozu.service
-[gen]: ../os-build/exherbo/generate.sh


### PR DESCRIPTION
A link was broken, as explained in #983

The same issues points to a paragraph of the doc that pointed to a script, but this script was removed by f2176a33