### PR TITLE
channels transmit protobuf messages (binary)

### DIFF
--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -7,8 +7,8 @@ use sozu_command_lib::proto::{
     command::{
         filtered_metrics, response_content::ContentType, AggregatedMetrics, AvailableMetrics,
         CertificateAndKey, CertificatesWithFingerprints, ClusterMetrics, FilteredMetrics,
-        ListedFrontends, ListenersList, RequestCounts, ResponseContent, WorkerInfos, WorkerMetrics,
-        WorkerResponses,
+        ListedFrontends, ListenersList, RequestCounts, ResponseContent, RunState, WorkerInfos,
+        WorkerMetrics, WorkerResponses,
     },
     display::concatenate_vector,
 };
@@ -125,7 +125,11 @@ pub fn print_status(worker_infos: WorkerInfos) {
     table.add_row(row!["worker id", "pid", "run state"]);
 
     for worker_info in worker_infos.vec {
-        let row = row!(worker_info.id, worker_info.pid, worker_info.run_state);
+        let row = row!(
+            worker_info.id,
+            worker_info.pid,
+            RunState::try_from(worker_info.run_state).unwrap().as_str_name()
+        );
         table.add_row(row);
     }
 


### PR DESCRIPTION
This is the last step in the implementation of protobuf in Sōzu: use protobuf for all communications of Sōzu, within and without. See #1000 

Coded with @Wonshtrum , this PR:
- makes channel transmit protobuf messages
- in a binary serialization
- with a fixed-size delimiter that tells how long the message is

Here is a simple benchmark of performance improvements:

```
We will serialize, write in a buffer, read from the buffer and deserialize, a 1000000 times, this object:
RequestHttpFrontend { cluster_id: Some("cluster_1"), address: "127.0.0.1:8080", hostname: "lolcatho.st", path: PathRule { kind: Prefix, value: "/" }, method: Some("GET"), position: Tree, tags: {"app_id": "a782f2e4-ee42-4384-9757-2b13d4198105", "owner": "Clever Cloud"} }
serde_json serialized it in 216 bytes
Serde JSON needed 23.838388363s
prost serialized it in 125 bytes
Prost needed 12.118231414s
```