### PR TITLE
Fix concurrent tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,7 +1927,6 @@ dependencies = [
  "libc",
  "mio",
  "rustls",
- "serial_test",
  "slab",
  "sozu-command-lib",
  "sozu-lib",

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -12,7 +12,6 @@ hyper-rustls = { version = "^0.24.1", default-features = false, features = ["web
 libc = "^0.2.147"
 mio = "^0.8.8"
 rustls = { version = "^0.21.6", features = ["dangerous_configuration"] }
-serial_test = "^2.0.0"
 slab = "^0.4.8"
 time = "^0.3.25"
 tokio = { version = "1.29.1", features = ["net", "rt-multi-thread"] }

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -28,7 +28,7 @@ The tests are flagged with the usual macros, so they will run with all other tes
 
     cargo test
 
-All tests are run one at a time with the `#[serial]` macro. You can run just one using
+You can run just one test using
 
     cargo test test_issue_810_timeout
 

--- a/e2e/src/tests/mod.rs
+++ b/e2e/src/tests/mod.rs
@@ -1,7 +1,6 @@
 mod tests;
 
 use std::{
-    cell::RefCell,
     io::stdin,
     net::SocketAddr,
     sync::atomic::{AtomicU16, Ordering},

--- a/e2e/src/tests/tests.rs
+++ b/e2e/src/tests/tests.rs
@@ -5,8 +5,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use serial_test::serial;
-
 use sozu_command_lib::{
     config::{FileConfig, ListenerBuilder},
     info,
@@ -1364,19 +1362,16 @@ fn try_max_connections() -> State {
     State::Success
 }
 
-#[serial]
 #[test]
 fn test_sync() {
     assert_eq!(try_sync(10, 100), State::Success);
 }
 
-#[serial]
 #[test]
 fn test_async() {
     assert_eq!(try_async(3, 10, 100), State::Success);
 }
 
-#[serial]
 #[test]
 fn test_hard_stop() {
     assert_eq!(
@@ -1389,7 +1384,6 @@ fn test_hard_stop() {
     );
 }
 
-#[serial]
 #[test]
 fn test_soft_stop() {
     assert_eq!(
@@ -1404,7 +1398,7 @@ fn test_soft_stop() {
 
 // https://github.com/sozu-proxy/sozu/issues/806
 // This should actually be a success
-#[serial]
+
 #[test]
 fn test_issue_806() {
     assert!(
@@ -1417,7 +1411,7 @@ fn test_issue_806() {
 }
 
 // https://github.com/sozu-proxy/sozu/issues/808
-#[serial]
+
 #[test]
 fn test_issue_808() {
     // this test is not relevant anymore, at least not like this
@@ -1434,7 +1428,7 @@ fn test_issue_808() {
 }
 
 // https://github.com/sozu-proxy/sozu/issues/810
-#[serial]
+
 #[test]
 fn test_issue_810_timeout() {
     assert_eq!(
@@ -1447,7 +1441,6 @@ fn test_issue_810_timeout() {
     );
 }
 
-#[serial]
 #[test]
 fn test_issue_810_panic_on_session_close() {
     assert_eq!(
@@ -1460,7 +1453,6 @@ fn test_issue_810_panic_on_session_close() {
     );
 }
 
-#[serial]
 #[test]
 fn test_issue_810_panic_on_missing_listener() {
     assert_eq!(
@@ -1473,7 +1465,6 @@ fn test_issue_810_panic_on_missing_listener() {
         );
 }
 
-#[serial]
 #[test]
 fn test_tls_endpoint() {
     assert_eq!(
@@ -1486,7 +1477,6 @@ fn test_tls_endpoint() {
     );
 }
 
-#[serial]
 #[test]
 fn test_http_behaviors() {
     assert_eq!(
@@ -1495,7 +1485,6 @@ fn test_http_behaviors() {
     );
 }
 
-#[serial]
 #[test]
 fn test_msg_close() {
     assert_eq!(
@@ -1504,7 +1493,6 @@ fn test_msg_close() {
     );
 }
 
-#[serial]
 #[test]
 fn test_blue_green() {
     assert_eq!(
@@ -1513,7 +1501,6 @@ fn test_blue_green() {
     );
 }
 
-#[serial]
 #[test]
 fn test_keep_alive() {
     assert_eq!(
@@ -1522,7 +1509,6 @@ fn test_keep_alive() {
     );
 }
 
-#[serial]
 #[test]
 fn test_stick() {
     assert_eq!(
@@ -1531,7 +1517,6 @@ fn test_stick() {
     );
 }
 
-#[serial]
 #[test]
 fn test_max_connections() {
     assert_eq!(

--- a/e2e/src/tests/tests.rs
+++ b/e2e/src/tests/tests.rs
@@ -905,7 +905,9 @@ fn try_http_behaviors() -> State {
     );
 
     info!("expecting 103");
-    backend.set_response("HTTP/1.1 103 Early Hint\r\nLink: </style.css>; rel=preload; as=style\r\n\r\nHTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\npong");
+    backend.set_response(
+        "HTTP/1.1 103 Early Hint\r\nLink: </style.css>; rel=preload; as=style\r\n\r\n",
+    );
     client.set_request("GET /103 HTTP/1.1\r\nHost: example.com\r\nContent-Length: 4\r\n\r\nping");
     client.connect();
     client.send();
@@ -922,6 +924,9 @@ fn try_http_behaviors() -> State {
         response.starts_with(&expected_response_start)
             && response.ends_with(&expected_response_end)
     );
+
+    backend.set_response("HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\npong");
+    backend.send(1);
 
     let expected_response_start = String::from("HTTP/1.1 200 OK\r\n");
     let expected_response_end = String::from("\r\n\r\npong");


### PR DESCRIPTION
The end-to-end tests would fail in the CI because they made use of the same range of ports for socket addresses.

This PR adds an atomic PortProvider that allows tests to run concurrently by using incremented port numbers for socket addresses.