### PR TITLE
Remove deny rule, enforce cluster checks when adding frontends and backends

### DIFF
--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -2,10 +2,7 @@ use std::{collections::BTreeMap, net::SocketAddr};
 
 use clap::{Parser, Subcommand};
 
-use sozu_command_lib::{
-    proto::command::{LoadBalancingAlgorithms, TlsVersion},
-    state::ClusterId as StateClusterId,
-};
+use sozu_command_lib::proto::command::{LoadBalancingAlgorithms, TlsVersion};
 
 #[derive(Parser, PartialEq, Eq, Clone, Debug)]
 #[clap(author, version, about)]
@@ -404,27 +401,6 @@ pub enum FrontendCmd {
 }
 
 #[derive(Subcommand, PartialEq, Eq, Clone, Debug)]
-pub enum ClusterId {
-    /// traffic will go to the backend servers with this cluster id
-    Id {
-        /// traffic will go to the backend servers with this cluster id
-        id: String,
-    },
-    /// traffic to this frontend will be rejected with HTTP 401
-    Deny,
-}
-
-#[allow(clippy::from_over_into)]
-impl std::convert::Into<Option<StateClusterId>> for ClusterId {
-    fn into(self) -> Option<StateClusterId> {
-        match self {
-            ClusterId::Deny => None,
-            ClusterId::Id { id } => Some(id),
-        }
-    }
-}
-
-#[derive(Subcommand, PartialEq, Eq, Clone, Debug)]
 pub enum HttpFrontendCmd {
     #[clap(name = "add")]
     Add {
@@ -434,8 +410,8 @@ pub enum HttpFrontendCmd {
             help = "frontend address, format: IP:port"
         )]
         address: SocketAddr,
-        #[clap(subcommand, name = "cluster_id")]
-        cluster_id: ClusterId,
+        #[clap(short = 'i', long = "id", help = "The id of the associated cluster")]
+        cluster_id: String,
         #[clap(long = "hostname", aliases = &["host"])]
         hostname: String,
         #[clap(short = 'p', long = "path-prefix", help = "URL prefix of the frontend")]
@@ -463,8 +439,8 @@ pub enum HttpFrontendCmd {
             help = "frontend address, format: IP:port"
         )]
         address: SocketAddr,
-        #[clap(subcommand, name = "cluster_id")]
-        cluster_id: ClusterId,
+        #[clap(short = 'i', long = "id", help = "The id of the associated cluster")]
+        cluster_id: String,
         #[clap(long = "hostname", aliases = &["host"])]
         hostname: String,
         #[clap(short = 'p', long = "path-prefix", help = "URL prefix of the frontend")]

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -150,10 +150,7 @@ pub fn print_frontend_list(frontends: ListedFrontends) {
         ]);
         for http_frontend in frontends.http_frontends.iter() {
             table.add_row(row!(
-                http_frontend
-                    .cluster_id
-                    .clone()
-                    .unwrap_or("Deny".to_owned()),
+                http_frontend.cluster_id,
                 http_frontend.address.to_string(),
                 http_frontend.hostname.to_string(),
                 format!("{:?}", http_frontend.path),
@@ -181,10 +178,7 @@ pub fn print_frontend_list(frontends: ListedFrontends) {
         ]);
         for https_frontend in frontends.https_frontends.iter() {
             table.add_row(row!(
-                https_frontend
-                    .cluster_id
-                    .clone()
-                    .unwrap_or("Deny".to_owned()),
+                https_frontend.cluster_id,
                 https_frontend.address.to_string(),
                 https_frontend.hostname.to_string(),
                 format!("{:?}", https_frontend.path),
@@ -514,10 +508,7 @@ pub fn print_cluster_responses(
 
         for (key, values) in http_frontends.iter() {
             let mut row = Vec::new();
-            match &key.cluster_id {
-                Some(cluster_id) => row.push(cell!(cluster_id)),
-                None => row.push(cell!("-")),
-            }
+            row.push(cell!(key.cluster_id));
             row.push(cell!(key.hostname));
             row.push(cell!(key.path));
 
@@ -538,10 +529,7 @@ pub fn print_cluster_responses(
 
         for (key, values) in https_frontends.iter() {
             let mut row = Vec::new();
-            match &key.cluster_id {
-                Some(cluster_id) => row.push(cell!(cluster_id)),
-                None => row.push(cell!("-")),
-            }
+            row.push(cell!(key.cluster_id));
             row.push(cell!(key.hostname));
             row.push(cell!(key.path));
 

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -200,11 +200,11 @@ impl CommandManager {
                 path_equals,
                 address,
                 method,
-                cluster_id: route,
+                cluster_id,
                 tags,
             } => self.send_request(
                 RequestType::AddHttpFrontend(RequestHttpFrontend {
-                    cluster_id: route.into(),
+                    cluster_id,
                     address: address.to_string(),
                     hostname,
                     path: PathRule::from_cli_options(path_prefix, path_regex, path_equals),
@@ -224,10 +224,10 @@ impl CommandManager {
                 path_equals,
                 address,
                 method,
-                cluster_id: route,
+                cluster_id,
             } => self.send_request(
                 RequestType::RemoveHttpFrontend(RequestHttpFrontend {
-                    cluster_id: route.into(),
+                    cluster_id,
                     address: address.to_string(),
                     hostname,
                     path: PathRule::from_cli_options(path_prefix, path_regex, path_equals),
@@ -248,11 +248,11 @@ impl CommandManager {
                 path_equals,
                 address,
                 method,
-                cluster_id: route,
+                cluster_id,
                 tags,
             } => self.send_request(
                 RequestType::AddHttpsFrontend(RequestHttpFrontend {
-                    cluster_id: route.into(),
+                    cluster_id,
                     address: address.to_string(),
                     hostname,
                     path: PathRule::from_cli_options(path_prefix, path_regex, path_equals),
@@ -272,10 +272,10 @@ impl CommandManager {
                 path_equals,
                 address,
                 method,
-                cluster_id: route,
+                cluster_id,
             } => self.send_request(
                 RequestType::RemoveHttpsFrontend(RequestHttpFrontend {
-                    cluster_id: route.into(),
+                    cluster_id,
                     address: address.to_string(),
                     hostname,
                     path: PathRule::from_cli_options(path_prefix, path_regex, path_equals),

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -209,7 +209,7 @@ message ListenersList {
 
 // An HTTP or HTTPS frontend, as order to, or received from, Sōzu
 message RequestHttpFrontend {
-    optional string cluster_id = 1;
+    required string cluster_id = 1;
     required string address = 2;
     required string hostname = 3;
     required PathRule path = 4;

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -921,7 +921,7 @@ impl HttpFrontendConfig {
 
             v.push(
                 RequestType::AddHttpsFrontend(RequestHttpFrontend {
-                    cluster_id: Some(cluster_id.to_string()),
+                    cluster_id: cluster_id.to_string(),
                     address: self.address.to_string(),
                     hostname: self.hostname.clone(),
                     path: self.path.clone(),
@@ -935,7 +935,7 @@ impl HttpFrontendConfig {
             //create the front both for HTTP and HTTPS if possible
             v.push(
                 RequestType::AddHttpFrontend(RequestHttpFrontend {
-                    cluster_id: Some(cluster_id.to_string()),
+                    cluster_id: cluster_id.to_string(),
                     address: self.address.to_string(),
                     hostname: self.hostname.clone(),
                     path: self.path.clone(),

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -26,8 +26,7 @@ impl Response {
 /// An HTTP or HTTPS frontend, as used *within* Sōzu
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HttpFrontend {
-    /// Send a 401, DENY, if cluster_id is None
-    pub cluster_id: Option<ClusterId>,
+    pub cluster_id: ClusterId,
     pub address: SocketAddr,
     pub hostname: String,
     #[serde(default)]

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -170,7 +170,18 @@ impl ConfigState {
         Ok(())
     }
 
+    /// Remove a cluster and all its children (frontends and backends)
     fn remove_cluster(&mut self, cluster_id: &str) -> Result<(), StateError> {
+        self.http_fronts
+            .retain(|_, front| front.cluster_id != cluster_id);
+
+        self.https_fronts
+            .retain(|_, front| front.cluster_id != cluster_id);
+
+        self.tcp_fronts.retain(|id, _| id != cluster_id);
+
+        self.backends.retain(|id, _| id != cluster_id);
+
         match self.clusters.remove(cluster_id) {
             Some(_) => Ok(()),
             None => Err(StateError::NotFound {

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -1146,18 +1146,14 @@ impl ConfigState {
             .collect();
 
         for front in self.http_fronts.values() {
-            if let Some(cluster_id) = &front.cluster_id {
-                if let Some(s) = h.get_mut(cluster_id) {
-                    front.hash(s);
-                }
+            if let Some(s) = h.get_mut(&front.cluster_id) {
+                front.hash(s);
             }
         }
 
         for front in self.https_fronts.values() {
-            if let Some(cluster_id) = &front.cluster_id {
-                if let Some(s) = h.get_mut(cluster_id) {
-                    front.hash(s);
-                }
+            if let Some(s) = h.get_mut(&front.cluster_id) {
+                front.hash(s);
             }
         }
 
@@ -1175,18 +1171,14 @@ impl ConfigState {
         let mut backends = Vec::new();
 
         for http_frontend in self.http_fronts.values() {
-            if let Some(id) = &http_frontend.cluster_id {
-                if id == cluster_id {
-                    http_frontends.push(http_frontend.clone().into());
-                }
+            if http_frontend.cluster_id == cluster_id {
+                http_frontends.push(http_frontend.clone().into());
             }
         }
 
         for https_frontend in self.https_fronts.values() {
-            if let Some(id) = &https_frontend.cluster_id {
-                if id == cluster_id {
-                    https_frontends.push(https_frontend.clone().into());
-                }
+            if https_frontend.cluster_id == cluster_id {
+                https_frontends.push(https_frontend.clone().into());
             }
         }
 
@@ -1226,17 +1218,13 @@ impl ConfigState {
 
         self.http_fronts.values().for_each(|front| {
             if domain_check(&front.hostname, &front.path, &hostname, &path) {
-                if let Some(id) = &front.cluster_id {
-                    cluster_ids.insert(id.to_string());
-                }
+                cluster_ids.insert(front.cluster_id.clone());
             }
         });
 
         self.https_fronts.values().for_each(|front| {
             if domain_check(&front.hostname, &front.path, &hostname, &path) {
-                if let Some(id) = &front.cluster_id {
-                    cluster_ids.insert(id.to_string());
-                }
+                cluster_ids.insert(front.cluster_id.clone());
             }
         });
 
@@ -1488,7 +1476,7 @@ mod tests {
         state
             .dispatch(
                 &RequestType::AddHttpFrontend(RequestHttpFrontend {
-                    cluster_id: Some(String::from("cluster_1")),
+                    cluster_id: String::from("cluster_1"),
                     hostname: String::from("lolcatho.st:8080"),
                     path: PathRule::prefix(String::from("/")),
                     address: "0.0.0.0:8080".to_string(),
@@ -1501,7 +1489,7 @@ mod tests {
         state
             .dispatch(
                 &RequestType::AddHttpFrontend(RequestHttpFrontend {
-                    cluster_id: Some(String::from("cluster_2")),
+                    cluster_id: String::from("cluster_2"),
                     hostname: String::from("test.local"),
                     path: PathRule::prefix(String::from("/abc")),
                     address: "0.0.0.0:8080".to_string(),
@@ -1583,7 +1571,7 @@ mod tests {
         state
             .dispatch(
                 &RequestType::AddHttpFrontend(RequestHttpFrontend {
-                    cluster_id: Some(String::from("cluster_1")),
+                    cluster_id: String::from("cluster_1"),
                     hostname: String::from("lolcatho.st:8080"),
                     path: PathRule::prefix(String::from("/")),
                     address: "0.0.0.0:8080".to_string(),
@@ -1596,7 +1584,7 @@ mod tests {
         state
             .dispatch(
                 &RequestType::AddHttpFrontend(RequestHttpFrontend {
-                    cluster_id: Some(String::from("cluster_2")),
+                    cluster_id: String::from("cluster_2"),
                     hostname: String::from("test.local"),
                     path: PathRule::prefix(String::from("/abc")),
                     address: "0.0.0.0:8080".to_string(),
@@ -1657,7 +1645,7 @@ mod tests {
         state2
             .dispatch(
                 &RequestType::AddHttpFrontend(RequestHttpFrontend {
-                    cluster_id: Some(String::from("cluster_1")),
+                    cluster_id: String::from("cluster_1"),
                     hostname: String::from("lolcatho.st:8080"),
                     path: PathRule::prefix(String::from("/")),
                     address: "0.0.0.0:8080".to_string(),
@@ -1717,7 +1705,7 @@ mod tests {
 
         let e: Vec<Request> = vec![
             RequestType::RemoveHttpFrontend(RequestHttpFrontend {
-                cluster_id: Some(String::from("cluster_2")),
+                cluster_id: String::from("cluster_2"),
                 hostname: String::from("test.local"),
                 path: PathRule::prefix(String::from("/abc")),
                 address: "0.0.0.0:8080".to_string(),
@@ -1781,7 +1769,7 @@ mod tests {
     fn cluster_ids_by_domain() {
         let mut config = ConfigState::new();
         let http_front_cluster1 = RequestHttpFrontend {
-            cluster_id: Some(String::from("MyCluster_1")),
+            cluster_id: String::from("MyCluster_1"),
             hostname: String::from("lolcatho.st"),
             path: PathRule::prefix(String::from("")),
             address: "0.0.0.0:8080".to_string(),
@@ -1789,7 +1777,7 @@ mod tests {
         };
 
         let https_front_cluster1 = RequestHttpFrontend {
-            cluster_id: Some(String::from("MyCluster_1")),
+            cluster_id: String::from("MyCluster_1"),
             hostname: String::from("lolcatho.st"),
             path: PathRule::prefix(String::from("")),
             address: "0.0.0.0:8443".to_string(),
@@ -1797,7 +1785,7 @@ mod tests {
         };
 
         let http_front_cluster2 = RequestHttpFrontend {
-            cluster_id: Some(String::from("MyCluster_2")),
+            cluster_id: String::from("MyCluster_2"),
             hostname: String::from("lolcatho.st"),
             path: PathRule::prefix(String::from("/api")),
             address: "0.0.0.0:8080".to_string(),
@@ -1805,7 +1793,7 @@ mod tests {
         };
 
         let https_front_cluster2 = RequestHttpFrontend {
-            cluster_id: Some(String::from("MyCluster_2")),
+            cluster_id: String::from("MyCluster_2"),
             hostname: String::from("lolcatho.st"),
             path: PathRule::prefix(String::from("/api")),
             address: "0.0.0.0:8443".to_string(),

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -519,6 +519,8 @@ impl ConfigState {
     }
 
     fn add_backend(&mut self, add_backend: &AddBackend) -> Result<(), StateError> {
+        self.check_for_cluster_presence(&add_backend.cluster_id)?;
+
         let backend = Backend {
             address: parse_socket_address(&add_backend.address)?,
             cluster_id: add_backend.cluster_id.clone(),
@@ -1911,6 +1913,16 @@ mod tests {
     #[test]
     fn duplicate_backends() {
         let mut state: ConfigState = Default::default();
+
+        let cluster_1 = Cluster {
+            cluster_id: "cluster_1".to_string(),
+            ..Default::default()
+        };
+
+        state
+            .dispatch(&RequestType::AddCluster(cluster_1).into())
+            .expect("Could not execute request");
+
         state
             .dispatch(
                 &RequestType::AddBackend(AddBackend {

--- a/e2e/src/sozu/worker.rs
+++ b/e2e/src/sozu/worker.rs
@@ -301,7 +301,7 @@ impl Worker {
         address: SocketAddr,
     ) -> RequestHttpFrontend {
         RequestHttpFrontend {
-            cluster_id: Some(cluster_id.into()),
+            cluster_id: cluster_id.into(),
             address: address.to_string(),
             hostname: String::from("localhost"),
             path: PathRule::prefix(String::from("/")),

--- a/lib/examples/main.rs
+++ b/lib/examples/main.rs
@@ -60,7 +60,7 @@ fn main() -> anyhow::Result<()> {
     });
 
     let http_front = RequestHttpFrontend {
-        cluster_id: Some(String::from("cluster_1")),
+        cluster_id: String::from("cluster_1"),
         address: "127.0.0.1:8080".to_string(),
         hostname: String::from("lolcatho.st"),
         path: PathRule::prefix(String::from("/")),
@@ -122,7 +122,7 @@ fn main() -> anyhow::Result<()> {
     });
 
     let tls_front = RequestHttpFrontend {
-        cluster_id: Some(String::from("cluster_1")),
+        cluster_id: String::from("cluster_1"),
         address: "127.0.0.1:8443".to_string(),
         hostname: String::from("lolcatho.st"),
         path: PathRule::prefix(String::from("/")),
@@ -171,7 +171,7 @@ fn main() -> anyhow::Result<()> {
     });
 
     let tls_front2 = RequestHttpFrontend {
-        cluster_id: Some(String::from("cluster_2")),
+        cluster_id: String::from("cluster_2"),
         address: "127.0.0.1:8443".to_string(),
         hostname: String::from("test.local"),
         path: PathRule::prefix(String::from("/")),

--- a/lib/examples/minimal.rs
+++ b/lib/examples/minimal.rs
@@ -65,7 +65,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     let http_front = RequestHttpFrontend {
-        cluster_id: Some("my-cluster".to_string()),
+        cluster_id: "my-cluster".to_string(),
         address: "127.0.0.1:8080".to_string(),
         hostname: "example.com".to_string(),
         path: PathRule::prefix(String::from("/")),

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -123,7 +123,7 @@
 //!  use sozu_command_lib::proto::command::{PathRule, RequestHttpFrontend, RulePosition};
 //!
 //! let http_front = RequestHttpFrontend {
-//!     cluster_id: Some("my-cluster".to_string()),
+//!     cluster_id: "my-cluster".to_string(),
 //!     address: "127.0.0.1:8080".to_string(),
 //!     hostname: "example.com".to_string(),
 //!     path: PathRule::prefix(String::from("/")),
@@ -274,7 +274,7 @@
 //!     };
 //!
 //!     let http_front = RequestHttpFrontend {
-//!         cluster_id: Some("my-cluster".to_string()),
+//!         cluster_id: "my-cluster".to_string(),
 //!         address: "127.0.0.1:8080".to_string(),
 //!         hostname: "example.com".to_string(),
 //!         path: PathRule::prefix(String::from("/")),
@@ -382,7 +382,7 @@ use sozu_command::{
     ObjectKind,
 };
 
-use crate::{backends::BackendMap, router::Route};
+use crate::backends::BackendMap;
 
 /// Anything that can be registered in mio (subscribe to kernel events)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -583,13 +583,14 @@ pub trait L7ListenerHandler {
 
     fn get_connect_timeout(&self) -> u32;
 
+    // TODO: rename this, since it returns a ClusterId, maybe… cluster_id_from_request()
     /// retrieve a frontend by parsing a request's hostname, uri and method
     fn frontend_from_request(
         &self,
         host: &str,
         uri: &str,
         method: &Method,
-    ) -> Result<Route, FrontendFromRequestError>;
+    ) -> Result<ClusterId, FrontendFromRequestError>;
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]


### PR DESCRIPTION
The deny rule, added at 5dc5c00581 seems of little value today. It returns a 401 HTTP response when a frontend without cluster has received a connection.

In conformity with the spirit of #996 , this PR **removes the possibility of creating a frontend without a cluster**. `cluster_id` is no longer an option, and the cluster is checked for existence when adding a frontend to the state.

This PR adds checks to be sure that backends, too, will not be added to the state if the corresponding cluster does not exist.

Last but not least, this pull requests adds this feature: **removing a cluster will remove its associated frontends and backends**. (but a cluster can still be edited with the AddFrontend request)