### PR TITLE
remove skipping of certificate update in GenericCertificateResolver

### DIFF
--- a/lib/src/tls.rs
+++ b/lib/src/tls.rs
@@ -191,11 +191,6 @@ impl CertificateResolver for GenericCertificateResolver {
             self.overrides.remove(&fingerprint);
         }
 
-        // We do not need to update the entry, if the certificate is already registered
-        if self.get_certificate(&fingerprint).is_some() {
-            return Ok(fingerprint);
-        }
-
         let (ok, certificates_to_remove) =
             self.should_insert(&fingerprint, &parsed_certificate_and_key)?;
         if !ok {


### PR DESCRIPTION
As pointed out by @justinkb, @newdev8 and others in this issue: #774 , those lines in the `add_certificate` method of the GenericCertificateResolver prevent persisting several subdomains:

```
        // We do not need to update the entry, if the certificate is already registered
        if self.get_certificate(&fingerprint).is_some() {
            return Ok(fingerprint);
        }
```

Removing these lines do not break any test, as the CI on this Pull Request should prove, and according to @justinkb, does solve the issue.

The best would be to have an e2e test for this behaviour with several subdomains. What do you think @Wonshtrum ?