### PR TITLE
Draft: HTTPS Mux SessionState

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,6 +1951,7 @@ dependencies = [
  "futures",
  "hyper",
  "hyper-rustls",
+ "kawa",
  "libc",
  "mio",
  "rustls",

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -454,6 +454,8 @@ pub enum HttpFrontendCmd {
         method: Option<String>,
         #[clap(long = "tags", help = "Specify tag (key-value pair) to apply on front-end (example: 'key=value, other-key=other-value')", value_parser = parse_tags)]
         tags: Option<BTreeMap<String, String>>,
+        #[clap(help = "the frontend uses http2 with prio-knowledge")]
+        h2: Option<bool>,
     },
     #[clap(name = "remove")]
     Remove {

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -434,7 +434,7 @@ impl CommandManager {
                     if let Some(response_content) = response.content {
                         let certs = match response_content.content_type {
                             Some(ContentType::CertificatesWithFingerprints(certs)) => certs.certs,
-                            _ => bail!(format!("Wrong response content {:?}", response_content)),
+                            _ => bail!(format!("Wrong response content {response_content:?}")),
                         };
                         if certs.is_empty() {
                             bail!("No certificates match your request.");

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -611,7 +611,7 @@ pub fn print_cluster_responses(
     clusters_table.set_format(*prettytable::format::consts::FORMAT_BOX_CHARS);
     let mut header = vec![cell!("cluster id")];
     for worker_id in worker_responses.map.keys() {
-        header.push(cell!(format!("worker {}", worker_id)));
+        header.push(cell!(format!("worker {worker_id}")));
     }
     header.push(cell!("desynchronized"));
     clusters_table.add_row(Row::new(header));
@@ -659,14 +659,14 @@ pub fn print_certificates_by_worker(
     }
 
     for (worker_id, response_content) in response_contents.iter() {
-        println!("Worker {}", worker_id);
+        println!("Worker {worker_id}");
         match &response_content.content_type {
             Some(ContentType::CertificatesByAddress(list)) => {
                 for certs in list.certificates.iter() {
                     println!("\t{}:", certs.address);
 
                     for summary in certs.certificate_summaries.iter() {
-                        println!("\t\t{}", summary);
+                        println!("\t\t{summary}");
                     }
 
                     println!();

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -202,6 +202,7 @@ impl CommandManager {
                 method,
                 cluster_id: route,
                 tags,
+                h2,
             } => self.send_request(
                 RequestType::AddHttpFrontend(RequestHttpFrontend {
                     cluster_id: route.into(),
@@ -214,6 +215,7 @@ impl CommandManager {
                         Some(tags) => tags,
                         None => BTreeMap::new(),
                     },
+                    h2: h2.unwrap_or(false),
                 })
                 .into(),
             ),
@@ -250,6 +252,7 @@ impl CommandManager {
                 method,
                 cluster_id: route,
                 tags,
+                h2,
             } => self.send_request(
                 RequestType::AddHttpsFrontend(RequestHttpFrontend {
                     cluster_id: route.into(),
@@ -262,6 +265,7 @@ impl CommandManager {
                         Some(tags) => tags,
                         None => BTreeMap::new(),
                     },
+                    h2: h2.unwrap_or(false),
                 })
                 .into(),
             ),

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -222,6 +222,7 @@ message RequestHttpFrontend {
     required RulePosition position = 6 [default = TREE];
     // custom tags to identify the frontend in the access logs
     map<string, string> tags = 7;
+    required bool h2 = 8;
 }
 
 message RequestTcpFrontend {

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -161,6 +161,7 @@ message HttpsListenerConfig {
     // The tickets allow the client to resume a session. This protects the client
     // agains session tracking. Defaults to 4.
     required uint64 send_tls13_tickets = 20;
+    repeated AlpnProtocol alpn = 21;
 }
 
 // details of an TCP listener
@@ -337,6 +338,11 @@ enum TlsVersion {
     TLS_V1_1 = 3;
     TLS_V1_2 = 4;
     TLS_V1_3 = 5;
+}
+
+enum AlpnProtocol {
+    Http11 = 0;
+    H2 = 1;
 }
 
 // A cluster is what binds a frontend to backends with routing rules

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -667,6 +667,11 @@ pub enum PathRuleType {
     Equals,
 }
 
+/// Congruent with command.proto
+fn default_rule_position() -> RulePosition {
+    RulePosition::Tree
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FileClusterFrontendConfig {
@@ -682,7 +687,7 @@ pub struct FileClusterFrontendConfig {
     pub certificate_chain: Option<String>,
     #[serde(default)]
     pub tls_versions: Vec<TlsVersion>,
-    #[serde(default)]
+    #[serde(default = "default_rule_position")]
     pub position: RulePosition,
     pub tags: Option<BTreeMap<String, String>>,
     pub h2: Option<bool>,

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -685,6 +685,7 @@ pub struct FileClusterFrontendConfig {
     #[serde(default)]
     pub position: RulePosition,
     pub tags: Option<BTreeMap<String, String>>,
+    pub h2: Option<bool>,
 }
 
 impl FileClusterFrontendConfig {
@@ -770,6 +771,7 @@ impl FileClusterFrontendConfig {
             path,
             method: self.method.clone(),
             tags: self.tags.clone(),
+            h2: self.h2.unwrap_or(false),
         })
     }
 }
@@ -795,6 +797,7 @@ pub struct FileClusterConfig {
     pub frontends: Vec<FileClusterFrontendConfig>,
     pub backends: Vec<BackendConfig>,
     pub protocol: FileClusterProtocolConfig,
+    pub http_version: Option<u8>,
     pub sticky_session: Option<bool>,
     pub https_redirect: Option<bool>,
     #[serde(default)]
@@ -920,6 +923,7 @@ pub struct HttpFrontendConfig {
     #[serde(default)]
     pub position: RulePosition,
     pub tags: Option<BTreeMap<String, String>>,
+    pub h2: bool,
 }
 
 impl HttpFrontendConfig {
@@ -955,6 +959,7 @@ impl HttpFrontendConfig {
                     path: self.path.clone(),
                     method: self.method.clone(),
                     position: self.position.into(),
+                    h2: self.h2,
                     tags,
                 })
                 .into(),
@@ -969,6 +974,7 @@ impl HttpFrontendConfig {
                     path: self.path.clone(),
                     method: self.method.clone(),
                     position: self.position.into(),
+                    h2: self.h2,
                     tags,
                 })
                 .into(),
@@ -1297,13 +1303,13 @@ impl ConfigBuilder {
         Ok(())
     }
 
-    fn push_http_listener(&mut self, mut listener: ListenerBuilder) -> Result<(), ConfigError> {
+    fn push_http_listener(&mut self, listener: ListenerBuilder) -> Result<(), ConfigError> {
         let listener = listener.to_http(Some(&self.built))?;
         self.built.http_listeners.push(listener);
         Ok(())
     }
 
-    fn push_tcp_listener(&mut self, mut listener: ListenerBuilder) -> Result<(), ConfigError> {
+    fn push_tcp_listener(&mut self, listener: ListenerBuilder) -> Result<(), ConfigError> {
         let listener = listener.to_tcp(Some(&self.built))?;
         self.built.tcp_listeners.push(listener);
         Ok(())

--- a/command/src/proto/display.rs
+++ b/command/src/proto/display.rs
@@ -32,9 +32,9 @@ impl Display for CertificateSummary {
 impl Display for QueryCertificatesFilters {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if let Some(d) = self.domain.clone() {
-            write!(f, "domain:{}", d)
+            write!(f, "domain:{d}")
         } else if let Some(fp) = self.fingerprint.clone() {
-            write!(f, "domain:{}", fp)
+            write!(f, "domain:{fp}")
         } else {
             write!(f, "all certificates")
         }

--- a/command/src/request.rs
+++ b/command/src/request.rs
@@ -210,6 +210,7 @@ impl RequestHttpFrontend {
                 }
             })?,
             tags: Some(self.tags),
+            h2: self.h2,
         })
     }
 }

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -39,6 +39,7 @@ pub struct HttpFrontend {
     #[serde(default)]
     pub position: RulePosition,
     pub tags: Option<BTreeMap<String, String>>,
+    pub h2: bool,
 }
 
 impl From<HttpFrontend> for RequestHttpFrontend {
@@ -54,6 +55,7 @@ impl From<HttpFrontend> for RequestHttpFrontend {
             path: val.path,
             method: val.method,
             position: val.position.into(),
+            h2: val.h2,
             tags,
         }
     }

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -478,7 +478,7 @@ impl ConfigState {
         if tcp_frontends.contains(&tcp_frontend) {
             return Err(StateError::Exists {
                 kind: ObjectKind::TcpFrontend,
-                id: format!("{:?}", tcp_frontend),
+                id: format!("{tcp_frontend:?}"),
             });
         }
 
@@ -497,7 +497,7 @@ impl ConfigState {
                 .get_mut(&front_to_remove.cluster_id)
                 .ok_or(StateError::NotFound {
                     kind: ObjectKind::TcpFrontend,
-                    id: format!("{:?}", front_to_remove),
+                    id: format!("{front_to_remove:?}"),
                 })?;
 
         let len = tcp_frontends.len();

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -5,6 +5,7 @@ rust-version = "1.70.0"
 edition = "2021"
 
 [dependencies]
+kawa = "0.6.3"
 futures = "^0.3.28"
 hyper = { version = "^0.14.27", features = ["client", "http1"] }
 hyper-rustls = { version = "^0.24.1", default-features = false, features = ["webpki-tokio", "http1", "tls12", "logging"] }

--- a/e2e/src/http_utils/mod.rs
+++ b/e2e/src/http_utils/mod.rs
@@ -24,14 +24,20 @@ pub fn http_request<S1: Into<String>, S2: Into<String>, S3: Into<String>, S4: In
     )
 }
 
-// the default value for the 404 error, as provided in the command lib,
-// used as default for listeners
-pub fn default_404_answer() -> String {
-    String::from(include_str!("../../../command/assets/404.html"))
-}
+use std::io::Write;
+use kawa;
 
-// the default value for the 503 error, as provided in the command lib,
-// used as default for listeners
-pub fn default_503_answer() -> String {
-    String::from(include_str!("../../../command/assets/503.html"))
+/// the default kawa answer for the error code provided, converted to HTTP/1.1
+pub fn default_answer(code: u16) -> String {
+    let mut kawa_answer = kawa::Kawa::new(
+        kawa::Kind::Response,
+        kawa::Buffer::new(kawa::SliceBuffer(&mut [])),
+    );
+    sozu_lib::protocol::mux::fill_default_answer(&mut kawa_answer, code);
+    kawa_answer.prepare(&mut kawa::h1::converter::H1BlockConverter);
+    let out = kawa_answer.as_io_slice();
+    let mut writer = std::io::BufWriter::new(Vec::new());
+    writer.write_vectored(&out).expect("WRITE");
+    let result = unsafe { std::str::from_utf8_unchecked(writer.buffer()) };
+    result.to_string()
 }

--- a/e2e/src/http_utils/mod.rs
+++ b/e2e/src/http_utils/mod.rs
@@ -24,8 +24,8 @@ pub fn http_request<S1: Into<String>, S2: Into<String>, S3: Into<String>, S4: In
     )
 }
 
-use std::io::Write;
 use kawa;
+use std::io::Write;
 
 /// the default kawa answer for the error code provided, converted to HTTP/1.1
 pub fn default_answer(code: u16) -> String {

--- a/e2e/src/mock/async_backend.rs
+++ b/e2e/src/mock/async_backend.rs
@@ -35,7 +35,7 @@ impl<A: Aggregator + Send + Sync + 'static> BackendHandle<A> {
         let name = name.into();
         let (stop_tx, mut stop_rx) = mpsc::channel::<()>(1);
         let (mut aggregator_tx, aggregator_rx) = mpsc::channel::<A>(1);
-        let listener = TcpListener::bind(address).expect("could not bind");
+        let listener = TcpListener::bind(address).expect(&format!("could not bind on: {address}"));
         let mut clients = Vec::new();
         let thread_name = name.to_owned();
 

--- a/e2e/src/mock/client.rs
+++ b/e2e/src/mock/client.rs
@@ -39,7 +39,7 @@ impl Client {
     /// Establish a TCP connection with its address,
     /// register the yielded TCP stream, apply timeouts
     pub fn connect(&mut self) {
-        let stream = TcpStream::connect(self.address).expect("could not connect");
+        let stream = TcpStream::connect(self.address).expect(&format!("could not connect to: {}", self.address));
         stream
             .set_read_timeout(Some(Duration::from_millis(100)))
             .expect("could not set read timeout");

--- a/e2e/src/mock/sync_backend.rs
+++ b/e2e/src/mock/sync_backend.rs
@@ -44,7 +44,7 @@ impl Backend {
 
     /// Binds itself to its address, stores the yielded TCP listener
     pub fn connect(&mut self) {
-        let listener = TcpListener::bind(self.address).expect("could not bind");
+        let listener = TcpListener::bind(self.address).expect(&format!("could not bind on: {}", self.address));
         let timeout = Duration::from_millis(100);
         let timeout = libc::timeval {
             tv_sec: 0,

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -39,6 +39,7 @@ use crate::{
             answers::HttpAnswers,
             parser::{hostname_and_port, Method},
         },
+        mux::{self, Mux},
         proxy_protocol::expect::ExpectProxyProtocol,
         Http, Pipe, SessionState,
     },
@@ -66,7 +67,8 @@ StateMachineBuilder! {
     /// 3. WebSocket (passthrough)
     enum HttpStateMachine impl SessionState {
         Expect(ExpectProxyProtocol<TcpStream>),
-        Http(Http<TcpStream, HttpListener>),
+        // Http(Http<TcpStream, HttpListener>),
+        Mux(Mux<TcpStream>),
         WebSocket(Pipe<TcpStream, HttpListener>),
     }
 }
@@ -125,22 +127,36 @@ impl HttpSession {
             gauge_add!("protocol.http", 1);
             let session_address = sock.peer_addr().ok();
 
-            HttpStateMachine::Http(Http::new(
-                answers.clone(),
-                configured_backend_timeout,
-                configured_connect_timeout,
-                configured_frontend_timeout,
-                container_frontend_timeout,
-                sock,
-                token,
-                listener.clone(),
-                pool.clone(),
-                Protocol::HTTP,
+            let mut context = mux::Context::new(pool.clone());
+            context
+                .create_stream(request_id, 1 << 16)
+                .ok_or(AcceptError::BufferCapacityReached)?;
+            let frontend = mux::Connection::new_h1_server(sock);
+            HttpStateMachine::Mux(Mux {
+                frontend_token: token,
+                frontend,
+                router: mux::Router::new(listener.clone()),
                 public_address,
-                request_id,
-                session_address,
-                sticky_name.clone(),
-            )?)
+                peer_address: session_address,
+                sticky_name: sticky_name.clone(),
+                context,
+            })
+            // HttpStateMachine::Http(Http::new(
+            //     answers.clone(),
+            //     configured_backend_timeout,
+            //     configured_connect_timeout,
+            //     configured_frontend_timeout,
+            //     container_frontend_timeout,
+            //     sock,
+            //     token,
+            //     listener.clone(),
+            //     pool.clone(),
+            //     Protocol::HTTP,
+            //     public_address,
+            //     request_id,
+            //     session_address,
+            //     sticky_name.clone(),
+            // )?)
         };
 
         let metrics = SessionMetrics::new(Some(wait_time));
@@ -164,7 +180,8 @@ impl HttpSession {
     pub fn upgrade(&mut self) -> SessionIsToBeClosed {
         debug!("HTTP::upgrade");
         let new_state = match self.state.take() {
-            HttpStateMachine::Http(http) => self.upgrade_http(http),
+            // HttpStateMachine::Http(http) => self.upgrade_http(http),
+            HttpStateMachine::Mux(mux) => self.upgrade_mux(mux),
             HttpStateMachine::Expect(expect) => self.upgrade_expect(expect),
             HttpStateMachine::WebSocket(ws) => self.upgrade_websocket(ws),
             HttpStateMachine::FailedUpgrade(_) => unreachable!(),
@@ -212,7 +229,8 @@ impl HttpSession {
 
                 gauge_add!("protocol.proxy.expect", -1);
                 gauge_add!("protocol.http", 1);
-                Some(HttpStateMachine::Http(http))
+                unimplemented!();
+                // Some(HttpStateMachine::Http(http))
             }
             _ => None,
         }
@@ -222,7 +240,7 @@ impl HttpSession {
         debug!("http switching to ws");
         let front_token = self.frontend_token;
         let back_token = unwrap_msg!(http.backend_token);
-        let ws_context = http.websocket_context();
+        let ws_context = http.context.websocket_context();
 
         let mut container_frontend_timeout = http.container_frontend_timeout;
         let mut container_backend_timeout = http.container_backend_timeout;
@@ -258,6 +276,69 @@ impl HttpSession {
         Some(HttpStateMachine::WebSocket(pipe))
     }
 
+    fn upgrade_mux(&mut self, mut mux: Mux<TcpStream>) -> Option<HttpStateMachine> {
+        debug!("mux switching to ws");
+        let stream = mux.context.streams.pop().unwrap();
+
+        let (frontend_readiness, frontend_socket) = match mux.frontend {
+            mux::Connection::H1(mux::ConnectionH1 {
+                readiness, socket, ..
+            }) => (readiness, socket),
+            // only h1<->h1 connections can upgrade to websocket
+            mux::Connection::H2(_) => unreachable!(),
+        };
+
+        let mux::StreamState::Linked(back_token) = stream.state else { unreachable!() };
+        let backend = mux.router.backends.remove(&back_token).unwrap();
+        let (cluster_id, backend_readiness, backend_socket) = match backend {
+            mux::Connection::H1(mux::ConnectionH1 {
+                position: mux::Position::Client(mux::BackendStatus::Connected(cluster_id)),
+                readiness,
+                socket,
+                ..
+            }) => (cluster_id, readiness, socket),
+            // the backend disconnected just after upgrade, abort
+            mux::Connection::H1(_) => return None,
+            // only h1<->h1 connections can upgrade to websocket
+            mux::Connection::H2(_) => unreachable!(),
+        };
+
+        let ws_context = stream.context.websocket_context();
+
+        // let mut container_frontend_timeout = http.container_frontend_timeout;
+        // let mut container_backend_timeout = http.container_backend_timeout;
+        // container_frontend_timeout.reset();
+        // container_backend_timeout.reset();
+
+        let mut pipe = Pipe::new(
+            stream.back.storage.buffer,
+            None,
+            Some(backend_socket),
+            None,
+            None,
+            None,
+            Some(cluster_id),
+            stream.front.storage.buffer,
+            self.frontend_token,
+            frontend_socket,
+            self.listener.clone(),
+            Protocol::HTTP,
+            stream.context.id,
+            stream.context.session_address,
+            Some(ws_context),
+        );
+
+        pipe.frontend_readiness.event = frontend_readiness.event;
+        pipe.backend_readiness.event = backend_readiness.event;
+        pipe.set_back_token(back_token);
+
+        gauge_add!("protocol.http", -1);
+        gauge_add!("protocol.ws", 1);
+        gauge_add!("http.active_requests", -1);
+        gauge_add!("websocket.active_requests", 1);
+        Some(HttpStateMachine::WebSocket(pipe))
+    }
+
     fn upgrade_websocket(&self, ws: Pipe<TcpStream, HttpListener>) -> Option<HttpStateMachine> {
         // what do we do here?
         error!("Upgrade called on WS, this should not happen");
@@ -277,7 +358,8 @@ impl ProxySession for HttpSession {
         // Restore gauges
         match self.state.marker() {
             StateMarker::Expect => gauge_add!("protocol.proxy.expect", -1),
-            StateMarker::Http => gauge_add!("protocol.http", -1),
+            // StateMarker::Http => gauge_add!("protocol.http", -1),
+            StateMarker::Mux => gauge_add!("protocol.http", -1),
             StateMarker::WebSocket => {
                 gauge_add!("protocol.ws", -1);
                 gauge_add!("websocket.active_requests", -1);
@@ -287,7 +369,7 @@ impl ProxySession for HttpSession {
         if self.state.failed() {
             match self.state.marker() {
                 StateMarker::Expect => incr!("http.upgrade.expect.failed"),
-                StateMarker::Http => incr!("http.upgrade.http.failed"),
+                StateMarker::Mux => incr!("http.upgrade.http.failed"),
                 StateMarker::WebSocket => incr!("http.upgrade.ws.failed"),
             }
             return;
@@ -1395,7 +1477,7 @@ mod tests {
         );
         println!("http client write: {w:?}");
 
-        let expected_answer = "HTTP/1.1 301 Moved Permanently\r\nContent-Length: 0\r\nLocation: https://localhost/redirected?true\r\n\r\n";
+        let expected_answer = "HTTP/1.1 301 Moved Permanently\r\nLocation: https://localhost/redirected?true\r\nContent-Length: 0\r\n\r\n";
         let mut buffer = [0; 4096];
         let mut index = 0;
         loop {

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -461,7 +461,7 @@ impl L7ListenerHandler for HttpListener {
 
         let now = Instant::now();
 
-        if let Route::ClusterId(cluster) = &route {
+        if let Route::Cluster { id: cluster, .. } = &route {
             time!(
                 "frontend_matching_time",
                 cluster,
@@ -671,7 +671,7 @@ impl HttpProxy {
         if !socket_errors.is_empty() {
             return Err(ProxyError::SoftStop {
                 proxy_protocol: "HTTP".to_string(),
-                error: format!("Error deregistering listen sockets: {:?}", socket_errors),
+                error: format!("Error deregistering listen sockets: {socket_errors:?}"),
             });
         }
 
@@ -694,7 +694,7 @@ impl HttpProxy {
         if !socket_errors.is_empty() {
             return Err(ProxyError::HardStop {
                 proxy_protocol: "HTTP".to_string(),
-                error: format!("Error deregistering listen sockets: {:?}", socket_errors),
+                error: format!("Error deregistering listen sockets: {socket_errors:?}"),
             });
         }
 
@@ -1467,6 +1467,7 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some(cluster_id1),
                 tags: None,
+                h2: false,
             })
             .expect("Could not add http frontend");
         fronts
@@ -1478,6 +1479,7 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some(cluster_id2),
                 tags: None,
+                h2: false,
             })
             .expect("Could not add http frontend");
         fronts
@@ -1489,6 +1491,7 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some(cluster_id3),
                 tags: None,
+                h2: false,
             })
             .expect("Could not add http frontend");
         fronts
@@ -1500,6 +1503,7 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some("cluster_1".to_owned()),
                 tags: None,
+                h2: false,
             })
             .expect("Could not add http frontend");
 
@@ -1531,19 +1535,31 @@ mod tests {
         let frontend5 = listener.frontend_from_request("domain", "/", &Method::Get);
         assert_eq!(
             frontend1.expect("should find frontend"),
-            Route::ClusterId("cluster_1".to_string())
+            Route::Cluster {
+                id: "cluster_1".to_string(),
+                h2: false
+            }
         );
         assert_eq!(
             frontend2.expect("should find frontend"),
-            Route::ClusterId("cluster_1".to_string())
+            Route::Cluster {
+                id: "cluster_1".to_string(),
+                h2: false
+            }
         );
         assert_eq!(
             frontend3.expect("should find frontend"),
-            Route::ClusterId("cluster_2".to_string())
+            Route::Cluster {
+                id: "cluster_2".to_string(),
+                h2: false
+            }
         );
         assert_eq!(
             frontend4.expect("should find frontend"),
-            Route::ClusterId("cluster_3".to_string())
+            Route::Cluster {
+                id: "cluster_3".to_string(),
+                h2: false
+            }
         );
         assert!(frontend5.is_err());
     }

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -442,18 +442,23 @@ impl ProxySession for HttpsSession {
             token,
             super::ready_to_string(events)
         );
+        println!("EVENT: {token:?}->{events:?}");
         self.last_event = Instant::now();
         self.metrics.wait_start();
         self.state.update_readiness(token, events);
     }
 
     fn ready(&mut self, session: Rc<RefCell<dyn ProxySession>>) -> SessionIsToBeClosed {
-        println!("READY");
+        let start = std::time::Instant::now();
+        println!("READY {start:?}");
         self.metrics.service_start();
 
         let session_result =
             self.state
                 .ready(session.clone(), self.proxy.clone(), &mut self.metrics);
+
+        let end = std::time::Instant::now();
+        println!("READY END {end:?} -> {:?}", end.duration_since(start));
 
         let to_be_closed = match session_result {
             SessionResult::Close => true,

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -318,6 +318,7 @@ impl HttpsSession {
                 },
                 streams: HashMap::new(),
                 state: mux::H2State::ClientPreface,
+                expect: Some((0, 24 + 9)),
             }),
         };
         let mut mux = Mux {
@@ -459,6 +460,7 @@ impl ProxySession for HttpsSession {
                 StateMarker::Http => incr!("https.upgrade.http.failed"),
                 StateMarker::WebSocket => incr!("https.upgrade.wss.failed"),
                 StateMarker::Http2 => incr!("https.upgrade.http2.failed"),
+                StateMarker::Mux => incr!("https.upgrade.mux.failed"),
             }
             return;
         }

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -293,9 +293,11 @@ impl HttpsSession {
         let mux = Mux {
             frontend_token: self.frontend_token,
             frontend,
-            backends: HashMap::new(),
             context: mux::Context::new(self.pool.clone(), handshake.request_id, 1 << 16).ok()?,
-            listener: self.listener.clone(),
+            router: mux::Router {
+                listener: self.listener.clone(),
+                backends: HashMap::new(),
+            },
             public_address: self.public_address,
             peer_address: self.peer_address,
             sticky_name: self.sticky_name.clone(),
@@ -532,7 +534,6 @@ impl L7ListenerHandler for HttpsListener {
         let (remaining_input, (hostname, _)) = match hostname_and_port(host.as_bytes()) {
             Ok(tuple) => tuple,
             Err(parse_error) => {
-                // parse_error contains a slice of given_host, which should NOT escape this scope
                 return Err(FrontendFromRequestError::HostParse {
                     host: host.to_owned(),
                     error: parse_error.to_string(),

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -466,10 +466,8 @@ impl ProxySession for HttpsSession {
             match self.state.marker() {
                 StateMarker::Expect => incr!("https.upgrade.expect.failed"),
                 StateMarker::Handshake => incr!("https.upgrade.handshake.failed"),
-                StateMarker::Http => incr!("https.upgrade.http.failed"),
                 StateMarker::WebSocket => incr!("https.upgrade.wss.failed"),
-                StateMarker::Http2 => incr!("https.upgrade.http2.failed"),
-                StateMarker::Mux => incr!("https.upgrade.mux.failed"),
+                StateMarker::Mux => incr!("https.upgrade.http.failed"),
             }
             return;
         }

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -66,8 +66,8 @@ use crate::{
     tls::{CertifiedKeyWrapper, MutexWrappedCertificateResolver, ResolveCertificate},
     util::UnwrapLog,
     AcceptError, CachedTags, FrontendFromRequestError, L7ListenerHandler, L7Proxy, ListenerError,
-    ListenerHandler, Protocol, ProxyConfiguration, ProxyError, ProxySession, Readiness,
-    SessionIsToBeClosed, SessionMetrics, SessionResult, StateMachineBuilder, StateResult,
+    ListenerHandler, Protocol, ProxyConfiguration, ProxyError, ProxySession, SessionIsToBeClosed,
+    SessionMetrics, SessionResult, StateMachineBuilder, StateResult,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -186,7 +186,7 @@ impl HttpsSession {
             HttpsStateMachine::Expect(expect, ssl) => self.upgrade_expect(expect, ssl),
             HttpsStateMachine::Handshake(handshake) => self.upgrade_handshake(handshake),
             HttpsStateMachine::Http(http) => self.upgrade_http(http),
-            HttpsStateMachine::Mux(mux) => unimplemented!(),
+            HttpsStateMachine::Mux(_) => unimplemented!(),
             HttpsStateMachine::Http2(_) => self.upgrade_http2(),
             HttpsStateMachine::WebSocket(wss) => self.upgrade_websocket(wss),
             HttpsStateMachine::FailedUpgrade(_) => unreachable!(),
@@ -250,12 +250,6 @@ impl HttpsSession {
     }
 
     fn upgrade_handshake(&mut self, handshake: TlsHandshake) -> Option<HttpsStateMachine> {
-        // Add 1st routing phase
-        // - get SNI
-        // - get ALPN
-        // - find corresponding listener
-        // - determine next protocol (tcps, https ,http2)
-
         let sni = handshake.session.server_name();
         let alpn = handshake.session.alpn_protocol();
         let alpn = alpn.and_then(|alpn| from_utf8(alpn).ok());
@@ -289,79 +283,25 @@ impl HttpsSession {
         };
 
         gauge_add!("protocol.tls.handshake", -1);
-        // return Some(HttpsStateMachine::Mux(Mux::new(
-        //     self.frontend_token,
-        //     handshake.request_id,
-        //     self.listener.clone(),
-        //     self.pool.clone(),
-        //     self.public_address,
-        //     self.peer_address,
-        //     self.sticky_name.clone(),
-        // )));
+
         use crate::protocol::mux;
         let mut frontend = match alpn {
             AlpnProtocol::Http11 => mux::Connection::new_h1_server(front_stream),
             AlpnProtocol::H2 => mux::Connection::new_h2_server(front_stream),
         };
         frontend.readiness_mut().event = handshake.frontend_readiness.event;
-        let mut mux = Mux {
+        let mux = Mux {
             frontend_token: self.frontend_token,
             frontend,
             backends: HashMap::new(),
-            streams: mux::Streams {
-                streams: Vec::new(),
-                pool: self.pool.clone(),
-            },
+            context: mux::Context::new(self.pool.clone(), handshake.request_id, 1 << 16).ok()?,
             listener: self.listener.clone(),
             public_address: self.public_address,
             peer_address: self.peer_address,
             sticky_name: self.sticky_name.clone(),
         };
-        mux.streams
-            .create_stream(handshake.request_id, 1 << 16)
-            .ok()?;
+        gauge_add!("protocol.https", 1);
         return Some(HttpsStateMachine::Mux(mux));
-        match alpn {
-            AlpnProtocol::Http11 => {
-                let mut http = Http::new(
-                    self.answers.clone(),
-                    self.configured_backend_timeout,
-                    self.configured_connect_timeout,
-                    self.configured_frontend_timeout,
-                    handshake.container_frontend_timeout,
-                    front_stream,
-                    self.frontend_token,
-                    self.listener.clone(),
-                    self.pool.clone(),
-                    Protocol::HTTPS,
-                    self.public_address,
-                    handshake.request_id,
-                    self.peer_address,
-                    self.sticky_name.clone(),
-                )
-                .ok()?;
-
-                http.frontend_readiness.event = handshake.frontend_readiness.event;
-
-                gauge_add!("protocol.https", 1);
-                Some(HttpsStateMachine::Http(http))
-            }
-            AlpnProtocol::H2 => {
-                let mut http = Http2::new(
-                    front_stream,
-                    self.frontend_token,
-                    self.pool.clone(),
-                    Some(self.public_address),
-                    None,
-                    self.sticky_name.clone(),
-                );
-
-                http.frontend.readiness.event = handshake.frontend_readiness.event;
-
-                gauge_add!("protocol.http2", 1);
-                Some(HttpsStateMachine::Http2(http))
-            }
-        }
     }
 
     fn upgrade_http(&self, http: Http<FrontRustls, HttpsListener>) -> Option<HttpsStateMachine> {

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -54,7 +54,7 @@ use crate::{
             answers::HttpAnswers,
             parser::{hostname_and_port, Method},
         },
-        mux::Mux,
+        mux::{self, Mux},
         proxy_protocol::expect::ExpectProxyProtocol,
         rustls::TlsHandshake,
         Http, Pipe, SessionState,
@@ -87,7 +87,7 @@ StateMachineBuilder! {
     enum HttpsStateMachine impl SessionState {
         Expect(ExpectProxyProtocol<MioTcpStream>, ServerConnection),
         Handshake(TlsHandshake),
-        Mux(Mux),
+        Mux(Mux<FrontRustls>),
         Http(Http<FrontRustls, HttpsListener>),
         WebSocket(Pipe<FrontRustls, HttpsListener>),
         Http2(Http2<FrontRustls>) -> todo!("H2"),
@@ -284,7 +284,6 @@ impl HttpsSession {
 
         gauge_add!("protocol.tls.handshake", -1);
 
-        use crate::protocol::mux;
         let mut context = mux::Context::new(self.pool.clone());
         let mut frontend = match alpn {
             AlpnProtocol::Http11 => {
@@ -300,10 +299,7 @@ impl HttpsSession {
             frontend_token: self.frontend_token,
             frontend,
             context,
-            router: mux::Router {
-                listener: self.listener.clone(),
-                backends: HashMap::new(),
-            },
+            router: mux::Router::new(self.listener.clone()),
             public_address: self.public_address,
             peer_address: self.peer_address,
             sticky_name: self.sticky_name.clone(),
@@ -314,7 +310,7 @@ impl HttpsSession {
         debug!("https switching to wss");
         let front_token = self.frontend_token;
         let back_token = unwrap_msg!(http.backend_token);
-        let ws_context = http.websocket_context();
+        let ws_context = http.context.websocket_context();
 
         let mut container_frontend_timeout = http.container_frontend_timeout;
         let mut container_backend_timeout = http.container_backend_timeout;

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -285,15 +285,21 @@ impl HttpsSession {
         gauge_add!("protocol.tls.handshake", -1);
 
         use crate::protocol::mux;
+        let mut context = mux::Context::new(self.pool.clone());
         let mut frontend = match alpn {
-            AlpnProtocol::Http11 => mux::Connection::new_h1_server(front_stream),
-            AlpnProtocol::H2 => mux::Connection::new_h2_server(front_stream),
+            AlpnProtocol::Http11 => {
+                context.create_stream(handshake.request_id, 1 << 16)?;
+                mux::Connection::new_h1_server(front_stream)
+            }
+            AlpnProtocol::H2 => mux::Connection::new_h2_server(front_stream, self.pool.clone())?,
         };
         frontend.readiness_mut().event = handshake.frontend_readiness.event;
-        let mux = Mux {
+
+        gauge_add!("protocol.https", 1);
+        Some(HttpsStateMachine::Mux(Mux {
             frontend_token: self.frontend_token,
             frontend,
-            context: mux::Context::new(self.pool.clone(), handshake.request_id, 1 << 16).ok()?,
+            context,
             router: mux::Router {
                 listener: self.listener.clone(),
                 backends: HashMap::new(),
@@ -301,9 +307,7 @@ impl HttpsSession {
             public_address: self.public_address,
             peer_address: self.peer_address,
             sticky_name: self.sticky_name.clone(),
-        };
-        gauge_add!("protocol.https", 1);
-        return Some(HttpsStateMachine::Mux(mux));
+        }))
     }
 
     fn upgrade_http(&self, http: Http<FrontRustls, HttpsListener>) -> Option<HttpsStateMachine> {

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -299,40 +299,27 @@ impl HttpsSession {
         //     self.sticky_name.clone(),
         // )));
         use crate::protocol::mux;
-        let frontend = match alpn {
-            AlpnProtocol::Http11 => mux::Connection::H1(mux::ConnectionH1 {
-                socket: front_stream,
-                position: mux::Position::Server,
-                readiness: Readiness {
-                    interest: Ready::READABLE | Ready::HUP | Ready::ERROR,
-                    event: handshake.frontend_readiness.event,
-                },
-                stream: 0,
-            }),
-            AlpnProtocol::H2 => mux::Connection::H2(mux::ConnectionH2 {
-                socket: front_stream,
-                position: mux::Position::Server,
-                readiness: Readiness {
-                    interest: Ready::READABLE | Ready::HUP | Ready::ERROR,
-                    event: handshake.frontend_readiness.event,
-                },
-                streams: HashMap::new(),
-                state: mux::H2State::ClientPreface,
-                expect: Some((0, 24 + 9)),
-            }),
+        let mut frontend = match alpn {
+            AlpnProtocol::Http11 => mux::Connection::new_h1_server(front_stream),
+            AlpnProtocol::H2 => mux::Connection::new_h2_server(front_stream),
         };
+        frontend.readiness_mut().event = handshake.frontend_readiness.event;
         let mut mux = Mux {
             frontend_token: self.frontend_token,
             frontend,
             backends: HashMap::new(),
-            streams: Vec::new(),
+            streams: mux::Streams {
+                streams: Vec::new(),
+                pool: self.pool.clone(),
+            },
             listener: self.listener.clone(),
-            pool: self.pool.clone(),
             public_address: self.public_address,
             peer_address: self.peer_address,
             sticky_name: self.sticky_name.clone(),
         };
-        mux.create_stream(handshake.request_id).ok()?;
+        mux.streams
+            .create_stream(handshake.request_id, 1 << 16)
+            .ok()?;
         return Some(HttpsStateMachine::Mux(mux));
         match alpn {
             AlpnProtocol::Http11 => {

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -54,6 +54,7 @@ use crate::{
             answers::HttpAnswers,
             parser::{hostname_and_port, Method},
         },
+        mux::Mux,
         proxy_protocol::expect::ExpectProxyProtocol,
         rustls::TlsHandshake,
         Http, Pipe, SessionState,
@@ -65,8 +66,8 @@ use crate::{
     tls::{CertifiedKeyWrapper, MutexWrappedCertificateResolver, ResolveCertificate},
     util::UnwrapLog,
     AcceptError, CachedTags, FrontendFromRequestError, L7ListenerHandler, L7Proxy, ListenerError,
-    ListenerHandler, Protocol, ProxyConfiguration, ProxyError, ProxySession, SessionIsToBeClosed,
-    SessionMetrics, SessionResult, StateMachineBuilder, StateResult,
+    ListenerHandler, Protocol, ProxyConfiguration, ProxyError, ProxySession, Readiness,
+    SessionIsToBeClosed, SessionMetrics, SessionResult, StateMachineBuilder, StateResult,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -86,6 +87,7 @@ StateMachineBuilder! {
     enum HttpsStateMachine impl SessionState {
         Expect(ExpectProxyProtocol<MioTcpStream>, ServerConnection),
         Handshake(TlsHandshake),
+        Mux(Mux),
         Http(Http<FrontRustls, HttpsListener>),
         WebSocket(Pipe<FrontRustls, HttpsListener>),
         Http2(Http2<FrontRustls>) -> todo!("H2"),
@@ -184,6 +186,7 @@ impl HttpsSession {
             HttpsStateMachine::Expect(expect, ssl) => self.upgrade_expect(expect, ssl),
             HttpsStateMachine::Handshake(handshake) => self.upgrade_handshake(handshake),
             HttpsStateMachine::Http(http) => self.upgrade_http(http),
+            HttpsStateMachine::Mux(mux) => unimplemented!(),
             HttpsStateMachine::Http2(_) => self.upgrade_http2(),
             HttpsStateMachine::WebSocket(wss) => self.upgrade_websocket(wss),
             HttpsStateMachine::FailedUpgrade(_) => unreachable!(),
@@ -271,6 +274,7 @@ impl HttpsSession {
             // Some client don't fill in the ALPN protocol, in this case we default to Http/1.1
             None => AlpnProtocol::Http11,
         };
+        println!("ALPN: {alpn:?}");
 
         if let Some(version) = handshake.session.protocol_version() {
             incr!(rustls_version_str(version));
@@ -285,6 +289,50 @@ impl HttpsSession {
         };
 
         gauge_add!("protocol.tls.handshake", -1);
+        // return Some(HttpsStateMachine::Mux(Mux::new(
+        //     self.frontend_token,
+        //     handshake.request_id,
+        //     self.listener.clone(),
+        //     self.pool.clone(),
+        //     self.public_address,
+        //     self.peer_address,
+        //     self.sticky_name.clone(),
+        // )));
+        use crate::protocol::mux;
+        let frontend = match alpn {
+            AlpnProtocol::Http11 => mux::Connection::H1(mux::ConnectionH1 {
+                socket: front_stream,
+                position: mux::Position::Server,
+                readiness: Readiness {
+                    interest: Ready::READABLE | Ready::HUP | Ready::ERROR,
+                    event: handshake.frontend_readiness.event,
+                },
+                stream: 0,
+            }),
+            AlpnProtocol::H2 => mux::Connection::H2(mux::ConnectionH2 {
+                socket: front_stream,
+                position: mux::Position::Server,
+                readiness: Readiness {
+                    interest: Ready::READABLE | Ready::HUP | Ready::ERROR,
+                    event: handshake.frontend_readiness.event,
+                },
+                streams: HashMap::new(),
+                state: mux::H2State::ClientPreface,
+            }),
+        };
+        let mut mux = Mux {
+            frontend_token: self.frontend_token,
+            frontend,
+            backends: HashMap::new(),
+            streams: Vec::new(),
+            listener: self.listener.clone(),
+            pool: self.pool.clone(),
+            public_address: self.public_address,
+            peer_address: self.peer_address,
+            sticky_name: self.sticky_name.clone(),
+        };
+        mux.create_stream(handshake.request_id).ok()?;
+        return Some(HttpsStateMachine::Mux(mux));
         match alpn {
             AlpnProtocol::Http11 => {
                 let mut http = Http::new(
@@ -396,6 +444,7 @@ impl ProxySession for HttpsSession {
             StateMarker::Expect => gauge_add!("protocol.proxy.expect", -1),
             StateMarker::Handshake => gauge_add!("protocol.tls.handshake", -1),
             StateMarker::Http => gauge_add!("protocol.https", -1),
+            StateMarker::Mux => gauge_add!("protocol.https", -1),
             StateMarker::WebSocket => {
                 gauge_add!("protocol.wss", -1);
                 gauge_add!("websocket.active_requests", -1);
@@ -464,6 +513,7 @@ impl ProxySession for HttpsSession {
     }
 
     fn ready(&mut self, session: Rc<RefCell<dyn ProxySession>>) -> SessionIsToBeClosed {
+        println!("READY");
         self.metrics.service_start();
 
         let session_result =

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -579,7 +579,7 @@ impl L7ListenerHandler for HttpsListener {
 
         let now = Instant::now();
 
-        if let Route::ClusterId(cluster) = &route {
+        if let Route::Cluster { id: cluster, .. } = &route {
             time!(
                 "frontend_matching_time",
                 cluster,
@@ -873,7 +873,7 @@ impl HttpsProxy {
         if !socket_errors.is_empty() {
             return Err(ProxyError::SoftStop {
                 proxy_protocol: "HTTPS".to_string(),
-                error: format!("Error deregistering listen sockets: {:?}", socket_errors),
+                error: format!("Error deregistering listen sockets: {socket_errors:?}"),
             });
         }
 
@@ -896,7 +896,7 @@ impl HttpsProxy {
         if !socket_errors.is_empty() {
             return Err(ProxyError::HardStop {
                 proxy_protocol: "HTTPS".to_string(),
-                error: format!("Error deregistering listen sockets: {:?}", socket_errors),
+                error: format!("Error deregistering listen sockets: {socket_errors:?}"),
             });
         }
 
@@ -1620,25 +1620,37 @@ mod tests {
             "lolcatho.st".as_bytes(),
             &PathRule::Prefix(uri1),
             &MethodRule::new(None),
-            &Route::ClusterId(cluster_id1.clone())
+            &Route::Cluster {
+                id: cluster_id1.clone(),
+                h2: false
+            }
         ));
         assert!(fronts.add_tree_rule(
             "lolcatho.st".as_bytes(),
             &PathRule::Prefix(uri2),
             &MethodRule::new(None),
-            &Route::ClusterId(cluster_id2)
+            &Route::Cluster {
+                id: cluster_id2,
+                h2: false
+            }
         ));
         assert!(fronts.add_tree_rule(
             "lolcatho.st".as_bytes(),
             &PathRule::Prefix(uri3),
             &MethodRule::new(None),
-            &Route::ClusterId(cluster_id3)
+            &Route::Cluster {
+                id: cluster_id3,
+                h2: false
+            }
         ));
         assert!(fronts.add_tree_rule(
             "other.domain".as_bytes(),
             &PathRule::Prefix("test".to_string()),
             &MethodRule::new(None),
-            &Route::ClusterId(cluster_id1)
+            &Route::Cluster {
+                id: cluster_id1,
+                h2: false
+            }
         ));
 
         let address: StdSocketAddr = FromStr::from_str("127.0.0.1:1032")
@@ -1680,25 +1692,37 @@ mod tests {
         let frontend1 = listener.frontend_from_request("lolcatho.st", "/", &Method::Get);
         assert_eq!(
             frontend1.expect("should find a frontend"),
-            Route::ClusterId("cluster_1".to_string())
+            Route::Cluster {
+                id: "cluster_1".to_string(),
+                h2: false
+            }
         );
         println!("TEST {}", line!());
         let frontend2 = listener.frontend_from_request("lolcatho.st", "/test", &Method::Get);
         assert_eq!(
             frontend2.expect("should find a frontend"),
-            Route::ClusterId("cluster_1".to_string())
+            Route::Cluster {
+                id: "cluster_1".to_string(),
+                h2: false
+            }
         );
         println!("TEST {}", line!());
         let frontend3 = listener.frontend_from_request("lolcatho.st", "/yolo/test", &Method::Get);
         assert_eq!(
             frontend3.expect("should find a frontend"),
-            Route::ClusterId("cluster_2".to_string())
+            Route::Cluster {
+                id: "cluster_2".to_string(),
+                h2: false
+            }
         );
         println!("TEST {}", line!());
         let frontend4 = listener.frontend_from_request("lolcatho.st", "/yolo/swag", &Method::Get);
         assert_eq!(
             frontend4.expect("should find a frontend"),
-            Route::ClusterId("cluster_3".to_string())
+            Route::Cluster {
+                id: "cluster_3".to_string(),
+                h2: false
+            }
         );
         println!("TEST {}", line!());
         let frontend5 = listener.frontend_from_request("domain", "/", &Method::Get);

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -33,10 +33,10 @@ use sozu_command::{
     config::DEFAULT_CIPHER_SUITES,
     logging,
     proto::command::{
-        request::RequestType, response_content::ContentType, AddCertificate, CertificateSummary,
-        CertificatesByAddress, Cluster, HttpsListenerConfig, ListOfCertificatesByAddress,
-        ListenerType, RemoveCertificate, RemoveListener, ReplaceCertificate, RequestHttpFrontend,
-        ResponseContent, TlsVersion,
+        request::RequestType, response_content::ContentType, AddCertificate, AlpnProtocol,
+        CertificateSummary, CertificatesByAddress, Cluster, HttpsListenerConfig,
+        ListOfCertificatesByAddress, ListenerType, RemoveCertificate, RemoveListener,
+        ReplaceCertificate, RequestHttpFrontend, ResponseContent, TlsVersion,
     },
     ready::Ready,
     request::WorkerRequest,
@@ -69,9 +69,6 @@ use crate::{
     SessionMetrics, SessionResult, StateMachineBuilder, StateResult,
 };
 
-// const SERVER_PROTOS: &[&str] = &["http/1.1", "h2"];
-const SERVER_PROTOS: &[&str] = &["http/1.1"];
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TlsCluster {
     cluster_id: String,
@@ -93,11 +90,6 @@ StateMachineBuilder! {
         WebSocket(Pipe<FrontRustls, HttpsListener>),
         Http2(Http2<FrontRustls>) -> todo!("H2"),
     }
-}
-
-pub enum AlpnProtocols {
-    H2,
-    Http11,
 }
 
 pub struct HttpsSession {
@@ -270,14 +262,14 @@ impl HttpsSession {
         );
 
         let alpn = match alpn {
-            Some("http/1.1") => AlpnProtocols::Http11,
-            Some("h2") => AlpnProtocols::H2,
+            Some("http/1.1") => AlpnProtocol::Http11,
+            Some("h2") => AlpnProtocol::H2,
             Some(other) => {
                 error!("Unsupported ALPN protocol: {}", other);
                 return None;
             }
             // Some client don't fill in the ALPN protocol, in this case we default to Http/1.1
-            None => AlpnProtocols::Http11,
+            None => AlpnProtocol::Http11,
         };
 
         if let Some(version) = handshake.session.protocol_version() {
@@ -294,7 +286,7 @@ impl HttpsSession {
 
         gauge_add!("protocol.tls.handshake", -1);
         match alpn {
-            AlpnProtocols::Http11 => {
+            AlpnProtocol::Http11 => {
                 let mut http = Http::new(
                     self.answers.clone(),
                     self.configured_backend_timeout,
@@ -318,7 +310,7 @@ impl HttpsSession {
                 gauge_add!("protocol.https", 1);
                 Some(HttpsStateMachine::Http(http))
             }
-            AlpnProtocols::H2 => {
+            AlpnProtocol::H2 => {
                 let mut http = Http2::new(
                     front_stream,
                     self.frontend_token,
@@ -760,11 +752,20 @@ impl HttpsListener {
             .with_cert_resolver(resolver);
         server_config.send_tls13_tickets = config.send_tls13_tickets as usize;
 
-        let mut protocols = SERVER_PROTOS
+        let protocols = config
+            .alpn
             .iter()
-            .map(|proto| proto.as_bytes().to_vec())
+            .filter_map(|protocol| match AlpnProtocol::from_i32(*protocol) {
+                Some(AlpnProtocol::Http11) => Some("http/1.1"),
+                Some(AlpnProtocol::H2) => Some("h2"),
+                other_protocol => {
+                    error!("unsupported ALPN protocol: {:?}", other_protocol);
+                    None
+                }
+            })
+            .map(|protocol| protocol.as_bytes().to_vec())
             .collect::<Vec<_>>();
-        server_config.alpn_protocols.append(&mut protocols);
+        server_config.alpn_protocols = protocols;
 
         Ok(server_config)
     }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -639,6 +639,8 @@ pub enum RetrieveClusterError {
     UnauthorizedRoute,
     #[error("{0}")]
     RetrieveFrontend(FrontendFromRequestError),
+    #[error("https redirect")]
+    HttpsRedirect,
 }
 
 /// Used in sessions

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -620,6 +620,8 @@ pub enum BackendConnectionError {
     MaxConnectionRetries(Option<String>),
     #[error("the sessions slab has reached maximum capacity")]
     MaxSessionsMemory,
+    #[error("the checkout pool has reached maximum capacity")]
+    MaxBuffers,
     #[error("error from the backend: {0}")]
     Backend(BackendError),
     #[error("failed to retrieve the cluster: {0}")]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -515,9 +515,7 @@ macro_rules! StateMachineBuilder {
             /// leaving a FailedUpgrade in its place.
             /// The FailedUpgrade retains the marker of the previous State.
             fn take(&mut self) -> $state_name {
-                let mut owned_state = $state_name::FailedUpgrade(self.marker());
-                std::mem::swap(&mut owned_state, self);
-                owned_state
+                std::mem::replace(self, $state_name::FailedUpgrade(self.marker()))
             }
             _fn_impl!{front_socket(&, self) -> &mio::net::TcpStream}
         }

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -36,7 +36,7 @@ pub struct HttpContext {
     pub user_agent: Option<String>,
 
     // ========== Read only
-    /// signals wether Kawa should write a "Connection" header with a "close" value (request and response)
+    /// signals whether Kawa should write a "Connection" header with a "close" value (request and response)
     pub closing: bool,
     /// the value of the custom header, named "Sozu-Id", that Kawa should write (request and response)
     pub id: Ulid,

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -349,4 +349,16 @@ impl HttpContext {
 
         Ok((given_authority, given_path, given_method))
     }
+
+    pub fn reset(&mut self) {
+        self.keep_alive_backend = true;
+        self.sticky_session_found = None;
+        self.method = None;
+        self.authority = None;
+        self.path = None;
+        self.status = None;
+        self.reason = None;
+        self.user_agent = None;
+        self.id = Ulid::generate();
+    }
 }

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -8,7 +8,7 @@ use rusty_ulid::Ulid;
 use crate::{
     pool::Checkout,
     protocol::http::{parser::compare_no_case, GenericHttpStream, Method},
-    Protocol,
+    Protocol, RetrieveClusterError,
 };
 
 /// This is the container used to store and use information about the session from within a Kawa parser callback
@@ -336,5 +336,17 @@ impl HttpContext {
             key: kawa::Store::Static(b"Sozu-Id"),
             val: kawa::Store::from_string(self.id.to_string()),
         }));
+    }
+
+    // -> host, path, method
+    pub fn extract_route(&self) -> Result<(&str, &str, &Method), RetrieveClusterError> {
+        let given_method = self.method.as_ref().ok_or(RetrieveClusterError::NoMethod)?;
+        let given_authority = self
+            .authority
+            .as_deref()
+            .ok_or(RetrieveClusterError::NoHost)?;
+        let given_path = self.path.as_deref().ok_or(RetrieveClusterError::NoPath)?;
+
+        Ok((given_authority, given_path, given_method))
     }
 }

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -6,6 +6,7 @@ use std::{
 use rusty_ulid::Ulid;
 
 use crate::{
+    logs::Endpoint,
     pool::Checkout,
     protocol::http::{parser::compare_no_case, GenericHttpStream, Method},
     Protocol, RetrieveClusterError,
@@ -348,6 +349,18 @@ impl HttpContext {
         let given_path = self.path.as_deref().ok_or(RetrieveClusterError::NoPath)?;
 
         Ok((given_authority, given_path, given_method))
+    }
+
+    /// Format the context of the websocket into a loggable String
+    pub fn websocket_context(&self) -> String {
+        Endpoint::Http {
+            method: self.method.as_ref(),
+            authority: self.authority.as_deref(),
+            path: self.path.as_deref(),
+            status: self.status,
+            reason: self.reason.as_deref(),
+        }
+        .to_string()
     }
 
     pub fn reset(&mut self) {

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -219,10 +219,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
     /// Reset the connection in case of keep-alive to be ready for the next request
     pub fn reset(&mut self) {
         trace!("==============reset");
-        self.context.keep_alive_frontend = true;
-        self.context.keep_alive_backend = true;
-        self.context.sticky_session_found = None;
-        self.context.id = Ulid::generate();
+        self.context.reset();
 
         self.request_stream.clear();
         self.response_stream.clear();

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -1124,8 +1124,8 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             }
         };
 
-        let (cluster_id, _) = match route {
-            Route::Cluster { id, h2 } => (id, h2),
+        let cluster_id = match route {
+            Route::Cluster { id, .. } => id,
             Route::Deny => {
                 self.set_answer(DefaultAnswerStatus::Answer401, None);
                 return Err(RetrieveClusterError::UnauthorizedRoute);

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -1124,8 +1124,8 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             }
         };
 
-        let cluster_id = match route {
-            Route::ClusterId(cluster_id) => cluster_id,
+        let (cluster_id, _) = match route {
+            Route::Cluster { id, h2 } => (id, h2),
             Route::Deny => {
                 self.set_answer(DefaultAnswerStatus::Answer401, None);
                 return Err(RetrieveClusterError::UnauthorizedRoute);

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -1078,32 +1078,11 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         true
     }
 
-    // -> host, path, method
-    pub fn extract_route(&self) -> Result<(&str, &str, &Method), RetrieveClusterError> {
-        let given_method = self
-            .context
-            .method
-            .as_ref()
-            .ok_or(RetrieveClusterError::NoMethod)?;
-        let given_authority = self
-            .context
-            .authority
-            .as_deref()
-            .ok_or(RetrieveClusterError::NoHost)?;
-        let given_path = self
-            .context
-            .path
-            .as_deref()
-            .ok_or(RetrieveClusterError::NoPath)?;
-
-        Ok((given_authority, given_path, given_method))
-    }
-
     fn cluster_id_from_request(
         &mut self,
         proxy: Rc<RefCell<dyn L7Proxy>>,
     ) -> Result<String, RetrieveClusterError> {
-        let (host, uri, method) = match self.extract_route() {
+        let (host, uri, method) = match self.context.extract_route() {
             Ok(tuple) => tuple,
             Err(cluster_error) => {
                 self.set_answer(DefaultAnswerStatus::Answer400, None);

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -755,20 +755,6 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         }
     }
 
-    /// Format the context of the websocket into a loggable String
-    pub fn websocket_context(&self) -> String {
-        format!(
-            "{}",
-            Endpoint::Http {
-                method: self.context.method.as_ref(),
-                authority: self.context.authority.as_deref(),
-                path: self.context.path.as_deref(),
-                status: self.context.status,
-                reason: self.context.reason.as_deref(),
-            }
-        )
-    }
-
     pub fn log_request(&self, metrics: &SessionMetrics, message: Option<&str>) {
         let listener = self.listener.borrow();
         let tags = self.context.authority.as_ref().and_then(|host| {

--- a/lib/src/protocol/mod.rs
+++ b/lib/src/protocol/mod.rs
@@ -1,5 +1,6 @@
 pub mod h2;
 pub mod kawa_h1;
+pub mod mux;
 pub mod pipe;
 pub mod proxy_protocol;
 pub mod rustls;

--- a/lib/src/protocol/mux/converter.rs
+++ b/lib/src/protocol/mux/converter.rs
@@ -7,12 +7,11 @@ use crate::protocol::http::parser::compare_no_case;
 use super::{
     parser::{FrameHeader, FrameType, H2Error},
     serializer::{gen_frame_header, gen_rst_stream},
-    StreamId, StreamState,
+    StreamId,
 };
 
 pub struct H2BlockConverter<'a> {
     pub stream_id: StreamId,
-    pub state: StreamState,
     pub encoder: &'a mut hpack::Encoder<'static>,
     pub out: Vec<u8>,
 }

--- a/lib/src/protocol/mux/converter.rs
+++ b/lib/src/protocol/mux/converter.rs
@@ -125,8 +125,7 @@ impl<'a, T: AsBuffer> BlockConverter<T> for H2BlockConverter<'a> {
                 ..
             }) => {
                 if end_header {
-                    let mut payload = Vec::new();
-                    std::mem::swap(&mut self.out, &mut payload);
+                    let payload = std::mem::replace(&mut self.out, Vec::new());
                     let mut header = [0; 9];
                     let flags = if end_stream { 1 } else { 0 } | if end_header { 4 } else { 0 };
                     gen_frame_header(

--- a/lib/src/protocol/mux/converter.rs
+++ b/lib/src/protocol/mux/converter.rs
@@ -1,0 +1,159 @@
+use kawa::{AsBuffer, Block, BlockConverter, Chunk, Flags, Kawa, Pair, StatusLine, Store};
+
+use super::{
+    parser::{FrameHeader, FrameType},
+    serializer::gen_frame_header,
+    StreamId,
+};
+
+pub struct H2BlockConverter<'a> {
+    pub stream_id: StreamId,
+    pub encoder: &'a mut hpack::Encoder<'static>,
+    pub out: Vec<u8>,
+}
+
+impl<'a, T: AsBuffer> BlockConverter<T> for H2BlockConverter<'a> {
+    fn call(&mut self, block: Block, kawa: &mut Kawa<T>) {
+        let buffer = kawa.storage.mut_buffer();
+        match block {
+            Block::StatusLine => match kawa.detached.status_line.pop() {
+                StatusLine::Request {
+                    method,
+                    authority,
+                    path,
+                    ..
+                } => {
+                    self.encoder
+                        .encode_header_into((b":method", method.data(buffer)), &mut self.out)
+                        .unwrap();
+                    self.encoder
+                        .encode_header_into((b":authority", authority.data(buffer)), &mut self.out)
+                        .unwrap();
+                    self.encoder
+                        .encode_header_into((b":path", path.data(buffer)), &mut self.out)
+                        .unwrap();
+                    self.encoder
+                        .encode_header_into((b":scheme", b"https"), &mut self.out)
+                        .unwrap();
+                }
+                StatusLine::Response { status, .. } => {
+                    self.encoder
+                        .encode_header_into((b":status", status.data(buffer)), &mut self.out)
+                        .unwrap();
+                }
+                StatusLine::Unknown => unreachable!(),
+            },
+            Block::Cookies => {
+                if kawa.detached.jar.is_empty() {
+                    return;
+                }
+                for cookie in kawa
+                    .detached
+                    .jar
+                    .drain(..)
+                    .filter(|cookie| !cookie.is_elided())
+                {
+                    let cookie = [cookie.key.data(buffer), b"=", cookie.val.data(buffer)].concat();
+                    self.encoder
+                        .encode_header_into((b"cookie", &cookie), &mut self.out)
+                        .unwrap();
+                }
+            }
+            Block::Header(Pair {
+                key: Store::Empty, ..
+            }) => {
+                // elided header
+            }
+            Block::Header(Pair { key, val }) => {
+                {
+                    // let key = key.data(kawa.storage.buffer());
+                    // let val = val.data(kawa.storage.buffer());
+                    // if compare_no_case(key, b"connection")
+                    //     || compare_no_case(key, b"host")
+                    //     || compare_no_case(key, b"http2-settings")
+                    //     || compare_no_case(key, b"keep-alive")
+                    //     || compare_no_case(key, b"proxy-connection")
+                    //     || compare_no_case(key, b"te") && !compare_no_case(val, b"trailers")
+                    //     || compare_no_case(key, b"trailer")
+                    //     || compare_no_case(key, b"transfer-encoding")
+                    //     || compare_no_case(key, b"upgrade")
+                    // {
+                    //     return;
+                    // }
+                }
+                self.encoder
+                    .encode_header_into((key.data(buffer), val.data(buffer)), &mut self.out)
+                    .unwrap();
+            }
+            Block::ChunkHeader(_) => {
+                // this converter doesn't align H1 chunks on H2 data frames
+            }
+            Block::Chunk(Chunk { data }) => {
+                let mut header = [0; 9];
+                let payload_len = match &data {
+                    Store::Empty => 0,
+                    Store::Detached(s) | Store::Slice(s) => s.len,
+                    Store::Static(s) => s.len() as u32,
+                    Store::Alloc(a, i) => a.len() as u32 - i,
+                };
+                gen_frame_header(
+                    &mut header,
+                    &FrameHeader {
+                        payload_len,
+                        frame_type: FrameType::Data,
+                        flags: 0,
+                        stream_id: self.stream_id,
+                    },
+                )
+                .unwrap();
+                kawa.push_out(Store::new_vec(&header));
+                kawa.push_out(data);
+                kawa.push_delimiter()
+            }
+            Block::Flags(Flags {
+                end_header,
+                end_stream,
+                ..
+            }) => {
+                if end_header {
+                    let mut payload = Vec::new();
+                    std::mem::swap(&mut self.out, &mut payload);
+                    let mut header = [0; 9];
+                    let flags = if end_stream { 1 } else { 0 } | if end_header { 4 } else { 0 };
+                    gen_frame_header(
+                        &mut header,
+                        &FrameHeader {
+                            payload_len: payload.len() as u32,
+                            frame_type: FrameType::Headers,
+                            flags,
+                            stream_id: self.stream_id,
+                        },
+                    )
+                    .unwrap();
+                    kawa.push_out(Store::new_vec(&header));
+                    kawa.push_out(Store::Alloc(payload.into_boxed_slice(), 0));
+                }
+                if end_stream {
+                    let mut header = [0; 9];
+                    gen_frame_header(
+                        &mut header,
+                        &FrameHeader {
+                            payload_len: 0,
+                            frame_type: FrameType::Data,
+                            flags: 1,
+                            stream_id: self.stream_id,
+                        },
+                    )
+                    .unwrap();
+                    kawa.push_out(Store::new_vec(&header));
+                }
+                if end_header || end_stream {
+                    kawa.push_delimiter()
+                }
+            }
+        }
+    }
+    fn finalize(&mut self, _kawa: &mut Kawa<T>) {
+        assert!(self.out.is_empty());
+    }
+}

--- a/lib/src/protocol/mux/converter.rs
+++ b/lib/src/protocol/mux/converter.rs
@@ -5,13 +5,14 @@ use kawa::{AsBuffer, Block, BlockConverter, Chunk, Flags, Kawa, Pair, StatusLine
 use crate::protocol::http::parser::compare_no_case;
 
 use super::{
-    parser::{FrameHeader, FrameType},
-    serializer::gen_frame_header,
-    StreamId,
+    parser::{FrameHeader, FrameType, H2Error},
+    serializer::{gen_frame_header, gen_rst_stream},
+    StreamId, StreamState,
 };
 
 pub struct H2BlockConverter<'a> {
     pub stream_id: StreamId,
+    pub state: StreamState,
     pub encoder: &'a mut hpack::Encoder<'static>,
     pub out: Vec<u8>,
 }
@@ -140,20 +141,25 @@ impl<'a, T: AsBuffer> BlockConverter<T> for H2BlockConverter<'a> {
                     .unwrap();
                     kawa.push_out(Store::new_vec(&header));
                     kawa.push_out(Store::Alloc(payload.into_boxed_slice(), 0));
-                }
-                if end_stream {
-                    let mut header = [0; 9];
-                    gen_frame_header(
-                        &mut header,
-                        &FrameHeader {
-                            payload_len: 0,
-                            frame_type: FrameType::Data,
-                            flags: 1,
-                            stream_id: self.stream_id,
-                        },
-                    )
-                    .unwrap();
-                    kawa.push_out(Store::new_vec(&header));
+                } else if end_stream {
+                    if kawa.is_error() {
+                        let mut frame = [0; 13];
+                        gen_rst_stream(&mut frame, self.stream_id, H2Error::InternalError).unwrap();
+                        kawa.push_out(Store::new_vec(&frame));
+                    } else {
+                        let mut header = [0; 9];
+                        gen_frame_header(
+                            &mut header,
+                            &FrameHeader {
+                                payload_len: 0,
+                                frame_type: FrameType::Data,
+                                flags: 1,
+                                stream_id: self.stream_id,
+                            },
+                        )
+                        .unwrap();
+                        kawa.push_out(Store::new_vec(&header));
+                    }
                 }
                 if end_header || end_stream {
                     kawa.push_delimiter()

--- a/lib/src/protocol/mux/converter.rs
+++ b/lib/src/protocol/mux/converter.rs
@@ -82,7 +82,10 @@ impl<'a, T: AsBuffer> BlockConverter<T> for H2BlockConverter<'a> {
                     // }
                 }
                 self.encoder
-                    .encode_header_into((key.data(buffer), val.data(buffer)), &mut self.out)
+                    .encode_header_into(
+                        (&key.data(buffer).to_ascii_lowercase(), val.data(buffer)),
+                        &mut self.out,
+                    )
                     .unwrap();
             }
             Block::ChunkHeader(_) => {

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -17,7 +17,7 @@ pub struct ConnectionH1<Front: SocketHandler> {
 }
 
 impl<Front: SocketHandler> ConnectionH1<Front> {
-    pub fn readable<E>(&mut self, context: &mut Context, endpoint: E) -> MuxResult
+    pub fn readable<E>(&mut self, context: &mut Context, mut endpoint: E) -> MuxResult
     where
         E: UpdateReadiness,
     {
@@ -44,6 +44,12 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         }
         if kawa.is_terminated() {
             self.readiness.interest.remove(Ready::READABLE);
+        }
+        if kawa.is_main_phase() {
+            endpoint
+                .readiness_mut(stream.token.unwrap())
+                .interest
+                .insert(Ready::WRITABLE)
         }
         MuxResult::Continue
     }

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -6,6 +6,8 @@ use crate::{
     Readiness,
 };
 
+use super::UpdateReadiness;
+
 pub struct ConnectionH1<Front: SocketHandler> {
     pub position: Position,
     pub readiness: Readiness,
@@ -15,7 +17,10 @@ pub struct ConnectionH1<Front: SocketHandler> {
 }
 
 impl<Front: SocketHandler> ConnectionH1<Front> {
-    pub fn readable(&mut self, context: &mut Context) -> MuxResult {
+    pub fn readable<E>(&mut self, context: &mut Context, endpoint: E) -> MuxResult
+    where
+        E: UpdateReadiness,
+    {
         println!("======= MUX H1 READABLE");
         let stream = &mut context.streams[self.stream];
         let kawa = stream.rbuffer(self.position);
@@ -42,7 +47,10 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         }
         MuxResult::Continue
     }
-    pub fn writable(&mut self, context: &mut Context) -> MuxResult {
+    pub fn writable<E>(&mut self, context: &mut Context, endpoint: E) -> MuxResult
+    where
+        E: UpdateReadiness,
+    {
         println!("======= MUX H1 WRITABLE");
         let stream = &mut context.streams[self.stream];
         let kawa = stream.wbuffer(self.position);

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -49,7 +49,7 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
             return MuxResult::Continue;
         }
 
-        let was_initial = kawa.is_initial();
+        let was_main_phase = kawa.is_main_phase();
         kawa::h1::parse(kawa, parts.context);
         debug_kawa(kawa);
         if kawa.is_error() {
@@ -80,7 +80,7 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
             }
             match self.position {
                 Position::Server => {
-                    if was_initial {
+                    if !was_main_phase {
                         self.requests += 1;
                         println_!("REQUESTS: {}", self.requests);
                         stream.state = StreamState::Link

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -30,7 +30,7 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
     where
         E: Endpoint,
     {
-        println!("======= MUX H1 READABLE");
+        println!("======= MUX H1 READABLE {:?}", self.position);
         let stream = &mut context.streams[self.stream];
         let parts = stream.split(&self.position);
         let kawa = parts.rbuffer;
@@ -72,7 +72,7 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
     where
         E: Endpoint,
     {
-        println!("======= MUX H1 WRITABLE");
+        println!("======= MUX H1 WRITABLE {:?}", self.position);
         let stream = &mut context.streams[self.stream];
         let kawa = stream.wbuffer(&self.position);
         kawa.prepare(&mut kawa::h1::BlockConverter);
@@ -122,7 +122,7 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         )
     }
 
-    pub fn end_stream(&mut self, stream: usize, context: &mut Context) {
+    pub fn end_stream(&mut self, stream: GlobalStreamId, context: &mut Context) {
         assert_eq!(stream, self.stream);
         let stream_context = &mut context.streams[stream].context;
         println!("end H1 stream {stream}: {stream_context:#?}");
@@ -144,8 +144,8 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         }
     }
 
-    pub fn start_stream(&mut self, stream: usize, context: &mut Context) {
-        println!("start H1 stream {stream}");
+    pub fn start_stream(&mut self, stream: GlobalStreamId, context: &mut Context) {
+        println!("start H1 stream {stream} {:?}", self.readiness);
         self.stream = stream;
         let mut owned_position = Position::Server;
         std::mem::swap(&mut owned_position, &mut self.position);

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -18,10 +18,7 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
     pub fn readable(&mut self, context: &mut Context) -> MuxResult {
         println!("======= MUX H1 READABLE");
         let stream = &mut context.streams.get(self.stream);
-        let kawa = match self.position {
-            Position::Client => &mut stream.front,
-            Position::Server => &mut stream.back,
-        };
+        let kawa = stream.rbuffer(self.position);
         let (size, status) = self.socket.socket_read(kawa.storage.space());
         println!("  size: {size}, status: {status:?}");
         if size > 0 {
@@ -37,6 +34,9 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         }
         kawa::h1::parse(kawa, &mut kawa::h1::NoCallbacks);
         kawa::debug_kawa(kawa);
+        if kawa.is_error() {
+            return MuxResult::Close(self.stream);
+        }
         if kawa.is_terminated() {
             self.readiness.interest.remove(Ready::READABLE);
         }
@@ -45,11 +45,9 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
     pub fn writable(&mut self, context: &mut Context) -> MuxResult {
         println!("======= MUX H1 WRITABLE");
         let stream = &mut context.streams.get(self.stream);
-        let kawa = match self.position {
-            Position::Client => &mut stream.back,
-            Position::Server => &mut stream.front,
-        };
+        let kawa = stream.wbuffer(self.position);
         kawa.prepare(&mut kawa::h1::BlockConverter);
+        kawa::debug_kawa(kawa);
         let bufs = kawa.as_io_slice();
         if bufs.is_empty() {
             self.readiness.interest.remove(Ready::WRITABLE);
@@ -62,6 +60,9 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
             // self.backend_readiness.interest.insert(Ready::READABLE);
         } else {
             self.readiness.event.remove(Ready::WRITABLE);
+        }
+        if kawa.is_terminated() && kawa.is_completed() {
+            self.readiness.interest.insert(Ready::READABLE);
         }
         MuxResult::Continue
     }

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -1,7 +1,7 @@
 use sozu_command::ready::Ready;
 
 use crate::{
-    protocol::mux::{Context, GlobalStreamId, MuxResult, Position, UpdateReadiness},
+    protocol::mux::{BackendStatus, Context, Endpoint, GlobalStreamId, MuxResult, Position},
     socket::SocketHandler,
     Readiness,
 };
@@ -14,14 +14,25 @@ pub struct ConnectionH1<Front: SocketHandler> {
     pub stream: GlobalStreamId,
 }
 
+impl<Front: SocketHandler> std::fmt::Debug for ConnectionH1<Front> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConnectionH1")
+            .field("position", &self.position)
+            .field("readiness", &self.readiness)
+            .field("socket", &self.socket.socket_ref())
+            .field("stream", &self.stream)
+            .finish()
+    }
+}
+
 impl<Front: SocketHandler> ConnectionH1<Front> {
     pub fn readable<E>(&mut self, context: &mut Context, mut endpoint: E) -> MuxResult
     where
-        E: UpdateReadiness,
+        E: Endpoint,
     {
         println!("======= MUX H1 READABLE");
         let stream = &mut context.streams[self.stream];
-        let parts = stream.split(self.position);
+        let parts = stream.split(&self.position);
         let kawa = parts.rbuffer;
         let (size, status) = self.socket.socket_read(kawa.storage.space());
         println!("  size: {size}, status: {status:?}");
@@ -48,7 +59,7 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         }
         if was_initial && kawa.is_main_phase() {
             match self.position {
-                Position::Client => endpoint
+                Position::Client(_) => endpoint
                     .readiness_mut(stream.token.unwrap())
                     .interest
                     .insert(Ready::WRITABLE),
@@ -57,13 +68,13 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         }
         MuxResult::Continue
     }
-    pub fn writable<E>(&mut self, context: &mut Context, endpoint: E) -> MuxResult
+    pub fn writable<E>(&mut self, context: &mut Context, mut endpoint: E) -> MuxResult
     where
-        E: UpdateReadiness,
+        E: Endpoint,
     {
         println!("======= MUX H1 WRITABLE");
         let stream = &mut context.streams[self.stream];
-        let kawa = stream.wbuffer(self.position);
+        let kawa = stream.wbuffer(&self.position);
         kawa.prepare(&mut kawa::h1::BlockConverter);
         kawa::debug_kawa(kawa);
         let bufs = kawa.as_io_slice();
@@ -80,8 +91,72 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
             self.readiness.event.remove(Ready::WRITABLE);
         }
         if kawa.is_terminated() && kawa.is_completed() {
-            self.readiness.interest.insert(Ready::READABLE);
+            match self.position {
+                Position::Client(_) => self.readiness.interest.insert(Ready::READABLE),
+                Position::Server => {
+                    endpoint.end_stream(stream.token.unwrap(), self.stream, context)
+                }
+            }
         }
         MuxResult::Continue
+    }
+
+    pub fn close<E>(&mut self, context: &mut Context, mut endpoint: E)
+    where
+        E: Endpoint,
+    {
+        match self.position {
+            Position::Client(BackendStatus::KeepAlive(_))
+            | Position::Client(BackendStatus::Disconnecting) => {
+                println!("close detached client ConnectionH1");
+                return;
+            }
+            Position::Client(BackendStatus::Connecting(_)) => todo!("reconnect"),
+            Position::Client(_) => {}
+            Position::Server => unreachable!(),
+        }
+        endpoint.end_stream(
+            context.streams[self.stream].token.unwrap(),
+            self.stream,
+            context,
+        )
+    }
+
+    pub fn end_stream(&mut self, stream: usize, context: &mut Context) {
+        assert_eq!(stream, self.stream);
+        let stream_context = &mut context.streams[stream].context;
+        println!("end H1 stream {stream}: {stream_context:#?}");
+        self.stream = usize::MAX;
+        let mut owned_position = Position::Server;
+        std::mem::swap(&mut owned_position, &mut self.position);
+        match owned_position {
+            Position::Client(BackendStatus::Connected(cluster_id))
+            | Position::Client(BackendStatus::Connecting(cluster_id)) => {
+                self.position = if stream_context.keep_alive_backend {
+                    Position::Client(BackendStatus::KeepAlive(cluster_id))
+                } else {
+                    Position::Client(BackendStatus::Disconnecting)
+                }
+            }
+            Position::Client(BackendStatus::KeepAlive(_))
+            | Position::Client(BackendStatus::Disconnecting) => unreachable!(),
+            Position::Server => todo!(),
+        }
+    }
+
+    pub fn start_stream(&mut self, stream: usize, context: &mut Context) {
+        println!("start H1 stream {stream}");
+        self.stream = stream;
+        let mut owned_position = Position::Server;
+        std::mem::swap(&mut owned_position, &mut self.position);
+        match owned_position {
+            Position::Client(BackendStatus::KeepAlive(cluster_id)) => {
+                self.position = Position::Client(BackendStatus::Connecting(cluster_id))
+            }
+            Position::Server => unreachable!(),
+            _ => {
+                self.position = owned_position;
+            }
+        }
     }
 }

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -1,0 +1,66 @@
+use sozu_command::ready::Ready;
+
+use crate::{
+    protocol::mux::{Context, GlobalStreamId, Position},
+    socket::{SocketHandler, SocketResult},
+    Readiness,
+};
+
+pub struct ConnectionH1<Front: SocketHandler> {
+    pub position: Position,
+    pub readiness: Readiness,
+    pub socket: Front,
+    /// note: a Server H1 will always reference stream 0, but a client can reference any stream
+    pub stream: GlobalStreamId,
+}
+
+impl<Front: SocketHandler> ConnectionH1<Front> {
+    pub fn readable(&mut self, context: &mut Context) {
+        println!("======= MUX H1 READABLE");
+        let stream = &mut context.streams.get(self.stream);
+        let kawa = match self.position {
+            Position::Client => &mut stream.front,
+            Position::Server => &mut stream.back,
+        };
+        let (size, status) = self.socket.socket_read(kawa.storage.space());
+        println!("  size: {size}, status: {status:?}");
+        if size > 0 {
+            kawa.storage.fill(size);
+        } else {
+            self.readiness.event.remove(Ready::READABLE);
+        }
+        match status {
+            SocketResult::Continue => {}
+            SocketResult::Closed => todo!(),
+            SocketResult::Error => todo!(),
+            SocketResult::WouldBlock => self.readiness.event.remove(Ready::READABLE),
+        }
+        kawa::h1::parse(kawa, &mut kawa::h1::NoCallbacks);
+        kawa::debug_kawa(kawa);
+        if kawa.is_terminated() {
+            self.readiness.interest.remove(Ready::READABLE);
+        }
+    }
+    pub fn writable(&mut self, context: &mut Context) {
+        println!("======= MUX H1 WRITABLE");
+        let stream = &mut context.streams.get(self.stream);
+        let kawa = match self.position {
+            Position::Client => &mut stream.back,
+            Position::Server => &mut stream.front,
+        };
+        kawa.prepare(&mut kawa::h1::BlockConverter);
+        let bufs = kawa.as_io_slice();
+        if bufs.is_empty() {
+            self.readiness.interest.remove(Ready::WRITABLE);
+            return;
+        }
+        let (size, status) = self.socket.socket_write_vectored(&bufs);
+        println!("  size: {size}, status: {status:?}");
+        if size > 0 {
+            kawa.consume(size);
+            // self.backend_readiness.interest.insert(Ready::READABLE);
+        } else {
+            self.readiness.event.remove(Ready::WRITABLE);
+        }
+    }
+}

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -8,16 +8,18 @@ use crate::{
         Position, StreamState,
     },
     socket::SocketHandler,
+    timer::TimeoutContainer,
     Readiness,
 };
 
 pub struct ConnectionH1<Front: SocketHandler> {
     pub position: Position,
     pub readiness: Readiness,
+    pub requests: usize,
     pub socket: Front,
     /// note: a Server H1 will always reference stream 0, but a client can reference any stream
     pub stream: GlobalStreamId,
-    pub requests: usize,
+    pub timeout_container: TimeoutContainer,
 }
 
 impl<Front: SocketHandler> std::fmt::Debug for ConnectionH1<Front> {

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -17,7 +17,7 @@ pub struct ConnectionH1<Front: SocketHandler> {
 impl<Front: SocketHandler> ConnectionH1<Front> {
     pub fn readable(&mut self, context: &mut Context) -> MuxResult {
         println!("======= MUX H1 READABLE");
-        let stream = &mut context.streams.get(self.stream);
+        let stream = &mut context.streams[self.stream];
         let kawa = stream.rbuffer(self.position);
         let (size, status) = self.socket.socket_read(kawa.storage.space());
         println!("  size: {size}, status: {status:?}");
@@ -44,7 +44,7 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
     }
     pub fn writable(&mut self, context: &mut Context) -> MuxResult {
         println!("======= MUX H1 WRITABLE");
-        let stream = &mut context.streams.get(self.stream);
+        let stream = &mut context.streams[self.stream];
         let kawa = stream.wbuffer(self.position);
         kawa.prepare(&mut kawa::h1::BlockConverter);
         kawa::debug_kawa(kawa);

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -50,6 +50,7 @@ impl Default for H2Settings {
 
 pub struct ConnectionH2<Front: SocketHandler> {
     pub decoder: hpack::Decoder<'static>,
+    pub encoder: hpack::Encoder<'static>,
     pub expect: Option<(H2StreamId, usize)>,
     pub position: Position,
     pub readiness: Readiness,
@@ -263,7 +264,7 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             (_, _) => {
                 let mut converter = converter::H2BlockConverter {
                     stream_id: 0,
-                    encoder: unsafe { std::mem::transmute(&mut self.decoder) },
+                    encoder: &mut self.encoder,
                     out: Vec::new(),
                 };
                 let mut want_write = false;

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -12,7 +12,7 @@ use crate::{
     Readiness,
 };
 
-use super::GenericHttpStream;
+use super::{GenericHttpStream, UpdateReadiness};
 
 #[derive(Debug)]
 pub enum H2State {
@@ -66,7 +66,10 @@ pub enum H2StreamId {
 }
 
 impl<Front: SocketHandler> ConnectionH2<Front> {
-    pub fn readable(&mut self, context: &mut Context) -> MuxResult {
+    pub fn readable<E>(&mut self, context: &mut Context, endpoint: E) -> MuxResult
+    where
+        E: UpdateReadiness,
+    {
         println!("======= MUX H2 READABLE");
         let (stream_id, kawa) = if let Some((stream_id, amount)) = self.expect {
             let kawa = match stream_id {
@@ -230,7 +233,10 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         MuxResult::Continue
     }
 
-    pub fn writable(&mut self, context: &mut Context) -> MuxResult {
+    pub fn writable<E>(&mut self, context: &mut Context, endpoint: E) -> MuxResult
+    where
+        E: UpdateReadiness,
+    {
         println!("======= MUX H2 WRITABLE");
         match (&self.state, &self.position) {
             (H2State::ClientPreface, Position::Client) => todo!("Send PRI + client Settings"),

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -13,6 +13,7 @@ use crate::{
         GlobalStreamId, MuxResult, Position, StreamId, StreamState,
     },
     socket::SocketHandler,
+    timer::TimeoutContainer,
     Readiness,
 };
 
@@ -94,6 +95,7 @@ pub struct ConnectionH2<Front: SocketHandler> {
     pub socket: Front,
     pub state: H2State,
     pub streams: HashMap<StreamId, GlobalStreamId>,
+    pub timeout_container: TimeoutContainer,
     pub window: u32,
     pub zero: GenericHttpStream,
 }

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -1,0 +1,274 @@
+use std::collections::HashMap;
+
+use kawa::h1::ParserCallbacks;
+use rusty_ulid::Ulid;
+use sozu_command::ready::Ready;
+
+use crate::{
+    protocol::mux::{
+        parser::{self, error_code_to_str, FrameHeader},
+        pkawa, serializer, Context, GlobalStreamId, Position, StreamId,
+    },
+    socket::SocketHandler,
+    Readiness,
+};
+
+#[derive(Debug)]
+pub enum H2State {
+    ClientPreface,
+    ClientSettings,
+    ServerSettings,
+    Header,
+    Frame(FrameHeader),
+    Error,
+}
+
+#[derive(Debug)]
+pub struct H2Settings {
+    settings_header_table_size: u32,
+    settings_enable_push: bool,
+    settings_max_concurrent_streams: u32,
+    settings_initial_window_size: u32,
+    settings_max_frame_size: u32,
+    settings_max_header_list_size: u32,
+}
+
+impl Default for H2Settings {
+    fn default() -> Self {
+        Self {
+            settings_header_table_size: 4096,
+            settings_enable_push: true,
+            settings_max_concurrent_streams: u32::MAX,
+            settings_initial_window_size: (1 << 16) - 1,
+            settings_max_frame_size: 1 << 14,
+            settings_max_header_list_size: u32::MAX,
+        }
+    }
+}
+
+pub struct ConnectionH2<Front: SocketHandler> {
+    // pub decoder: hpack::Decoder<'static>,
+    pub expect: Option<(GlobalStreamId, usize)>,
+    pub position: Position,
+    pub readiness: Readiness,
+    pub settings: H2Settings,
+    pub socket: Front,
+    pub state: H2State,
+    pub streams: HashMap<StreamId, GlobalStreamId>,
+}
+
+impl<Front: SocketHandler> ConnectionH2<Front> {
+    pub fn readable(&mut self, context: &mut Context) {
+        println!("======= MUX H2 READABLE");
+        let kawa = if let Some((stream_id, amount)) = self.expect {
+            let kawa = context.streams.get(stream_id).front(self.position);
+            let (size, status) = self.socket.socket_read(&mut kawa.storage.space()[..amount]);
+            println!("{:?}({stream_id}, {amount}) {size} {status:?}", self.state);
+            if size > 0 {
+                kawa.storage.fill(size);
+                if size == amount {
+                    self.expect = None;
+                } else {
+                    self.expect = Some((stream_id, amount - size));
+                    return;
+                }
+            } else {
+                self.readiness.event.remove(Ready::READABLE);
+                return;
+            }
+            kawa
+        } else {
+            self.readiness.event.remove(Ready::READABLE);
+            return;
+        };
+        match (&self.state, &self.position) {
+            (H2State::ClientPreface, Position::Client) => {
+                error!("Waiting for ClientPreface to finish writing")
+            }
+            (H2State::ClientPreface, Position::Server) => {
+                let i = kawa.storage.data();
+                let i = match parser::preface(i) {
+                    Ok((i, _)) => i,
+                    Err(e) => panic!("{e:?}"),
+                };
+                match parser::frame_header(i) {
+                    Ok((
+                        _,
+                        parser::FrameHeader {
+                            payload_len,
+                            frame_type: parser::FrameType::Settings,
+                            flags: 0,
+                            stream_id: 0,
+                        },
+                    )) => {
+                        kawa.storage.clear();
+                        self.state = H2State::ClientSettings;
+                        self.expect = Some((0, payload_len as usize));
+                    }
+                    _ => todo!(),
+                };
+            }
+            (H2State::ClientSettings, Position::Server) => {
+                let i = kawa.storage.data();
+                match parser::settings_frame(i, i.len()) {
+                    Ok((_, settings)) => {
+                        kawa.storage.clear();
+                        self.handle(settings, context);
+                    }
+                    Err(e) => panic!("{e:?}"),
+                }
+                let kawa = &mut context.streams.zero.back;
+                self.state = H2State::ServerSettings;
+                match serializer::gen_frame_header(
+                    kawa.storage.space(),
+                    &parser::FrameHeader {
+                        payload_len: 6 * 2,
+                        frame_type: parser::FrameType::Settings,
+                        flags: 0,
+                        stream_id: 0,
+                    },
+                ) {
+                    Ok((_, size)) => kawa.storage.fill(size),
+                    Err(e) => panic!("could not serialize HeaderFrame: {e:?}"),
+                };
+                // kawa.storage
+                //     .write(&[1, 3, 0, 0, 0, 100, 0, 4, 0, 1, 0, 0])
+                //     .unwrap();
+                match serializer::gen_frame_header(
+                    kawa.storage.space(),
+                    &parser::FrameHeader {
+                        payload_len: 0,
+                        frame_type: parser::FrameType::Settings,
+                        flags: 1,
+                        stream_id: 0,
+                    },
+                ) {
+                    Ok((_, size)) => kawa.storage.fill(size),
+                    Err(e) => panic!("could not serialize HeaderFrame: {e:?}"),
+                };
+                self.readiness.interest.insert(Ready::WRITABLE);
+                self.readiness.interest.remove(Ready::READABLE);
+            }
+            (H2State::ServerSettings, Position::Client) => todo!("Receive server Settings"),
+            (H2State::ServerSettings, Position::Server) => {
+                error!("waiting for ServerPreface to finish writing")
+            }
+            (H2State::Header, Position::Server) => {
+                let i = kawa.storage.data();
+                println!("  header: {i:?}");
+                match parser::frame_header(i) {
+                    Ok((_, header)) => {
+                        println!("{header:?}");
+                        kawa.storage.clear();
+                        let stream_id = if let Some(stream_id) = self.streams.get(&header.stream_id)
+                        {
+                            *stream_id
+                        } else {
+                            self.create_stream(header.stream_id, context)
+                        };
+                        let stream_id = if header.frame_type == parser::FrameType::Data {
+                            stream_id
+                        } else {
+                            0
+                        };
+                        println!("{} {} {:#?}", header.stream_id, stream_id, self.streams);
+                        self.expect = Some((stream_id as usize, header.payload_len as usize));
+                        self.state = H2State::Frame(header);
+                    }
+                    Err(e) => panic!("{e:?}"),
+                };
+            }
+            (H2State::Frame(header), Position::Server) => {
+                let i = kawa.storage.data();
+                println!("  data: {i:?}");
+                match parser::frame_body(i, header, self.settings.settings_max_frame_size) {
+                    Ok((_, frame)) => {
+                        kawa.storage.clear();
+                        self.handle(frame, context);
+                    }
+                    Err(e) => panic!("{e:?}"),
+                }
+                self.state = H2State::Header;
+                self.expect = Some((0, 9));
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn writable(&mut self, context: &mut Context) {
+        println!("======= MUX H2 WRITABLE");
+        match (&self.state, &self.position) {
+            (H2State::ClientPreface, Position::Client) => todo!("Send PRI + client Settings"),
+            (H2State::ClientPreface, Position::Server) => unreachable!(),
+            (H2State::ServerSettings, Position::Client) => unreachable!(),
+            (H2State::ServerSettings, Position::Server) => {
+                let kawa = &mut context.streams.zero.back;
+                println!("{:?}", kawa.storage.data());
+                let (size, status) = self.socket.socket_write(kawa.storage.data());
+                println!("  size: {size}, status: {status:?}");
+                let size = kawa.storage.available_data();
+                kawa.storage.consume(size);
+                if kawa.storage.is_empty() {
+                    self.readiness.interest.remove(Ready::WRITABLE);
+                    self.readiness.interest.insert(Ready::READABLE);
+                    self.state = H2State::Header;
+                    self.expect = Some((0, 9));
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn create_stream(&mut self, stream_id: StreamId, context: &mut Context) -> GlobalStreamId {
+        match context.create_stream(Ulid::generate(), self.settings.settings_initial_window_size) {
+            Ok(global_stream_id) => {
+                self.streams.insert(stream_id, global_stream_id);
+                global_stream_id
+            }
+            Err(e) => panic!("{e:?}"),
+        }
+    }
+
+    fn handle(&mut self, frame: parser::Frame, context: &mut Context) {
+        println!("{frame:?}");
+        match frame {
+            parser::Frame::Data(_) => todo!(),
+            parser::Frame::Headers(headers) => {
+                // if !headers.end_headers {
+                //     self.state = H2State::Continuation
+                // }
+                let global_stream_id = self.streams.get(&headers.stream_id).unwrap();
+                let kawa = context.streams.zero.front(self.position);
+                let buffer = headers.header_block_fragment.data(kawa.storage.buffer());
+                let stream = &mut context.streams.others[*global_stream_id - 1];
+                let kawa = &mut stream.front;
+                pkawa::handle_header(kawa, buffer, &mut context.decoder);
+                stream.context.on_headers(kawa);
+            }
+            parser::Frame::Priority(priority) => (),
+            parser::Frame::RstStream(_) => todo!(),
+            parser::Frame::Settings(settings) => {
+                for setting in settings.settings {
+                    match setting.identifier {
+                        1 => self.settings.settings_header_table_size = setting.value,
+                        2 => self.settings.settings_enable_push = setting.value == 1,
+                        3 => self.settings.settings_max_concurrent_streams = setting.value,
+                        4 => self.settings.settings_initial_window_size = setting.value,
+                        5 => self.settings.settings_max_frame_size = setting.value,
+                        6 => self.settings.settings_max_header_list_size = setting.value,
+                        other => panic!("setting_id: {other}"),
+                    }
+                }
+                println!("{:#?}", self.settings);
+            }
+            parser::Frame::PushPromise(_) => todo!(),
+            parser::Frame::Ping(_) => todo!(),
+            parser::Frame::GoAway(goaway) => panic!("{}", error_code_to_str(goaway.error_code)),
+            parser::Frame::WindowUpdate(update) => {
+                let global_stream_id = *self.streams.get(&update.stream_id).unwrap();
+                context.streams.get(global_stream_id).window += update.increment as i32;
+            }
+            parser::Frame::Continuation(_) => todo!(),
+        }
+    }
+}

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -251,14 +251,11 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                 println!("{:?}", kawa.storage.data());
                 let (size, status) = self.socket.socket_write(kawa.storage.data());
                 println!("  size: {size}, status: {status:?}");
-                let size = kawa.storage.available_data();
-                kawa.storage.consume(size);
-                if kawa.storage.is_empty() {
-                    self.readiness.interest.remove(Ready::WRITABLE);
-                    self.readiness.interest.insert(Ready::READABLE);
-                    self.state = H2State::Header;
-                    self.expect = Some((H2StreamId::Zero, 9));
-                }
+                kawa.storage.clear();
+                self.readiness.interest.remove(Ready::WRITABLE);
+                self.readiness.interest.insert(Ready::READABLE);
+                self.state = H2State::Header;
+                self.expect = Some((H2StreamId::Zero, 9));
                 MuxResult::Continue
             }
             (H2State::Error, _) => unreachable!(),

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -1,0 +1,446 @@
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    io::Write,
+    net::SocketAddr,
+    rc::{Rc, Weak},
+};
+
+use mio::{net::TcpStream, Token};
+use rusty_ulid::Ulid;
+use sozu_command::ready::Ready;
+
+mod parser;
+mod serializer;
+
+use crate::{
+    https::HttpsListener,
+    pool::{Checkout, Pool},
+    protocol::SessionState,
+    socket::{FrontRustls, SocketHandler, SocketResult},
+    AcceptError, L7Proxy, ProxySession, Readiness, SessionMetrics, SessionResult, StateResult,
+};
+
+/// Generic Http representation using the Kawa crate using the Checkout of Sozu as buffer
+type GenericHttpStream = kawa::Kawa<Checkout>;
+type StreamId = usize;
+type GlobalStreamId = usize;
+
+pub enum Position {
+    Client,
+    Server,
+}
+
+pub struct ConnectionH1<Front: SocketHandler> {
+    pub socket: Front,
+    pub position: Position,
+    pub readiness: Readiness,
+    pub stream: GlobalStreamId,
+}
+
+pub enum H2State {
+    ClientPreface,
+    ServerPreface,
+    Connected,
+    Error,
+}
+pub struct ConnectionH2<Front: SocketHandler> {
+    pub socket: Front,
+    pub position: Position,
+    pub readiness: Readiness,
+    pub state: H2State,
+    pub streams: HashMap<StreamId, GlobalStreamId>,
+    // context_hpack: HpackContext,
+    // settings: SettiongsH2,
+}
+pub struct Stream {
+    pub request_id: Ulid,
+    pub front: GenericHttpStream,
+    pub back: GenericHttpStream,
+}
+
+pub enum Connection<Front: SocketHandler> {
+    H1(ConnectionH1<Front>),
+    H2(ConnectionH2<Front>),
+}
+impl<Front: SocketHandler> Connection<Front> {
+    fn readiness(&self) -> &Readiness {
+        match self {
+            Connection::H1(c) => &c.readiness,
+            Connection::H2(c) => &c.readiness,
+        }
+    }
+    fn readiness_mut(&mut self) -> &mut Readiness {
+        match self {
+            Connection::H1(c) => &mut c.readiness,
+            Connection::H2(c) => &mut c.readiness,
+        }
+    }
+    fn readable(&mut self, streams: &mut [Stream]) {
+        match self {
+            Connection::H1(c) => c.readable(streams),
+            Connection::H2(c) => c.readable(streams),
+        }
+    }
+    fn writable(&mut self, streams: &mut [Stream]) {
+        match self {
+            Connection::H1(c) => c.writable(streams),
+            Connection::H2(c) => c.writable(streams),
+        }
+    }
+}
+
+pub struct Mux {
+    pub frontend_token: Token,
+    pub frontend: Connection<FrontRustls>,
+    pub backends: HashMap<Token, Connection<TcpStream>>,
+    pub streams: Vec<Stream>,
+    pub listener: Rc<RefCell<HttpsListener>>,
+    pub pool: Weak<RefCell<Pool>>,
+    pub public_address: SocketAddr,
+    pub peer_address: Option<SocketAddr>,
+    pub sticky_name: String,
+}
+
+impl SessionState for Mux {
+    fn ready(
+        &mut self,
+        session: Rc<RefCell<dyn ProxySession>>,
+        proxy: Rc<RefCell<dyn L7Proxy>>,
+        metrics: &mut SessionMetrics,
+    ) -> SessionResult {
+        let mut counter = 0;
+        let max_loop_iterations = 100000;
+
+        if self.frontend.readiness().event.is_hup() {
+            return SessionResult::Close;
+        }
+
+        let streams = &mut self.streams;
+        while counter < max_loop_iterations {
+            let mut dirty = false;
+
+            if self.frontend.readiness().filter_interest().is_readable() {
+                self.frontend.readable(streams);
+                dirty = true;
+            }
+
+            for (_, backend) in self.backends.iter_mut() {
+                if backend.readiness().filter_interest().is_writable() {
+                    backend.writable(streams);
+                    dirty = true;
+                }
+
+                if backend.readiness().filter_interest().is_readable() {
+                    backend.readable(streams);
+                    dirty = true;
+                }
+            }
+
+            if self.frontend.readiness().filter_interest().is_writable() {
+                self.frontend.writable(streams);
+                dirty = true;
+            }
+
+            for backend in self.backends.values() {
+                if backend.readiness().filter_interest().is_hup()
+                    || backend.readiness().filter_interest().is_error()
+                {
+                    return SessionResult::Close;
+                }
+            }
+
+            if !dirty {
+                break;
+            }
+
+            counter += 1;
+        }
+
+        if counter == max_loop_iterations {
+            incr!("http.infinite_loop.error");
+            return SessionResult::Close;
+        }
+
+        SessionResult::Continue
+    }
+
+    fn update_readiness(&mut self, token: Token, events: sozu_command::ready::Ready) {
+        if token == self.frontend_token {
+            self.frontend.readiness_mut().event |= events;
+        } else if let Some(c) = self.backends.get_mut(&token) {
+            c.readiness_mut().event |= events;
+        }
+    }
+
+    fn timeout(&mut self, token: Token, metrics: &mut SessionMetrics) -> StateResult {
+        println!("MuxState::timeout({token:?})");
+        StateResult::CloseSession
+    }
+
+    fn cancel_timeouts(&mut self) {
+        println!("MuxState::cancel_timeouts");
+    }
+
+    fn print_state(&self, context: &str) {
+        error!(
+            "\
+{} Session(Mux)
+\tFrontend:
+\t\ttoken: {:?}\treadiness: {:?}",
+            context,
+            self.frontend_token,
+            self.frontend.readiness()
+        );
+    }
+    fn close(&mut self, _proxy: Rc<RefCell<dyn L7Proxy>>, _metrics: &mut SessionMetrics) {
+        let s = match &mut self.frontend {
+            Connection::H1(c) => &mut c.socket,
+            Connection::H2(c) => &mut c.socket,
+        };
+        let mut b = [0; 1024];
+        let (size, status) = s.socket_read(&mut b);
+        println!("{size} {status:?} {:?}", &b[..size]);
+    }
+}
+
+impl Mux {
+    // pub fn new(
+    //     frontend_token: Token,
+    //     request_id: Ulid,
+    //     listener: Rc<RefCell<HttpsListener>>,
+    //     pool: Weak<RefCell<Pool>>,
+    //     public_address: SocketAddr,
+    //     peer_address: Option<SocketAddr>,
+    //     sticky_name: String,
+    // ) -> Self {
+    //     Self {
+    //         frontend_token,
+    //         frontend: todo!(),
+    //         backends: todo!(),
+    //         streams: todo!(),
+    //     }
+    // }
+    pub fn front_socket(&self) -> &TcpStream {
+        match &self.frontend {
+            Connection::H1(c) => &c.socket.stream,
+            Connection::H2(c) => &c.socket.stream,
+        }
+    }
+
+    pub fn create_stream(&mut self, request_id: Ulid) -> Result<GlobalStreamId, AcceptError> {
+        let (front_buffer, back_buffer) = match self.pool.upgrade() {
+            Some(pool) => {
+                let mut pool = pool.borrow_mut();
+                match (pool.checkout(), pool.checkout()) {
+                    (Some(front_buffer), Some(back_buffer)) => (front_buffer, back_buffer),
+                    _ => return Err(AcceptError::BufferCapacityReached),
+                }
+            }
+            None => return Err(AcceptError::BufferCapacityReached),
+        };
+        self.streams.push(Stream {
+            request_id,
+            front: GenericHttpStream::new(kawa::Kind::Request, kawa::Buffer::new(front_buffer)),
+            back: GenericHttpStream::new(kawa::Kind::Request, kawa::Buffer::new(back_buffer)),
+        });
+        Ok(self.streams.len() - 1)
+    }
+}
+
+impl<Front: SocketHandler> ConnectionH2<Front> {
+    fn readable(&mut self, streams: &mut [Stream]) {
+        println!("======= MUX H2 READABLE");
+        match (&self.state, &self.position) {
+            (H2State::ClientPreface, Position::Client) => {
+                error!("Waiting for ClientPreface to finish writing")
+            }
+            (H2State::ClientPreface, Position::Server) => {
+                let stream = &mut streams[0];
+                let kawa = &mut stream.front;
+                let mut i = [0; 33];
+
+                // let (size, status) = self.socket.socket_read(kawa.storage.space());
+                // println!("{:02x?}", &kawa.storage.buffer()[..size]);
+                // unreachable!();
+
+                let (size, status) = self.socket.socket_read(&mut i);
+
+                println!("{size} {status:?} {i:02x?}");
+                let i = match parser::preface(&i) {
+                    Ok((i, _)) => i,
+                    Err(_) => todo!(),
+                };
+                let header = match parser::frame_header(&i) {
+                    Ok((
+                        _,
+                        header @ parser::FrameHeader {
+                            payload_len: _,
+                            frame_type: parser::FrameType::Settings,
+                            flags: 0,
+                            stream_id: 0,
+                        },
+                    )) => header,
+                    _ => todo!(),
+                };
+                let (size, status) = self
+                    .socket
+                    .socket_read(&mut kawa.storage.space()[..header.payload_len as usize]);
+                kawa.storage.fill(size);
+                let i = kawa.storage.data();
+                println!("  {size} {status:?} {i:02x?}");
+                match parser::settings_frame(i, &header) {
+                    Ok((_, settings)) => println!("{settings:?}"),
+                    Err(_) => todo!(),
+                }
+                let kawa = &mut stream.back;
+                self.state = H2State::ServerPreface;
+                match serializer::gen_frame_header(
+                    kawa.storage.space(),
+                    &parser::FrameHeader {
+                        payload_len: 6 * 2,
+                        frame_type: parser::FrameType::Settings,
+                        flags: 0,
+                        stream_id: 0,
+                    },
+                ) {
+                    Ok((_, size)) => kawa.storage.fill(size),
+                    Err(e) => panic!("could not serialize HeaderFrame: {e:?}"),
+                };
+                // kawa.storage
+                //     .write(&[1, 3, 0, 0, 0, 100, 0, 4, 0, 1, 0, 0])
+                //     .unwrap();
+                match serializer::gen_frame_header(
+                    kawa.storage.space(),
+                    &parser::FrameHeader {
+                        payload_len: 0,
+                        frame_type: parser::FrameType::Settings,
+                        flags: 1,
+                        stream_id: 0,
+                    },
+                ) {
+                    Ok((_, size)) => kawa.storage.fill(size),
+                    Err(e) => panic!("could not serialize HeaderFrame: {e:?}"),
+                };
+                self.readiness.interest.insert(Ready::WRITABLE);
+                self.readiness.interest.remove(Ready::READABLE);
+            }
+            (H2State::ServerPreface, Position::Client) => todo!("Receive server Settings"),
+            (H2State::ServerPreface, Position::Server) => {
+                error!("waiting for ServerPreface to finish writing")
+            }
+            (H2State::Connected, Position::Server) => {
+                let mut header = [0; 9];
+                let (size, status) = self.socket.socket_read(&mut header);
+                println!("  size: {size}, status: {status:?}");
+                if size == 0 {
+                    self.readiness.event.remove(Ready::READABLE);
+                    return;
+                }
+                println!("{:?}", &header[..size]);
+                let len = match parser::frame_header(&header) {
+                    Ok((_, h)) => {
+                        println!("{h:?}");
+                        h.payload_len as usize
+                    }
+                    Err(_) => {
+                        self.state = H2State::Error;
+                        return;
+                    }
+                };
+                let kawa = &mut streams[0].front;
+                kawa.storage.clear();
+                let (size, status) = self.socket.socket_read(&mut kawa.storage.space()[..len]);
+                kawa.storage.fill(size);
+                let i = kawa.storage.data();
+                println!("  {size} {status:?} {i:?}");
+            }
+            _ => unreachable!(),
+        }
+    }
+    fn writable(&mut self, streams: &mut [Stream]) {
+        println!("======= MUX H2 WRITABLE");
+        match (&self.state, &self.position) {
+            (H2State::ClientPreface, Position::Client) => todo!("Send PRI + client Settings"),
+            (H2State::ClientPreface, Position::Server) => unreachable!(),
+            (H2State::ServerPreface, Position::Client) => unreachable!(),
+            (H2State::Connected, Position::Server) | (H2State::ServerPreface, Position::Server) => {
+                let stream = &mut streams[0];
+                let kawa = &mut stream.back;
+                println!("{:?}", kawa.storage.data());
+                let (size, status) = self.socket.socket_write(kawa.storage.data());
+                println!("  size: {size}, status: {status:?}");
+                let size = kawa.storage.available_data();
+                kawa.storage.consume(size);
+                if kawa.storage.is_empty() {
+                    self.readiness.interest.remove(Ready::WRITABLE);
+                    self.readiness.interest.insert(Ready::READABLE);
+                    self.state = H2State::Connected;
+                }
+            }
+            _ => unreachable!(),
+        }
+        // for global_stream_id in self.streams.values() {
+        //     let stream = &mut streams[*global_stream_id];
+        //     let kawa = match self.position {
+        //         Position::Client => &mut stream.back,
+        //         Position::Server => &mut stream.front,
+        //     };
+        //     kawa.prepare(&mut kawa::h2::BlockConverter);
+        //     let (size, status) = self.socket.socket_write_vectored(&kawa.as_io_slice());
+        //     println!("  size: {size}, status: {status:?}");
+        //     kawa.consume(size);
+        // }
+    }
+}
+
+impl<Front: SocketHandler> ConnectionH1<Front> {
+    fn readable(&mut self, streams: &mut [Stream]) {
+        println!("======= MUX H1 READABLE");
+        let stream = &mut streams[self.stream];
+        let kawa = match self.position {
+            Position::Client => &mut stream.front,
+            Position::Server => &mut stream.back,
+        };
+        let (size, status) = self.socket.socket_read(kawa.storage.space());
+        println!("  size: {size}, status: {status:?}");
+        if size > 0 {
+            kawa.storage.fill(size);
+        } else {
+            self.readiness.event.remove(Ready::READABLE);
+        }
+        match status {
+            SocketResult::Continue => {}
+            SocketResult::Closed => todo!(),
+            SocketResult::Error => todo!(),
+            SocketResult::WouldBlock => self.readiness.event.remove(Ready::READABLE),
+        }
+        kawa::h1::parse(kawa, &mut kawa::h1::NoCallbacks);
+        kawa::debug_kawa(kawa);
+        if kawa.is_terminated() {
+            self.readiness.interest.remove(Ready::READABLE);
+        }
+    }
+    fn writable(&mut self, streams: &mut [Stream]) {
+        println!("======= MUX H1 WRITABLE");
+        let stream = &mut streams[self.stream];
+        let kawa = match self.position {
+            Position::Client => &mut stream.back,
+            Position::Server => &mut stream.front,
+        };
+        kawa.prepare(&mut kawa::h1::BlockConverter);
+        let bufs = kawa.as_io_slice();
+        if bufs.is_empty() {
+            self.readiness.interest.remove(Ready::WRITABLE);
+            return;
+        }
+        let (size, status) = self.socket.socket_write_vectored(&bufs);
+        println!("  size: {size}, status: {status:?}");
+        if size > 0 {
+            kawa.consume(size);
+            // self.backend_readiness.interest.insert(Ready::READABLE);
+        } else {
+            self.readiness.event.remove(Ready::WRITABLE);
+        }
+    }
+}

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -107,6 +107,7 @@ impl<Front: SocketHandler> Connection<Front> {
             zero: kawa::Kawa::new(kawa::Kind::Request, kawa::Buffer::new(buffer)),
             window: 1 << 16,
             decoder: hpack::Decoder::new(),
+            encoder: hpack::Encoder::new(),
         }))
     }
     pub fn new_h2_client(
@@ -130,6 +131,7 @@ impl<Front: SocketHandler> Connection<Front> {
             zero: kawa::Kawa::new(kawa::Kind::Request, kawa::Buffer::new(buffer)),
             window: 1 << 16,
             decoder: hpack::Decoder::new(),
+            encoder: hpack::Encoder::new(),
         }))
     }
 
@@ -590,7 +592,7 @@ impl SessionState for Mux {
                     || backend.readiness().filter_interest().is_error()
                 {
                     println!("{:?} {:?}", backend.readiness(), backend.socket());
-                    return SessionResult::Close;
+                    // return SessionResult::Close;
                 }
             }
 

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -207,7 +207,7 @@ impl<Front: SocketHandler> Connection<Front> {
                 interest: Ready::WRITABLE | Ready::READABLE | Ready::HUP | Ready::ERROR,
                 event: Ready::EMPTY,
             },
-            stream: 0,
+            stream: usize::MAX - 1,
             requests: 0,
             timeout_container,
         })
@@ -309,6 +309,12 @@ impl<Front: SocketHandler> Connection<Front> {
         match self {
             Connection::H1(c) => c.socket.socket_ref(),
             Connection::H2(c) => c.socket.socket_ref(),
+        }
+    }
+    fn force_disconnect(&mut self) -> MuxResult {
+        match self {
+            Connection::H1(c) => c.force_disconnect(),
+            Connection::H2(c) => c.force_disconnect(),
         }
     }
     fn readable<E>(&mut self, context: &mut Context, endpoint: E) -> MuxResult
@@ -1073,8 +1079,10 @@ impl<Front: SocketHandler + std::fmt::Debug> SessionState for Mux<Front> {
             Connection::H1(_) => false,
             Connection::H2(_) => true,
         };
-        let mut is_to_be_closed = true;
+        let mut should_close = true;
+        let mut should_write = false;
         if self.frontend_token == token {
+            println_!("MuxState::timeout_frontend({:#?})", self.frontend);
             self.frontend.timeout_container().triggered();
             let front_readiness = self.frontend.readiness_mut();
             for stream in &mut self.context.streams {
@@ -1085,27 +1093,27 @@ impl<Front: SocketHandler + std::fmt::Debug> SessionState for Mux<Front> {
                         // in most cases it was just reserved, so we can just ignore them.
                         if !front_is_h2 {
                             set_default_answer(stream, front_readiness, 408);
-                            is_to_be_closed = false;
+                            should_write = true;
                         }
                     }
                     StreamState::Link => {
                         // This is an unusual case, as we have both a complete request and no
                         // available backend yet. For now, we answer with 503
                         set_default_answer(stream, front_readiness, 503);
-                        is_to_be_closed = false;
+                        should_write = true;
                     }
                     StreamState::Linked(_) => {
                         // A stream Linked to a backend is waiting for the response, not the answer.
                         // For streaming or malformed requests, it is possible that the request is not
                         // terminated at this point. For now, we do nothing and
-                        is_to_be_closed = false;
+                        should_close = false;
                     }
                     StreamState::Unlinked => {
                         // A stream Unlinked already has a response and its backend closed.
                         // In case it hasn't finished proxying we wait. Otherwise it is a stream
                         // kept alive for a new request, which can be killed.
                         if !stream.back.is_completed() {
-                            is_to_be_closed = false;
+                            should_close = false;
                         }
                     }
                     StreamState::Recycle => {
@@ -1115,6 +1123,7 @@ impl<Front: SocketHandler + std::fmt::Debug> SessionState for Mux<Front> {
                 }
             }
         } else if let Some(backend) = self.router.backends.get_mut(&token) {
+            println_!("MuxState::timeout_backend({:#?})", backend);
             backend.timeout_container().triggered();
             let front_readiness = self.frontend.readiness_mut();
             for stream_id in 0..self.context.streams.len() {
@@ -1123,24 +1132,40 @@ impl<Front: SocketHandler + std::fmt::Debug> SessionState for Mux<Front> {
                     if token == back_token {
                         // This stream is linked to the backend that timedout.
                         if stream.back.is_terminated() || stream.back.is_error() {
+                            println!(
+                                "Stream terminated or in error, do nothing, just wait a bit more"
+                            );
                             // Nothing to do, simply wait for the remaining bytes to be proxied
                             if !stream.back.is_completed() {
-                                is_to_be_closed = false;
+                                should_close = false;
                             }
                         } else if stream.back.is_initial() {
                             // The response has not started yet
+                            println!("Stream still waiting for response, send 504");
                             set_default_answer(stream, front_readiness, 504);
-                            is_to_be_closed = false;
+                            should_write = true;
                         } else {
+                            println!("Stream waiting for end of response, forcefully terminate it");
                             forcefully_terminate_answer(stream, front_readiness);
-                            is_to_be_closed = false;
+                            should_write = true;
                         }
-                        backend.end_stream(0, &mut self.context);
+                        backend.end_stream(stream_id, &mut self.context);
+                        backend.force_disconnect();
                     }
                 }
             }
         }
-        if is_to_be_closed {
+        if should_write {
+            return match self
+                .frontend
+                .writable(&mut self.context, EndpointClient(&mut self.router))
+            {
+                MuxResult::Continue => StateResult::Continue,
+                MuxResult::Upgrade => StateResult::Upgrade,
+                MuxResult::CloseSession => StateResult::CloseSession,
+            };
+        }
+        if should_close {
             StateResult::CloseSession
         } else {
             StateResult::Continue
@@ -1160,11 +1185,19 @@ impl<Front: SocketHandler + std::fmt::Debug> SessionState for Mux<Front> {
             "\
 {} Session(Mux)
 \tFrontend:
-\t\ttoken: {:?}\treadiness: {:?}",
+\t\ttoken: {:?}\treadiness: {:?}
+\tBackend(s):",
             context,
             self.frontend_token,
             self.frontend.readiness()
         );
+        for (backend_token, backend) in &self.router.backends {
+            error!(
+                "\t\ttoken: {:?}\treadiness: {:?}",
+                backend_token,
+                backend.readiness()
+            )
+        }
     }
 
     fn close(&mut self, _proxy: Rc<RefCell<dyn L7Proxy>>, _metrics: &mut SessionMetrics) {
@@ -1182,9 +1215,10 @@ impl<Front: SocketHandler + std::fmt::Debug> SessionState for Mux<Front> {
                 let out = kawa.as_io_slice();
                 let mut writer = std::io::BufWriter::new(Vec::new());
                 let amount = writer.write_vectored(&out).unwrap();
-                println_!("amount: {amount}\n{}", unsafe {
-                    std::str::from_utf8_unchecked(writer.buffer())
-                });
+                println_!(
+                    "amount: {amount}\n{}",
+                    String::from_utf8_lossy(writer.buffer())
+                );
             }
         }
     }

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -79,7 +79,7 @@ impl<Front: SocketHandler> Connection<Front> {
             socket: front_stream,
             position: Position::Client,
             readiness: Readiness {
-                interest: Ready::WRITABLE | Ready::HUP | Ready::ERROR,
+                interest: Ready::WRITABLE | Ready::READABLE | Ready::HUP | Ready::ERROR,
                 event: Ready::EMPTY,
             },
             stream: stream_id,
@@ -120,7 +120,7 @@ impl<Front: SocketHandler> Connection<Front> {
             socket: front_stream,
             position: Position::Client,
             readiness: Readiness {
-                interest: Ready::WRITABLE | Ready::HUP | Ready::ERROR,
+                interest: Ready::WRITABLE | Ready::READABLE | Ready::HUP | Ready::ERROR,
                 event: Ready::EMPTY,
             },
             streams: HashMap::new(),

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -119,6 +119,7 @@ impl<Front: SocketHandler> Connection<Front> {
             window: 1 << 16,
             decoder: hpack::Decoder::new(),
             encoder: hpack::Encoder::new(),
+            last_stream_id: 0,
         }))
     }
     pub fn new_h2_client(
@@ -133,7 +134,7 @@ impl<Front: SocketHandler> Connection<Front> {
             socket: front_stream,
             position: Position::Client(BackendStatus::Connecting(cluster_id)),
             readiness: Readiness {
-                interest: Ready::WRITABLE | Ready::READABLE | Ready::HUP | Ready::ERROR,
+                interest: Ready::WRITABLE | Ready::HUP | Ready::ERROR,
                 event: Ready::EMPTY,
             },
             streams: HashMap::new(),
@@ -144,6 +145,7 @@ impl<Front: SocketHandler> Connection<Front> {
             window: 1 << 16,
             decoder: hpack::Decoder::new(),
             encoder: hpack::Encoder::new(),
+            last_stream_id: 0,
         }))
     }
 
@@ -206,14 +208,14 @@ impl<Front: SocketHandler> Connection<Front> {
         }
     }
 
-    fn end_stream(&mut self, stream: usize, context: &mut Context) {
+    fn end_stream(&mut self, stream: GlobalStreamId, context: &mut Context) {
         match self {
             Connection::H1(c) => c.end_stream(stream, context),
             Connection::H2(c) => c.end_stream(stream, context),
         }
     }
 
-    fn start_stream(&mut self, stream: usize, context: &mut Context) {
+    fn start_stream(&mut self, stream: GlobalStreamId, context: &mut Context) {
         match self {
             Connection::H1(c) => c.start_stream(stream, context),
             Connection::H2(c) => c.start_stream(stream, context),
@@ -300,6 +302,7 @@ impl<'a> Endpoint for EndpointClient<'a> {
 
 pub struct Stream {
     // pub request_id: Ulid,
+    pub active: bool,
     pub window: i32,
     pub token: Option<Token>,
     front: GenericHttpStream,
@@ -315,6 +318,27 @@ pub struct StreamParts<'a> {
     pub context: &'a mut HttpContext,
 }
 
+fn temporary_http_context(request_id: Ulid) -> HttpContext {
+    HttpContext {
+        keep_alive_backend: true,
+        keep_alive_frontend: true,
+        sticky_session_found: None,
+        method: None,
+        authority: None,
+        path: None,
+        status: None,
+        reason: None,
+        user_agent: None,
+        closing: false,
+        id: request_id,
+        protocol: crate::Protocol::HTTPS,
+        public_address: "0.0.0.0:80".parse().unwrap(),
+        session_address: None,
+        sticky_name: "SOZUBALANCEID".to_owned(),
+        sticky_session: None,
+    }
+}
+
 impl Stream {
     pub fn new(pool: Weak<RefCell<Pool>>, request_id: Ulid, window: u32) -> Option<Self> {
         let (front_buffer, back_buffer) = match pool.upgrade() {
@@ -328,28 +352,12 @@ impl Stream {
             None => return None,
         };
         Some(Self {
+            active: true,
             window: window as i32,
             token: None,
             front: GenericHttpStream::new(kawa::Kind::Request, kawa::Buffer::new(front_buffer)),
             back: GenericHttpStream::new(kawa::Kind::Response, kawa::Buffer::new(back_buffer)),
-            context: HttpContext {
-                keep_alive_backend: true,
-                keep_alive_frontend: true,
-                sticky_session_found: None,
-                method: None,
-                authority: None,
-                path: None,
-                status: None,
-                reason: None,
-                user_agent: None,
-                closing: false,
-                id: request_id,
-                protocol: crate::Protocol::HTTPS,
-                public_address: "0.0.0.0:80".parse().unwrap(),
-                session_address: None,
-                sticky_name: "SOZUBALANCEID".to_owned(),
-                sticky_session: None,
-            },
+            context: temporary_http_context(request_id),
         })
     }
     pub fn split(&mut self, position: &Position) -> StreamParts<'_> {
@@ -387,6 +395,20 @@ pub struct Context {
 
 impl Context {
     pub fn create_stream(&mut self, request_id: Ulid, window: u32) -> Option<GlobalStreamId> {
+        for (stream_id, stream) in self.streams.iter_mut().enumerate() {
+            if !stream.active {
+                println!("Reuse stream: {stream_id}");
+                stream.window = window as i32;
+                stream.context = temporary_http_context(request_id);
+                stream.back.clear();
+                stream.back.storage.clear();
+                stream.front.clear();
+                stream.front.storage.clear();
+                stream.token = None;
+                stream.active = true;
+                return Some(stream_id);
+            }
+        }
         self.streams
             .push(Stream::new(self.pool.clone(), request_id, window)?);
         Some(self.streams.len() - 1)
@@ -470,6 +492,7 @@ impl Router {
         println!("connect: {cluster_id} (stick={frontend_should_stick}, h2={h2}) -> (reuse={reuse_token:?})");
 
         let token = if let Some(token) = reuse_token {
+            println!("reused backend: {:#?}", self.backends.get(&token).unwrap());
             token
         } else {
             let mut socket = self.backend_from_request(
@@ -499,7 +522,11 @@ impl Router {
                 error!("error registering back socket({:?}): {:?}", socket, e);
             }
 
-            let connection = Connection::new_h1_client(socket, cluster_id);
+            let connection = if h2 {
+                Connection::new_h2_client(socket, cluster_id, context.pool.clone()).unwrap()
+            } else {
+                Connection::new_h1_client(socket, cluster_id)
+            };
             self.backends.insert(token, connection);
             token
         };

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -6,11 +6,12 @@ use std::{
     rc::{Rc, Weak},
 };
 
-use kawa::h1::ParserCallbacks;
 use mio::{net::TcpStream, Token};
 use rusty_ulid::Ulid;
 use sozu_command::ready::Ready;
 
+mod h1;
+mod h2;
 mod parser;
 mod pkawa;
 mod serializer;
@@ -18,12 +19,16 @@ mod serializer;
 use crate::{
     https::HttpsListener,
     pool::{Checkout, Pool},
-    protocol::{mux::parser::error_code_to_str, SessionState},
-    socket::{FrontRustls, SocketHandler, SocketResult},
+    protocol::{
+        http::editor::HttpContext,
+        mux::{h1::ConnectionH1, h2::ConnectionH2},
+        SessionState,
+    },
+    socket::{FrontRustls, SocketHandler},
     AcceptError, L7Proxy, ProxySession, Readiness, SessionMetrics, SessionResult, StateResult,
 };
 
-use super::http::editor::HttpContext;
+use self::h2::{H2State, H2Settings};
 
 /// Generic Http representation using the Kawa crate using the Checkout of Sozu as buffer
 type GenericHttpStream = kawa::Kawa<Checkout>;
@@ -34,81 +39,6 @@ type GlobalStreamId = usize;
 pub enum Position {
     Client,
     Server,
-}
-
-pub struct ConnectionH1<Front: SocketHandler> {
-    pub position: Position,
-    pub readiness: Readiness,
-    pub socket: Front,
-    /// note: a Server H1 will always reference stream 0, but a client can reference any stream
-    pub stream: GlobalStreamId,
-}
-
-#[derive(Debug)]
-pub enum H2State {
-    ClientPreface,
-    ClientSettings,
-    ServerSettings,
-    Header,
-    Frame(parser::FrameHeader),
-    Error,
-}
-
-#[derive(Debug)]
-pub struct H2Settings {
-    settings_header_table_size: u32,
-    settings_enable_push: bool,
-    settings_max_concurrent_streams: u32,
-    settings_initial_window_size: u32,
-    settings_max_frame_size: u32,
-    settings_max_header_list_size: u32,
-}
-
-impl Default for H2Settings {
-    fn default() -> Self {
-        Self {
-            settings_header_table_size: 4096,
-            settings_enable_push: true,
-            settings_max_concurrent_streams: u32::MAX,
-            settings_initial_window_size: (1 << 16) - 1,
-            settings_max_frame_size: 1 << 14,
-            settings_max_header_list_size: u32::MAX,
-        }
-    }
-}
-
-pub struct ConnectionH2<Front: SocketHandler> {
-    // pub decoder: hpack::Decoder<'static>,
-    pub expect: Option<(GlobalStreamId, usize)>,
-    pub position: Position,
-    pub readiness: Readiness,
-    pub settings: H2Settings,
-    pub socket: Front,
-    pub state: H2State,
-    pub streams: HashMap<StreamId, GlobalStreamId>,
-}
-
-pub struct Stream {
-    // pub request_id: Ulid,
-    pub window: i32,
-    pub front: GenericHttpStream,
-    pub back: GenericHttpStream,
-    pub context: HttpContext,
-}
-
-impl Stream {
-    pub fn front(&mut self, position: Position) -> &mut GenericHttpStream {
-        match position {
-            Position::Client => &mut self.back,
-            Position::Server => &mut self.front,
-        }
-    }
-    pub fn back(&mut self, position: Position) -> &mut GenericHttpStream {
-        match position {
-            Position::Client => &mut self.front,
-            Position::Server => &mut self.back,
-        }
-    }
 }
 
 pub enum Connection<Front: SocketHandler> {
@@ -195,26 +125,48 @@ impl<Front: SocketHandler> Connection<Front> {
     }
 }
 
+pub struct Stream {
+    // pub request_id: Ulid,
+    pub window: i32,
+    pub front: GenericHttpStream,
+    pub back: GenericHttpStream,
+    pub context: HttpContext,
+}
+
+impl Stream {
+    pub fn front(&mut self, position: Position) -> &mut GenericHttpStream {
+        match position {
+            Position::Client => &mut self.back,
+            Position::Server => &mut self.front,
+        }
+    }
+    pub fn back(&mut self, position: Position) -> &mut GenericHttpStream {
+        match position {
+            Position::Client => &mut self.front,
+            Position::Server => &mut self.back,
+        }
+    }
+}
+
 pub struct Streams {
     zero: Stream,
     others: Vec<Stream>,
+}
+
+impl Streams {
+    pub fn get(&mut self, stream_id: GlobalStreamId) -> &mut Stream {
+        if stream_id == 0 {
+            &mut self.zero
+        } else {
+            &mut self.others[stream_id - 1]
+        }
+    }
 }
 
 pub struct Context {
     pub streams: Streams,
     pub pool: Weak<RefCell<Pool>>,
     pub decoder: hpack::Decoder<'static>,
-}
-
-pub struct Mux {
-    pub frontend_token: Token,
-    pub frontend: Connection<FrontRustls>,
-    pub backends: HashMap<Token, Connection<TcpStream>>,
-    pub listener: Rc<RefCell<HttpsListener>>,
-    pub public_address: SocketAddr,
-    pub peer_address: Option<SocketAddr>,
-    pub sticky_name: String,
-    pub context: Context,
 }
 
 impl Context {
@@ -285,14 +237,15 @@ impl Context {
     }
 }
 
-impl Streams {
-    pub fn get(&mut self, stream_id: GlobalStreamId) -> &mut Stream {
-        if stream_id == 0 {
-            &mut self.zero
-        } else {
-            &mut self.others[stream_id - 1]
-        }
-    }
+pub struct Mux {
+    pub frontend_token: Token,
+    pub frontend: Connection<FrontRustls>,
+    pub backends: HashMap<Token, Connection<TcpStream>>,
+    pub listener: Rc<RefCell<HttpsListener>>,
+    pub public_address: SocketAddr,
+    pub peer_address: Option<SocketAddr>,
+    pub sticky_name: String,
+    pub context: Context,
 }
 
 impl Mux {
@@ -413,273 +366,6 @@ impl SessionState for Mux {
             println!("amount: {amount}\n{}", unsafe {
                 std::str::from_utf8_unchecked(writer.buffer())
             });
-        }
-    }
-}
-
-impl<Front: SocketHandler> ConnectionH2<Front> {
-    fn readable(&mut self, context: &mut Context) {
-        println!("======= MUX H2 READABLE");
-        let kawa = if let Some((stream_id, amount)) = self.expect {
-            let kawa = context.streams.get(stream_id).front(self.position);
-            let (size, status) = self.socket.socket_read(&mut kawa.storage.space()[..amount]);
-            println!("{:?}({stream_id}, {amount}) {size} {status:?}", self.state);
-            if size > 0 {
-                kawa.storage.fill(size);
-                if size == amount {
-                    self.expect = None;
-                } else {
-                    self.expect = Some((stream_id, amount - size));
-                    return;
-                }
-            } else {
-                self.readiness.event.remove(Ready::READABLE);
-                return;
-            }
-            kawa
-        } else {
-            self.readiness.event.remove(Ready::READABLE);
-            return;
-        };
-        match (&self.state, &self.position) {
-            (H2State::ClientPreface, Position::Client) => {
-                error!("Waiting for ClientPreface to finish writing")
-            }
-            (H2State::ClientPreface, Position::Server) => {
-                let i = kawa.storage.data();
-                let i = match parser::preface(i) {
-                    Ok((i, _)) => i,
-                    Err(e) => panic!("{e:?}"),
-                };
-                match parser::frame_header(i) {
-                    Ok((
-                        _,
-                        parser::FrameHeader {
-                            payload_len,
-                            frame_type: parser::FrameType::Settings,
-                            flags: 0,
-                            stream_id: 0,
-                        },
-                    )) => {
-                        kawa.storage.clear();
-                        self.state = H2State::ClientSettings;
-                        self.expect = Some((0, payload_len as usize));
-                    }
-                    _ => todo!(),
-                };
-            }
-            (H2State::ClientSettings, Position::Server) => {
-                let i = kawa.storage.data();
-                match parser::settings_frame(i, i.len()) {
-                    Ok((_, settings)) => {
-                        kawa.storage.clear();
-                        self.handle(settings, context);
-                    }
-                    Err(e) => panic!("{e:?}"),
-                }
-                let kawa = &mut context.streams.zero.back;
-                self.state = H2State::ServerSettings;
-                match serializer::gen_frame_header(
-                    kawa.storage.space(),
-                    &parser::FrameHeader {
-                        payload_len: 6 * 2,
-                        frame_type: parser::FrameType::Settings,
-                        flags: 0,
-                        stream_id: 0,
-                    },
-                ) {
-                    Ok((_, size)) => kawa.storage.fill(size),
-                    Err(e) => panic!("could not serialize HeaderFrame: {e:?}"),
-                };
-                // kawa.storage
-                //     .write(&[1, 3, 0, 0, 0, 100, 0, 4, 0, 1, 0, 0])
-                //     .unwrap();
-                match serializer::gen_frame_header(
-                    kawa.storage.space(),
-                    &parser::FrameHeader {
-                        payload_len: 0,
-                        frame_type: parser::FrameType::Settings,
-                        flags: 1,
-                        stream_id: 0,
-                    },
-                ) {
-                    Ok((_, size)) => kawa.storage.fill(size),
-                    Err(e) => panic!("could not serialize HeaderFrame: {e:?}"),
-                };
-                self.readiness.interest.insert(Ready::WRITABLE);
-                self.readiness.interest.remove(Ready::READABLE);
-            }
-            (H2State::ServerSettings, Position::Client) => todo!("Receive server Settings"),
-            (H2State::ServerSettings, Position::Server) => {
-                error!("waiting for ServerPreface to finish writing")
-            }
-            (H2State::Header, Position::Server) => {
-                let i = kawa.storage.data();
-                println!("  header: {i:?}");
-                match parser::frame_header(i) {
-                    Ok((_, header)) => {
-                        println!("{header:?}");
-                        kawa.storage.clear();
-                        let stream_id = if let Some(stream_id) = self.streams.get(&header.stream_id)
-                        {
-                            *stream_id
-                        } else {
-                            self.create_stream(header.stream_id, context)
-                        };
-                        let stream_id = if header.frame_type == parser::FrameType::Data {
-                            stream_id
-                        } else {
-                            0
-                        };
-                        println!("{} {} {:#?}", header.stream_id, stream_id, self.streams);
-                        self.expect = Some((stream_id as usize, header.payload_len as usize));
-                        self.state = H2State::Frame(header);
-                    }
-                    Err(e) => panic!("{e:?}"),
-                };
-            }
-            (H2State::Frame(header), Position::Server) => {
-                let i = kawa.storage.data();
-                println!("  data: {i:?}");
-                match parser::frame_body(i, header, self.settings.settings_max_frame_size) {
-                    Ok((_, frame)) => {
-                        kawa.storage.clear();
-                        self.handle(frame, context);
-                    }
-                    Err(e) => panic!("{e:?}"),
-                }
-                self.state = H2State::Header;
-                self.expect = Some((0, 9));
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    fn writable(&mut self, context: &mut Context) {
-        println!("======= MUX H2 WRITABLE");
-        match (&self.state, &self.position) {
-            (H2State::ClientPreface, Position::Client) => todo!("Send PRI + client Settings"),
-            (H2State::ClientPreface, Position::Server) => unreachable!(),
-            (H2State::ServerSettings, Position::Client) => unreachable!(),
-            (H2State::ServerSettings, Position::Server) => {
-                let kawa = &mut context.streams.zero.back;
-                println!("{:?}", kawa.storage.data());
-                let (size, status) = self.socket.socket_write(kawa.storage.data());
-                println!("  size: {size}, status: {status:?}");
-                let size = kawa.storage.available_data();
-                kawa.storage.consume(size);
-                if kawa.storage.is_empty() {
-                    self.readiness.interest.remove(Ready::WRITABLE);
-                    self.readiness.interest.insert(Ready::READABLE);
-                    self.state = H2State::Header;
-                    self.expect = Some((0, 9));
-                }
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn create_stream(&mut self, stream_id: StreamId, context: &mut Context) -> GlobalStreamId {
-        match context.create_stream(Ulid::generate(), self.settings.settings_initial_window_size) {
-            Ok(global_stream_id) => {
-                self.streams.insert(stream_id, global_stream_id);
-                global_stream_id
-            }
-            Err(e) => panic!("{e:?}"),
-        }
-    }
-
-    fn handle(&mut self, frame: parser::Frame, context: &mut Context) {
-        println!("{frame:?}");
-        match frame {
-            parser::Frame::Data(_) => todo!(),
-            parser::Frame::Headers(headers) => {
-                // if !headers.end_headers {
-                //     self.state = H2State::Continuation
-                // }
-                let global_stream_id = self.streams.get(&headers.stream_id).unwrap();
-                let kawa = context.streams.zero.front(self.position);
-                let buffer = headers.header_block_fragment.data(kawa.storage.buffer());
-                let stream = &mut context.streams.others[*global_stream_id - 1];
-                let kawa = &mut stream.front;
-                pkawa::handle_header(kawa, buffer, &mut context.decoder);
-                stream.context.on_headers(kawa);
-            }
-            parser::Frame::Priority(priority) => (),
-            parser::Frame::RstStream(_) => todo!(),
-            parser::Frame::Settings(settings) => {
-                for setting in settings.settings {
-                    match setting.identifier {
-                        1 => self.settings.settings_header_table_size = setting.value,
-                        2 => self.settings.settings_enable_push = setting.value == 1,
-                        3 => self.settings.settings_max_concurrent_streams = setting.value,
-                        4 => self.settings.settings_initial_window_size = setting.value,
-                        5 => self.settings.settings_max_frame_size = setting.value,
-                        6 => self.settings.settings_max_header_list_size = setting.value,
-                        other => panic!("setting_id: {other}"),
-                    }
-                }
-                println!("{:#?}", self.settings);
-            }
-            parser::Frame::PushPromise(_) => todo!(),
-            parser::Frame::Ping(_) => todo!(),
-            parser::Frame::GoAway(goaway) => panic!("{}", error_code_to_str(goaway.error_code)),
-            parser::Frame::WindowUpdate(update) => {
-                let global_stream_id = *self.streams.get(&update.stream_id).unwrap();
-                context.streams.get(global_stream_id).window += update.increment as i32;
-            }
-            parser::Frame::Continuation(_) => todo!(),
-        }
-    }
-}
-
-impl<Front: SocketHandler> ConnectionH1<Front> {
-    fn readable(&mut self, context: &mut Context) {
-        println!("======= MUX H1 READABLE");
-        let stream = &mut context.streams.get(self.stream);
-        let kawa = match self.position {
-            Position::Client => &mut stream.front,
-            Position::Server => &mut stream.back,
-        };
-        let (size, status) = self.socket.socket_read(kawa.storage.space());
-        println!("  size: {size}, status: {status:?}");
-        if size > 0 {
-            kawa.storage.fill(size);
-        } else {
-            self.readiness.event.remove(Ready::READABLE);
-        }
-        match status {
-            SocketResult::Continue => {}
-            SocketResult::Closed => todo!(),
-            SocketResult::Error => todo!(),
-            SocketResult::WouldBlock => self.readiness.event.remove(Ready::READABLE),
-        }
-        kawa::h1::parse(kawa, &mut kawa::h1::NoCallbacks);
-        kawa::debug_kawa(kawa);
-        if kawa.is_terminated() {
-            self.readiness.interest.remove(Ready::READABLE);
-        }
-    }
-    fn writable(&mut self, context: &mut Context) {
-        println!("======= MUX H1 WRITABLE");
-        let stream = &mut context.streams.get(self.stream);
-        let kawa = match self.position {
-            Position::Client => &mut stream.back,
-            Position::Server => &mut stream.front,
-        };
-        kawa.prepare(&mut kawa::h1::BlockConverter);
-        let bufs = kawa.as_io_slice();
-        if bufs.is_empty() {
-            self.readiness.interest.remove(Ready::WRITABLE);
-            return;
-        }
-        let (size, status) = self.socket.socket_write_vectored(&bufs);
-        println!("  size: {size}, status: {status:?}");
-        if size > 0 {
-            kawa.consume(size);
-            // self.backend_readiness.interest.insert(Ready::READABLE);
-        } else {
-            self.readiness.event.remove(Ready::WRITABLE);
         }
     }
 }

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -23,7 +23,11 @@ use crate::{
     pool::{Checkout, Pool},
     protocol::{
         http::editor::HttpContext,
-        mux::{h1::ConnectionH1, h2::ConnectionH2},
+        mux::{
+            h1::ConnectionH1,
+            h2::{ConnectionH2, H2Settings, H2State, H2StreamId},
+            parser::H2Error,
+        },
         SessionState,
     },
     router::Route,
@@ -32,7 +36,16 @@ use crate::{
     RetrieveClusterError, SessionMetrics, SessionResult, StateResult,
 };
 
-use self::h2::{H2Settings, H2State, H2StreamId};
+#[macro_export]
+macro_rules! println_ {
+    ($($t:expr),*) => {
+        println!($($t),*)
+        // $(let _ = &$t;)*
+    };
+}
+fn debug_kawa(_kawa: &GenericHttpStream) {
+    // kawa::debug_kawa(_kawa);
+}
 
 /// Generic Http representation using the Kawa crate using the Checkout of Sozu as buffer
 type GenericHttpStream = kawa::Kawa<Checkout>;
@@ -55,7 +68,7 @@ pub enum BackendStatus {
 
 pub enum MuxResult {
     Continue,
-    CloseSession,
+    CloseSession(H2Error),
     Close(GlobalStreamId),
     Connect(GlobalStreamId),
 }
@@ -117,7 +130,8 @@ impl<Front: SocketHandler> Connection<Front> {
             state: H2State::ClientPreface,
             expect_read: Some((H2StreamId::Zero, 24 + 9)),
             expect_write: None,
-            settings: H2Settings::default(),
+            local_settings: H2Settings::default(),
+            peer_settings: H2Settings::default(),
             zero: kawa::Kawa::new(kawa::Kind::Request, kawa::Buffer::new(buffer)),
             window: 1 << 16,
             decoder: hpack::Decoder::new(),
@@ -144,7 +158,8 @@ impl<Front: SocketHandler> Connection<Front> {
             state: H2State::ClientPreface,
             expect_read: None,
             expect_write: None,
-            settings: H2Settings::default(),
+            local_settings: H2Settings::default(),
+            peer_settings: H2Settings::default(),
             zero: kawa::Kawa::new(kawa::Kind::Request, kawa::Buffer::new(buffer)),
             window: 1 << 16,
             decoder: hpack::Decoder::new(),
@@ -281,7 +296,7 @@ fn update_readiness_after_read(
     status: SocketResult,
     readiness: &mut Readiness,
 ) -> bool {
-    println!("  size={size}, status={status:?}");
+    println_!("  size={size}, status={status:?}");
     match status {
         SocketResult::Continue => {}
         SocketResult::Closed | SocketResult::Error => {
@@ -303,7 +318,7 @@ fn update_readiness_after_write(
     status: SocketResult,
     readiness: &mut Readiness,
 ) -> bool {
-    println!("  size={size}, status={status:?}");
+    println_!("  size={size}, status={status:?}");
     match status {
         SocketResult::Continue => {}
         SocketResult::Closed | SocketResult::Error => {
@@ -447,7 +462,7 @@ impl Context {
     pub fn create_stream(&mut self, request_id: Ulid, window: u32) -> Option<GlobalStreamId> {
         for (stream_id, stream) in self.streams.iter_mut().enumerate() {
             if !stream.active {
-                println!("Reuse stream: {stream_id}");
+                println_!("Reuse stream: {stream_id}");
                 stream.window = window as i32;
                 stream.context = temporary_http_context(request_id);
                 stream.back.clear();
@@ -507,7 +522,9 @@ impl Router {
         let mut reuse_connecting = true;
         for (token, backend) in &self.backends {
             match (h2, reuse_connecting, backend.position()) {
-                (_, _, Position::Server) => panic!("Backend connection behaves like a server"),
+                (_, _, Position::Server) => {
+                    unreachable!("Backend connection behaves like a server")
+                }
                 (_, _, Position::Client(BackendStatus::Disconnecting)) => {}
 
                 (true, _, Position::Client(BackendStatus::Connected(old_cluster_id))) => {
@@ -523,8 +540,10 @@ impl Router {
                     }
                 }
                 (true, false, Position::Client(BackendStatus::Connecting(_))) => {}
-                (true, _, Position::Client(BackendStatus::KeepAlive(_))) => {
-                    panic!("ConnectionH2 behaves like H1")
+                (true, _, Position::Client(BackendStatus::KeepAlive(old_cluster_id))) => {
+                    if *old_cluster_id == cluster_id {
+                        unreachable!("ConnectionH2 behaves like H1")
+                    }
                 }
 
                 (false, _, Position::Client(BackendStatus::KeepAlive(old_cluster_id))) => {
@@ -539,10 +558,10 @@ impl Router {
                 | (false, _, Position::Client(BackendStatus::Connecting(_))) => {}
             }
         }
-        println!("connect: {cluster_id} (stick={frontend_should_stick}, h2={h2}) -> (reuse={reuse_token:?})");
+        println_!("connect: {cluster_id} (stick={frontend_should_stick}, h2={h2}) -> (reuse={reuse_token:?})");
 
         let token = if let Some(token) = reuse_token {
-            println!("reused backend: {:#?}", self.backends.get(&token).unwrap());
+            println_!("reused backend: {:#?}", self.backends.get(&token).unwrap());
             token
         } else {
             let mut socket = self.backend_from_request(
@@ -573,7 +592,10 @@ impl Router {
             }
 
             let connection = if h2 {
-                Connection::new_h2_client(socket, cluster_id, context.pool.clone()).unwrap()
+                match Connection::new_h2_client(socket, cluster_id, context.pool.clone()) {
+                    Some(connection) => connection,
+                    None => return Err(BackendConnectionError::MaxBuffers),
+                }
             } else {
                 Connection::new_h1_client(socket, cluster_id)
             };
@@ -599,7 +621,9 @@ impl Router {
         let (host, uri, method) = match context.extract_route() {
             Ok(tuple) => tuple,
             Err(cluster_error) => {
-                panic!("{}", cluster_error);
+                // we are past kawa parsing if it succeeded this can't fail
+                // if the request was malformed it was caught by kawa and we sent a 400
+                panic!("{cluster_error}");
                 // self.set_answer(DefaultAnswerStatus::Answer400, None);
                 // return Err(cluster_error);
             }
@@ -613,18 +637,18 @@ impl Router {
         let route = match route_result {
             Ok(route) => route,
             Err(frontend_error) => {
-                panic!("{}", frontend_error);
+                println!("{}", frontend_error);
                 // self.set_answer(DefaultAnswerStatus::Answer404, None);
-                // return Err(RetrieveClusterError::RetrieveFrontend(frontend_error));
+                return Err(RetrieveClusterError::RetrieveFrontend(frontend_error));
             }
         };
 
         let cluster_id = match route {
             Route::Cluster { id, h2 } => (id, h2),
             Route::Deny => {
-                panic!("Route::Deny");
+                println!("Route::Deny");
                 // self.set_answer(DefaultAnswerStatus::Answer401, None);
-                // return Err(RetrieveClusterError::UnauthorizedRoute);
+                return Err(RetrieveClusterError::UnauthorizedRoute);
             }
         };
 
@@ -647,9 +671,9 @@ impl Router {
                 proxy,
             )
             .map_err(|backend_error| {
-                panic!("{backend_error}")
+                println!("{backend_error}");
                 // self.set_answer(DefaultAnswerStatus::Answer503, None);
-                // BackendConnectionError::Backend(backend_error)
+                BackendConnectionError::Backend(backend_error)
             })?;
 
         if frontend_should_stick {
@@ -709,6 +733,10 @@ impl Mux {
     pub fn front_socket(&self) -> &TcpStream {
         self.frontend.socket()
     }
+
+    fn goaway(&mut self, e: H2Error) {
+        todo!()
+    }
 }
 
 impl SessionState for Mux {
@@ -725,17 +753,19 @@ impl SessionState for Mux {
             return SessionResult::Close;
         }
 
-        let context = &mut self.context;
+        let start = std::time::Instant::now();
+        println_!("{start:?}");
         while counter < max_loop_iterations {
             let mut dirty = false;
 
+            let context = &mut self.context;
             if self.frontend.readiness().filter_interest().is_readable() {
                 match self
                     .frontend
                     .readable(context, EndpointClient(&mut self.router))
                 {
                     MuxResult::Continue => (),
-                    MuxResult::CloseSession => return SessionResult::Close,
+                    MuxResult::CloseSession(e) => self.goaway(e),
                     MuxResult::Close(_) => todo!(),
                     MuxResult::Connect(stream_id) => {
                         match self.router.connect(
@@ -747,7 +777,7 @@ impl SessionState for Mux {
                         ) {
                             Ok(_) => (),
                             Err(error) => {
-                                println!("{error}");
+                                println_!("{error}");
                             }
                         }
                     }
@@ -755,11 +785,12 @@ impl SessionState for Mux {
                 dirty = true;
             }
 
+            let context = &mut self.context;
             let mut dead_backends = Vec::new();
             for (token, backend) in self.router.backends.iter_mut() {
                 let readiness = backend.readiness().filter_interest();
                 if readiness.is_hup() || readiness.is_error() {
-                    println!("{token:?} -> {:?}", backend);
+                    println_!("{token:?} -> {:?}", backend);
                     backend.close(context, EndpointServer(&mut self.frontend));
                     dead_backends.push(*token);
                 }
@@ -775,7 +806,10 @@ impl SessionState for Mux {
                     }
                     match backend.writable(context, EndpointServer(&mut self.frontend)) {
                         MuxResult::Continue => (),
-                        MuxResult::CloseSession => return SessionResult::Close,
+                        MuxResult::CloseSession(e) => {
+                            self.goaway(e);
+                            break;
+                        }
                         MuxResult::Close(_) => todo!(),
                         MuxResult::Connect(_) => unreachable!(),
                     }
@@ -785,7 +819,10 @@ impl SessionState for Mux {
                 if readiness.is_readable() {
                     match backend.readable(context, EndpointServer(&mut self.frontend)) {
                         MuxResult::Continue => (),
-                        MuxResult::CloseSession => return SessionResult::Close,
+                        MuxResult::CloseSession(e) => {
+                            self.goaway(e);
+                            break;
+                        }
                         MuxResult::Close(_) => todo!(),
                         MuxResult::Connect(_) => unreachable!(),
                     }
@@ -796,17 +833,18 @@ impl SessionState for Mux {
                 for token in &dead_backends {
                     self.router.backends.remove(token);
                 }
-                println!("FRONTEND: {:#?}", &self.frontend);
-                println!("BACKENDS: {:#?}", self.router.backends);
+                println_!("FRONTEND: {:#?}", &self.frontend);
+                println_!("BACKENDS: {:#?}", self.router.backends);
             }
 
+            let context = &mut self.context;
             if self.frontend.readiness().filter_interest().is_writable() {
                 match self
                     .frontend
                     .writable(context, EndpointClient(&mut self.router))
                 {
                     MuxResult::Continue => (),
-                    MuxResult::CloseSession => return SessionResult::Close,
+                    MuxResult::CloseSession(e) => self.goaway(e),
                     MuxResult::Close(_) => todo!(),
                     MuxResult::Connect(_) => unreachable!(),
                 }
@@ -822,7 +860,6 @@ impl SessionState for Mux {
 
         if counter == max_loop_iterations {
             incr!("http.infinite_loop.error");
-            panic!();
             return SessionResult::Close;
         }
 
@@ -838,12 +875,12 @@ impl SessionState for Mux {
     }
 
     fn timeout(&mut self, token: Token, _metrics: &mut SessionMetrics) -> StateResult {
-        println!("MuxState::timeout({token:?})");
+        println_!("MuxState::timeout({token:?})");
         StateResult::CloseSession
     }
 
     fn cancel_timeouts(&mut self) {
-        println!("MuxState::cancel_timeouts");
+        println_!("MuxState::cancel_timeouts");
     }
 
     fn print_state(&self, context: &str) {
@@ -864,15 +901,15 @@ impl SessionState for Mux {
         };
         let mut b = [0; 1024];
         let (size, status) = s.socket_read(&mut b);
-        println!("{size} {status:?} {:?}", &b[..size]);
+        println_!("{size} {status:?} {:?}", &b[..size]);
         for stream in &mut self.context.streams {
             for kawa in [&mut stream.front, &mut stream.back] {
-                kawa::debug_kawa(kawa);
+                debug_kawa(kawa);
                 kawa.prepare(&mut kawa::h1::BlockConverter);
                 let out = kawa.as_io_slice();
                 let mut writer = std::io::BufWriter::new(Vec::new());
                 let amount = writer.write_vectored(&out).unwrap();
-                println!("amount: {amount}\n{}", unsafe {
+                println_!("amount: {amount}\n{}", unsafe {
                     std::str::from_utf8_unchecked(writer.buffer())
                 });
             }

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -1,7 +1,7 @@
 use std::{
     cell::RefCell,
     collections::HashMap,
-    io::{ErrorKind, Write},
+    io::ErrorKind,
     net::{Shutdown, SocketAddr},
     rc::{Rc, Weak},
 };

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -171,6 +171,8 @@ impl<Front: SocketHandler> Connection<Front> {
 struct EndpointServer<'a>(&'a mut Connection<FrontRustls>);
 struct EndpointClient<'a>(&'a mut Router);
 
+// note: EndpointServer are used by client Connection, they do not know the frontend Token
+// they will use the Stream's Token which is their backend token
 impl<'a> UpdateReadiness for EndpointServer<'a> {
     fn readiness(&self, _token: Token) -> &Readiness {
         self.0.readiness()
@@ -188,9 +190,38 @@ impl<'a> UpdateReadiness for EndpointClient<'a> {
     }
 }
 
+// enum Stream {
+//     Idle {
+//         window: i32,
+//     },
+//     Open {
+//         window: i32,
+//         token: Token,
+//         front: GenericHttpStream,
+//         back: GenericHttpStream,
+//         context: HttpContext,
+//     },
+//     Reserved {
+//         window: i32,
+//         token: Token,
+//         position: Position,
+//         buffer: GenericHttpStream,
+//         context: HttpContext,
+//     },
+//     HalfClosed {
+//         window: i32,
+//         token: Token,
+//         position: Position,
+//         buffer: GenericHttpStream,
+//         context: HttpContext,
+//     },
+//     Closed,
+// }
+
 pub struct Stream {
     // pub request_id: Ulid,
     pub window: i32,
+    pub token: Option<Token>,
     front: GenericHttpStream,
     back: GenericHttpStream,
     pub context: HttpContext,
@@ -218,6 +249,7 @@ impl Stream {
         };
         Some(Self {
             window: window as i32,
+            token: None,
             front: GenericHttpStream::new(kawa::Kind::Request, kawa::Buffer::new(front_buffer)),
             back: GenericHttpStream::new(kawa::Kind::Response, kawa::Buffer::new(back_buffer)),
             context: HttpContext {
@@ -304,7 +336,8 @@ impl Router {
         proxy: Rc<RefCell<dyn L7Proxy>>,
         metrics: &mut SessionMetrics,
     ) -> Result<(), BackendConnectionError> {
-        let context = &mut context.streams[stream_id].context;
+        let stream = &mut context.streams[stream_id];
+        let context = &mut stream.context;
         // we should get if the route is H2 or not here
         // for now we assume it's H1
         let cluster_id = self
@@ -346,6 +379,7 @@ impl Router {
             error!("error registering back socket({:?}): {:?}", socket, e);
         }
 
+        stream.token.insert(backend_token);
         self.backends
             .insert(backend_token, Connection::new_h1_client(socket, stream_id));
         Ok(())
@@ -490,7 +524,10 @@ impl SessionState for Mux {
             let mut dirty = false;
 
             if self.frontend.readiness().filter_interest().is_readable() {
-                match self.frontend.readable(context, EndpointClient(&mut self.router)) {
+                match self
+                    .frontend
+                    .readable(context, EndpointClient(&mut self.router))
+                {
                     MuxResult::Continue => (),
                     MuxResult::CloseSession => return SessionResult::Close,
                     MuxResult::Close(_) => todo!(),
@@ -535,7 +572,10 @@ impl SessionState for Mux {
             }
 
             if self.frontend.readiness().filter_interest().is_writable() {
-                match self.frontend.writable(context, EndpointClient(&mut self.router)) {
+                match self
+                    .frontend
+                    .writable(context, EndpointClient(&mut self.router))
+                {
                     MuxResult::Continue => (),
                     MuxResult::CloseSession => return SessionResult::Close,
                     MuxResult::Close(_) => todo!(),

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -3,6 +3,7 @@ use std::{
     collections::HashMap,
     net::SocketAddr,
     rc::{Rc, Weak},
+    str::from_utf8_unchecked,
 };
 
 use mio::{net::TcpStream, Token};
@@ -22,7 +23,7 @@ use crate::{
 
 /// Generic Http representation using the Kawa crate using the Checkout of Sozu as buffer
 type GenericHttpStream = kawa::Kawa<Checkout>;
-type StreamId = usize;
+type StreamId = u32;
 type GlobalStreamId = usize;
 
 #[derive(Debug, Clone, Copy)]
@@ -32,9 +33,9 @@ pub enum Position {
 }
 
 pub struct ConnectionH1<Front: SocketHandler> {
-    pub socket: Front,
     pub position: Position,
     pub readiness: Readiness,
+    pub socket: Front,
     pub stream: GlobalStreamId,
 }
 
@@ -44,21 +45,47 @@ pub enum H2State {
     ClientSettings,
     ServerSettings,
     Header,
-    Frame,
+    Frame(parser::FrameHeader),
     Error,
 }
+
+#[derive(Debug)]
+pub struct H2Settings {
+    settings_header_table_size: u32,
+    settings_enable_push: bool,
+    settings_max_concurrent_streams: u32,
+    settings_initial_window_size: u32,
+    settings_max_frame_size: u32,
+    settings_max_header_list_size: u32,
+}
+
+impl Default for H2Settings {
+    fn default() -> Self {
+        Self {
+            settings_header_table_size: 4096,
+            settings_enable_push: true,
+            settings_max_concurrent_streams: u32::MAX,
+            settings_initial_window_size: (1 << 16) - 1,
+            settings_max_frame_size: 1 << 14,
+            settings_max_header_list_size: u32::MAX,
+        }
+    }
+}
+
 pub struct ConnectionH2<Front: SocketHandler> {
-    pub socket: Front,
+    pub decoder: hpack::Decoder<'static>,
+    pub expect: Option<(GlobalStreamId, usize)>,
     pub position: Position,
     pub readiness: Readiness,
+    pub settings: H2Settings,
+    pub socket: Front,
     pub state: H2State,
     pub streams: HashMap<StreamId, GlobalStreamId>,
-    pub expect: Option<(GlobalStreamId, usize)>,
-    // context_hpack: HpackContext,
-    // settings: SettiongsH2,
 }
+
 pub struct Stream {
     pub request_id: Ulid,
+    pub window: i32,
     pub front: GenericHttpStream,
     pub back: GenericHttpStream,
 }
@@ -82,26 +109,81 @@ pub enum Connection<Front: SocketHandler> {
     H1(ConnectionH1<Front>),
     H2(ConnectionH2<Front>),
 }
+
 impl<Front: SocketHandler> Connection<Front> {
-    fn readiness(&self) -> &Readiness {
+    pub fn new_h1_server(front_stream: Front) -> Connection<Front> {
+        Connection::H1(ConnectionH1 {
+            socket: front_stream,
+            position: Position::Server,
+            readiness: Readiness {
+                interest: Ready::READABLE | Ready::HUP | Ready::ERROR,
+                event: Ready::EMPTY,
+            },
+            stream: 0,
+        })
+    }
+    pub fn new_h1_client(front_stream: Front) -> Connection<Front> {
+        Connection::H1(ConnectionH1 {
+            socket: front_stream,
+            position: Position::Client,
+            readiness: Readiness {
+                interest: Ready::WRITABLE | Ready::HUP | Ready::ERROR,
+                event: Ready::EMPTY,
+            },
+            stream: 0,
+        })
+    }
+
+    pub fn new_h2_server(front_stream: Front) -> Connection<Front> {
+        Connection::H2(ConnectionH2 {
+            socket: front_stream,
+            position: Position::Server,
+            readiness: Readiness {
+                interest: Ready::READABLE | Ready::HUP | Ready::ERROR,
+                event: Ready::EMPTY,
+            },
+            streams: HashMap::from([(0, 0)]),
+            state: H2State::ClientPreface,
+            expect: Some((0, 24 + 9)),
+            settings: H2Settings::default(),
+            decoder: hpack::Decoder::new(),
+        })
+    }
+    pub fn new_h2_client(front_stream: Front) -> Connection<Front> {
+        Connection::H2(ConnectionH2 {
+            socket: front_stream,
+            position: Position::Client,
+            readiness: Readiness {
+                interest: Ready::WRITABLE | Ready::HUP | Ready::ERROR,
+                event: Ready::EMPTY,
+            },
+            streams: HashMap::from([(0, 0)]),
+            state: H2State::ClientPreface,
+            expect: None,
+            settings: H2Settings::default(),
+            decoder: hpack::Decoder::new(),
+        })
+    }
+
+    pub fn readiness(&self) -> &Readiness {
         match self {
             Connection::H1(c) => &c.readiness,
             Connection::H2(c) => &c.readiness,
         }
     }
-    fn readiness_mut(&mut self) -> &mut Readiness {
+    pub fn readiness_mut(&mut self) -> &mut Readiness {
         match self {
             Connection::H1(c) => &mut c.readiness,
             Connection::H2(c) => &mut c.readiness,
         }
     }
-    fn readable(&mut self, streams: &mut [Stream]) {
+    fn readable(&mut self, streams: &mut Streams) {
         match self {
             Connection::H1(c) => c.readable(streams),
             Connection::H2(c) => c.readable(streams),
         }
     }
-    fn writable(&mut self, streams: &mut [Stream]) {
+    fn writable(&mut self, streams: &mut Streams) {
         match self {
             Connection::H1(c) => c.writable(streams),
             Connection::H2(c) => c.writable(streams),
@@ -109,16 +191,67 @@ impl<Front: SocketHandler> Connection<Front> {
     }
 }
 
+pub struct Streams {
+    pub streams: Vec<Stream>,
+    pub pool: Weak<RefCell<Pool>>,
+}
+
 pub struct Mux {
     pub frontend_token: Token,
     pub frontend: Connection<FrontRustls>,
     pub backends: HashMap<Token, Connection<TcpStream>>,
-    pub streams: Vec<Stream>,
     pub listener: Rc<RefCell<HttpsListener>>,
-    pub pool: Weak<RefCell<Pool>>,
     pub public_address: SocketAddr,
     pub peer_address: Option<SocketAddr>,
     pub sticky_name: String,
+    pub streams: Streams,
+}
+
+impl Streams {
+    pub fn create_stream(
+        &mut self,
+        request_id: Ulid,
+        window: u32,
+    ) -> Result<GlobalStreamId, AcceptError> {
+        let (front_buffer, back_buffer) = match self.pool.upgrade() {
+            Some(pool) => {
+                let mut pool = pool.borrow_mut();
+                match (pool.checkout(), pool.checkout()) {
+                    (Some(front_buffer), Some(back_buffer)) => (front_buffer, back_buffer),
+                    _ => return Err(AcceptError::BufferCapacityReached),
+                }
+            }
+            None => return Err(AcceptError::BufferCapacityReached),
+        };
+        self.streams.push(Stream {
+            request_id,
+            window: window as i32,
+            front: GenericHttpStream::new(kawa::Kind::Request, kawa::Buffer::new(front_buffer)),
+            back: GenericHttpStream::new(kawa::Kind::Response, kawa::Buffer::new(back_buffer)),
+        });
+        Ok(self.streams.len() - 1)
+    }
+}
+
+impl std::ops::Deref for Streams {
+    type Target = [Stream];
+    fn deref(&self) -> &Self::Target {
+        &self.streams
+    }
+}
+impl std::ops::DerefMut for Streams {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.streams
+    }
+}
+
+impl Mux {
+    pub fn front_socket(&self) -> &TcpStream {
+        match &self.frontend {
+            Connection::H1(c) => &c.socket.stream,
+            Connection::H2(c) => &c.socket.stream,
+        }
+    }
 }
 
 impl SessionState for Mux {
@@ -223,36 +356,8 @@ impl SessionState for Mux {
     }
 }
 
-impl Mux {
-    pub fn front_socket(&self) -> &TcpStream {
-        match &self.frontend {
-            Connection::H1(c) => &c.socket.stream,
-            Connection::H2(c) => &c.socket.stream,
-        }
-    }
-
-    pub fn create_stream(&mut self, request_id: Ulid) -> Result<GlobalStreamId, AcceptError> {
-        let (front_buffer, back_buffer) = match self.pool.upgrade() {
-            Some(pool) => {
-                let mut pool = pool.borrow_mut();
-                match (pool.checkout(), pool.checkout()) {
-                    (Some(front_buffer), Some(back_buffer)) => (front_buffer, back_buffer),
-                    _ => return Err(AcceptError::BufferCapacityReached),
-                }
-            }
-            None => return Err(AcceptError::BufferCapacityReached),
-        };
-        self.streams.push(Stream {
-            request_id,
-            front: GenericHttpStream::new(kawa::Kind::Request, kawa::Buffer::new(front_buffer)),
-            back: GenericHttpStream::new(kawa::Kind::Request, kawa::Buffer::new(back_buffer)),
-        });
-        Ok(self.streams.len() - 1)
-    }
-}
-
 impl<Front: SocketHandler> ConnectionH2<Front> {
-    fn readable(&mut self, streams: &mut [Stream]) {
+    fn readable(&mut self, streams: &mut Streams) {
         println!("======= MUX H2 READABLE");
         let kawa = if let Some((stream_id, amount)) = self.expect {
             let kawa = streams[stream_id].front(self.position);
@@ -305,10 +410,12 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             (H2State::ClientSettings, Position::Server) => {
                 let i = kawa.storage.data();
                 match parser::settings_frame(i, i.len()) {
-                    Ok((_, settings)) => println!("{settings:?}"),
+                    Ok((_, settings)) => {
+                        kawa.storage.clear();
+                        self.handle(settings, streams);
+                    }
                     Err(e) => panic!("{e:?}"),
                 }
-                kawa.storage.clear();
                 let kawa = &mut streams[0].back;
                 self.state = H2State::ServerSettings;
                 match serializer::gen_frame_header(
@@ -352,17 +459,34 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                     Ok((_, header)) => {
                         println!("{header:?}");
                         kawa.storage.clear();
-                        self.state = H2State::Frame;
-                        self.expect =
-                            Some((header.stream_id as usize, header.payload_len as usize));
+                        let stream_id = if let Some(stream_id) = self.streams.get(&header.stream_id)
+                        {
+                            *stream_id
+                        } else {
+                            self.create_stream(header.stream_id, streams)
+                        };
+                        let stream_id = if header.frame_type == parser::FrameType::Headers {
+                            0
+                        } else {
+                            stream_id
+                        };
+                        println!("{} {} {:#?}", header.stream_id, stream_id, self.streams);
+                        self.expect = Some((stream_id as usize, header.payload_len as usize));
+                        self.state = H2State::Frame(header);
                     }
                     Err(e) => panic!("{e:?}"),
                 };
             }
-            (H2State::Frame, Position::Server) => {
+            (H2State::Frame(header), Position::Server) => {
                 let i = kawa.storage.data();
                 println!("  data: {i:?}");
-                kawa.storage.clear();
+                match parser::frame_body(i, header, self.settings.settings_max_frame_size) {
+                    Ok((_, frame)) => {
+                        kawa.storage.clear();
+                        self.handle(frame, streams);
+                    }
+                    Err(e) => panic!("{e:?}"),
+                }
                 self.state = H2State::Header;
                 self.expect = Some((0, 9));
             }
@@ -370,7 +494,7 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         }
     }
 
-    fn writable(&mut self, streams: &mut [Stream]) {
+    fn writable(&mut self, streams: &mut Streams) {
         println!("======= MUX H2 WRITABLE");
         match (&self.state, &self.position) {
             (H2State::ClientPreface, Position::Client) => todo!("Send PRI + client Settings"),
@@ -393,22 +517,60 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             }
             _ => unreachable!(),
         }
-        // for global_stream_id in self.streams.values() {
-        //     let stream = &mut streams[*global_stream_id];
-        //     let kawa = match self.position {
-        //         Position::Client => &mut stream.back,
-        //         Position::Server => &mut stream.front,
-        //     };
-        //     kawa.prepare(&mut kawa::h2::BlockConverter);
-        //     let (size, status) = self.socket.socket_write_vectored(&kawa.as_io_slice());
-        //     println!("  size: {size}, status: {status:?}");
-        //     kawa.consume(size);
-        // }
+    }
+
+    pub fn create_stream(&mut self, stream_id: StreamId, streams: &mut Streams) -> GlobalStreamId {
+        match streams.create_stream(Ulid::generate(), self.settings.settings_initial_window_size) {
+            Ok(global_stream_id) => {
+                self.streams.insert(stream_id, global_stream_id);
+                global_stream_id
+            }
+            Err(e) => panic!("{e:?}"),
+        }
+    }
+
+    fn handle(&mut self, frame: parser::Frame, streams: &mut Streams) {
+        println!("{frame:?}");
+        match frame {
+            parser::Frame::Data(_) => todo!(),
+            parser::Frame::Headers(headers) => {
+                let kawa = streams[0].front(self.position);
+                let buffer = headers.header_block_fragment.data(kawa.storage.buffer());
+                println!("{buffer:?}");
+                let result = self.decoder.decode(buffer).unwrap();
+                for (k, v) in result {
+                    unsafe { println!("{} {}", from_utf8_unchecked(&k), from_utf8_unchecked(&v)) };
+                }
+            }
+            parser::Frame::Priority => todo!(),
+            parser::Frame::RstStream(_) => todo!(),
+            parser::Frame::Settings(settings) => {
+                for setting in settings.settings {
+                    match setting.identifier {
+                        1 => self.settings.settings_header_table_size = setting.value,
+                        2 => self.settings.settings_enable_push = setting.value == 1,
+                        3 => self.settings.settings_max_concurrent_streams = setting.value,
+                        4 => self.settings.settings_initial_window_size = setting.value,
+                        5 => self.settings.settings_max_frame_size = setting.value,
+                        6 => self.settings.settings_max_header_list_size = setting.value,
+                        other => panic!("setting_id: {other}"),
+                    }
+                }
+                println!("{:#?}", self.settings);
+            }
+            parser::Frame::PushPromise => todo!(),
+            parser::Frame::Ping(_) => todo!(),
+            parser::Frame::GoAway => todo!(),
+            parser::Frame::WindowUpdate(update) => {
+                streams[update.stream_id as usize].window += update.increment as i32;
+            }
+            parser::Frame::Continuation => todo!(),
+        }
     }
 }
 
 impl<Front: SocketHandler> ConnectionH1<Front> {
-    fn readable(&mut self, streams: &mut [Stream]) {
+    fn readable(&mut self, streams: &mut Streams) {
         println!("======= MUX H1 READABLE");
         let stream = &mut streams[self.stream];
         let kawa = match self.position {
@@ -434,7 +596,7 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
             self.readiness.interest.remove(Ready::READABLE);
         }
     }
-    fn writable(&mut self, streams: &mut [Stream]) {
+    fn writable(&mut self, streams: &mut Streams) {
         println!("======= MUX H1 WRITABLE");
         let stream = &mut streams[self.stream];
         let kawa = match self.position {

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -26,7 +26,6 @@ use crate::{
         mux::{
             h1::ConnectionH1,
             h2::{ConnectionH2, H2Settings, H2State, H2StreamId},
-            parser::H2Error,
         },
         SessionState,
     },
@@ -54,8 +53,9 @@ type GenericHttpStream = kawa::Kawa<Checkout>;
 type StreamId = u32;
 type GlobalStreamId = usize;
 
-/// Replace the content of the kawa buffer with a default Sozu answer for a given status code
-fn set_default_answer(kawa: &mut GenericHttpStream, readiness: &mut Readiness, code: u16) {
+/// Replace the content of the kawa message with a default Sozu answer for a given status code
+fn set_default_answer(stream: &mut Stream, readiness: &mut Readiness, code: u16) {
+    let kawa = &mut stream.back;
     kawa.clear();
     kawa.storage.clear();
     kawa.detached.status_line = kawa::StatusLine::Response {
@@ -84,10 +84,14 @@ fn set_default_answer(kawa: &mut GenericHttpStream, readiness: &mut Readiness, c
         end_stream: true,
     }));
     kawa.parsing_phase = kawa::ParsingPhase::Terminated;
+    stream.state = StreamState::Unlinked;
     readiness.interest.insert(Ready::WRITABLE);
 }
 
-fn forcefully_terminate_answer(kawa: &mut GenericHttpStream, readiness: &mut Readiness) {
+/// Forcefully terminates a kawa message by setting the "end_stream" flag and setting the parsing_phase to Error.
+/// An H2 converter will produce an RstStream frame.
+fn forcefully_terminate_answer(stream: &mut Stream, readiness: &mut Readiness) {
+    let kawa = &mut stream.back;
     kawa.push_block(kawa::Block::Flags(kawa::Flags {
         end_body: false,
         end_chunk: false,
@@ -96,6 +100,7 @@ fn forcefully_terminate_answer(kawa: &mut GenericHttpStream, readiness: &mut Rea
     }));
     kawa.parsing_phase = kawa::ParsingPhase::Error;
     debug_kawa(kawa);
+    stream.state = StreamState::Unlinked;
     readiness.interest.insert(Ready::WRITABLE);
 }
 
@@ -115,13 +120,7 @@ pub enum BackendStatus {
 
 pub enum MuxResult {
     Continue,
-    CloseSession(H2Error),
-}
-
-#[derive(Debug)]
-pub enum Connection<Front: SocketHandler> {
-    H1(ConnectionH1<Front>),
-    H2(ConnectionH2<Front>),
+    CloseSession,
 }
 
 pub trait Endpoint {
@@ -137,6 +136,12 @@ pub trait Endpoint {
     /// the stream might be recovering from a disconnection, in any case at this point its response MUST be empty.
     /// If the start_stream is called on a H2 server it means the stream is a server push and its request MUST be empty.
     fn start_stream(&mut self, token: Token, stream: GlobalStreamId, context: &mut Context);
+}
+
+#[derive(Debug)]
+pub enum Connection<Front: SocketHandler> {
+    H1(ConnectionH1<Front>),
+    H2(ConnectionH2<Front>),
 }
 
 impl<Front: SocketHandler> Connection<Front> {
@@ -803,10 +808,6 @@ impl Mux {
     pub fn front_socket(&self) -> &TcpStream {
         self.frontend.socket()
     }
-
-    fn goaway(&mut self, e: H2Error) {
-        todo!()
-    }
 }
 
 impl SessionState for Mux {
@@ -833,8 +834,8 @@ impl SessionState for Mux {
                         .frontend
                         .readable(context, EndpointClient(&mut self.router))
                     {
-                        MuxResult::Continue => (),
-                        MuxResult::CloseSession(e) => self.goaway(e),
+                        MuxResult::Continue => {}
+                        MuxResult::CloseSession => return SessionResult::Close,
                     }
                 }
 
@@ -851,31 +852,25 @@ impl SessionState for Mux {
                     }
 
                     if backend.readiness().filter_interest().is_writable() {
-                        let mut owned_position = Position::Server;
                         let position = backend.position_mut();
-                        std::mem::swap(&mut owned_position, position);
-                        match owned_position {
+                        match position {
                             Position::Client(BackendStatus::Connecting(cluster_id)) => {
-                                *position = Position::Client(BackendStatus::Connected(cluster_id));
+                                *position = Position::Client(BackendStatus::Connected(
+                                    std::mem::take(cluster_id),
+                                ));
                             }
-                            _ => *position = owned_position,
+                            _ => {}
                         }
                         match backend.writable(context, EndpointServer(&mut self.frontend)) {
-                            MuxResult::Continue => (),
-                            MuxResult::CloseSession(e) => {
-                                self.goaway(e);
-                                break;
-                            }
+                            MuxResult::Continue => {}
+                            MuxResult::CloseSession => return SessionResult::Close,
                         }
                     }
 
                     if backend.readiness().filter_interest().is_readable() {
                         match backend.readable(context, EndpointServer(&mut self.frontend)) {
-                            MuxResult::Continue => (),
-                            MuxResult::CloseSession(e) => {
-                                self.goaway(e);
-                                break;
-                            }
+                            MuxResult::Continue => {}
+                            MuxResult::CloseSession => return SessionResult::Close,
                         }
                     }
 
@@ -903,8 +898,8 @@ impl SessionState for Mux {
                         .frontend
                         .writable(context, EndpointClient(&mut self.router))
                     {
-                        MuxResult::Continue => (),
-                        MuxResult::CloseSession(e) => self.goaway(e),
+                        MuxResult::Continue => {}
+                        MuxResult::CloseSession => return SessionResult::Close,
                     }
                 }
 
@@ -937,24 +932,24 @@ impl SessionState for Mux {
                         Ok(_) => {}
                         Err(error) => {
                             println_!("Connection error: {error}");
-                            let kawa = &mut context.streams[stream_id].back;
+                            let stream = &mut context.streams[stream_id];
                             use BackendConnectionError as BE;
                             match error {
                                 BE::Backend(BackendError::NoBackendForCluster(_))
                                 | BE::MaxConnectionRetries(_)
                                 | BE::MaxSessionsMemory
                                 | BE::MaxBuffers => {
-                                    set_default_answer(kawa, front_readiness, 503);
+                                    set_default_answer(stream, front_readiness, 503);
                                 }
                                 BE::RetrieveClusterError(
                                     RetrieveClusterError::RetrieveFrontend(_),
                                 ) => {
-                                    set_default_answer(kawa, front_readiness, 404);
+                                    set_default_answer(stream, front_readiness, 404);
                                 }
                                 BE::RetrieveClusterError(
                                     RetrieveClusterError::UnauthorizedRoute,
                                 ) => {
-                                    set_default_answer(kawa, front_readiness, 401);
+                                    set_default_answer(stream, front_readiness, 401);
                                 }
 
                                 BE::Backend(_) => {}

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -39,10 +39,18 @@ type GenericHttpStream = kawa::Kawa<Checkout>;
 type StreamId = u32;
 type GlobalStreamId = usize;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug)]
 pub enum Position {
-    Client,
+    Client(BackendStatus),
     Server,
+}
+
+#[derive(Debug)]
+pub enum BackendStatus {
+    Connecting(String),
+    Connected(String),
+    KeepAlive(String),
+    Disconnecting,
 }
 
 pub enum MuxResult {
@@ -52,14 +60,17 @@ pub enum MuxResult {
     Connect(GlobalStreamId),
 }
 
+#[derive(Debug)]
 pub enum Connection<Front: SocketHandler> {
     H1(ConnectionH1<Front>),
     H2(ConnectionH2<Front>),
 }
 
-pub trait UpdateReadiness {
+pub trait Endpoint {
     fn readiness(&self, token: Token) -> &Readiness;
     fn readiness_mut(&mut self, token: Token) -> &mut Readiness;
+    fn end_stream(&mut self, token: Token, stream: GlobalStreamId, context: &mut Context);
+    fn start_stream(&mut self, token: Token, stream: GlobalStreamId, context: &mut Context);
 }
 
 impl<Front: SocketHandler> Connection<Front> {
@@ -74,15 +85,15 @@ impl<Front: SocketHandler> Connection<Front> {
             stream: 0,
         })
     }
-    pub fn new_h1_client(front_stream: Front, stream_id: GlobalStreamId) -> Connection<Front> {
+    pub fn new_h1_client(front_stream: Front, cluster_id: String) -> Connection<Front> {
         Connection::H1(ConnectionH1 {
             socket: front_stream,
-            position: Position::Client,
+            position: Position::Client(BackendStatus::Connecting(cluster_id)),
             readiness: Readiness {
                 interest: Ready::WRITABLE | Ready::READABLE | Ready::HUP | Ready::ERROR,
                 event: Ready::EMPTY,
             },
-            stream: stream_id,
+            stream: 0,
         })
     }
 
@@ -112,6 +123,7 @@ impl<Front: SocketHandler> Connection<Front> {
     }
     pub fn new_h2_client(
         front_stream: Front,
+        cluster_id: String,
         pool: Weak<RefCell<Pool>>,
     ) -> Option<Connection<Front>> {
         let buffer = pool
@@ -119,7 +131,7 @@ impl<Front: SocketHandler> Connection<Front> {
             .and_then(|pool| pool.borrow_mut().checkout())?;
         Some(Connection::H2(ConnectionH2 {
             socket: front_stream,
-            position: Position::Client,
+            position: Position::Client(BackendStatus::Connecting(cluster_id)),
             readiness: Readiness {
                 interest: Ready::WRITABLE | Ready::READABLE | Ready::HUP | Ready::ERROR,
                 event: Ready::EMPTY,
@@ -147,6 +159,18 @@ impl<Front: SocketHandler> Connection<Front> {
             Connection::H2(c) => &mut c.readiness,
         }
     }
+    fn position(&self) -> &Position {
+        match self {
+            Connection::H1(c) => &c.position,
+            Connection::H2(c) => &c.position,
+        }
+    }
+    fn position_mut(&mut self) -> &mut Position {
+        match self {
+            Connection::H1(c) => &mut c.position,
+            Connection::H2(c) => &mut c.position,
+        }
+    }
     pub fn socket(&self) -> &TcpStream {
         match self {
             Connection::H1(c) => c.socket.socket_ref(),
@@ -155,7 +179,7 @@ impl<Front: SocketHandler> Connection<Front> {
     }
     fn readable<E>(&mut self, context: &mut Context, endpoint: E) -> MuxResult
     where
-        E: UpdateReadiness,
+        E: Endpoint,
     {
         match self {
             Connection::H1(c) => c.readable(context, endpoint),
@@ -164,11 +188,35 @@ impl<Front: SocketHandler> Connection<Front> {
     }
     fn writable<E>(&mut self, context: &mut Context, endpoint: E) -> MuxResult
     where
-        E: UpdateReadiness,
+        E: Endpoint,
     {
         match self {
             Connection::H1(c) => c.writable(context, endpoint),
             Connection::H2(c) => c.writable(context, endpoint),
+        }
+    }
+
+    fn close<E>(&mut self, context: &mut Context, endpoint: E)
+    where
+        E: Endpoint,
+    {
+        match self {
+            Connection::H1(c) => c.close(context, endpoint),
+            Connection::H2(c) => c.close(context, endpoint),
+        }
+    }
+
+    fn end_stream(&mut self, stream: usize, context: &mut Context) {
+        match self {
+            Connection::H1(c) => c.end_stream(stream, context),
+            Connection::H2(c) => c.end_stream(stream, context),
+        }
+    }
+
+    fn start_stream(&mut self, stream: usize, context: &mut Context) {
+        match self {
+            Connection::H1(c) => c.start_stream(stream, context),
+            Connection::H2(c) => c.start_stream(stream, context),
         }
     }
 }
@@ -178,20 +226,47 @@ struct EndpointClient<'a>(&'a mut Router);
 
 // note: EndpointServer are used by client Connection, they do not know the frontend Token
 // they will use the Stream's Token which is their backend token
-impl<'a> UpdateReadiness for EndpointServer<'a> {
+impl<'a> Endpoint for EndpointServer<'a> {
     fn readiness(&self, _token: Token) -> &Readiness {
         self.0.readiness()
     }
     fn readiness_mut(&mut self, _token: Token) -> &mut Readiness {
         self.0.readiness_mut()
     }
+
+    fn end_stream(&mut self, token: Token, stream: GlobalStreamId, context: &mut Context) {
+        // this may be used to forward H2<->H2 RstStream
+        // or to handle backend hup
+        self.0.end_stream(stream, context);
+    }
+
+    fn start_stream(&mut self, token: Token, stream: GlobalStreamId, context: &mut Context) {
+        // this may be used to forward H2<->H2 PushPromise
+        todo!()
+    }
 }
-impl<'a> UpdateReadiness for EndpointClient<'a> {
+impl<'a> Endpoint for EndpointClient<'a> {
     fn readiness(&self, token: Token) -> &Readiness {
         self.0.backends.get(&token).unwrap().readiness()
     }
     fn readiness_mut(&mut self, token: Token) -> &mut Readiness {
         self.0.backends.get_mut(&token).unwrap().readiness_mut()
+    }
+
+    fn end_stream(&mut self, token: Token, stream: GlobalStreamId, context: &mut Context) {
+        self.0
+            .backends
+            .get_mut(&token)
+            .unwrap()
+            .end_stream(stream, context);
+    }
+
+    fn start_stream(&mut self, token: Token, stream: GlobalStreamId, context: &mut Context) {
+        self.0
+            .backends
+            .get_mut(&token)
+            .unwrap()
+            .start_stream(stream, context);
     }
 }
 
@@ -258,8 +333,8 @@ impl Stream {
             front: GenericHttpStream::new(kawa::Kind::Request, kawa::Buffer::new(front_buffer)),
             back: GenericHttpStream::new(kawa::Kind::Response, kawa::Buffer::new(back_buffer)),
             context: HttpContext {
-                keep_alive_backend: false,
-                keep_alive_frontend: false,
+                keep_alive_backend: true,
+                keep_alive_frontend: true,
                 sticky_session_found: None,
                 method: None,
                 authority: None,
@@ -277,9 +352,9 @@ impl Stream {
             },
         })
     }
-    pub fn split(&mut self, position: Position) -> StreamParts<'_> {
+    pub fn split(&mut self, position: &Position) -> StreamParts<'_> {
         match position {
-            Position::Client => StreamParts {
+            Position::Client(_) => StreamParts {
                 rbuffer: &mut self.back,
                 wbuffer: &mut self.front,
                 context: &mut self.context,
@@ -291,15 +366,15 @@ impl Stream {
             },
         }
     }
-    pub fn rbuffer(&mut self, position: Position) -> &mut GenericHttpStream {
+    pub fn rbuffer(&mut self, position: &Position) -> &mut GenericHttpStream {
         match position {
-            Position::Client => &mut self.back,
+            Position::Client(_) => &mut self.back,
             Position::Server => &mut self.front,
         }
     }
-    pub fn wbuffer(&mut self, position: Position) -> &mut GenericHttpStream {
+    pub fn wbuffer(&mut self, position: &Position) -> &mut GenericHttpStream {
         match position {
-            Position::Client => &mut self.front,
+            Position::Client(_) => &mut self.front,
             Position::Server => &mut self.back,
         }
     }
@@ -340,13 +415,13 @@ impl Router {
         metrics: &mut SessionMetrics,
     ) -> Result<(), BackendConnectionError> {
         let stream = &mut context.streams[stream_id];
-        let context = &mut stream.context;
-        // we should get if the route is H2 or not here
-        // for now we assume it's H1
-        let cluster_id = self
-            .cluster_id_from_request(context, proxy.clone())
+        // when reused, a stream should be detached from its old connection, if not we could end
+        // with concurrent connections on a single endpoint
+        assert!(stream.token.is_none());
+        let stream_context = &mut stream.context;
+        let (cluster_id, h2) = self
+            .route_from_request(stream_context, proxy.clone())
             .map_err(BackendConnectionError::RetrieveClusterError)?;
-        println!("{cluster_id}!!!!!");
 
         let frontend_should_stick = proxy
             .borrow()
@@ -355,44 +430,95 @@ impl Router {
             .map(|cluster| cluster.sticky_session)
             .unwrap_or(false);
 
-        let mut socket = self.backend_from_request(
-            &cluster_id,
-            frontend_should_stick,
-            context,
-            proxy.clone(),
-            metrics,
-        )?;
+        let mut reuse_token = None;
+        // let mut priority = 0;
+        let mut reuse_connecting = true;
+        for (token, backend) in &self.backends {
+            match (h2, reuse_connecting, backend.position()) {
+                (_, _, Position::Server) => panic!("Backend connection behaves like a server"),
+                (_, _, Position::Client(BackendStatus::Disconnecting)) => {}
 
-        if let Err(e) = socket.set_nodelay(true) {
-            error!(
-                "error setting nodelay on back socket({:?}): {:?}",
-                socket, e
-            );
+                (true, _, Position::Client(BackendStatus::Connected(old_cluster_id))) => {
+                    if *old_cluster_id == cluster_id {
+                        reuse_token = Some(*token);
+                        reuse_connecting = false;
+                        break;
+                    }
+                }
+                (true, true, Position::Client(BackendStatus::Connecting(old_cluster_id))) => {
+                    if *old_cluster_id == cluster_id {
+                        reuse_token = Some(*token)
+                    }
+                }
+                (true, false, Position::Client(BackendStatus::Connecting(_))) => {}
+                (true, _, Position::Client(BackendStatus::KeepAlive(_))) => {
+                    panic!("ConnectionH2 behaves like H1")
+                }
+
+                (false, _, Position::Client(BackendStatus::KeepAlive(old_cluster_id))) => {
+                    if *old_cluster_id == cluster_id {
+                        reuse_token = Some(*token);
+                        reuse_connecting = false;
+                        break;
+                    }
+                }
+                // can't bundle H1 streams together
+                (false, _, Position::Client(BackendStatus::Connected(_)))
+                | (false, _, Position::Client(BackendStatus::Connecting(_))) => {}
+            }
         }
-        // self.backend_readiness.interest = Ready::WRITABLE | Ready::HUP | Ready::ERROR;
-        // self.backend_connection_status = BackendConnectionStatus::Connecting(Instant::now());
+        println!("connect: {cluster_id} (stick={frontend_should_stick}, h2={h2}) -> (reuse={reuse_token:?})");
 
-        let backend_token = proxy.borrow().add_session(session);
+        let token = if let Some(token) = reuse_token {
+            token
+        } else {
+            let mut socket = self.backend_from_request(
+                &cluster_id,
+                frontend_should_stick,
+                stream_context,
+                proxy.clone(),
+                metrics,
+            )?;
 
-        if let Err(e) = proxy.borrow().register_socket(
-            &mut socket,
-            backend_token,
-            Interest::READABLE | Interest::WRITABLE,
-        ) {
-            error!("error registering back socket({:?}): {:?}", socket, e);
-        }
+            if let Err(e) = socket.set_nodelay(true) {
+                error!(
+                    "error setting nodelay on back socket({:?}): {:?}",
+                    socket, e
+                );
+            }
+            // self.backend_readiness.interest = Ready::WRITABLE | Ready::HUP | Ready::ERROR;
+            // self.backend_connection_status = BackendConnectionStatus::Connecting(Instant::now());
 
-        stream.token = Some(backend_token);
+            let token = proxy.borrow().add_session(session);
+
+            if let Err(e) = proxy.borrow().register_socket(
+                &mut socket,
+                token,
+                Interest::READABLE | Interest::WRITABLE,
+            ) {
+                error!("error registering back socket({:?}): {:?}", socket, e);
+            }
+
+            let connection = Connection::new_h1_client(socket, cluster_id);
+            self.backends.insert(token, connection);
+            token
+        };
+
+        // link stream to backend
+        stream.token = Some(token);
+        // link backend to stream
         self.backends
-            .insert(backend_token, Connection::new_h1_client(socket, stream_id));
+            .get_mut(&token)
+            .unwrap()
+            .start_stream(stream_id, context);
         Ok(())
     }
 
-    fn cluster_id_from_request(
+    fn route_from_request(
         &mut self,
         context: &mut HttpContext,
         _proxy: Rc<RefCell<dyn L7Proxy>>,
-    ) -> Result<String, RetrieveClusterError> {
+    ) -> Result<(String, bool), RetrieveClusterError> {
         let (host, uri, method) = match context.extract_route() {
             Ok(tuple) => tuple,
             Err(cluster_error) => {
@@ -417,7 +543,7 @@ impl Router {
         };
 
         let cluster_id = match route {
-            Route::Cluster { id, .. } => id,
+            Route::Cluster { id, h2 } => (id, h2),
             Route::Deny => {
                 panic!("Route::Deny");
                 // self.set_answer(DefaultAnswerStatus::Answer401, None);
@@ -552,8 +678,28 @@ impl SessionState for Mux {
                 dirty = true;
             }
 
-            for (_, backend) in self.router.backends.iter_mut() {
-                if backend.readiness().filter_interest().is_writable() {
+            let mut dead_backends = Vec::new();
+            for (token, backend) in self.router.backends.iter_mut() {
+                let readiness = backend.readiness().filter_interest();
+                if readiness.is_hup() || readiness.is_error() {
+                    println!(
+                        "{token:?} -> {:?} {:?}",
+                        backend.readiness(),
+                        backend.socket()
+                    );
+                    backend.close(context, EndpointServer(&mut self.frontend));
+                    dead_backends.push(*token);
+                }
+                if readiness.is_writable() {
+                    let mut owned_position = Position::Server;
+                    let position = backend.position_mut();
+                    std::mem::swap(&mut owned_position, position);
+                    match owned_position {
+                        Position::Client(BackendStatus::Connecting(cluster_id)) => {
+                            *position = Position::Client(BackendStatus::Connected(cluster_id));
+                        }
+                        _ => *position = owned_position,
+                    }
                     match backend.writable(context, EndpointServer(&mut self.frontend)) {
                         MuxResult::Continue => (),
                         MuxResult::CloseSession => return SessionResult::Close,
@@ -563,7 +709,7 @@ impl SessionState for Mux {
                     dirty = true;
                 }
 
-                if backend.readiness().filter_interest().is_readable() {
+                if readiness.is_readable() {
                     match backend.readable(context, EndpointServer(&mut self.frontend)) {
                         MuxResult::Continue => (),
                         MuxResult::CloseSession => return SessionResult::Close,
@@ -572,6 +718,13 @@ impl SessionState for Mux {
                     }
                     dirty = true;
                 }
+            }
+            if !dead_backends.is_empty() {
+                for token in &dead_backends {
+                    self.router.backends.remove(token);
+                }
+                println!("FRONTEND: {:#?}", &self.frontend);
+                println!("BACKENDS: {:#?}", self.router.backends);
             }
 
             if self.frontend.readiness().filter_interest().is_writable() {
@@ -585,15 +738,6 @@ impl SessionState for Mux {
                     MuxResult::Connect(_) => unreachable!(),
                 }
                 dirty = true;
-            }
-
-            for backend in self.router.backends.values() {
-                if backend.readiness().filter_interest().is_hup()
-                    || backend.readiness().filter_interest().is_error()
-                {
-                    println!("{:?} {:?}", backend.readiness(), backend.socket());
-                    // return SessionResult::Close;
-                }
             }
 
             if !dirty {

--- a/lib/src/protocol/mux/parser.rs
+++ b/lib/src/protocol/mux/parser.rs
@@ -250,7 +250,7 @@ pub fn frame<'a>(input: &'a [u8], max_frame_size: u32) -> IResult<&'a [u8], Fram
             if header.payload_len % 6 != 0 {
                 return Err(Err::Failure(Error::new(input, InnerError::FrameSizeError)));
             }
-            settings_frame(i, &header)?
+            settings_frame(i, header.payload_len as usize)?
         }
         FrameType::Ping => {
             if header.payload_len != 8 {
@@ -408,9 +408,9 @@ pub struct Setting {
 
 pub fn settings_frame<'a, 'b>(
     input: &'a [u8],
-    header: &'b FrameHeader,
+    payload_len: usize,
 ) -> IResult<&'a [u8], Frame<'a>, Error<'a>> {
-    let (i, data) = take(header.payload_len)(input)?;
+    let (i, data) = take(payload_len)(input)?;
 
     let (_, settings) = many0(map(
         complete(tuple((be_u16, be_u32))),

--- a/lib/src/protocol/mux/parser.rs
+++ b/lib/src/protocol/mux/parser.rs
@@ -103,7 +103,10 @@ impl<'a> Error<'a> {
         Error { input, error }
     }
     pub fn new_h2(input: &'a [u8], error: H2Error) -> Error<'a> {
-        Error { input, error: InnerError::H2(error) }
+        Error {
+            input,
+            error: InnerError::H2(error),
+        }
     }
 }
 

--- a/lib/src/protocol/mux/parser.rs
+++ b/lib/src/protocol/mux/parser.rs
@@ -391,7 +391,6 @@ pub fn headers_frame<'a>(
             stream_id: header.stream_id,
             stream_dependency,
             weight,
-            // header_block_fragment,
             header_block_fragment: Slice::new(input, header_block_fragment),
             end_stream: header.flags & 0x1 != 0,
             end_headers: header.flags & 0x4 != 0,

--- a/lib/src/protocol/mux/parser.rs
+++ b/lib/src/protocol/mux/parser.rs
@@ -360,18 +360,12 @@ pub fn headers_frame<'a>(
         (i, None)
     };
 
-    let (i, stream_dependency) = if header.flags & 0x20 != 0 {
-        let (i, dep) = stream_dependency(i)?;
-        (i, Some(dep))
-    } else {
-        (i, None)
-    };
-
-    let (i, weight) = if header.flags & 0x20 != 0 {
+    let (i, stream_dependency, weight) = if header.flags & 0x20 != 0 {
+        let (i, stream_dependency) = stream_dependency(i)?;
         let (i, weight) = be_u8(i)?;
-        (i, Some(weight))
+        (i, Some(stream_dependency), Some(weight))
     } else {
-        (i, None)
+        (i, None, None)
     };
 
     if pad_length.is_some() && i.len() <= pad_length.unwrap() as usize {
@@ -521,10 +515,7 @@ pub fn ping_frame<'a>(
     let (i, data) = take(8usize)(input)?;
 
     let mut p = Ping { payload: [0; 8] };
-
-    for i in 0..8 {
-        p.payload[i] = data[i];
-    }
+    p.payload[..8].copy_from_slice(&data[..8]);
 
     Ok((i, Frame::Ping(p)))
 }

--- a/lib/src/protocol/mux/parser.rs
+++ b/lib/src/protocol/mux/parser.rs
@@ -1,0 +1,468 @@
+use std::convert::From;
+
+use nom::{
+    bytes::streaming::{tag, take},
+    combinator::{complete, map, map_opt},
+    error::{ErrorKind, ParseError},
+    multi::many0,
+    number::streaming::{be_u16, be_u24, be_u32, be_u8},
+    sequence::tuple,
+    Err, HexDisplay, IResult, Offset,
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct FrameHeader {
+    pub payload_len: u32,
+    pub frame_type: FrameType,
+    pub flags: u8,
+    pub stream_id: u32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum FrameType {
+    Data,
+    Headers,
+    Priority,
+    RstStream,
+    Settings,
+    PushPromise,
+    Ping,
+    GoAway,
+    WindowUpdate,
+    Continuation,
+}
+
+/*
+const NO_ERROR: u32 = 0x0;
+const PROTOCOL_ERROR: u32 = 0x1;
+const INTERNAL_ERROR: u32 = 0x2;
+const FLOW_CONTROL_ERROR: u32 = 0x3;
+const SETTINGS_TIMEOUT: u32 = 0x4;
+const STREAM_CLOSED: u32 = 0x5;
+const FRAME_SIZE_ERROR: u32 = 0x6;
+const REFUSED_STREAM: u32 = 0x7;
+const CANCEL: u32 = 0x8;
+const COMPRESSION_ERROR: u32 = 0x9;
+const CONNECT_ERROR: u32 = 0xa;
+const ENHANCE_YOUR_CALM: u32 = 0xb;
+const INADEQUATE_SECURITY: u32 = 0xc;
+const HTTP_1_1_REQUIRED: u32 = 0xd;
+*/
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Error<'a> {
+    pub input: &'a [u8],
+    pub error: InnerError,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum InnerError {
+    Nom(ErrorKind),
+    NoError,
+    ProtocolError,
+    InternalError,
+    FlowControlError,
+    SettingsTimeout,
+    StreamClosed,
+    FrameSizeError,
+    RefusedStream,
+    Cancel,
+    CompressionError,
+    ConnectError,
+    EnhanceYourCalm,
+    InadequateSecurity,
+    HTTP11Required,
+}
+
+impl<'a> Error<'a> {
+    pub fn new(input: &'a [u8], error: InnerError) -> Error<'a> {
+        Error { input, error }
+    }
+}
+
+impl<'a> ParseError<&'a [u8]> for Error<'a> {
+    fn from_error_kind(input: &'a [u8], kind: ErrorKind) -> Self {
+        Error {
+            input,
+            error: InnerError::Nom(kind),
+        }
+    }
+
+    fn append(input: &'a [u8], kind: ErrorKind, other: Self) -> Self {
+        Error {
+            input,
+            error: InnerError::Nom(kind),
+        }
+    }
+}
+
+impl<'a> From<(&'a [u8], ErrorKind)> for Error<'a> {
+    fn from((input, kind): (&'a [u8], ErrorKind)) -> Self {
+        Error {
+            input,
+            error: InnerError::Nom(kind),
+        }
+    }
+}
+
+pub fn preface(i: &[u8]) -> IResult<&[u8], &[u8]> {
+    tag(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")(i)
+}
+
+// https://httpwg.org/specs/rfc7540.html#rfc.section.4.1
+/*named!(pub frame_header<FrameHeader>,
+  do_parse!(
+    payload_len: dbg_dmp!(be_u24) >>
+    frame_type: map_opt!(be_u8, convert_frame_type) >>
+    flags: dbg_dmp!(be_u8) >>
+    stream_id: dbg_dmp!(verify!(be_u32, |id| {
+      match frame_type {
+
+      }
+    }) >>
+    (FrameHeader { payload_len, frame_type, flags, stream_id })
+  )
+);
+  */
+
+pub fn frame_header(input: &[u8]) -> IResult<&[u8], FrameHeader, Error> {
+    let (i1, payload_len) = be_u24(input)?;
+    let (i2, frame_type) = map_opt(be_u8, convert_frame_type)(i1)?;
+    let (i3, flags) = be_u8(i2)?;
+    let (i4, stream_id) = be_u32(i3)?;
+
+    Ok((
+        i4,
+        FrameHeader {
+            payload_len,
+            frame_type,
+            flags,
+            stream_id,
+        },
+    ))
+}
+
+fn convert_frame_type(t: u8) -> Option<FrameType> {
+    info!("got frame type: {}", t);
+    match t {
+        0 => Some(FrameType::Data),
+        1 => Some(FrameType::Headers),
+        2 => Some(FrameType::Priority),
+        3 => Some(FrameType::RstStream),
+        4 => Some(FrameType::Settings),
+        5 => Some(FrameType::PushPromise),
+        6 => Some(FrameType::Ping),
+        7 => Some(FrameType::GoAway),
+        8 => Some(FrameType::WindowUpdate),
+        9 => Some(FrameType::Continuation),
+        _ => None,
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Frame<'a> {
+    Data(Data<'a>),
+    Headers(Headers<'a>),
+    Priority,
+    RstStream(RstStream),
+    Settings(Settings),
+    PushPromise,
+    Ping(Ping),
+    GoAway,
+    WindowUpdate(WindowUpdate),
+    Continuation,
+}
+
+impl<'a> Frame<'a> {
+    pub fn is_stream_specific(&self) -> bool {
+        match self {
+            Frame::Data(_)
+            | Frame::Headers(_)
+            | Frame::Priority
+            | Frame::RstStream(_)
+            | Frame::PushPromise
+            | Frame::Continuation => true,
+            Frame::Settings(_) | Frame::Ping(_) | Frame::GoAway => false,
+            Frame::WindowUpdate(w) => w.stream_id != 0,
+        }
+    }
+
+    pub fn stream_id(&self) -> u32 {
+        match self {
+            Frame::Data(d) => d.stream_id,
+            Frame::Headers(h) => h.stream_id,
+            Frame::Priority => unimplemented!(),
+            Frame::RstStream(r) => r.stream_id,
+            Frame::PushPromise => unimplemented!(),
+            Frame::Continuation => unimplemented!(),
+            Frame::Settings(_) | Frame::Ping(_) | Frame::GoAway => 0,
+            Frame::WindowUpdate(w) => w.stream_id,
+        }
+    }
+}
+
+pub fn frame<'a>(input: &'a [u8], max_frame_size: u32) -> IResult<&'a [u8], Frame<'a>, Error<'a>> {
+    let (i, header) = frame_header(input)?;
+
+    info!("got frame header: {:?}", header);
+
+    if header.payload_len > max_frame_size {
+        return Err(Err::Failure(Error::new(input, InnerError::FrameSizeError)));
+    }
+
+    let valid_stream_id = match header.frame_type {
+        FrameType::Data
+        | FrameType::Headers
+        | FrameType::Priority
+        | FrameType::RstStream
+        | FrameType::PushPromise
+        | FrameType::Continuation => header.stream_id != 0,
+        FrameType::Settings | FrameType::Ping | FrameType::GoAway => header.stream_id == 0,
+        FrameType::WindowUpdate => true,
+    };
+
+    if !valid_stream_id {
+        return Err(Err::Failure(Error::new(input, InnerError::ProtocolError)));
+    }
+
+    let f = match header.frame_type {
+        FrameType::Data => data_frame(i, &header)?,
+        FrameType::Headers => headers_frame(i, &header)?,
+        FrameType::Priority => {
+            if header.payload_len != 5 {
+                return Err(Err::Failure(Error::new(input, InnerError::FrameSizeError)));
+            }
+            unimplemented!();
+        }
+        FrameType::RstStream => {
+            if header.payload_len != 4 {
+                return Err(Err::Failure(Error::new(input, InnerError::FrameSizeError)));
+            }
+            rst_stream_frame(i, &header)?
+        }
+        FrameType::PushPromise => {
+            unimplemented!();
+        }
+        FrameType::Continuation => {
+            unimplemented!();
+        }
+        FrameType::Settings => {
+            if header.payload_len % 6 != 0 {
+                return Err(Err::Failure(Error::new(input, InnerError::FrameSizeError)));
+            }
+            settings_frame(i, &header)?
+        }
+        FrameType::Ping => {
+            if header.payload_len != 8 {
+                return Err(Err::Failure(Error::new(input, InnerError::FrameSizeError)));
+            }
+            ping_frame(i, &header)?
+        }
+        FrameType::GoAway => {
+            unimplemented!();
+        }
+        FrameType::WindowUpdate => {
+            if header.payload_len != 4 {
+                return Err(Err::Failure(Error::new(input, InnerError::FrameSizeError)));
+            }
+            window_update_frame(i, &header)?
+        }
+    };
+
+    Ok(f)
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Data<'a> {
+    pub stream_id: u32,
+    pub payload: &'a [u8],
+    pub end_stream: bool,
+}
+
+pub fn data_frame<'a, 'b>(
+    input: &'a [u8],
+    header: &'b FrameHeader,
+) -> IResult<&'a [u8], Frame<'a>, Error<'a>> {
+    let (remaining, i) = take(header.payload_len)(input)?;
+
+    let (i1, pad_length) = if header.flags & 0x8 != 0 {
+        let (i, pad_length) = be_u8(i)?;
+        (i, Some(pad_length))
+    } else {
+        (i, None)
+    };
+
+    if pad_length.is_some() && i1.len() <= pad_length.unwrap() as usize {
+        return Err(Err::Failure(Error::new(input, InnerError::ProtocolError)));
+    }
+
+    let (_, payload) = take(i1.len() - pad_length.unwrap_or(0) as usize)(i1)?;
+
+    Ok((
+        remaining,
+        Frame::Data(Data {
+            stream_id: header.stream_id,
+            payload,
+            end_stream: header.flags & 0x1 != 0,
+        }),
+    ))
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Headers<'a> {
+    pub stream_id: u32,
+    pub stream_dependency: Option<StreamDependency>,
+    pub weight: Option<u8>,
+    pub header_block_fragment: &'a [u8],
+    pub end_stream: bool,
+    pub end_headers: bool,
+    pub priority: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct StreamDependency {
+    pub exclusive: bool,
+    pub stream_id: u32,
+}
+
+pub fn headers_frame<'a, 'b>(
+    input: &'a [u8],
+    header: &'b FrameHeader,
+) -> IResult<&'a [u8], Frame<'a>, Error<'a>> {
+    let (remaining, i) = take(header.payload_len)(input)?;
+
+    let (i1, pad_length) = if header.flags & 0x8 != 0 {
+        let (i, pad_length) = be_u8(i)?;
+        (i, Some(pad_length))
+    } else {
+        (i, None)
+    };
+
+    let (i2, stream_dependency) = if header.flags & 0x20 != 0 {
+        let (i, stream) = map(be_u32, |i| StreamDependency {
+            exclusive: i & 0x8000 != 0,
+            stream_id: i & 0x7FFF,
+        })(i1)?;
+        (i, Some(stream))
+    } else {
+        (i1, None)
+    };
+
+    let (i3, weight) = if header.flags & 0x20 != 0 {
+        let (i, weight) = be_u8(i2)?;
+        (i, Some(weight))
+    } else {
+        (i2, None)
+    };
+
+    if pad_length.is_some() && i3.len() <= pad_length.unwrap() as usize {
+        return Err(Err::Failure(Error::new(input, InnerError::ProtocolError)));
+    }
+
+    let (_, header_block_fragment) = take(i3.len() - pad_length.unwrap_or(0) as usize)(i3)?;
+
+    Ok((
+        remaining,
+        Frame::Headers(Headers {
+            stream_id: header.stream_id,
+            stream_dependency,
+            weight,
+            header_block_fragment,
+            end_stream: header.flags & 0x1 != 0,
+            end_headers: header.flags & 0x4 != 0,
+            priority: header.flags & 0x20 != 0,
+        }),
+    ))
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RstStream {
+    pub stream_id: u32,
+    pub error_code: u32,
+}
+
+pub fn rst_stream_frame<'a, 'b>(
+    input: &'a [u8],
+    header: &'b FrameHeader,
+) -> IResult<&'a [u8], Frame<'a>, Error<'a>> {
+    let (i, error_code) = be_u32(input)?;
+    Ok((
+        i,
+        Frame::RstStream(RstStream {
+            stream_id: header.stream_id,
+            error_code,
+        }),
+    ))
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Settings {
+    pub settings: Vec<Setting>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Setting {
+    pub identifier: u16,
+    pub value: u32,
+}
+
+pub fn settings_frame<'a, 'b>(
+    input: &'a [u8],
+    header: &'b FrameHeader,
+) -> IResult<&'a [u8], Frame<'a>, Error<'a>> {
+    let (i, data) = take(header.payload_len)(input)?;
+
+    let (_, settings) = many0(map(
+        complete(tuple((be_u16, be_u32))),
+        |(identifier, value)| Setting { identifier, value },
+    ))(data)?;
+
+    Ok((i, Frame::Settings(Settings { settings })))
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Ping {
+    pub payload: [u8; 8],
+}
+
+pub fn ping_frame<'a, 'b>(
+    input: &'a [u8],
+    header: &'b FrameHeader,
+) -> IResult<&'a [u8], Frame<'a>, Error<'a>> {
+    let (i, data) = take(8usize)(input)?;
+
+    let mut p = Ping { payload: [0; 8] };
+
+    for i in 0..8 {
+        p.payload[i] = data[i];
+    }
+
+    Ok((i, Frame::Ping(p)))
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct WindowUpdate {
+    pub stream_id: u32,
+    pub increment: u32,
+}
+
+pub fn window_update_frame<'a, 'b>(
+    input: &'a [u8],
+    header: &'b FrameHeader,
+) -> IResult<&'a [u8], Frame<'a>, Error<'a>> {
+    let (i, increment) = be_u32(input)?;
+    let increment = increment & 0x7FFF;
+
+    //FIXME: if stream id is 0, trat it as connection error?
+    if increment == 0 {
+        return Err(Err::Failure(Error::new(input, InnerError::ProtocolError)));
+    }
+
+    Ok((
+        i,
+        Frame::WindowUpdate(WindowUpdate {
+            stream_id: header.stream_id,
+            increment,
+        }),
+    ))
+}

--- a/lib/src/protocol/mux/pkawa.rs
+++ b/lib/src/protocol/mux/pkawa.rs
@@ -45,7 +45,7 @@ pub fn handle_header<C>(
                     } else if compare_no_case(&k, b":scheme") {
                         scheme = val;
                     } else if compare_no_case(&k, b"cookie") {
-                        panic!("cookies should be split in pairs");
+                        todo!("cookies should be split in pairs");
                     } else {
                         if compare_no_case(&k, b"content-length") {
                             let length =

--- a/lib/src/protocol/mux/pkawa.rs
+++ b/lib/src/protocol/mux/pkawa.rs
@@ -1,0 +1,107 @@
+use std::{io::Write, str::from_utf8_unchecked};
+
+use crate::protocol::http::parser::compare_no_case;
+
+use super::GenericHttpStream;
+
+pub fn handle_header(kawa: &mut GenericHttpStream, input: &[u8], decoder: &mut hpack::Decoder) {
+    println!("{input:?}");
+    kawa.push_block(kawa::Block::StatusLine);
+    kawa.detached.status_line = match kawa.kind {
+        kawa::Kind::Request => {
+            let mut method = kawa::Store::Empty;
+            let mut authority = kawa::Store::Empty;
+            let mut path = kawa::Store::Empty;
+            let mut scheme = kawa::Store::Empty;
+            decoder
+                .decode_with_cb(input, |k, v| {
+                    let start = kawa.storage.end as u32;
+                    kawa.storage.write(&k).unwrap();
+                    kawa.storage.write(&v).unwrap();
+                    let len_key = k.len() as u32;
+                    let len_val = v.len() as u32;
+                    let key = kawa::Store::Slice(kawa::repr::Slice {
+                        start,
+                        len: len_key,
+                    });
+                    let val = kawa::Store::Slice(kawa::repr::Slice {
+                        start: start + len_key,
+                        len: len_val,
+                    });
+
+                    if compare_no_case(&k, b":method") {
+                        method = val;
+                    } else if compare_no_case(&k, b":authority") {
+                        authority = val;
+                    } else if compare_no_case(&k, b":path") {
+                        path = val;
+                    } else if compare_no_case(&k, b":scheme") {
+                        scheme = val;
+                    } else {
+                        kawa.push_block(kawa::Block::Header(kawa::Pair { key, val }));
+                    }
+                })
+                .unwrap();
+            let buffer = kawa.storage.data();
+            let uri = unsafe {
+                format!(
+                    "{}://{}{}",
+                    from_utf8_unchecked(scheme.data(buffer)),
+                    from_utf8_unchecked(authority.data(buffer)),
+                    from_utf8_unchecked(path.data(buffer))
+                )
+            };
+            println!("Reconstructed URI: {uri}");
+            kawa::StatusLine::Request {
+                version: kawa::Version::V20,
+                method,
+                uri: kawa::Store::from_string(uri),
+                authority,
+                path,
+            }
+        }
+        kawa::Kind::Response => {
+            let mut code = 0;
+            let mut status = kawa::Store::Empty;
+            decoder
+                .decode_with_cb(input, |k, v| {
+                    let start = kawa.storage.end as u32;
+                    kawa.storage.write(&k).unwrap();
+                    kawa.storage.write(&v).unwrap();
+                    let len_key = k.len() as u32;
+                    let len_val = v.len() as u32;
+                    let key = kawa::Store::Slice(kawa::repr::Slice {
+                        start,
+                        len: len_key,
+                    });
+                    let val = kawa::Store::Slice(kawa::repr::Slice {
+                        start: start + len_key,
+                        len: len_val,
+                    });
+
+                    if compare_no_case(&k, b":status") {
+                        status = val;
+                        code = unsafe {
+                            std::str::from_utf8_unchecked(&k)
+                                .parse::<u16>()
+                                .ok()
+                                .unwrap()
+                        }
+                    } else {
+                        kawa.push_block(kawa::Block::Header(kawa::Pair { key, val }));
+                    }
+                })
+                .unwrap();
+            kawa::StatusLine::Response {
+                version: kawa::Version::V20,
+                code,
+                status,
+                reason: kawa::Store::Empty,
+            }
+        }
+    };
+
+    // everything has been parsed
+    kawa.storage.head = kawa.storage.end;
+    kawa.parsing_phase = kawa::ParsingPhase::Chunks { first: true };
+}

--- a/lib/src/protocol/mux/pkawa.rs
+++ b/lib/src/protocol/mux/pkawa.rs
@@ -117,7 +117,7 @@ pub fn handle_header<C>(
                 version: Version::V20,
                 code,
                 status,
-                reason: Store::Static(b"Default"),
+                reason: Store::Static(b"FromH2"),
             }
         }
     };

--- a/lib/src/protocol/mux/pkawa.rs
+++ b/lib/src/protocol/mux/pkawa.rs
@@ -56,20 +56,22 @@ pub fn handle_header<C>(
                     }
                 })
                 .unwrap();
-            let buffer = kawa.storage.data();
-            let uri = unsafe {
-                format!(
-                    "{}://{}{}",
-                    from_utf8_unchecked(scheme.data(buffer)),
-                    from_utf8_unchecked(authority.data(buffer)),
-                    from_utf8_unchecked(path.data(buffer))
-                )
-            };
-            println!("Reconstructed URI: {uri}");
+            // uri is only used by H1 statusline, in most cases it only consists of the path
+            // a better algorithm should be used though
+            // let buffer = kawa.storage.data();
+            // let uri = unsafe {
+            //     format!(
+            //         "{}://{}{}",
+            //         from_utf8_unchecked(scheme.data(buffer)),
+            //         from_utf8_unchecked(authority.data(buffer)),
+            //         from_utf8_unchecked(path.data(buffer))
+            //     )
+            // };
+            // println!("Reconstructed URI: {uri}");
             kawa::StatusLine::Request {
                 version: kawa::Version::V20,
                 method,
-                uri: kawa::Store::from_string(uri),
+                uri: path.clone(), //kawa::Store::from_string(uri),
                 authority,
                 path,
             }

--- a/lib/src/protocol/mux/pkawa.rs
+++ b/lib/src/protocol/mux/pkawa.rs
@@ -44,6 +44,8 @@ pub fn handle_header<C>(
                         path = val;
                     } else if compare_no_case(&k, b":scheme") {
                         scheme = val;
+                    } else if compare_no_case(&k, b"cookie") {
+                        panic!("cookies should be split in pairs");
                     } else {
                         if compare_no_case(&k, b"content-length") {
                             let length =
@@ -145,6 +147,11 @@ pub fn handle_header<C>(
         }));
         kawa.body_size = BodySize::Length(0);
     }
+
+    if kawa.parsing_phase == ParsingPhase::Terminated {
+        return;
+    }
+
     kawa.parsing_phase = match kawa.body_size {
         BodySize::Chunked => ParsingPhase::Chunks { first: true },
         BodySize::Length(0) => ParsingPhase::Terminated,

--- a/lib/src/protocol/mux/pkawa.rs
+++ b/lib/src/protocol/mux/pkawa.rs
@@ -46,6 +46,8 @@ pub fn handle_header<C>(
                         scheme = val;
                     } else if compare_no_case(&k, b"cookie") {
                         todo!("cookies should be split in pairs");
+                    } else if compare_no_case(&k, b"priority") {
+                        unimplemented!();
                     } else {
                         if compare_no_case(&k, b"content-length") {
                             let length =

--- a/lib/src/protocol/mux/serializer.rs
+++ b/lib/src/protocol/mux/serializer.rs
@@ -1,0 +1,37 @@
+use cookie_factory::{
+    bytes::{be_u24, be_u32, be_u8},
+    gen,
+    sequence::tuple,
+    GenError,
+};
+
+use super::parser::{FrameHeader, FrameType};
+
+pub fn gen_frame_header<'a, 'b>(
+    buf: &'a mut [u8],
+    frame: &'b FrameHeader,
+) -> Result<(&'a mut [u8], usize), GenError> {
+    let serializer = tuple((
+        be_u24(frame.payload_len),
+        be_u8(serialize_frame_type(&frame.frame_type)),
+        be_u8(frame.flags),
+        be_u32(frame.stream_id),
+    ));
+
+    gen(serializer, buf).map(|(buf, size)| (buf, size as usize))
+}
+
+pub fn serialize_frame_type(f: &FrameType) -> u8 {
+    match *f {
+        FrameType::Data => 0,
+        FrameType::Headers => 1,
+        FrameType::Priority => 2,
+        FrameType::RstStream => 3,
+        FrameType::Settings => 4,
+        FrameType::PushPromise => 5,
+        FrameType::Ping => 6,
+        FrameType::GoAway => 7,
+        FrameType::WindowUpdate => 8,
+        FrameType::Continuation => 9,
+    }
+}

--- a/lib/src/protocol/mux/serializer.rs
+++ b/lib/src/protocol/mux/serializer.rs
@@ -114,3 +114,26 @@ pub fn gen_rst_stream<'a>(
         gen(be_u32(error_code as u32), buf).map(|(buf, size)| (buf, (old_size + size as usize)))
     })
 }
+
+pub fn gen_goaway<'a>(
+    buf: &'a mut [u8],
+    last_stream_id: u32,
+    error_code: H2Error,
+) -> Result<(&'a mut [u8], usize), GenError> {
+    gen_frame_header(
+        buf,
+        &FrameHeader {
+            payload_len: 4,
+            frame_type: FrameType::GoAway,
+            flags: 0,
+            stream_id: 0,
+        },
+    )
+    .and_then(|(buf, old_size)| {
+        gen(
+            tuple((be_u32(last_stream_id), be_u32(error_code as u32))),
+            buf,
+        )
+        .map(|(buf, size)| (buf, (old_size + size as usize)))
+    })
+}

--- a/lib/src/protocol/mux/serializer.rs
+++ b/lib/src/protocol/mux/serializer.rs
@@ -1,5 +1,3 @@
-use core::slice;
-
 use cookie_factory::{
     bytes::{be_u16, be_u24, be_u32, be_u8},
     combinator::slice,

--- a/lib/src/protocol/mux/serializer.rs
+++ b/lib/src/protocol/mux/serializer.rs
@@ -1,11 +1,21 @@
+use core::slice;
+
 use cookie_factory::{
-    bytes::{be_u24, be_u32, be_u8},
+    bytes::{be_u16, be_u24, be_u32, be_u8},
+    combinator::slice,
     gen,
     sequence::tuple,
     GenError,
 };
 
-use super::parser::{FrameHeader, FrameType};
+use super::{
+    h2::H2Settings,
+    parser::{FrameHeader, FrameType},
+};
+
+pub const H2_PRI: &str = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+pub const SETTINGS_ACKNOWLEDGEMENT: [u8; 9] = [0, 0, 0, 4, 1, 0, 0, 0, 0];
+pub const PING_ACKNOWLEDGEMENT_HEADER: [u8; 9] = [0, 0, 0, 6, 1, 0, 0, 0, 0];
 
 pub fn gen_frame_header<'a, 'b>(
     buf: &'a mut [u8],
@@ -34,4 +44,56 @@ pub fn serialize_frame_type(f: &FrameType) -> u8 {
         FrameType::WindowUpdate => 8,
         FrameType::Continuation => 9,
     }
+}
+
+// pub fn gen_settings_acknoledgement<'a>(buf: &'a mut [u8]) {
+//     for (i, b) in SETTINGS_ACKNOWLEDGEMENT.iter().enumerate() {
+//         buf[i] = *b;
+//     }
+// }
+
+pub fn gen_ping_acknolegment<'a>(
+    buf: &'a mut [u8],
+    payload: &[u8],
+) -> Result<(&'a mut [u8], usize), GenError> {
+    gen(
+        tuple((slice(PING_ACKNOWLEDGEMENT_HEADER), slice(payload))),
+        buf,
+    )
+    .map(|(buf, size)| (buf, size as usize))
+}
+
+pub fn gen_settings<'a>(
+    buf: &'a mut [u8],
+    settings: &H2Settings,
+) -> Result<(&'a mut [u8], usize), GenError> {
+    gen_frame_header(
+        buf,
+        &FrameHeader {
+            payload_len: 6 * 6,
+            frame_type: FrameType::Settings,
+            flags: 0,
+            stream_id: 0,
+        },
+    )
+    .and_then(|(buf, old_size)| {
+        gen(
+            tuple((
+                be_u16(1),
+                be_u32(settings.settings_header_table_size),
+                be_u16(2),
+                be_u32(settings.settings_enable_push as u32),
+                be_u16(3),
+                be_u32(settings.settings_max_concurrent_streams),
+                be_u16(4),
+                be_u32(settings.settings_initial_window_size),
+                be_u16(5),
+                be_u32(settings.settings_max_frame_size),
+                be_u16(6),
+                be_u32(settings.settings_max_header_list_size),
+            )),
+            buf,
+        )
+        .map(|(buf, size)| (buf, (old_size + size as usize)))
+    })
 }

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -937,7 +937,7 @@ mod tests {
             ),
             Ok(Route::Cluster {
                 id: "examplewildcard".to_string(),
-                h2: true
+                h2: false
             })
         );
         assert_eq!(

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -134,7 +134,10 @@ impl Router {
         let method_rule = MethodRule::new(front.method.clone());
 
         let route = match &front.cluster_id {
-            Some(cluster_id) => Route::ClusterId(cluster_id.clone()),
+            Some(cluster_id) => Route::Cluster {
+                id: cluster_id.clone(),
+                h2: front.h2,
+            },
             None => Route::Deny,
         };
 
@@ -162,7 +165,7 @@ impl Router {
             }
         };
         if !success {
-            return Err(RouterError::AddRoute(format!("{:?}", front)));
+            return Err(RouterError::AddRoute(format!("{front:?}")));
         }
         Ok(())
     }
@@ -197,7 +200,7 @@ impl Router {
             }
         };
         if !remove_success {
-            return Err(RouterError::RemoveRoute(format!("{:?}", front)));
+            return Err(RouterError::RemoveRoute(format!("{front:?}")));
         }
         Ok(())
     }
@@ -598,7 +601,7 @@ pub enum Route {
     /// send a 401 default answer
     Deny,
     /// the cluster to which the frontend belongs
-    ClusterId(ClusterId),
+    Cluster { id: ClusterId, h2: bool },
 }
 
 #[cfg(test)]
@@ -717,27 +720,42 @@ mod tests {
             b"*.sozu.io",
             &PathRule::Prefix("".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("base".to_string())
+            &Route::Cluster {
+                id: "base".to_string(),
+                h2: false
+            }
         ));
         println!("{:#?}", router.tree);
         assert_eq!(
             router.lookup("www.sozu.io", "/api", &Method::Get),
-            Ok(Route::ClusterId("base".to_string()))
+            Ok(Route::Cluster {
+                id: "base".to_string(),
+                h2: false
+            })
         );
         assert!(router.add_tree_rule(
             b"*.sozu.io",
             &PathRule::Prefix("/api".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("api".to_string())
+            &Route::Cluster {
+                id: "api".to_string(),
+                h2: false
+            }
         ));
         println!("{:#?}", router.tree);
         assert_eq!(
             router.lookup("www.sozu.io", "/ap", &Method::Get),
-            Ok(Route::ClusterId("base".to_string()))
+            Ok(Route::Cluster {
+                id: "base".to_string(),
+                h2: false
+            })
         );
         assert_eq!(
             router.lookup("www.sozu.io", "/api", &Method::Get),
-            Ok(Route::ClusterId("api".to_string()))
+            Ok(Route::Cluster {
+                id: "api".to_string(),
+                h2: false
+            })
         );
     }
 
@@ -756,27 +774,42 @@ mod tests {
             b"*.sozu.io",
             &PathRule::Prefix("".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("base".to_string())
+            &Route::Cluster {
+                id: "base".to_string(),
+                h2: false
+            }
         ));
         println!("{:#?}", router.tree);
         assert_eq!(
             router.lookup("www.sozu.io", "/api", &Method::Get),
-            Ok(Route::ClusterId("base".to_string()))
+            Ok(Route::Cluster {
+                id: "base".to_string(),
+                h2: false
+            })
         );
         assert!(router.add_tree_rule(
             b"api.sozu.io",
             &PathRule::Prefix("".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("api".to_string())
+            &Route::Cluster {
+                id: "api".to_string(),
+                h2: false
+            }
         ));
         println!("{:#?}", router.tree);
         assert_eq!(
             router.lookup("www.sozu.io", "/api", &Method::Get),
-            Ok(Route::ClusterId("base".to_string()))
+            Ok(Route::Cluster {
+                id: "base".to_string(),
+                h2: false
+            })
         );
         assert_eq!(
             router.lookup("api.sozu.io", "/api", &Method::Get),
-            Ok(Route::ClusterId("api".to_string()))
+            Ok(Route::Cluster {
+                id: "api".to_string(),
+                h2: false
+            })
         );
     }
 
@@ -788,23 +821,35 @@ mod tests {
             b"www./.*/.io",
             &PathRule::Prefix("".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("base".to_string())
+            &Route::Cluster {
+                id: "base".to_string(),
+                h2: false
+            }
         ));
         println!("{:#?}", router.tree);
         assert!(router.add_tree_rule(
             b"www.doc./.*/.io",
             &PathRule::Prefix("".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("doc".to_string())
+            &Route::Cluster {
+                id: "doc".to_string(),
+                h2: false
+            }
         ));
         println!("{:#?}", router.tree);
         assert_eq!(
             router.lookup("www.sozu.io", "/", &Method::Get),
-            Ok(Route::ClusterId("base".to_string()))
+            Ok(Route::Cluster {
+                id: "base".to_string(),
+                h2: false
+            })
         );
         assert_eq!(
             router.lookup("www.doc.sozu.io", "/", &Method::Get),
-            Ok(Route::ClusterId("doc".to_string()))
+            Ok(Route::Cluster {
+                id: "doc".to_string(),
+                h2: false
+            })
         );
         assert!(router.remove_tree_rule(
             b"www./.*/.io",
@@ -815,7 +860,10 @@ mod tests {
         assert!(router.lookup("www.sozu.io", "/", &Method::Get).is_err());
         assert_eq!(
             router.lookup("www.doc.sozu.io", "/", &Method::Get),
-            Ok(Route::ClusterId("doc".to_string()))
+            Ok(Route::Cluster {
+                id: "doc".to_string(),
+                h2: false
+            })
         );
     }
 
@@ -827,30 +875,45 @@ mod tests {
             &"*".parse::<DomainRule>().unwrap(),
             &PathRule::Prefix("/.well-known/acme-challenge".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("acme".to_string())
+            &Route::Cluster {
+                id: "acme".to_string(),
+                h2: false
+            }
         ));
         assert!(router.add_tree_rule(
             "www.example.com".as_bytes(),
             &PathRule::Prefix("/".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("example".to_string())
+            &Route::Cluster {
+                id: "example".to_string(),
+                h2: false
+            }
         ));
         assert!(router.add_tree_rule(
             "*.test.example.com".as_bytes(),
             &PathRule::Regex(Regex::new("/hello[A-Z]+/").unwrap()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("examplewildcard".to_string())
+            &Route::Cluster {
+                id: "examplewildcard".to_string(),
+                h2: false
+            }
         ));
         assert!(router.add_tree_rule(
             "/test[0-9]/.example.com".as_bytes(),
             &PathRule::Prefix("/".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("exampleregex".to_string())
+            &Route::Cluster {
+                id: "exampleregex".to_string(),
+                h2: false
+            }
         ));
 
         assert_eq!(
             router.lookup("www.example.com", "/helloA", &Method::new(&b"GET"[..])),
-            Ok(Route::ClusterId("example".to_string()))
+            Ok(Route::Cluster {
+                id: "example".to_string(),
+                h2: false
+            })
         );
         assert_eq!(
             router.lookup(
@@ -858,7 +921,10 @@ mod tests {
                 "/.well-known/acme-challenge",
                 &Method::new(&b"GET"[..])
             ),
-            Ok(Route::ClusterId("acme".to_string()))
+            Ok(Route::Cluster {
+                id: "acme".to_string(),
+                h2: false
+            })
         );
         assert!(router
             .lookup("www.test.example.com", "/", &Method::new(&b"GET"[..]))
@@ -869,11 +935,28 @@ mod tests {
                 "/helloAB/",
                 &Method::new(&b"GET"[..])
             ),
-            Ok(Route::ClusterId("examplewildcard".to_string()))
+            Ok(Route::Cluster {
+                id: "examplewildcard".to_string(),
+                h2: true
+            })
+        );
+        assert_eq!(
+            router.lookup(
+                "www.test.example.com",
+                "/helloAB/",
+                &Method::new(&b"GET"[..])
+            ),
+            Ok(Route::Cluster {
+                id: "examplewildcard".to_string(),
+                h2: false
+            })
         );
         assert_eq!(
             router.lookup("test1.example.com", "/helloAB/", &Method::new(&b"GET"[..])),
-            Ok(Route::ClusterId("exampleregex".to_string()))
+            Ok(Route::Cluster {
+                id: "exampleregex".to_string(),
+                h2: false
+            })
         );
     }
 }

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -1305,8 +1305,7 @@ impl Server {
 
                         None => {
                             let error = format!(
-                                "Couldn't deactivate HTTPS listener at address {:?}",
-                                address
+                                "Couldn't deactivate HTTPS listener at address {address:?}",
                             );
                             error!("{}", error);
                             return WorkerResponse::error(req_id, error);
@@ -1345,7 +1344,7 @@ impl Server {
                     Some((token, listener)) => (token, listener),
                     None => {
                         let error =
-                            format!("Couldn't deactivate TCP listener at address {:?}", address);
+                            format!("Couldn't deactivate TCP listener at address {address:?}");
                         error!("{}", error);
                         return WorkerResponse::error(req_id, error);
                     }

--- a/lib/src/socket.rs
+++ b/lib/src/socket.rs
@@ -171,6 +171,12 @@ pub struct FrontRustls {
     pub session: ServerConnection,
 }
 
+impl std::fmt::Debug for FrontRustls {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("FrontRustls")
+    }
+}
+
 impl SocketHandler for FrontRustls {
     fn socket_read(&mut self, buf: &mut [u8]) -> (usize, SocketResult) {
         let mut size = 0usize;

--- a/lib/src/socket.rs
+++ b/lib/src/socket.rs
@@ -196,7 +196,7 @@ impl SocketHandler for FrontRustls {
                 break;
             }
 
-            if !can_read | is_error | is_closed {
+            if !can_read || is_error || is_closed {
                 break;
             }
 


### PR DESCRIPTION
This is the final stage of our proposition to support HTTP/2 in Sozu.
Taking full advantage of kawa translating Mux is a state that handles one frontend connection and up to N backend connections in a protocol-agnostic way. Protocol specifics are secluded in connection implementations which only sees its internal state, a shared Context, and a protocol-agnostic interface to its opposite endpoint.
The translation is smoothly and transparently handled by kawa while Mux treats connections all the same.

Note: I really think Mux is a good way to abstract a lot of cases and reduce the amount of code necessary to handle them. However, it might be overengineered and suboptimal for the most common cases (H1 -> H1 and H2 -> { H2, H2, ... }) since it always operates as if in the worst-case scenario ( H2 -> { H2, H1, ... } ).