### PR TITLE
Transmit config to new worker with a protobuf type + protobuf channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,6 +1524,7 @@ dependencies = [
  "nom",
  "num_cpus",
  "paw",
+ "prost",
  "serde",
  "serde_json",
  "sozu-command-lib",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -29,6 +29,7 @@ nom = "^7.1.3"
 paw = "^1.0.0"
 serde = { version = "^1.0.195", features = ["derive"] }
 serde_json = "^1.0.111"
+prost = "^0.12.3"
 time = "^0.3.29"
 tempfile = "^3.9.0"
 termion = "^3.0.0"

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -74,12 +74,12 @@ pub enum SubCmd {
             help = "Worker's channel buffer size",
             default_value = "1000000"
         )]
-        command_buffer_size: usize,
+        command_buffer_size: u64,
         #[clap(
             long = "max-command-buffer-size",
             help = "Worker's channel max buffer size"
         )]
-        max_command_buffer_size: Option<usize>,
+        max_command_buffer_size: Option<u64>,
     },
     #[clap(
         name = "main",
@@ -95,12 +95,12 @@ pub enum SubCmd {
             help = "Main process channel buffer size",
             default_value = "1000000"
         )]
-        command_buffer_size: usize,
+        command_buffer_size: u64,
         #[clap(
             long = "max-command-buffer-size",
             help = "Main process channel max buffer size"
         )]
-        max_command_buffer_size: Option<usize>,
+        max_command_buffer_size: Option<u64>,
     },
 
     // sozu command line

--- a/bin/src/command/server.rs
+++ b/bin/src/command/server.rs
@@ -22,11 +22,9 @@ use sozu_command_lib::{
     config::Config,
     proto::command::{
         request::RequestType, response_content::ContentType, Request, ResponseContent,
-        ResponseStatus, RunState, Status,
+        ResponseStatus, RunState, Status, WorkerRequest, WorkerResponse,
     },
     ready::Ready,
-    request::WorkerRequest,
-    response::WorkerResponse,
     scm_socket::{Listeners, ScmSocket, ScmSocketError},
     state::ConfigState,
 };
@@ -155,7 +153,7 @@ impl Gatherer for DefaultGatherer {
         worker_id: WorkerId,
         message: WorkerResponse,
     ) {
-        match message.status {
+        match ResponseStatus::try_from(message.status).unwrap() {
             ResponseStatus::Ok => self.ok += 1,
             ResponseStatus::Failure => self.errors += 1,
             ResponseStatus::Processing => client.return_processing(format!(

--- a/bin/src/command/server.rs
+++ b/bin/src/command/server.rs
@@ -153,13 +153,14 @@ impl Gatherer for DefaultGatherer {
         worker_id: WorkerId,
         message: WorkerResponse,
     ) {
-        match ResponseStatus::try_from(message.status).unwrap() {
-            ResponseStatus::Ok => self.ok += 1,
-            ResponseStatus::Failure => self.errors += 1,
-            ResponseStatus::Processing => client.return_processing(format!(
+        match ResponseStatus::try_from(message.status) {
+            Ok(ResponseStatus::Ok) => self.ok += 1,
+            Ok(ResponseStatus::Failure) => self.errors += 1,
+            Ok(ResponseStatus::Processing) => client.return_processing(format!(
                 "Worker {} is processing {}. {}",
                 worker_id, message.id, message.message
             )),
+            Err(e) => warn!("error decoding response status: {}", e),
         }
         self.responses.push((worker_id, message));
     }

--- a/bin/src/command/server.rs
+++ b/bin/src/command/server.rs
@@ -219,7 +219,7 @@ impl CommandHub {
         if let Err(err) = self.register(token, &mut stream) {
             error!("Could not register client: {}", err);
         }
-        let channel = Channel::new(stream, 4096, usize::MAX);
+        let channel = Channel::new(stream, 4096, u64::MAX);
         let id = self.next_client_id();
         let session = ClientSession::new(channel, id, token);
         info!("register new client: {}", id);

--- a/bin/src/command/sessions.rs
+++ b/bin/src/command/sessions.rs
@@ -6,10 +6,11 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use sozu_command_lib::{
     channel::Channel,
-    proto::command::{Request, Response, ResponseContent, ResponseStatus, RunState, WorkerInfo},
+    proto::command::{
+        Request, Response, ResponseContent, ResponseStatus, RunState, WorkerInfo, WorkerRequest,
+        WorkerResponse,
+    },
     ready::Ready,
-    request::WorkerRequest,
-    response::WorkerResponse,
     scm_socket::ScmSocket,
 };
 

--- a/bin/src/command/sessions.rs
+++ b/bin/src/command/sessions.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use libc::pid_t;
 use mio::Token;
-use serde::{de::DeserializeOwned, Serialize};
+use prost::Message;
 
 use sozu_command_lib::{
     channel::Channel,
@@ -265,8 +265,8 @@ impl WorkerSession {
 /// read and parse messages (Requests or Responses) from the channel
 pub fn extract_messages<Tx, Rx>(channel: &mut Channel<Tx, Rx>) -> Vec<Rx>
 where
-    Tx: Debug + Serialize,
-    Rx: Debug + DeserializeOwned,
+    Tx: Debug + Default + Message,
+    Rx: Debug + Default + Message,
 {
     let mut messages = Vec::new();
     loop {

--- a/bin/src/command/upgrade.rs
+++ b/bin/src/command/upgrade.rs
@@ -8,8 +8,8 @@ use sozu_command_lib::{
     config::Config,
     proto::command::{
         request::RequestType, ResponseStatus, ReturnListenSockets, RunState, SoftStop,
+        WorkerResponse,
     },
-    response::WorkerResponse,
     state::ConfigState,
 };
 
@@ -236,7 +236,8 @@ impl Gatherer for UpgradeWorkerTask {
         worker_id: WorkerId,
         message: WorkerResponse,
     ) {
-        match message.status {
+        // TODO: there's gotta be a better way than unwrapping here
+        match ResponseStatus::try_from(message.status).unwrap() {
             ResponseStatus::Ok => {
                 self.ok += 1;
                 match self.progress {

--- a/bin/src/command/upgrade.rs
+++ b/bin/src/command/upgrade.rs
@@ -236,9 +236,8 @@ impl Gatherer for UpgradeWorkerTask {
         worker_id: WorkerId,
         message: WorkerResponse,
     ) {
-        // TODO: there's gotta be a better way than unwrapping here
-        match ResponseStatus::try_from(message.status).unwrap() {
-            ResponseStatus::Ok => {
+        match ResponseStatus::try_from(message.status) {
+            Ok(ResponseStatus::Ok) => {
                 self.ok += 1;
                 match self.progress {
                     UpgradeWorkerProgress::RequestingListenSockets { .. } => {}
@@ -250,11 +249,12 @@ impl Gatherer for UpgradeWorkerTask {
                     }
                 }
             }
-            ResponseStatus::Failure => self.errors += 1,
-            ResponseStatus::Processing => client.return_processing(format!(
+            Ok(ResponseStatus::Failure) => self.errors += 1,
+            Ok(ResponseStatus::Processing) => client.return_processing(format!(
                 "Worker {} is processing {}. {}",
                 worker_id, message.id, message.message
             )),
+            Err(e) => warn!("error decoding response status: {}", e),
         }
         self.responses.push((worker_id, message));
     }

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -73,8 +73,6 @@ pub fn ctl(args: cli::Args) -> Result<(), CtlError> {
         setup_logging_with_config(&config, "CTL");
     }
 
-    debug!("started CLI with config: {:?}", config);
-
     // If the command is `config check` then exit because if we are here, the configuration is valid
     if let SubCmd::Config {
         cmd: ConfigCmd::Check,

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -73,6 +73,8 @@ pub fn ctl(args: cli::Args) -> Result<(), CtlError> {
         setup_logging_with_config(&config, "CTL");
     }
 
+    debug!("started CLI with config: {:?}", config);
+
     // If the command is `config check` then exit because if we are here, the configuration is valid
     if let SubCmd::Config {
         cmd: ConfigCmd::Check,

--- a/bin/src/upgrade.rs
+++ b/bin/src/upgrade.rs
@@ -151,8 +151,8 @@ pub fn fork_main_into_new_main(
 pub fn begin_new_main_process(
     new_to_old_channel_fd: i32,
     upgrade_file_fd: i32,
-    command_buffer_size: usize,
-    max_command_buffer_size: usize,
+    command_buffer_size: u64,
+    max_command_buffer_size: u64,
 ) -> Result<(), UpgradeError> {
     let mut fork_confirmation_channel: Channel<bool, ()> = Channel::new(
         unsafe { UnixStream::from_raw_fd(new_to_old_channel_fd) },

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -25,9 +25,9 @@ use tempfile::tempfile;
 
 use sozu_command_lib::{
     channel::{Channel, ChannelError},
-    config::{Config, ServerConfig},
-    logging::{setup_logging, setup_logging_with_config},
-    proto::command::{WorkerRequest, WorkerResponse},
+    config::Config,
+    logging::setup_logging,
+    proto::command::{ServerConfig, WorkerRequest, WorkerResponse},
     ready::Ready,
     request::{read_requests_from_file, RequestError},
     scm_socket::{Listeners, ScmSocket, ScmSocketError},
@@ -232,8 +232,8 @@ pub fn fork_main_into_worker(
 
     let mut main_to_worker_channel: Channel<ServerConfig, WorkerResponse> = Channel::new(
         main_to_worker,
-        worker_config.command_buffer_size,
-        worker_config.max_command_buffer_size,
+        worker_config.command_buffer_size as usize,
+        worker_config.max_command_buffer_size as usize,
     );
 
     // DISCUSS: should we really block the channel just to write on it?

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -125,11 +125,8 @@ pub fn begin_worker_process(
     );
     info!("worker {} starting...", id);
 
-    // let initial_state = read_requests_from_file(&mut configuration_state_file)
-
     let initial_state = read_initial_state_from_file(&mut configuration_state_file)
         .map_err(WorkerError::ReadRequestsFromFile)?;
-    // .expect("could not parse configuration state data");
 
     worker_to_main_channel
         .nonblocking()
@@ -201,10 +198,8 @@ pub fn fork_main_into_worker(
     })?;
 
     state
-        // .write_requests_to_file(&mut state_file)
         .write_initial_state_to_file(&mut state_file)
         .map_err(WorkerError::WriteStateFile)?;
-    // .expect("Could not write state to file");
 
     state_file.rewind().map_err(WorkerError::Rewind)?;
 
@@ -234,7 +229,7 @@ pub fn fork_main_into_worker(
         }
     })?;
 
-    let worker_config = ServerConfig::from_config(config);
+    let worker_config = ServerConfig::from(config);
 
     let mut main_to_worker_channel: Channel<ServerConfig, WorkerResponse> = Channel::new(
         main_to_worker,

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -26,12 +26,13 @@ use sozu_command_lib::{
     channel::{Channel, ChannelError},
     config::Config,
     logging::setup_logging_with_config,
+    proto::command::{WorkerRequest, WorkerResponse},
     ready::Ready,
-    request::{read_requests_from_file, RequestError, WorkerRequest},
-    response::WorkerResponse,
+    request::{read_requests_from_file, RequestError},
     scm_socket::{Listeners, ScmSocket, ScmSocketError},
     state::{ConfigState, StateError},
 };
+
 use sozu_lib::{
     metrics::{self, MetricError},
     server::{Server, ServerError as LibServerError},

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -86,8 +86,8 @@ pub fn begin_worker_process(
     worker_to_main_scm_fd: i32,
     configuration_state_fd: i32,
     id: i32,
-    command_buffer_size: usize,
-    max_command_buffer_size: usize,
+    command_buffer_size: u64,
+    max_command_buffer_size: u64,
 ) -> Result<(), WorkerError> {
     let mut worker_to_main_channel: Channel<WorkerResponse, ServerConfig> = Channel::new(
         unsafe { UnixStream::from_raw_fd(worker_to_main_channel_fd) },
@@ -232,8 +232,8 @@ pub fn fork_main_into_worker(
 
     let mut main_to_worker_channel: Channel<ServerConfig, WorkerResponse> = Channel::new(
         main_to_worker,
-        worker_config.command_buffer_size as usize,
-        worker_config.max_command_buffer_size as usize,
+        worker_config.command_buffer_size,
+        worker_config.max_command_buffer_size,
     );
 
     // DISCUSS: should we really block the channel just to write on it?

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -29,7 +29,7 @@ use sozu_command_lib::{
     logging::setup_logging,
     proto::command::{ServerConfig, WorkerRequest, WorkerResponse},
     ready::Ready,
-    request::{read_requests_from_file, RequestError},
+    request::{read_initial_state_from_file, RequestError},
     scm_socket::{Listeners, ScmSocket, ScmSocketError},
     state::{ConfigState, StateError},
 };
@@ -124,8 +124,12 @@ pub fn begin_worker_process(
         worker_config
     );
     info!("worker {} starting...", id);
-    let initial_state = read_requests_from_file(&mut configuration_state_file)
+
+    // let initial_state = read_requests_from_file(&mut configuration_state_file)
+
+    let initial_state = read_initial_state_from_file(&mut configuration_state_file)
         .map_err(WorkerError::ReadRequestsFromFile)?;
+    // .expect("could not parse configuration state data");
 
     worker_to_main_channel
         .nonblocking()
@@ -197,8 +201,10 @@ pub fn fork_main_into_worker(
     })?;
 
     state
-        .write_requests_to_file(&mut state_file)
+        // .write_requests_to_file(&mut state_file)
+        .write_initial_state_to_file(&mut state_file)
         .map_err(WorkerError::WriteStateFile)?;
+    // .expect("Could not write state to file");
 
     state_file.rewind().map_err(WorkerError::Rewind)?;
 

--- a/command/src/channel.rs
+++ b/command/src/channel.rs
@@ -36,11 +36,9 @@ pub enum ChannelError {
     NothingRead,
     #[error("invalid char set in command message, ignoring: {0}")]
     InvalidCharSet(String),
-    #[error("Error deserializing message")]
-    Serde(serde_json::error::Error),
     #[error("could not set the timeout of the unix stream with file descriptor {fd}: {error}")]
     SetTimeout { fd: i32, error: String },
-    #[error("Could not change the blocking status of the unix stream with file descriptor {fd}: {error}")]
+    #[error("Could not change the blocking status ef the unix stream with file descriptor {fd}: {error}")]
     BlockingStatus { fd: i32, error: String },
     #[error("Connection error: {0:?}")]
     Connection(Option<std::io::Error>),

--- a/command/src/channel.rs
+++ b/command/src/channel.rs
@@ -8,13 +8,11 @@ use std::{
         io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
         net::UnixStream as StdUnixStream,
     },
-    str::from_utf8,
     time::Duration,
 };
 
 use mio::{event::Source, net::UnixStream as MioUnixStream};
-use serde::{de::DeserializeOwned, ser::Serialize};
-use serde_json;
+use prost::{DecodeError, Message as ProstMessage};
 
 use crate::{buffer::growable::Buffer, ready::Ready};
 
@@ -46,10 +44,17 @@ pub enum ChannelError {
     BlockingStatus { fd: i32, error: String },
     #[error("Connection error: {0:?}")]
     Connection(Option<std::io::Error>),
+    #[error("Invalid protobuf message: {0}")]
+    InvalidProtobufMessage(DecodeError),
+    #[error("This should never happen (index out of bound on a tested buffer)")]
+    MismatchBufferSize,
 }
 
-/// A wrapper around unix socket using the mio crate.
-/// Used in pairs to communicate, in a blocking or non-blocking way.
+/// Channel meant for communication between Sōzu processes over a UNIX socket.
+/// It wraps a unix socket using the mio crate, and transmit prost messages
+/// by serializing them in a binary format, with a fix-sized delimiter.
+/// To function, channels must come in pairs, one for each agent.
+/// They can function in a blocking or non-blocking way.
 pub struct Channel<Tx, Rx> {
     pub sock: MioUnixStream,
     pub front_buf: Buffer,
@@ -80,7 +85,7 @@ impl<Tx, Rx> std::fmt::Debug for Channel<Tx, Rx> {
     }
 }
 
-impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
+impl<Tx: Debug + ProstMessage + Default, Rx: Debug + ProstMessage + Default> Channel<Tx, Rx> {
     /// Creates a nonblocking channel on a given socket path
     pub fn from_path(
         path: &str,
@@ -107,7 +112,9 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
         }
     }
 
-    pub fn into<Tx2: Debug + Serialize, Rx2: Debug + DeserializeOwned>(self) -> Channel<Tx2, Rx2> {
+    pub fn into<Tx2: Debug + ProstMessage + Default, Rx2: Debug + ProstMessage + Default>(
+        self,
+    ) -> Channel<Tx2, Rx2> {
         Channel {
             sock: self.sock,
             front_buf: self.front_buf,
@@ -170,6 +177,7 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
         self.blocking
     }
 
+    /// Get the raw file descriptor of the UNIX socket
     pub fn fd(&self) -> RawFd {
         self.sock.as_raw_fd()
     }
@@ -182,7 +190,7 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
         self.readiness & self.interest
     }
 
-    /// Checks wether we want and can read or write, and calls the appropriate handler.
+    /// Check wether we want and can read or write, and calls the appropriate handler.
     pub fn run(&mut self) -> Result<(), ChannelError> {
         let interest = self.interest & self.readiness;
 
@@ -196,7 +204,7 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
         Ok(())
     }
 
-    /// Handles readability by filling the front buffer with the socket data.
+    /// Handle readability by filling the front buffer with the socket data.
     pub fn readable(&mut self) -> Result<usize, ChannelError> {
         if !(self.interest & self.readiness).is_readable() {
             return Err(ChannelError::Connection(None));
@@ -239,7 +247,7 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
         Ok(count)
     }
 
-    /// Handles writability by writing the content of the back buffer onto the socket
+    /// Handle writability by writing the content of the back buffer onto the socket
     pub fn writable(&mut self) -> Result<usize, ChannelError> {
         if !(self.interest & self.readiness).is_writable() {
             return Err(ChannelError::Connection(None));
@@ -282,9 +290,9 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
 
     /// Depending on the blocking status:
     ///
-    /// Blocking: waits for the front buffer to be filled, and parses a message from it
+    /// Blocking: wait for the front buffer to be filled, and parse a message from it
     ///
-    /// Nonblocking: parses a message from the front buffer, without waiting.
+    /// Nonblocking: parse a message from the front buffer, without waiting.
     /// Prefer using `channel.readable()` before
     pub fn read_message(&mut self) -> Result<Rx, ChannelError> {
         if self.blocking {
@@ -294,35 +302,21 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
         }
     }
 
-    /// Parses a message from the front buffer, without waiting
-    fn read_message_nonblocking(&mut self) -> Result<Rx, ChannelError> {
-        match self.front_buf.data().iter().position(|&x| x == 0) {
-            Some(position) => self.read_and_parse_from_front_buffer(position),
-            None => {
-                if self.front_buf.available_space() == 0 {
-                    if (self.front_buf.capacity() as u64) == self.max_buffer_size {
-                        error!("command buffer full, cannot grow more, ignoring");
-                    } else {
-                        println!("growing channel");
-                        let new_size = min(
-                            self.front_buf.capacity() + 5000,
-                            self.max_buffer_size as usize,
-                        );
-                        self.front_buf.grow(new_size);
-                    }
-                }
-
-                self.interest.insert(Ready::READABLE);
-                Err(ChannelError::NothingRead)
-            }
-        }
-    }
-
     fn read_message_blocking(&mut self) -> Result<Rx, ChannelError> {
         self.read_message_blocking_timeout(None)
     }
 
-    /// Waits for the front buffer to be filled, and parses a message from it.
+    /// Parse a message from the front buffer, without waiting
+    fn read_message_nonblocking(&mut self) -> Result<Rx, ChannelError> {
+        if let Some(message) = self.try_read_delimited_message()? {
+            return Ok(message);
+        }
+
+        self.interest.insert(Ready::READABLE);
+        Err(ChannelError::NothingRead)
+    }
+
+    /// Wait for the front buffer to be filled, and parses a message from it.
     pub fn read_message_blocking_timeout(
         &mut self,
         timeout: Option<Duration>,
@@ -339,29 +333,18 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
                 }
             }
 
-            match self.front_buf.data().iter().position(|&x| x == 0) {
-                Some(position) => break self.read_and_parse_from_front_buffer(position),
-                None => {
-                    if self.front_buf.available_space() == 0 {
-                        if (self.front_buf.capacity() as u64) == self.max_buffer_size {
-                            return Err(ChannelError::BufferFull);
-                        }
-                        let new_size = min(
-                            self.front_buf.capacity() + 5000,
-                            self.max_buffer_size as usize,
-                        );
-                        self.front_buf.grow(new_size);
-                    }
-                    match self.sock.read(self.front_buf.space()) {
-                        Ok(0) => break Err(ChannelError::NoByteToRead),
-                        Ok(bytes_read) => self.front_buf.fill(bytes_read),
-                        Err(io_error) => match io_error.kind() {
-                            ErrorKind::WouldBlock => continue, // ignore 10 millisecond timeouts
-                            _ => break Err(ChannelError::Read(io_error)),
-                        },
-                    };
-                }
+            if let Some(message) = self.try_read_delimited_message()? {
+                return Ok(message);
             }
+
+            match self.sock.read(self.front_buf.space()) {
+                Ok(0) => return Err(ChannelError::NoByteToRead),
+                Ok(bytes_read) => self.front_buf.fill(bytes_read),
+                Err(io_error) => match io_error.kind() {
+                    ErrorKind::WouldBlock => continue, // ignore 10 millisecond timeouts
+                    _ => break Err(ChannelError::Read(io_error)),
+                },
+            };
         };
 
         self.set_timeout(None)?;
@@ -369,14 +352,34 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
         status
     }
 
-    fn read_and_parse_from_front_buffer(&mut self, position: usize) -> Result<Rx, ChannelError> {
-        let utf8_str = from_utf8(&self.front_buf.data()[..position])
-            .map_err(|from_error| ChannelError::InvalidCharSet(from_error.to_string()))?;
+    /// parse a prost message from the front buffer, grow it if necessary
+    fn try_read_delimited_message(&mut self) -> Result<Option<Rx>, ChannelError> {
+        let buffer = self.front_buf.data();
+        if buffer.len() >= delimiter_size() {
+            let delimiter = buffer[..delimiter_size()]
+                .try_into()
+                .map_err(|_| ChannelError::MismatchBufferSize)?;
+            let message_len = usize::from_le_bytes(delimiter);
 
-        let json_parsed = serde_json::from_str(utf8_str).map_err(ChannelError::Serde)?;
+            if buffer.len() >= message_len {
+                let message = Rx::decode(&buffer[delimiter_size()..message_len])
+                    .map_err(|decode_error| ChannelError::InvalidProtobufMessage(decode_error))?;
+                self.front_buf.consume(message_len);
+                return Ok(Some(message));
+            }
+        }
 
-        self.front_buf.consume(position + 1);
-        Ok(json_parsed)
+        if self.front_buf.available_space() == 0 {
+            if (self.front_buf.capacity() as u64) == self.max_buffer_size {
+                return Err(ChannelError::BufferFull);
+            }
+            let new_size = min(
+                self.front_buf.capacity() + 5000,
+                self.max_buffer_size as usize,
+            );
+            self.front_buf.grow(new_size);
+        }
+        Ok(None)
     }
 
     /// Checks whether the channel is blocking or nonblocking, writes the message.
@@ -393,33 +396,7 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
     /// Writes the message in the buffer, but NOT on the socket.
     /// you have to call channel.run() afterwards
     fn write_message_nonblocking(&mut self, message: &Tx) -> Result<(), ChannelError> {
-        let message = match serde_json::to_string(message) {
-            Ok(string) => string.into_bytes(),
-            Err(_) => Vec::new(),
-        };
-
-        let message_len = message.len() + 1;
-        if message_len > self.back_buf.available_space() {
-            self.back_buf.shift();
-        }
-
-        if message_len > self.back_buf.available_space() {
-            if message_len - self.back_buf.available_space() + self.back_buf.capacity()
-                > (self.max_buffer_size as usize)
-            {
-                return Err(ChannelError::MessageTooLarge(self.back_buf.capacity()));
-            }
-
-            let new_length =
-                message_len - self.back_buf.available_space() + self.back_buf.capacity();
-            self.back_buf.grow(new_length);
-        }
-
-        self.back_buf.write(&message).map_err(ChannelError::Write)?;
-
-        self.back_buf
-            .write(&b"\0"[..])
-            .map_err(ChannelError::Write)?;
+        self.write_delimited_message(message)?;
 
         self.interest.insert(Ready::WRITABLE);
 
@@ -428,32 +405,7 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
 
     /// fills the back buffer with data AND writes on the socket
     fn write_message_blocking(&mut self, message: &Tx) -> Result<(), ChannelError> {
-        let message = match serde_json::to_string(message) {
-            Ok(string) => string.into_bytes(),
-            Err(_) => Vec::new(),
-        };
-
-        let msg_len = &message.len() + 1;
-        if msg_len > self.back_buf.available_space() {
-            self.back_buf.shift();
-        }
-
-        if msg_len > self.back_buf.available_space() {
-            if msg_len - self.back_buf.available_space() + self.back_buf.capacity()
-                > (self.max_buffer_size as usize)
-            {
-                return Err(ChannelError::MessageTooLarge(self.back_buf.capacity()));
-            }
-
-            let new_len = msg_len - self.back_buf.available_space() + self.back_buf.capacity();
-            self.back_buf.grow(new_len);
-        }
-
-        self.back_buf.write(&message).map_err(ChannelError::Write)?;
-
-        self.back_buf
-            .write(&b"\0"[..])
-            .map_err(ChannelError::Write)?;
+        self.write_delimited_message(message)?;
 
         loop {
             let size = self.back_buf.available_data();
@@ -471,13 +423,51 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
         }
         Ok(())
     }
+
+    /// write a message on the back buffer, using our own delimiter (the delimiter of prost
+    /// is not trustworthy since its size may change)
+    pub fn write_delimited_message(&mut self, message: &Tx) -> Result<(), ChannelError> {
+        let payload = message.encode_to_vec();
+
+        let payload_len = payload.len() + delimiter_size();
+
+        let delimiter = payload_len.to_le_bytes();
+
+        if payload_len > self.back_buf.available_space() {
+            self.back_buf.shift();
+        }
+
+        if payload_len > self.back_buf.available_space() {
+            if payload_len - self.back_buf.available_space() + self.back_buf.capacity()
+                > (self.max_buffer_size as usize)
+            {
+                return Err(ChannelError::MessageTooLarge(self.back_buf.capacity()));
+            }
+
+            let new_length =
+                payload_len - self.back_buf.available_space() + self.back_buf.capacity();
+            self.back_buf.grow(new_length);
+        }
+
+        self.back_buf
+            .write_all(&delimiter)
+            .map_err(ChannelError::Write)?;
+        self.back_buf
+            .write_all(&payload)
+            .map_err(ChannelError::Write)?;
+
+        Ok(())
+    }
+}
+
+/// the payload is prefixed with a delimiter of sizeof(usize) bytes
+pub const fn delimiter_size() -> usize {
+    std::mem::size_of::<usize>()
 }
 
 type ChannelResult<Tx, Rx> = Result<(Channel<Tx, Rx>, Channel<Rx, Tx>), ChannelError>;
 
-impl<Tx: Debug + DeserializeOwned + Serialize, Rx: Debug + DeserializeOwned + Serialize>
-    Channel<Tx, Rx>
-{
+impl<Tx: Debug + ProstMessage + Default, Rx: Debug + ProstMessage + Default> Channel<Tx, Rx> {
     /// creates a channel pair: `(blocking_channel, nonblocking_channel)`
     pub fn generate(buffer_size: u64, max_buffer_size: u64) -> ChannelResult<Tx, Rx> {
         let (command, proxy) = MioUnixStream::pair().map_err(ChannelError::Read)?;
@@ -496,7 +486,9 @@ impl<Tx: Debug + DeserializeOwned + Serialize, Rx: Debug + DeserializeOwned + Se
     }
 }
 
-impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Iterator for Channel<Tx, Rx> {
+impl<Tx: Debug + ProstMessage + Default, Rx: Debug + ProstMessage + Default> Iterator
+    for Channel<Tx, Rx>
+{
     type Item = Rx;
     fn next(&mut self) -> Option<Self::Item> {
         self.read_message().ok()
@@ -534,31 +526,35 @@ mod tests {
 
     use super::*;
 
-    #[derive(Serialize, Deserialize, Debug, PartialEq)]
-    struct Serializable(u32);
+    #[derive(Clone, PartialEq, prost::Message)]
+    pub struct ProtobufMessage {
+        #[prost(uint32, required, tag = "1")]
+        inner: u32,
+    }
+
+    fn test_channels() -> (
+        Channel<ProtobufMessage, ProtobufMessage>,
+        Channel<ProtobufMessage, ProtobufMessage>,
+    ) {
+        Channel::generate(1000, 10000).expect("could not generate blocking channels for testing")
+    }
 
     #[test]
     fn unblock_a_channel() {
-        let (mut blocking, _nonblocking): (
-            Channel<Serializable, Serializable>,
-            Channel<Serializable, Serializable>,
-        ) = Channel::generate(1000, 10000).expect("could not generate blocking channels");
+        let (mut blocking, _nonblocking) = test_channels();
         assert!(blocking.nonblocking().is_ok())
     }
 
     #[test]
     fn generate_blocking_and_nonblocking_channels() {
-        let (blocking_channel, nonblocking_channel): (
-            Channel<Serializable, Serializable>,
-            Channel<Serializable, Serializable>,
-        ) = Channel::generate(1000, 10000).expect("could not generatie blocking channels");
+        let (blocking_channel, nonblocking_channel) = test_channels();
 
         assert!(blocking_channel.is_blocking());
         assert!(!nonblocking_channel.is_blocking());
 
         let (nonblocking_channel_1, nonblocking_channel_2): (
-            Channel<Serializable, Serializable>,
-            Channel<Serializable, Serializable>,
+            Channel<ProtobufMessage, ProtobufMessage>,
+            Channel<ProtobufMessage, ProtobufMessage>,
         ) = Channel::generate_nonblocking(1000, 10000)
             .expect("could not generatie nonblocking channels");
 
@@ -568,12 +564,9 @@ mod tests {
 
     #[test]
     fn write_and_read_message_blocking() {
-        let (mut blocking_channel, mut nonblocking_channel): (
-            Channel<Serializable, Serializable>,
-            Channel<Serializable, Serializable>,
-        ) = Channel::generate(1000, 10000).expect("Could not create nonblocking channel");
+        let (mut blocking_channel, mut nonblocking_channel) = test_channels();
 
-        let message_to_send = Serializable(42);
+        let message_to_send = ProtobufMessage { inner: 42 };
 
         nonblocking_channel
             .blocking()
@@ -582,41 +575,38 @@ mod tests {
             .write_message(&message_to_send)
             .expect("Could not write message on channel");
 
-        println!("we wrote a message!");
+        trace!("we wrote a message!");
 
-        println!("reading message..");
+        trace!("reading message..");
         // blocking_channel.readable();
         let message = blocking_channel
             .read_message()
             .expect("Could not read message on channel");
-        println!("read message!");
+        trace!("read message!");
 
-        assert_eq!(message, Serializable(42));
+        assert_eq!(message, ProtobufMessage { inner: 42 });
     }
 
     #[test]
     fn read_message_blocking_with_timeout_fails() {
-        let (mut reading_channel, mut writing_channel): (
-            Channel<Serializable, Serializable>,
-            Channel<Serializable, Serializable>,
-        ) = Channel::generate(1000, 10000).expect("Could not create nonblocking channel");
+        let (mut reading_channel, mut writing_channel) = test_channels();
         writing_channel.blocking().expect("Could not block channel");
 
-        println!("reading message in a detached thread, with a timeout of 100 milliseconds...");
+        trace!("reading message in a detached thread, with a timeout of 100 milliseconds...");
         let awaiting_with_timeout = thread::spawn(move || {
             let message =
                 reading_channel.read_message_blocking_timeout(Some(Duration::from_millis(100)));
-            println!("read message!");
+            trace!("read message!");
             message
         });
 
-        println!("Waiting 200 milliseconds…");
+        trace!("Waiting 200 milliseconds…");
         thread::sleep(std::time::Duration::from_millis(200));
 
         writing_channel
-            .write_message(&Serializable(200))
+            .write_message(&ProtobufMessage { inner: 200 })
             .expect("Could not write message on channel");
-        println!("we wrote a message that should arrive too late!");
+        trace!("we wrote a message that should arrive too late!");
 
         let arrived_too_late = awaiting_with_timeout
             .join()
@@ -627,48 +617,42 @@ mod tests {
 
     #[test]
     fn read_message_blocking_with_timeout_succeeds() {
-        let (mut reading_channel, mut writing_channel): (
-            Channel<Serializable, Serializable>,
-            Channel<Serializable, Serializable>,
-        ) = Channel::generate(1000, 10000).expect("Could not create nonblocking channel");
+        let (mut reading_channel, mut writing_channel) = test_channels();
         writing_channel.blocking().expect("Could not block channel");
 
-        println!("reading message in a detached thread, with a timeout of 200 milliseconds...");
+        trace!("reading message in a detached thread, with a timeout of 200 milliseconds...");
         let awaiting_with_timeout = thread::spawn(move || {
             let message = reading_channel
                 .read_message_blocking_timeout(Some(Duration::from_millis(200)))
                 .expect("Could not read message with timeout on blocking channel");
-            println!("read message!");
+            trace!("read message!");
             message
         });
 
-        println!("Waiting 100 milliseconds…");
+        trace!("Waiting 100 milliseconds…");
         thread::sleep(std::time::Duration::from_millis(100));
 
         writing_channel
-            .write_message(&Serializable(100))
+            .write_message(&ProtobufMessage { inner: 100 })
             .expect("Could not write message on channel");
-        println!("we wrote a message that should arrive on time!");
+        trace!("we wrote a message that should arrive on time!");
 
         let arrived_on_time = awaiting_with_timeout
             .join()
             .expect("error with receiving message from awaiting thread");
 
-        assert_eq!(arrived_on_time, Serializable(100));
+        assert_eq!(arrived_on_time, ProtobufMessage { inner: 100 });
     }
 
     #[test]
     fn exhaustive_use_of_nonblocking_channels() {
         // - two nonblocking channels A and B, identical
-        let (mut channel_a, mut channel_b): (
-            Channel<Serializable, Serializable>,
-            Channel<Serializable, Serializable>,
-        ) = Channel::generate(1000, 10000).expect("Could not create nonblocking channel");
+        let (mut channel_a, mut channel_b) = test_channels();
         channel_a.nonblocking().expect("Could not block channel");
 
         // write on A
         channel_a
-            .write_message(&Serializable(1))
+            .write_message(&ProtobufMessage { inner: 1 })
             .expect("Could not write message on channel");
 
         // set B as readable, normally mio tells when to, by giving events
@@ -680,7 +664,7 @@ mod tests {
 
         // write another message on A
         channel_a
-            .write_message(&Serializable(2))
+            .write_message(&ProtobufMessage { inner: 2 })
             .expect("Could not write message on channel");
 
         // insert a handle_events Ready::writable on A
@@ -690,7 +674,7 @@ mod tests {
         channel_a.run().expect("Failed to run the channel");
 
         // maybe a thread sleep
-        // thread::sleep(std::time::Duration::from_millis(100));
+        thread::sleep(std::time::Duration::from_millis(100));
 
         // receive with B using run()
         channel_b.run().expect("Failed to run the channel");
@@ -699,11 +683,11 @@ mod tests {
         let message_1 = channel_b
             .read_message()
             .expect("Could not read message on channel");
-        assert_eq!(message_1, Serializable(1));
+        assert_eq!(message_1, ProtobufMessage { inner: 1 });
 
         let message_2 = channel_b
             .read_message()
             .expect("Could not read message on channel");
-        assert_eq!(message_2, Serializable(2));
+        assert_eq!(message_2, ProtobufMessage { inner: 2 });
     }
 }

--- a/command/src/channel.rs
+++ b/command/src/channel.rs
@@ -361,7 +361,7 @@ impl<Tx: Debug + ProstMessage + Default, Rx: Debug + ProstMessage + Default> Cha
 
             if buffer.len() >= message_len {
                 let message = Rx::decode(&buffer[delimiter_size()..message_len])
-                    .map_err(|decode_error| ChannelError::InvalidProtobufMessage(decode_error))?;
+                    .map_err(ChannelError::InvalidProtobufMessage)?;
                 self.front_buf.consume(message_len);
                 return Ok(Some(message));
             }

--- a/command/src/channel.rs
+++ b/command/src/channel.rs
@@ -54,7 +54,7 @@ pub struct Channel<Tx, Rx> {
     pub sock: MioUnixStream,
     pub front_buf: Buffer,
     pub back_buf: Buffer,
-    max_buffer_size: usize,
+    max_buffer_size: u64,
     pub readiness: Ready,
     pub interest: Ready,
     blocking: bool,
@@ -84,8 +84,8 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
     /// Creates a nonblocking channel on a given socket path
     pub fn from_path(
         path: &str,
-        buffer_size: usize,
-        max_buffer_size: usize,
+        buffer_size: u64,
+        max_buffer_size: u64,
     ) -> Result<Channel<Tx, Rx>, ChannelError> {
         let unix_stream = MioUnixStream::connect(path)
             .map_err(|io_error| ChannelError::Connection(Some(io_error)))?;
@@ -93,11 +93,11 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
     }
 
     /// Creates a nonblocking channel, using a unix stream
-    pub fn new(sock: MioUnixStream, buffer_size: usize, max_buffer_size: usize) -> Channel<Tx, Rx> {
+    pub fn new(sock: MioUnixStream, buffer_size: u64, max_buffer_size: u64) -> Channel<Tx, Rx> {
         Channel {
             sock,
-            front_buf: Buffer::with_capacity(buffer_size),
-            back_buf: Buffer::with_capacity(buffer_size),
+            front_buf: Buffer::with_capacity(buffer_size as usize),
+            back_buf: Buffer::with_capacity(buffer_size as usize),
             max_buffer_size,
             readiness: Ready::EMPTY,
             interest: Ready::READABLE,
@@ -300,11 +300,14 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
             Some(position) => self.read_and_parse_from_front_buffer(position),
             None => {
                 if self.front_buf.available_space() == 0 {
-                    if self.front_buf.capacity() == self.max_buffer_size {
+                    if (self.front_buf.capacity() as u64) == self.max_buffer_size {
                         error!("command buffer full, cannot grow more, ignoring");
                     } else {
                         println!("growing channel");
-                        let new_size = min(self.front_buf.capacity() + 5000, self.max_buffer_size);
+                        let new_size = min(
+                            self.front_buf.capacity() + 5000,
+                            self.max_buffer_size as usize,
+                        );
                         self.front_buf.grow(new_size);
                     }
                 }
@@ -340,10 +343,13 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
                 Some(position) => break self.read_and_parse_from_front_buffer(position),
                 None => {
                     if self.front_buf.available_space() == 0 {
-                        if self.front_buf.capacity() == self.max_buffer_size {
-                            break Err(ChannelError::BufferFull);
+                        if (self.front_buf.capacity() as u64) == self.max_buffer_size {
+                            return Err(ChannelError::BufferFull);
                         }
-                        let new_size = min(self.front_buf.capacity() + 5000, self.max_buffer_size);
+                        let new_size = min(
+                            self.front_buf.capacity() + 5000,
+                            self.max_buffer_size as usize,
+                        );
                         self.front_buf.grow(new_size);
                     }
                     match self.sock.read(self.front_buf.space()) {
@@ -399,7 +405,7 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
 
         if message_len > self.back_buf.available_space() {
             if message_len - self.back_buf.available_space() + self.back_buf.capacity()
-                > self.max_buffer_size
+                > (self.max_buffer_size as usize)
             {
                 return Err(ChannelError::MessageTooLarge(self.back_buf.capacity()));
             }
@@ -434,7 +440,7 @@ impl<Tx: Debug + Serialize, Rx: Debug + DeserializeOwned> Channel<Tx, Rx> {
 
         if msg_len > self.back_buf.available_space() {
             if msg_len - self.back_buf.available_space() + self.back_buf.capacity()
-                > self.max_buffer_size
+                > (self.max_buffer_size as usize)
             {
                 return Err(ChannelError::MessageTooLarge(self.back_buf.capacity()));
             }
@@ -473,7 +479,7 @@ impl<Tx: Debug + DeserializeOwned + Serialize, Rx: Debug + DeserializeOwned + Se
     Channel<Tx, Rx>
 {
     /// creates a channel pair: `(blocking_channel, nonblocking_channel)`
-    pub fn generate(buffer_size: usize, max_buffer_size: usize) -> ChannelResult<Tx, Rx> {
+    pub fn generate(buffer_size: u64, max_buffer_size: u64) -> ChannelResult<Tx, Rx> {
         let (command, proxy) = MioUnixStream::pair().map_err(ChannelError::Read)?;
         let proxy_channel = Channel::new(proxy, buffer_size, max_buffer_size);
         let mut command_channel = Channel::new(command, buffer_size, max_buffer_size);
@@ -482,10 +488,7 @@ impl<Tx: Debug + DeserializeOwned + Serialize, Rx: Debug + DeserializeOwned + Se
     }
 
     /// creates a pair of nonblocking channels
-    pub fn generate_nonblocking(
-        buffer_size: usize,
-        max_buffer_size: usize,
-    ) -> ChannelResult<Tx, Rx> {
+    pub fn generate_nonblocking(buffer_size: u64, max_buffer_size: u64) -> ChannelResult<Tx, Rx> {
         let (command, proxy) = MioUnixStream::pair().map_err(ChannelError::Read)?;
         let proxy_channel = Channel::new(proxy, buffer_size, max_buffer_size);
         let command_channel = Channel::new(command, buffer_size, max_buffer_size);

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -675,3 +675,13 @@ message ServerConfig {
     required uint64 max_command_buffer_size = 14 [default = 2000000];
     optional ServerMetricsConfig metrics = 15;
 }
+
+// Addresses of listeners, passed to new workers
+message ListenersCount {
+    // socket addresses of HTTP listeners
+    repeated string http = 1;
+    // socket addresses of HTTPS listeners
+    repeated string tls = 2;
+    // socket addresses of TCP listeners
+    repeated string tcp = 3;
+}

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -648,3 +648,30 @@ message WorkerResponse {
     required string message = 3;
     optional ResponseContent content = 4;
 }
+
+// intended to workers
+message ServerMetricsConfig {
+    required string address = 1;
+    required bool tagged_metrics = 2;
+    optional string prefix = 3;
+}
+
+// Used by a worker to start its server loop.
+// The defaults should match those of the config module
+message ServerConfig {
+    required uint64 max_connections = 1 [default = 10000];
+    required uint32 front_timeout = 2 [default = 60];
+    required uint32 back_timeout = 3 [default = 30];
+    required uint32 connect_timeout = 4 [default = 3];
+    required uint32 zombie_check_interval = 5 [default = 1800];
+    required uint32 accept_queue_timeout = 6 [default = 60];
+    required uint64 min_buffers = 7 [default = 1];
+    required uint64 max_buffers = 8 [default = 1000];
+    required uint64 buffer_size = 9 [default = 16393];
+    required string log_level = 10 [default = "info"];
+    required string log_target = 11 [default = "stdout"];
+    optional string log_access_target = 12;
+    required uint64 command_buffer_size = 13 [default = 1000000];
+    required uint64 max_command_buffer_size = 14 [default = 2000000];
+    optional ServerMetricsConfig metrics = 15;
+}

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -685,3 +685,9 @@ message ListenersCount {
     // socket addresses of TCP listeners
     repeated string tcp = 3;
 }
+
+// the Sōzu state, passed to a new worker.
+// Consists in a collection of worker requests
+message InitialState {
+    repeated WorkerRequest requests = 1;
+}

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -603,6 +603,7 @@ message Percentiles {
     required uint64 p_99_99 = 6;
     required uint64 p_99_999 = 7;
     required uint64 p_100 = 8;
+    required uint64 sum = 9;
 }
 
 message RequestCounts {
@@ -631,4 +632,19 @@ message Uint128 {
     // lower value, last 8 bytes of the ip
     required uint64 high = 2;
 
+}
+
+// This is sent only from Sōzu to Sōzu
+message WorkerRequest {
+    required string id = 1;
+    required Request content = 2;
+}
+
+// A response as sent by a worker
+message WorkerResponse {
+    required string id = 1;
+    required ResponseStatus status = 2;
+    // an associated message to detail failure, success or processing
+    required string message = 3;
+    optional ResponseContent content = 4;
 }

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -144,22 +144,22 @@ pub const DEFAULT_WORKER_AUTOMATIC_RESTART: bool = true;
 pub const DEFAULT_AUTOMATIC_STATE_SAVE: bool = false;
 
 /// minimum number of buffers (1)
-pub const DEFAULT_MIN_BUFFERS: usize = 1;
+pub const DEFAULT_MIN_BUFFERS: u64 = 1;
 
 /// maximum number of buffers (1 000)
-pub const DEFAULT_MAX_BUFFERS: usize = 1_000;
+pub const DEFAULT_MAX_BUFFERS: u64 = 1_000;
 
 /// size of the buffers, in bytes (16 KB)
-pub const DEFAULT_BUFFER_SIZE: usize = 16_393;
+pub const DEFAULT_BUFFER_SIZE: u64 = 16_393;
 
 /// maximum number of simultaneous connections (10 000)
 pub const DEFAULT_MAX_CONNECTIONS: usize = 10_000;
 
 /// size of the buffer for the channels, in bytes. Must be bigger than the size of the data received. (1 MB)
-pub const DEFAULT_COMMAND_BUFFER_SIZE: usize = 1_000_000;
+pub const DEFAULT_COMMAND_BUFFER_SIZE: u64 = 1_000_000;
 
 /// maximum size of the buffer for the channels, in bytes. (2 MB)
-pub const DEFAULT_MAX_COMMAND_BUFFER_SIZE: usize = 2_000_000;
+pub const DEFAULT_MAX_COMMAND_BUFFER_SIZE: u64 = 2_000_000;
 
 /// wether to avoid register cluster metrics in the local drain
 pub const DEFAULT_DISABLE_CLUSTER_METRICS: bool = false;
@@ -1077,12 +1077,12 @@ impl ClusterConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Default, Deserialize)]
 pub struct FileConfig {
     pub command_socket: Option<String>,
-    pub command_buffer_size: Option<usize>,
-    pub max_command_buffer_size: Option<usize>,
+    pub command_buffer_size: Option<u64>,
+    pub max_command_buffer_size: Option<u64>,
     pub max_connections: Option<usize>,
-    pub min_buffers: Option<usize>,
-    pub max_buffers: Option<usize>,
-    pub buffer_size: Option<usize>,
+    pub min_buffers: Option<u64>,
+    pub max_buffers: Option<u64>,
+    pub buffer_size: Option<u64>,
     pub saved_state: Option<String>,
     #[serde(default)]
     pub automatic_state_save: Option<bool>,
@@ -1434,12 +1434,12 @@ impl ConfigBuilder {
 pub struct Config {
     pub config_path: String,
     pub command_socket: String,
-    pub command_buffer_size: usize,
-    pub max_command_buffer_size: usize,
+    pub command_buffer_size: u64,
+    pub max_command_buffer_size: u64,
     pub max_connections: usize,
-    pub min_buffers: usize,
-    pub max_buffers: usize,
-    pub buffer_size: usize,
+    pub min_buffers: u64,
+    pub max_buffers: u64,
+    pub buffer_size: u64,
     pub saved_state: Option<String>,
     #[serde(default)]
     pub automatic_state_save: bool,
@@ -1763,14 +1763,14 @@ impl ServerConfig {
             connect_timeout: config.connect_timeout,
             zombie_check_interval: config.zombie_check_interval,
             accept_queue_timeout: config.accept_queue_timeout,
-            min_buffers: config.min_buffers as u64,
-            max_buffers: config.max_buffers as u64,
-            buffer_size: config.buffer_size as u64,
+            min_buffers: config.min_buffers,
+            max_buffers: config.max_buffers,
+            buffer_size: config.buffer_size,
             log_level: config.log_level.clone(),
             log_target: config.log_target.clone(),
             log_access_target: config.log_access_target.clone(),
-            command_buffer_size: config.command_buffer_size as u64,
-            max_command_buffer_size: config.max_command_buffer_size as u64,
+            command_buffer_size: config.command_buffer_size,
+            max_command_buffer_size: config.max_command_buffer_size,
             metrics,
         }
     }

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -1211,7 +1211,7 @@ impl ConfigBuilder {
                 .unwrap_or_else(|| String::from("stdout")),
             max_buffers: file_config.max_buffers.unwrap_or(DEFAULT_MAX_BUFFERS),
             max_command_buffer_size: file_config
-                .command_buffer_size
+                .max_command_buffer_size
                 .unwrap_or(DEFAULT_MAX_COMMAND_BUFFER_SIZE),
             max_connections: file_config
                 .max_connections

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -143,6 +143,9 @@ pub const DEFAULT_WORKER_AUTOMATIC_RESTART: bool = true;
 /// wether to save the state automatically (false)
 pub const DEFAULT_AUTOMATIC_STATE_SAVE: bool = false;
 
+/// minimum number of buffers (1)
+pub const DEFAULT_MIN_BUFFERS: usize = 1;
+
 /// maximum number of buffers (1 000)
 pub const DEFAULT_MAX_BUFFERS: usize = 1_000;
 
@@ -1218,8 +1221,8 @@ impl ConfigBuilder {
                 .disable_cluster_metrics
                 .unwrap_or(DEFAULT_DISABLE_CLUSTER_METRICS),
             min_buffers: std::cmp::min(
-                file_config.min_buffers.unwrap_or(1),
-                file_config.max_buffers.unwrap_or(1000),
+                file_config.min_buffers.unwrap_or(DEFAULT_MIN_BUFFERS),
+                file_config.max_buffers.unwrap_or(DEFAULT_MAX_BUFFERS),
             ),
             pid_file_path: file_config.pid_file_path.clone(),
             request_timeout: file_config
@@ -1751,6 +1754,9 @@ pub struct ServerConfig {
     pub connect_timeout: u32,
     pub zombie_check_interval: u32,
     pub accept_queue_timeout: u32,
+    pub min_buffers: usize,
+    pub max_buffers: usize,
+    pub buffer_size: usize,
 }
 
 impl ServerConfig {
@@ -1762,6 +1768,9 @@ impl ServerConfig {
             connect_timeout: config.connect_timeout,
             zombie_check_interval: config.zombie_check_interval,
             accept_queue_timeout: config.accept_queue_timeout,
+            min_buffers: config.min_buffers,
+            max_buffers: config.max_buffers,
+            buffer_size: config.buffer_size,
         }
     }
 
@@ -1774,12 +1783,15 @@ impl ServerConfig {
 impl Default for ServerConfig {
     fn default() -> ServerConfig {
         ServerConfig {
-            max_connections: 10000,
-            front_timeout: 60,
-            back_timeout: 30,
-            connect_timeout: 3,
-            zombie_check_interval: 30 * 60,
-            accept_queue_timeout: 60,
+            max_connections: DEFAULT_MAX_CONNECTIONS,
+            front_timeout: DEFAULT_FRONT_TIMEOUT,
+            back_timeout: DEFAULT_BACK_TIMEOUT,
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            zombie_check_interval: DEFAULT_ZOMBIE_CHECK_INTERVAL,
+            accept_queue_timeout: DEFAULT_ACCEPT_QUEUE_TIMEOUT,
+            min_buffers: DEFAULT_MIN_BUFFERS,
+            max_buffers: DEFAULT_MAX_BUFFERS,
+            buffer_size: DEFAULT_BUFFER_SIZE,
         }
     }
 }

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -1743,6 +1743,47 @@ fn display_toml_error(file: &str, error: &toml::de::Error) {
     }
 }
 
+/// Used by a worker to start its server loop
+pub struct ServerConfig {
+    pub max_connections: usize,
+    pub front_timeout: u32,
+    pub back_timeout: u32,
+    pub connect_timeout: u32,
+    pub zombie_check_interval: u32,
+    pub accept_queue_timeout: u32,
+}
+
+impl ServerConfig {
+    pub fn from_config(config: &Config) -> ServerConfig {
+        ServerConfig {
+            max_connections: config.max_connections,
+            front_timeout: config.front_timeout,
+            back_timeout: config.back_timeout,
+            connect_timeout: config.connect_timeout,
+            zombie_check_interval: config.zombie_check_interval,
+            accept_queue_timeout: config.accept_queue_timeout,
+        }
+    }
+
+    /// size of the slab for the Session manager
+    pub fn slab_capacity(&self) -> usize {
+        10 + 2 * self.max_connections
+    }
+}
+
+impl Default for ServerConfig {
+    fn default() -> ServerConfig {
+        ServerConfig {
+            max_connections: 10000,
+            front_timeout: 60,
+            back_timeout: 30,
+            connect_timeout: 3,
+            zombie_check_interval: 30 * 60,
+            accept_queue_timeout: 60,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -65,8 +65,8 @@ use crate::{
         request::RequestType, ActivateListener, AddBackend, AddCertificate, CertificateAndKey,
         Cluster, HttpListenerConfig, HttpsListenerConfig, ListenerType, LoadBalancingAlgorithms,
         LoadBalancingParams, LoadMetric, MetricsConfiguration, PathRule, ProxyProtocolConfig,
-        Request, RequestHttpFrontend, RequestTcpFrontend, RulePosition, SocketAddress,
-        TcpListenerConfig, TlsVersion, WorkerRequest,
+        Request, RequestHttpFrontend, RequestTcpFrontend, RulePosition, ServerConfig,
+        ServerMetricsConfig, SocketAddress, TcpListenerConfig, TlsVersion, WorkerRequest,
     },
     ObjectKind,
 };
@@ -1746,33 +1746,6 @@ fn display_toml_error(file: &str, error: &toml::de::Error) {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ServerMetricsConfig {
-    pub address: String,
-    pub tagged_metrics: bool,
-    pub prefix: Option<String>,
-}
-
-/// Used by a worker to start its server loop
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ServerConfig {
-    pub max_connections: usize,
-    pub front_timeout: u32,
-    pub back_timeout: u32,
-    pub connect_timeout: u32,
-    pub zombie_check_interval: u32,
-    pub accept_queue_timeout: u32,
-    pub min_buffers: usize,
-    pub max_buffers: usize,
-    pub buffer_size: usize,
-    pub log_level: String,
-    pub log_target: String,
-    pub log_access_target: Option<String>,
-    pub command_buffer_size: usize,
-    pub max_command_buffer_size: usize,
-    pub metrics: Option<ServerMetricsConfig>,
-}
-
 impl ServerConfig {
     /// reduce the config to the bare minimum needed by a worker
     pub fn from_config(config: &Config) -> ServerConfig {
@@ -1784,49 +1757,27 @@ impl ServerConfig {
             })
         });
         ServerConfig {
-            max_connections: config.max_connections,
+            max_connections: config.max_connections as u64,
             front_timeout: config.front_timeout,
             back_timeout: config.back_timeout,
             connect_timeout: config.connect_timeout,
             zombie_check_interval: config.zombie_check_interval,
             accept_queue_timeout: config.accept_queue_timeout,
-            min_buffers: config.min_buffers,
-            max_buffers: config.max_buffers,
-            buffer_size: config.buffer_size,
+            min_buffers: config.min_buffers as u64,
+            max_buffers: config.max_buffers as u64,
+            buffer_size: config.buffer_size as u64,
             log_level: config.log_level.clone(),
             log_target: config.log_target.clone(),
             log_access_target: config.log_access_target.clone(),
-            command_buffer_size: config.command_buffer_size,
-            max_command_buffer_size: config.max_command_buffer_size,
+            command_buffer_size: config.command_buffer_size as u64,
+            max_command_buffer_size: config.max_command_buffer_size as u64,
             metrics,
         }
     }
 
     /// size of the slab for the Session manager
-    pub fn slab_capacity(&self) -> usize {
+    pub fn slab_capacity(&self) -> u64 {
         10 + 2 * self.max_connections
-    }
-}
-
-impl Default for ServerConfig {
-    fn default() -> ServerConfig {
-        ServerConfig {
-            max_connections: DEFAULT_MAX_CONNECTIONS,
-            front_timeout: DEFAULT_FRONT_TIMEOUT,
-            back_timeout: DEFAULT_BACK_TIMEOUT,
-            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
-            zombie_check_interval: DEFAULT_ZOMBIE_CHECK_INTERVAL,
-            accept_queue_timeout: DEFAULT_ACCEPT_QUEUE_TIMEOUT,
-            min_buffers: DEFAULT_MIN_BUFFERS,
-            max_buffers: DEFAULT_MAX_BUFFERS,
-            buffer_size: DEFAULT_BUFFER_SIZE,
-            log_level: "info".to_string(),
-            log_target: "stdout".to_string(),
-            log_access_target: None,
-            command_buffer_size: DEFAULT_COMMAND_BUFFER_SIZE,
-            max_command_buffer_size: DEFAULT_MAX_COMMAND_BUFFER_SIZE,
-            metrics: None,
-        }
     }
 }
 

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -66,9 +66,8 @@ use crate::{
         Cluster, HttpListenerConfig, HttpsListenerConfig, ListenerType, LoadBalancingAlgorithms,
         LoadBalancingParams, LoadMetric, MetricsConfiguration, PathRule, ProxyProtocolConfig,
         Request, RequestHttpFrontend, RequestTcpFrontend, RulePosition, SocketAddress,
-        TcpListenerConfig, TlsVersion,
+        TcpListenerConfig, TlsVersion, WorkerRequest,
     },
-    request::WorkerRequest,
     ObjectKind,
 };
 
@@ -700,7 +699,7 @@ impl FileClusterFrontendConfig {
             }
         };
 
-        let chain_opt = match self.certificate_chain.as_ref() {
+        let certificate_chain = match self.certificate_chain.as_ref() {
             None => None,
             Some(path) => {
                 let certificate_chain = Config::load_file(path)?;
@@ -721,7 +720,7 @@ impl FileClusterFrontendConfig {
             hostname,
             certificate: certificate_opt,
             key: key_opt,
-            certificate_chain: chain_opt,
+            certificate_chain,
             tls_versions: self.tls_versions.clone(),
             position: self.position,
             path,

--- a/command/src/parser.rs
+++ b/command/src/parser.rs
@@ -70,10 +70,7 @@ where
 mod test {
     use super::*;
 
-    use crate::{
-        proto::command::{request::RequestType, Status, SubscribeEvents},
-        request::WorkerRequest,
-    };
+    use crate::proto::command::{request::RequestType, Status, SubscribeEvents, WorkerRequest};
 
     #[test]
     fn parse_one_worker_request() {

--- a/command/src/request.rs
+++ b/command/src/request.rs
@@ -122,15 +122,6 @@ impl Request {
     }
 }
 
-/*
-/// This is sent only from Sōzu to Sōzu
-#[derive(Debug, Clone, Serialize, PartialEq, Eq, Deserialize)]
-pub struct WorkerRequest {
-    pub id: MessageId,
-    pub content: Request,
-}
-*/
-
 impl WorkerRequest {
     pub fn new(id: String, content: Request) -> Self {
         Self { id, content }

--- a/command/src/request.rs
+++ b/command/src/request.rs
@@ -15,11 +15,11 @@ use crate::{
     proto::{
         command::{
             ip_address, request::RequestType, IpAddress, LoadBalancingAlgorithms, PathRuleKind,
-            Request, RequestHttpFrontend, RulePosition, SocketAddress, Uint128,
+            Request, RequestHttpFrontend, RulePosition, SocketAddress, Uint128, WorkerRequest,
         },
         display::format_request_type,
     },
-    response::{HttpFrontend, MessageId},
+    response::HttpFrontend,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -122,12 +122,14 @@ impl Request {
     }
 }
 
+/*
 /// This is sent only from Sōzu to Sōzu
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, Deserialize)]
 pub struct WorkerRequest {
     pub id: MessageId,
     pub content: Request,
 }
+*/
 
 impl WorkerRequest {
     pub fn new(id: String, content: Request) -> Self {

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -4,7 +4,7 @@ use crate::{
     proto::command::{
         AddBackend, FilteredTimeSerie, LoadBalancingParams, PathRule, PathRuleKind,
         RequestHttpFrontend, RequestTcpFrontend, Response, ResponseContent, ResponseStatus,
-        RulePosition, RunState,
+        RulePosition, RunState, WorkerResponse,
     },
     state::ClusterId,
 };
@@ -224,15 +224,6 @@ struct StatePath {
 
 pub type MessageId = String;
 
-/// A response as sent by a worker
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct WorkerResponse {
-    pub id: MessageId,
-    pub status: ResponseStatus,
-    pub message: String,
-    pub content: Option<ResponseContent>,
-}
-
 impl WorkerResponse {
     pub fn ok<T>(id: T) -> Self
     where
@@ -241,7 +232,7 @@ impl WorkerResponse {
         Self {
             id: id.to_string(),
             message: String::new(),
-            status: ResponseStatus::Ok,
+            status: ResponseStatus::Ok.into(),
             content: None,
         }
     }
@@ -252,7 +243,7 @@ impl WorkerResponse {
     {
         Self {
             id: id.to_string(),
-            status: ResponseStatus::Ok,
+            status: ResponseStatus::Ok.into(),
             message: String::new(),
             content: Some(content),
         }
@@ -266,7 +257,7 @@ impl WorkerResponse {
         Self {
             id: id.to_string(),
             message: error.to_string(),
-            status: ResponseStatus::Failure,
+            status: ResponseStatus::Failure.into(),
             content: None,
         }
     }
@@ -278,25 +269,25 @@ impl WorkerResponse {
         Self {
             id: id.to_string(),
             message: String::new(),
-            status: ResponseStatus::Processing,
+            status: ResponseStatus::Processing.into(),
             content: None,
         }
     }
 
-    pub fn status<T>(id: T, status: ResponseStatus) -> Self
+    pub fn with_status<T>(id: T, status: ResponseStatus) -> Self
     where
         T: ToString,
     {
         Self {
             id: id.to_string(),
             message: String::new(),
-            status,
+            status: status.into(),
             content: None,
         }
     }
 
     pub fn is_failure(&self) -> bool {
-        self.status == ResponseStatus::Failure
+        self.status == ResponseStatus::Failure as i32
     }
 }
 

--- a/command/src/scm_socket.rs
+++ b/command/src/scm_socket.rs
@@ -116,7 +116,7 @@ impl ScmSocket {
         debug!("{} received :{:?}", self.fd, (size, file_descriptor_length));
 
         let listeners_count = ListenersCount::decode_length_delimited(&buf[..size])
-            .map_err(|error| ScmSocketError::DecodeError(error))?;
+            .map_err(ScmSocketError::DecodeError)?;
 
         let mut http_addresses = parse_addresses(&listeners_count.http)?;
         let mut tls_addresses = parse_addresses(&listeners_count.tls)?;

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -1383,11 +1383,9 @@ impl ConfigState {
 
     // create requests needed for a worker to recreate the state
     pub fn produce_initial_state(&self) -> InitialState {
-        let mut counter = 0usize;
         let mut worker_requests = Vec::new();
-        for request in self.generate_requests() {
+        for (counter, request) in self.generate_requests().into_iter().enumerate() {
             worker_requests.push(WorkerRequest::new(format!("SAVE-{counter}"), request));
-            counter += 1;
         }
         InitialState {
             requests: worker_requests,

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -21,11 +21,10 @@ use crate::{
             HttpsListenerConfig, ListedFrontends, ListenerType, ListenersList, PathRule,
             QueryCertificatesFilters, RemoveBackend, RemoveCertificate, RemoveListener,
             ReplaceCertificate, Request, RequestCounts, RequestHttpFrontend, RequestTcpFrontend,
-            SocketAddress, TcpListenerConfig,
+            SocketAddress, TcpListenerConfig, WorkerRequest,
         },
         display::format_request_type,
     },
-    request::WorkerRequest,
     response::{Backend, HttpFrontend, TcpFrontend},
     ObjectKind,
 };

--- a/e2e/src/sozu/worker.rs
+++ b/e2e/src/sozu/worker.rs
@@ -12,12 +12,12 @@ use sozu_lib as sozu;
 use sozu::server::Server;
 use sozu_command::{
     channel::Channel,
-    config::{ConfigBuilder, FileConfig, ServerConfig},
+    config::{ConfigBuilder, FileConfig},
     logging::setup_logging,
     proto::command::{
         request::RequestType, AddBackend, Cluster, HardStop, LoadBalancingParams, PathRule,
         Request, RequestHttpFrontend, RequestTcpFrontend, ReturnListenSockets, RulePosition,
-        SoftStop, WorkerRequest, WorkerResponse,
+        ServerConfig, SoftStop, WorkerRequest, WorkerResponse,
     },
     scm_socket::{Listeners, ScmSocket},
     state::ConfigState,
@@ -72,9 +72,11 @@ impl Worker {
     ) -> (ScmSocket, Channel<WorkerRequest, WorkerResponse>, Server) {
         let (scm_main_to_worker, scm_worker_to_main) =
             UnixStream::pair().expect("could not create unix stream pair");
-        let (cmd_main_to_worker, cmd_worker_to_main) =
-            Channel::generate(config.command_buffer_size, config.max_command_buffer_size)
-                .expect("could not create a channel");
+        let (cmd_main_to_worker, cmd_worker_to_main) = Channel::generate(
+            config.command_buffer_size as usize,
+            config.max_command_buffer_size as usize,
+        )
+        .expect("could not create a channel");
 
         set_no_close_exec(scm_main_to_worker.as_raw_fd());
         set_no_close_exec(scm_worker_to_main.as_raw_fd());
@@ -117,9 +119,11 @@ impl Worker {
         let name = name.into();
         let (scm_main_to_worker, scm_worker_to_main) =
             UnixStream::pair().expect("could not create unix stream pair");
-        let (cmd_main_to_worker, cmd_worker_to_main) =
-            Channel::generate(config.command_buffer_size, config.max_command_buffer_size)
-                .expect("could not create a channel");
+        let (cmd_main_to_worker, cmd_worker_to_main) = Channel::generate(
+            config.command_buffer_size as usize,
+            config.max_command_buffer_size as usize,
+        )
+        .expect("could not create a channel");
 
         set_no_close_exec(scm_main_to_worker.as_raw_fd());
         set_no_close_exec(scm_worker_to_main.as_raw_fd());

--- a/e2e/src/sozu/worker.rs
+++ b/e2e/src/sozu/worker.rs
@@ -72,11 +72,9 @@ impl Worker {
     ) -> (ScmSocket, Channel<WorkerRequest, WorkerResponse>, Server) {
         let (scm_main_to_worker, scm_worker_to_main) =
             UnixStream::pair().expect("could not create unix stream pair");
-        let (cmd_main_to_worker, cmd_worker_to_main) = Channel::generate(
-            config.command_buffer_size as usize,
-            config.max_command_buffer_size as usize,
-        )
-        .expect("could not create a channel");
+        let (cmd_main_to_worker, cmd_worker_to_main) =
+            Channel::generate(config.command_buffer_size, config.max_command_buffer_size)
+                .expect("could not create a channel");
 
         set_no_close_exec(scm_main_to_worker.as_raw_fd());
         set_no_close_exec(scm_worker_to_main.as_raw_fd());
@@ -119,11 +117,9 @@ impl Worker {
         let name = name.into();
         let (scm_main_to_worker, scm_worker_to_main) =
             UnixStream::pair().expect("could not create unix stream pair");
-        let (cmd_main_to_worker, cmd_worker_to_main) = Channel::generate(
-            config.command_buffer_size as usize,
-            config.max_command_buffer_size as usize,
-        )
-        .expect("could not create a channel");
+        let (cmd_main_to_worker, cmd_worker_to_main) =
+            Channel::generate(config.command_buffer_size, config.max_command_buffer_size)
+                .expect("could not create a channel");
 
         set_no_close_exec(scm_main_to_worker.as_raw_fd());
         set_no_close_exec(scm_worker_to_main.as_raw_fd());

--- a/e2e/src/sozu/worker.rs
+++ b/e2e/src/sozu/worker.rs
@@ -17,10 +17,8 @@ use sozu_command::{
     proto::command::{
         request::RequestType, AddBackend, Cluster, HardStop, LoadBalancingParams, PathRule,
         Request, RequestHttpFrontend, RequestTcpFrontend, ReturnListenSockets, RulePosition,
-        SoftStop,
+        SoftStop, WorkerRequest, WorkerResponse,
     },
-    request::WorkerRequest,
-    response::WorkerResponse,
     scm_socket::{Listeners, ScmSocket},
     state::ConfigState,
 };

--- a/e2e/src/sozu/worker.rs
+++ b/e2e/src/sozu/worker.rs
@@ -53,7 +53,7 @@ impl Worker {
         let config = ConfigBuilder::new(file_config, "")
             .into_config()
             .expect("could not create Config");
-        ServerConfig::from_config(&config)
+        ServerConfig::from(&config)
     }
 
     pub fn empty_config() -> (ServerConfig, Listeners, ConfigState) {

--- a/e2e/src/sozu/worker.rs
+++ b/e2e/src/sozu/worker.rs
@@ -88,14 +88,7 @@ impl Worker {
             .send_listeners(&listeners)
             .expect("could not send listeners");
 
-        let initial_state = state
-            .generate_requests()
-            .into_iter()
-            .map(|request| WorkerRequest {
-                id: "initial_state".to_string(),
-                content: request,
-            })
-            .collect();
+        let initial_state = state.produce_initial_state();
         let server = Server::try_new_from_config(
             cmd_worker_to_main,
             scm_worker_to_main,
@@ -133,14 +126,7 @@ impl Worker {
             .expect("could not send listeners");
 
         let thread_config = config.to_owned();
-        let initial_state = state
-            .generate_requests()
-            .into_iter()
-            .map(|request| WorkerRequest {
-                id: "initial_state".to_string(),
-                content: request,
-            })
-            .collect();
+        let initial_state = state.produce_initial_state();
         let thread_name = name.to_owned();
         let thread_scm_worker_to_main = scm_worker_to_main.to_owned();
 

--- a/e2e/src/tests/mod.rs
+++ b/e2e/src/tests/mod.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use sozu_command_lib::{
-    config::{ListenerBuilder, ServerConfig},
-    proto::command::{request::RequestType, ActivateListener, ListenerType, Request},
+    config::ListenerBuilder,
+    proto::command::{request::RequestType, ActivateListener, ListenerType, Request, ServerConfig},
     scm_socket::Listeners,
     state::ConfigState,
 };

--- a/e2e/src/tests/mod.rs
+++ b/e2e/src/tests/mod.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use sozu_command_lib::{
-    config::{Config, ListenerBuilder},
+    config::{ListenerBuilder, ServerConfig},
     proto::command::{request::RequestType, ActivateListener, ListenerType, Request},
     scm_socket::Listeners,
     state::ConfigState,
@@ -46,7 +46,7 @@ fn provide_port() -> u16 {
 /// - n backends ("cluster_0-{0..n}")
 pub fn setup_test<S: Into<String>>(
     name: S,
-    config: Config,
+    config: ServerConfig,
     listeners: Listeners,
     state: ConfigState,
     front_address: SocketAddr,
@@ -108,7 +108,7 @@ pub fn setup_test<S: Into<String>>(
 
 pub fn setup_async_test<S: Into<String>>(
     name: S,
-    config: Config,
+    config: ServerConfig,
     listeners: Listeners,
     state: ConfigState,
     front_address: SocketAddr,
@@ -145,7 +145,7 @@ pub fn setup_async_test<S: Into<String>>(
 
 pub fn setup_sync_test<S: Into<String>>(
     name: S,
-    config: Config,
+    config: ServerConfig,
     listeners: Listeners,
     state: ConfigState,
     front_address: SocketAddr,

--- a/lib/examples/http.rs
+++ b/lib/examples/http.rs
@@ -14,10 +14,8 @@ use sozu_command_lib::{
     logging::setup_logging,
     proto::command::{
         request::RequestType, AddBackend, Cluster, LoadBalancingAlgorithms, LoadBalancingParams,
-        PathRule, RequestHttpFrontend, RulePosition, SocketAddress,
+        PathRule, RequestHttpFrontend, RulePosition, SocketAddress, WorkerRequest, WorkerResponse,
     },
-    request::WorkerRequest,
-    response::WorkerResponse,
 };
 
 fn main() -> anyhow::Result<()> {

--- a/lib/examples/https.rs
+++ b/lib/examples/https.rs
@@ -15,9 +15,8 @@ use sozu_command_lib::{
     logging::setup_logging,
     proto::command::{
         request::RequestType, AddBackend, AddCertificate, CertificateAndKey, LoadBalancingParams,
-        PathRule, RequestHttpFrontend, SocketAddress,
+        PathRule, RequestHttpFrontend, SocketAddress, WorkerRequest,
     },
-    request::WorkerRequest,
 };
 
 fn main() -> anyhow::Result<()> {

--- a/lib/examples/tcp.rs
+++ b/lib/examples/tcp.rs
@@ -12,9 +12,8 @@ use sozu_command_lib::{
     logging::setup_logging,
     proto::command::{
         request::RequestType, AddBackend, LoadBalancingParams, RequestTcpFrontend, SocketAddress,
-        TcpListenerConfig,
+        TcpListenerConfig, WorkerRequest,
     },
-    request::WorkerRequest,
 };
 
 fn main() -> anyhow::Result<()> {

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -17,6 +17,7 @@ use rusty_ulid::Ulid;
 use time::{Duration, Instant};
 
 use sozu_command::{
+    config::ServerConfig,
     logging,
     proto::command::{
         request::RequestType, Cluster, HttpListenerConfig, ListenerType, RemoveListener,

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -20,11 +20,10 @@ use sozu_command::{
     logging,
     proto::command::{
         request::RequestType, Cluster, HttpListenerConfig, ListenerType, RemoveListener,
-        RequestHttpFrontend,
+        RequestHttpFrontend, WorkerRequest, WorkerResponse,
     },
     ready::Ready,
-    request::WorkerRequest,
-    response::{HttpFrontend, WorkerResponse},
+    response::HttpFrontend,
     state::ClusterId,
 };
 
@@ -1058,8 +1057,9 @@ mod tests {
     use crate::sozu_command::{
         channel::Channel,
         config::ListenerBuilder,
-        proto::command::{LoadBalancingAlgorithms, LoadBalancingParams, PathRule, RulePosition},
-        request::WorkerRequest,
+        proto::command::{
+            LoadBalancingAlgorithms, LoadBalancingParams, PathRule, RulePosition, WorkerRequest,
+        },
         response::{Backend, HttpFrontend},
     };
 

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -20,7 +20,7 @@ use sozu_command::{
     logging,
     proto::command::{
         request::RequestType, Cluster, HttpListenerConfig, ListenerType, RemoveListener,
-        RequestHttpFrontend, ServerConfig, WorkerRequest, WorkerResponse,
+        RequestHttpFrontend, WorkerRequest, WorkerResponse,
     },
     ready::Ready,
     response::HttpFrontend,

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -17,11 +17,10 @@ use rusty_ulid::Ulid;
 use time::{Duration, Instant};
 
 use sozu_command::{
-    config::ServerConfig,
     logging,
     proto::command::{
         request::RequestType, Cluster, HttpListenerConfig, ListenerType, RemoveListener,
-        RequestHttpFrontend, WorkerRequest, WorkerResponse,
+        RequestHttpFrontend, ServerConfig, WorkerRequest, WorkerResponse,
     },
     ready::Ready,
     response::HttpFrontend,

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -36,13 +36,13 @@ use time::{Duration, Instant};
 
 use sozu_command::{
     certificate::Fingerprint,
-    config::{ServerConfig, DEFAULT_CIPHER_SUITES},
+    config::DEFAULT_CIPHER_SUITES,
     logging,
     proto::command::{
         request::RequestType, response_content::ContentType, AddCertificate, CertificateSummary,
         CertificatesByAddress, Cluster, HttpsListenerConfig, ListOfCertificatesByAddress,
         ListenerType, RemoveCertificate, RemoveListener, ReplaceCertificate, RequestHttpFrontend,
-        ResponseContent, TlsVersion, WorkerRequest, WorkerResponse,
+        ResponseContent, ServerConfig, TlsVersion, WorkerRequest, WorkerResponse,
     },
     ready::Ready,
     response::HttpFrontend,

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -28,14 +28,15 @@ use rustls::{
         },
         CryptoProvider,
     },
-    CipherSuite, ProtocolVersion, ServerConfig, ServerConnection, SupportedCipherSuite,
+    CipherSuite, ProtocolVersion, ServerConfig as RustlsServerConfig, ServerConnection,
+    SupportedCipherSuite,
 };
 use rusty_ulid::Ulid;
 use time::{Duration, Instant};
 
 use sozu_command::{
     certificate::Fingerprint,
-    config::DEFAULT_CIPHER_SUITES,
+    config::{ServerConfig, DEFAULT_CIPHER_SUITES},
     logging,
     proto::command::{
         request::RequestType, response_content::ContentType, AddCertificate, CertificateSummary,
@@ -529,7 +530,7 @@ pub struct HttpsListener {
     fronts: Router,
     listener: Option<MioTcpListener>,
     resolver: Arc<MutexWrappedCertificateResolver>,
-    rustls_details: Arc<ServerConfig>,
+    rustls_details: Arc<RustlsServerConfig>,
     tags: BTreeMap<String, CachedTags>,
     token: Token,
 }
@@ -705,7 +706,7 @@ impl HttpsListener {
     pub fn create_rustls_context(
         config: &HttpsListenerConfig,
         resolver: Arc<MutexWrappedCertificateResolver>,
-    ) -> Result<ServerConfig, ListenerError> {
+    ) -> Result<RustlsServerConfig, ListenerError> {
         let cipher_names = if config.cipher_list.is_empty() {
             DEFAULT_CIPHER_SUITES.to_vec()
         } else {
@@ -758,7 +759,7 @@ impl HttpsListener {
             ..ring::default_provider()
         };
 
-        let mut server_config = ServerConfig::builder_with_provider(provider.into())
+        let mut server_config = RustlsServerConfig::builder_with_provider(provider.into())
             .with_protocol_versions(&versions[..])
             .map_err(|err| ListenerError::BuildRustls(err.to_string()))?
             .with_no_client_auth()
@@ -1593,7 +1594,7 @@ mod tests {
         let address = SocketAddress::new_v4(127, 0, 0, 1, 1032);
         let resolver = Arc::new(MutexWrappedCertificateResolver::default());
 
-        let server_config = ServerConfig::builder_with_protocol_versions(&[
+        let server_config = RustlsServerConfig::builder_with_protocol_versions(&[
             &rustls::version::TLS12,
             &rustls::version::TLS13,
         ])

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -41,11 +41,10 @@ use sozu_command::{
         request::RequestType, response_content::ContentType, AddCertificate, CertificateSummary,
         CertificatesByAddress, Cluster, HttpsListenerConfig, ListOfCertificatesByAddress,
         ListenerType, RemoveCertificate, RemoveListener, ReplaceCertificate, RequestHttpFrontend,
-        ResponseContent, TlsVersion,
+        ResponseContent, TlsVersion, WorkerRequest, WorkerResponse,
     },
     ready::Ready,
-    request::WorkerRequest,
-    response::{HttpFrontend, WorkerResponse},
+    response::HttpFrontend,
     state::ClusterId,
 };
 

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -42,7 +42,7 @@ use sozu_command::{
         request::RequestType, response_content::ContentType, AddCertificate, CertificateSummary,
         CertificatesByAddress, Cluster, HttpsListenerConfig, ListOfCertificatesByAddress,
         ListenerType, RemoveCertificate, RemoveListener, ReplaceCertificate, RequestHttpFrontend,
-        ResponseContent, ServerConfig, TlsVersion, WorkerRequest, WorkerResponse,
+        ResponseContent, TlsVersion, WorkerRequest, WorkerResponse,
     },
     ready::Ready,
     response::HttpFrontend,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1116,8 +1116,9 @@ pub mod testing {
     pub use mio::{net::UnixStream, Poll, Registry, Token};
     pub use slab::Slab;
     pub use sozu_command::{
-        config::ServerConfig,
-        proto::command::{HttpListenerConfig, HttpsListenerConfig, TcpListenerConfig},
+        proto::command::{
+            HttpListenerConfig, HttpsListenerConfig, ServerConfig, TcpListenerConfig,
+        },
         scm_socket::{Listeners, ScmSocket},
     };
 
@@ -1153,7 +1154,7 @@ pub mod testing {
         let event_loop = Poll::new().with_context(|| "Failed at creating event loop")?;
         let backends = Rc::new(RefCell::new(BackendMap::new()));
         let server_config = ServerConfig {
-            max_connections: max_buffers,
+            max_connections: max_buffers as u64,
             ..Default::default()
         };
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -53,8 +53,7 @@
 //! ```ignore
 //! use sozu_command_lib::{
 //!     channel::Channel,
-//!     request::WorkerRequest,
-//!     response::WorkerResponse,
+//!     proto::command::{WorkerRequest, WorkerResponse},
 //! };
 //!
 //! let (mut command_channel, proxy_channel): (
@@ -167,8 +166,7 @@
 //!
 //! ```ignore
 //! use sozu_command_lib::{
-//!     proto::command::{Request, request::RequestType},
-//!     request::WorkerRequest,
+//!     proto::command::{Request, request::RequestType, WorkerRequest},
 //! };
 //!
 //! command_channel
@@ -227,9 +225,8 @@
 //!     logging::setup_logging,
 //!     proto::command::{
 //!         request::RequestType, AddBackend, Cluster, LoadBalancingAlgorithms, LoadBalancingParams,
-//!         PathRule, Request, RequestHttpFrontend, RulePosition, SocketAddress,
+//!         PathRule, Request, RequestHttpFrontend, RulePosition, SocketAddress,WorkerRequest,
 //!     },
-//!     request::WorkerRequest,
 //! };
 //!
 //! fn main() -> anyhow::Result<()> {
@@ -361,10 +358,8 @@ use time::{Duration, Instant};
 use tls::CertificateResolverError;
 
 use sozu_command::{
-    proto::command::{Cluster, ListenerType, RequestHttpFrontend},
+    proto::command::{Cluster, ListenerType, RequestHttpFrontend, WorkerRequest, WorkerResponse},
     ready::Ready,
-    request::WorkerRequest,
-    response::WorkerResponse,
     state::ClusterId,
     ObjectKind,
 };

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1116,6 +1116,7 @@ pub mod testing {
     pub use mio::{net::UnixStream, Poll, Registry, Token};
     pub use slab::Slab;
     pub use sozu_command::{
+        config::ServerConfig,
         proto::command::{HttpListenerConfig, HttpsListenerConfig, TcpListenerConfig},
         scm_socket::{Listeners, ScmSocket},
     };
@@ -1126,7 +1127,7 @@ pub mod testing {
         https::HttpsProxy,
         pool::Pool,
         server::Server,
-        server::{ListenSession, ProxyChannel, ServerConfig, SessionManager},
+        server::{ListenSession, ProxyChannel, SessionManager},
         tcp::TcpProxy,
         Protocol, ProxySession,
     };

--- a/lib/src/metrics/local_drain.rs
+++ b/lib/src/metrics/local_drain.rs
@@ -89,6 +89,7 @@ impl AggregatedMetric {
 }
 
 pub fn histogram_to_percentiles(hist: &Histogram<u32>) -> Percentiles {
+    let sum = hist.len() as f64 * hist.mean();
     Percentiles {
         samples: hist.len(),
         p_50: hist.value_at_percentile(50.0),
@@ -98,6 +99,7 @@ pub fn histogram_to_percentiles(hist: &Histogram<u32>) -> Percentiles {
         p_99_99: hist.value_at_percentile(99.99),
         p_99_999: hist.value_at_percentile(99.999),
         p_100: hist.value_at_percentile(100.0),
+        sum: sum as u64,
     }
 }
 

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -17,7 +17,7 @@ use time::{Duration, Instant};
 
 use sozu_command::{
     channel::Channel,
-    config::Config,
+    config::{Config, ServerConfig},
     proto::command::{
         request::RequestType, response_content::ContentType, ActivateListener, AddBackend,
         CertificatesWithFingerprints, Cluster, ClusterHashes, ClusterInformations,
@@ -97,45 +97,6 @@ impl From<usize> for SessionToken {
 impl From<SessionToken> for usize {
     fn from(val: SessionToken) -> usize {
         val.0
-    }
-}
-
-pub struct ServerConfig {
-    pub max_connections: usize,
-    pub front_timeout: u32,
-    pub back_timeout: u32,
-    pub connect_timeout: u32,
-    pub zombie_check_interval: u32,
-    pub accept_queue_timeout: u32,
-}
-
-impl ServerConfig {
-    pub fn from_config(config: &Config) -> ServerConfig {
-        ServerConfig {
-            max_connections: config.max_connections,
-            front_timeout: config.front_timeout,
-            back_timeout: config.back_timeout,
-            connect_timeout: config.connect_timeout,
-            zombie_check_interval: config.zombie_check_interval,
-            accept_queue_timeout: config.accept_queue_timeout,
-        }
-    }
-
-    fn slab_capacity(&self) -> usize {
-        10 + 2 * self.max_connections
-    }
-}
-
-impl Default for ServerConfig {
-    fn default() -> ServerConfig {
-        ServerConfig {
-            max_connections: 10000,
-            front_timeout: 60,
-            back_timeout: 30,
-            connect_timeout: 3,
-            zombie_check_interval: 30 * 60,
-            accept_queue_timeout: 60,
-        }
     }
 }
 

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -17,13 +17,13 @@ use time::{Duration, Instant};
 
 use sozu_command::{
     channel::Channel,
-    config::ServerConfig,
     proto::command::{
         request::RequestType, response_content::ContentType, ActivateListener, AddBackend,
         CertificatesWithFingerprints, Cluster, ClusterHashes, ClusterInformations,
         DeactivateListener, Event, HttpListenerConfig, HttpsListenerConfig, ListenerType,
         LoadBalancingAlgorithms, LoadMetric, MetricsConfiguration, RemoveBackend, Request,
-        ResponseStatus, TcpListenerConfig as CommandTcpListener, WorkerRequest, WorkerResponse,
+        ResponseStatus, ServerConfig, TcpListenerConfig as CommandTcpListener, WorkerRequest,
+        WorkerResponse,
     },
     ready::Ready,
     scm_socket::{Listeners, ScmSocket, ScmSocketError},
@@ -248,17 +248,17 @@ impl Server {
     ) -> Result<Self, ServerError> {
         let event_loop = Poll::new().map_err(ServerError::CreatePoll)?;
         let pool = Rc::new(RefCell::new(Pool::with_capacity(
-            config.min_buffers,
-            config.max_buffers,
-            config.buffer_size,
+            config.min_buffers as usize,
+            config.max_buffers as usize,
+            config.buffer_size as usize,
         )));
         let backends = Rc::new(RefCell::new(BackendMap::new()));
 
         //FIXME: we will use a few entries for the channel, metrics socket and the listeners
         //FIXME: for HTTP/2, we will have more than 2 entries per session
         let sessions: Rc<RefCell<SessionManager>> = SessionManager::new(
-            Slab::with_capacity(config.slab_capacity()),
-            config.max_connections,
+            Slab::with_capacity(config.slab_capacity() as usize),
+            config.max_connections as usize,
         );
         {
             let mut s = sessions.borrow_mut();

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -23,11 +23,9 @@ use sozu_command::{
         CertificatesWithFingerprints, Cluster, ClusterHashes, ClusterInformations,
         DeactivateListener, Event, HttpListenerConfig, HttpsListenerConfig, ListenerType,
         LoadBalancingAlgorithms, LoadMetric, MetricsConfiguration, RemoveBackend, Request,
-        ResponseStatus, TcpListenerConfig as CommandTcpListener,
+        ResponseStatus, TcpListenerConfig as CommandTcpListener, WorkerRequest, WorkerResponse,
     },
     ready::Ready,
-    request::WorkerRequest,
-    response::{MessageId, WorkerResponse},
     scm_socket::{Listeners, ScmSocket, ScmSocketError},
     state::ConfigState,
 };
@@ -67,7 +65,7 @@ pub fn push_event(event: Event) {
         (*queue.borrow_mut()).push_back(WorkerResponse {
             id: "EVENT".to_string(),
             message: String::new(),
-            status: ResponseStatus::Processing,
+            status: ResponseStatus::Processing.into(),
             content: Some(ContentType::Event(event).into()),
         });
     });
@@ -274,7 +272,7 @@ pub struct Server {
     scm: ScmSocket,
     sessions: Rc<RefCell<SessionManager>>,
     should_poll_at: Option<Instant>,
-    shutting_down: Option<MessageId>,
+    shutting_down: Option<String>,
     tcp: Rc<RefCell<tcp::TcpProxy>>,
     zombie_check_interval: Duration,
 }
@@ -948,9 +946,8 @@ impl Server {
                     ContentType::Clusters(ClusterInformations {
                         vec: self
                             .config_state
-                            .cluster_state(cluster_id)
-                            .into_iter()
-                            .collect(),
+                            .cluster_state(&cluster_id)
+                            .map_or(vec![], |ci| vec![ci]),
                     })
                     .into(),
                 ));

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -247,13 +247,13 @@ impl Server {
         expects_initial_status: bool,
     ) -> Result<Self, ServerError> {
         let event_loop = Poll::new().map_err(ServerError::CreatePoll)?;
+        let server_config = ServerConfig::from_config(&config);
         let pool = Rc::new(RefCell::new(Pool::with_capacity(
-            config.min_buffers,
-            config.max_buffers,
-            config.buffer_size,
+            server_config.min_buffers,
+            server_config.max_buffers,
+            server_config.buffer_size,
         )));
         let backends = Rc::new(RefCell::new(BackendMap::new()));
-        let server_config = ServerConfig::from_config(&config);
 
         //FIXME: we will use a few entries for the channel, metrics socket and the listeners
         //FIXME: for HTTP/2, we will have more than 2 entries per session

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -15,7 +15,8 @@ use rusty_ulid::Ulid;
 use time::{Duration, Instant};
 
 use sozu_command::{
-    config::ServerConfig, config::MAX_LOOP_ITERATIONS, proto::command::request::RequestType,
+    config::MAX_LOOP_ITERATIONS,
+    proto::command::{request::RequestType, ServerConfig},
     ObjectKind,
 };
 

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -33,10 +33,9 @@ use crate::{
         logging,
         proto::command::{
             Event, EventKind, ProxyProtocolConfig, RequestTcpFrontend, TcpListenerConfig,
+            WorkerRequest, WorkerResponse,
         },
         ready::Ready,
-        request::WorkerRequest,
-        response::WorkerResponse,
         state::ClusterId,
     },
     timer::TimeoutContainer,
@@ -1518,9 +1517,10 @@ mod tests {
     use sozu_command::{
         channel::Channel,
         config::ListenerBuilder,
-        proto::command::{request::RequestType, LoadBalancingParams, RequestTcpFrontend},
-        request::WorkerRequest,
-        response::WorkerResponse,
+        proto::command::{
+            request::RequestType, LoadBalancingParams, RequestTcpFrontend, WorkerRequest,
+            WorkerResponse,
+        },
     };
     static TEST_FINISHED: AtomicBool = AtomicBool::new(false);
 

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -14,11 +14,7 @@ use mio::{
 use rusty_ulid::Ulid;
 use time::{Duration, Instant};
 
-use sozu_command::{
-    config::MAX_LOOP_ITERATIONS,
-    proto::command::{request::RequestType, ServerConfig},
-    ObjectKind,
-};
+use sozu_command::{config::MAX_LOOP_ITERATIONS, proto::command::request::RequestType, ObjectKind};
 
 use crate::{
     backends::{Backend, BackendMap},

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -14,7 +14,10 @@ use mio::{
 use rusty_ulid::Ulid;
 use time::{Duration, Instant};
 
-use sozu_command::{config::MAX_LOOP_ITERATIONS, proto::command::request::RequestType, ObjectKind};
+use sozu_command::{
+    config::ServerConfig, config::MAX_LOOP_ITERATIONS, proto::command::request::RequestType,
+    ObjectKind,
+};
 
 use crate::{
     backends::{Backend, BackendMap},


### PR DESCRIPTION
When a new worker is created, the whole `Config` object is passed to it:

https://github.com/sozu-proxy/sozu/blob/bc49d7f41d94b37bfc37a4a2d2c7ecb27db80d9f/bin/src/worker.rs#L340-L342

This `Config` object contains necessary infos, like timeouts, but also proxy business infos like clusters, frontends etc. that are not used directly and are re-sent to the new worker later on in a different form.

Since we strive to have a protobuf-only communication both without and within Sōzu,
and since the `Config` object can be translated to protobuf only with difficulty, and no real purpose (as most of it is unused),
this PR changes the passing of the `Config` object to a `ServerConfig`. This struct was already derived from `Config`, was present in the Sōzu lib, but now:
- it is completed with necessary fields (buffer sizes, etc)
- it is written in protobuf
- it is passed to a new worker when created

This PR paves the way to changing the Sōzu channels in order to stop serializing structs to JSON, but to make use of the protobuf binary serialization.

One thing remains in a JSON form, though: requests written to a state file and passed to sōzu using a `LoadState` message.