### PR TITLE
Fix display of nonexisting cluster

### DIFF
--- a/bin/config.toml
+++ b/bin/config.toml
@@ -44,9 +44,9 @@ command_socket = "./sozu.sock"
 # buffer will grow up to max_command_buffer_size. If the buffer is still not large
 # enough sozu will close the connection
 # defaults to 1000000
-command_buffer_size = 16384
+command_buffer_size = 1_000_000
 # defaults to command_buffer_size * 2
-max_command_buffer_size = 163840
+max_command_buffer_size = 2_000_000
 
 # the number of worker processes that will handle traffic
 # defaults to 2 workers
@@ -89,7 +89,7 @@ buffer_size = 16393
 
 # how much time (in milliseconds) sozu command line will wait for a command to complete.
 # Defaults to 1000 milliseconds
-# ctl_command_timeout = 1000
+ctl_command_timeout = 60_000
 
 # PID file is a file containing the PID of the main process of sozu.
 # It can be helpful to help systemd or any other service system to keep track

--- a/bin/config.toml
+++ b/bin/config.toml
@@ -44,9 +44,9 @@ command_socket = "./sozu.sock"
 # buffer will grow up to max_command_buffer_size. If the buffer is still not large
 # enough sozu will close the connection
 # defaults to 1000000
-command_buffer_size = 1_000_000
+command_buffer_size = 16384
 # defaults to command_buffer_size * 2
-max_command_buffer_size = 2_000_000
+max_command_buffer_size = 163840
 
 # the number of worker processes that will handle traffic
 # defaults to 2 workers
@@ -89,7 +89,7 @@ buffer_size = 16393
 
 # how much time (in milliseconds) sozu command line will wait for a command to complete.
 # Defaults to 1000 milliseconds
-ctl_command_timeout = 60_000
+# ctl_command_timeout = 1000
 
 # PID file is a file containing the PID of the main process of sozu.
 # It can be helpful to help systemd or any other service system to keep track

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -451,8 +451,10 @@ pub fn print_cluster_responses(
         for (worker_id, response_content) in worker_responses.map.iter() {
             if let Some(ContentType::Clusters(clusters)) = &response_content.content_type {
                 for cluster in clusters.vec.iter() {
-                    let entry = cluster_infos.entry(cluster).or_insert(Vec::new());
-                    entry.push(worker_id.to_owned());
+                    if cluster.configuration.is_some() {
+                        let entry = cluster_infos.entry(cluster).or_insert(Vec::new());
+                        entry.push(worker_id.to_owned());
+                    }
 
                     for frontend in cluster.http_frontends.iter() {
                         let entry = http_frontends.entry(frontend).or_insert(Vec::new());
@@ -485,7 +487,7 @@ pub fn print_cluster_responses(
                 .configuration
                 .as_ref()
                 .map(|conf| conf.cluster_id.to_owned())
-                .unwrap_or_else(String::new)));
+                .unwrap_or_else(|| String::from("None"))));
             row.push(cell!(cluster_info
                 .configuration
                 .as_ref()

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -1129,7 +1129,7 @@ impl ConfigState {
 
     // FIXME: what about deny rules?
     pub fn hash_state(&self) -> BTreeMap<ClusterId, u64> {
-        let mut hm: HashMap<String, DefaultHasher> = self
+        let mut hm: HashMap<ClusterId, DefaultHasher> = self
             .clusters
             .keys()
             .map(|cluster_id| {
@@ -1141,10 +1141,11 @@ impl ConfigState {
                 if let Some(tcp_fronts) = self.tcp_fronts.get(cluster_id) {
                     tcp_fronts.iter().collect::<BTreeSet<_>>().hash(&mut hasher)
                 }
-                (cluster_id.to_string(), hasher)
+                (cluster_id.to_owned(), hasher)
             })
             .collect();
 
+            
         for front in self.http_fronts.values() {
             if let Some(cluster_id) = &front.cluster_id {
                 if let Some(hasher) = hm.get_mut(cluster_id) {


### PR DESCRIPTION
a non-existing cluster would still get "displayed" in with a default line without an id:

```
┌────┬────────────────┬────────────────┬───┬───┬──────┐
│ id │ sticky_session │ https_redirect │ 0 │ 1 │ main │
├────┼────────────────┼────────────────┼───┼───┼──────┤
│    │ false          │ false          │ X │ X │ X    │
└────┴────────────────┴────────────────┴───┴───┴──────┘
```

this PR removes this undesirable effect