### PR TITLE
deny_traffic field in frontends

### DIFF
--- a/bin/config.toml
+++ b/bin/config.toml
@@ -260,6 +260,7 @@ load_balancing = "ROUND_ROBIN"
 # - sticky_session = false # activates sticky sessions for this cluster
 # - https_redirect = false #  activates automatic redirection to HTTPS for this cluster
 # - custom_tag: a tag to retrieve a frontend with the CLI or in the logs
+# - deny_traffic: return a 401 for this frontend (defaults to false)
 frontends = [
     { address = "0.0.0.0:8080", hostname = "lolcatho.st", tags = { key = "value" }, path = "/api" },
     # HTTPS frontends also have an optional `tls_versions` key like the HTTPS listeners

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -404,27 +404,6 @@ pub enum FrontendCmd {
 }
 
 #[derive(Subcommand, PartialEq, Eq, Clone, Debug)]
-pub enum ClusterId {
-    /// traffic will go to the backend servers with this cluster id
-    Id {
-        /// traffic will go to the backend servers with this cluster id
-        id: String,
-    },
-    /// traffic to this frontend will be rejected with HTTP 401
-    Deny,
-}
-
-#[allow(clippy::from_over_into)]
-impl std::convert::Into<Option<StateClusterId>> for ClusterId {
-    fn into(self) -> Option<StateClusterId> {
-        match self {
-            ClusterId::Deny => None,
-            ClusterId::Id { id } => Some(id),
-        }
-    }
-}
-
-#[derive(Subcommand, PartialEq, Eq, Clone, Debug)]
 pub enum HttpFrontendCmd {
     #[clap(name = "add")]
     Add {
@@ -434,8 +413,8 @@ pub enum HttpFrontendCmd {
             help = "frontend address, format: IP:port"
         )]
         address: SocketAddr,
-        #[clap(subcommand, name = "cluster_id")]
-        cluster_id: ClusterId,
+        #[clap(short = 'i', long = "cluster-id", help = "identifies a cluster")]
+        cluster_id: String,
         #[clap(long = "hostname", aliases = &["host"])]
         hostname: String,
         #[clap(short = 'p', long = "path-prefix", help = "URL prefix of the frontend")]
@@ -454,6 +433,12 @@ pub enum HttpFrontendCmd {
         method: Option<String>,
         #[clap(long = "tags", help = "Specify tag (key-value pair) to apply on front-end (example: 'key=value, other-key=other-value')", value_parser = parse_tags)]
         tags: Option<BTreeMap<String, String>>,
+        #[clap(
+            short = 'd',
+            long = "deny-traffic",
+            help = "send a 401 on this address"
+        )]
+        deny_traffic: Option<bool>,
     },
     #[clap(name = "remove")]
     Remove {
@@ -463,8 +448,8 @@ pub enum HttpFrontendCmd {
             help = "frontend address, format: IP:port"
         )]
         address: SocketAddr,
-        #[clap(subcommand, name = "cluster_id")]
-        cluster_id: ClusterId,
+        #[clap(short = 'i', long = "cluster-id", help = "identifies a cluster")]
+        cluster_id: String,
         #[clap(long = "hostname", aliases = &["host"])]
         hostname: String,
         #[clap(short = 'p', long = "path-prefix", help = "URL prefix of the frontend")]
@@ -506,6 +491,12 @@ pub enum TcpFrontendCmd {
             value_parser = parse_tags
         )]
         tags: Option<BTreeMap<String, String>>,
+        #[clap(
+            short = 'd',
+            long = "deny-traffic",
+            help = "send a 401 on this address"
+        )]
+        deny_traffic: Option<bool>,
     },
     #[clap(name = "remove")]
     Remove {

--- a/bin/src/ctl/display.rs
+++ b/bin/src/ctl/display.rs
@@ -150,10 +150,7 @@ pub fn print_frontend_list(frontends: ListedFrontends) {
         ]);
         for http_frontend in frontends.http_frontends.iter() {
             table.add_row(row!(
-                http_frontend
-                    .cluster_id
-                    .clone()
-                    .unwrap_or("Deny".to_owned()),
+                http_frontend.cluster_id,
                 http_frontend.address.to_string(),
                 http_frontend.hostname.to_string(),
                 format!("{:?}", http_frontend.path),
@@ -181,10 +178,7 @@ pub fn print_frontend_list(frontends: ListedFrontends) {
         ]);
         for https_frontend in frontends.https_frontends.iter() {
             table.add_row(row!(
-                https_frontend
-                    .cluster_id
-                    .clone()
-                    .unwrap_or("Deny".to_owned()),
+                https_frontend.cluster_id,
                 https_frontend.address.to_string(),
                 https_frontend.hostname.to_string(),
                 format!("{:?}", https_frontend.path),
@@ -516,10 +510,7 @@ pub fn print_cluster_responses(
 
         for (key, values) in http_frontends.iter() {
             let mut row = Vec::new();
-            match &key.cluster_id {
-                Some(cluster_id) => row.push(cell!(cluster_id)),
-                None => row.push(cell!("-")),
-            }
+            row.push(cell!(key.cluster_id));
             row.push(cell!(key.hostname));
             row.push(cell!(key.path));
 
@@ -540,10 +531,7 @@ pub fn print_cluster_responses(
 
         for (key, values) in https_frontends.iter() {
             let mut row = Vec::new();
-            match &key.cluster_id {
-                Some(cluster_id) => row.push(cell!(cluster_id)),
-                None => row.push(cell!("-")),
-            }
+            row.push(cell!(key.cluster_id));
             row.push(cell!(key.hostname));
             row.push(cell!(key.path));
 

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -172,11 +172,17 @@ impl CommandManager {
 
     pub fn tcp_frontend_command(&mut self, cmd: TcpFrontendCmd) -> anyhow::Result<()> {
         match cmd {
-            TcpFrontendCmd::Add { id, address, tags } => self.send_request(
+            TcpFrontendCmd::Add {
+                id,
+                address,
+                tags,
+                deny_traffic,
+            } => self.send_request(
                 RequestType::AddTcpFrontend(RequestTcpFrontend {
                     cluster_id: id,
                     address: address.to_string(),
                     tags: tags.unwrap_or(BTreeMap::new()),
+                    deny_traffic: deny_traffic.unwrap_or(false),
                 })
                 .into(),
             ),
@@ -202,6 +208,7 @@ impl CommandManager {
                 method,
                 cluster_id: route,
                 tags,
+                deny_traffic,
             } => self.send_request(
                 RequestType::AddHttpFrontend(RequestHttpFrontend {
                     cluster_id: route.into(),
@@ -214,6 +221,7 @@ impl CommandManager {
                         Some(tags) => tags,
                         None => BTreeMap::new(),
                     },
+                    deny_traffic: deny_traffic.unwrap_or(false),
                 })
                 .into(),
             ),
@@ -224,10 +232,10 @@ impl CommandManager {
                 path_equals,
                 address,
                 method,
-                cluster_id: route,
+                cluster_id,
             } => self.send_request(
                 RequestType::RemoveHttpFrontend(RequestHttpFrontend {
-                    cluster_id: route.into(),
+                    cluster_id,
                     address: address.to_string(),
                     hostname,
                     path: PathRule::from_cli_options(path_prefix, path_regex, path_equals),
@@ -248,11 +256,12 @@ impl CommandManager {
                 path_equals,
                 address,
                 method,
-                cluster_id: route,
+                cluster_id,
                 tags,
+                deny_traffic,
             } => self.send_request(
                 RequestType::AddHttpsFrontend(RequestHttpFrontend {
-                    cluster_id: route.into(),
+                    cluster_id,
                     address: address.to_string(),
                     hostname,
                     path: PathRule::from_cli_options(path_prefix, path_regex, path_equals),
@@ -262,6 +271,7 @@ impl CommandManager {
                         Some(tags) => tags,
                         None => BTreeMap::new(),
                     },
+                    deny_traffic: deny_traffic.unwrap_or(false),
                 })
                 .into(),
             ),
@@ -272,10 +282,10 @@ impl CommandManager {
                 path_equals,
                 address,
                 method,
-                cluster_id: route,
+                cluster_id,
             } => self.send_request(
                 RequestType::RemoveHttpsFrontend(RequestHttpFrontend {
-                    cluster_id: route.into(),
+                    cluster_id,
                     address: address.to_string(),
                     hostname,
                     path: PathRule::from_cli_options(path_prefix, path_regex, path_equals),

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -209,7 +209,6 @@ message ListenersList {
 
 // An HTTP or HTTPS frontend, as order to, or received from, Sōzu
 message RequestHttpFrontend {
-    optional string cluster_id = 1;
     required string address = 2;
     required string hostname = 3;
     required PathRule path = 4;
@@ -217,14 +216,17 @@ message RequestHttpFrontend {
     required RulePosition position = 6 [default = TREE];
     // custom tags to identify the frontend in the access logs
     map<string, string> tags = 7;
+    required string cluster_id = 8;
+    required bool deny_traffic = 9 [default = false];
 }
 
 message RequestTcpFrontend {
-    required string cluster_id = 1;
     // the socket address on which to listen for incoming traffic
     required string address = 2;
     // custom tags to identify the frontend in the access logs
     map<string, string> tags = 3;
+    required string cluster_id = 4;
+    required bool deny_traffic = 5 [default = false];
 }
 
 // list the frontends, filtered by protocol and/or domain

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -657,6 +657,7 @@ pub struct FileClusterFrontendConfig {
     #[serde(default)]
     pub position: RulePosition,
     pub tags: Option<BTreeMap<String, String>>,
+    pub deny_traffic: Option<bool>,
 }
 
 impl FileClusterFrontendConfig {
@@ -686,6 +687,7 @@ impl FileClusterFrontendConfig {
         Ok(TcpFrontendConfig {
             address: self.address,
             tags: self.tags.clone(),
+            deny_traffic: self.deny_traffic,
         })
     }
 
@@ -742,6 +744,7 @@ impl FileClusterFrontendConfig {
             path,
             method: self.method.clone(),
             tags: self.tags.clone(),
+            deny_traffic: self.deny_traffic,
         })
     }
 }
@@ -892,6 +895,7 @@ pub struct HttpFrontendConfig {
     #[serde(default)]
     pub position: RulePosition,
     pub tags: Option<BTreeMap<String, String>>,
+    pub deny_traffic: Option<bool>,
 }
 
 impl HttpFrontendConfig {
@@ -921,13 +925,14 @@ impl HttpFrontendConfig {
 
             v.push(
                 RequestType::AddHttpsFrontend(RequestHttpFrontend {
-                    cluster_id: Some(cluster_id.to_string()),
+                    cluster_id: cluster_id.to_string(),
                     address: self.address.to_string(),
                     hostname: self.hostname.clone(),
                     path: self.path.clone(),
                     method: self.method.clone(),
                     position: self.position.into(),
                     tags,
+                    deny_traffic: self.deny_traffic.unwrap_or(false),
                 })
                 .into(),
             );
@@ -935,13 +940,14 @@ impl HttpFrontendConfig {
             //create the front both for HTTP and HTTPS if possible
             v.push(
                 RequestType::AddHttpFrontend(RequestHttpFrontend {
-                    cluster_id: Some(cluster_id.to_string()),
+                    cluster_id: cluster_id.to_string(),
                     address: self.address.to_string(),
                     hostname: self.hostname.clone(),
                     path: self.path.clone(),
                     method: self.method.clone(),
                     position: self.position.into(),
                     tags,
+                    deny_traffic: self.deny_traffic.unwrap_or(false),
                 })
                 .into(),
             );
@@ -1010,6 +1016,7 @@ impl HttpClusterConfig {
 pub struct TcpFrontendConfig {
     pub address: SocketAddr,
     pub tags: Option<BTreeMap<String, String>>,
+    pub deny_traffic: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -1042,6 +1049,7 @@ impl TcpClusterConfig {
                     cluster_id: self.cluster_id.clone(),
                     address: frontend.address.to_string(),
                     tags: frontend.tags.clone().unwrap_or(BTreeMap::new()),
+                    deny_traffic: frontend.deny_traffic.unwrap_or(false),
                 })
                 .into(),
             );

--- a/command/src/request.rs
+++ b/command/src/request.rs
@@ -151,6 +151,7 @@ impl RequestHttpFrontend {
                 }
             })?,
             tags: Some(self.tags),
+            deny_traffic: self.deny_traffic,
         })
     }
 }

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -26,8 +26,7 @@ impl Response {
 /// An HTTP or HTTPS frontend, as used *within* Sōzu
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HttpFrontend {
-    /// Send a 401, DENY, if cluster_id is None
-    pub cluster_id: Option<ClusterId>,
+    pub cluster_id: ClusterId,
     pub address: SocketAddr,
     pub hostname: String,
     #[serde(default)]
@@ -39,6 +38,8 @@ pub struct HttpFrontend {
     #[serde(default)]
     pub position: RulePosition,
     pub tags: Option<BTreeMap<String, String>>,
+    /// Send a 401, DENY, if true
+    pub deny_traffic: bool,
 }
 
 impl From<HttpFrontend> for RequestHttpFrontend {
@@ -55,6 +56,7 @@ impl From<HttpFrontend> for RequestHttpFrontend {
             method: val.method,
             position: val.position.into(),
             tags,
+            deny_traffic: val.deny_traffic,
         }
     }
 }
@@ -148,6 +150,8 @@ pub struct TcpFrontend {
     pub address: SocketAddr,
     /// custom tags to identify the frontend in the access logs
     pub tags: BTreeMap<String, String>,
+    /// Send a 401, DENY, if true
+    pub deny_traffic: bool,
 }
 
 impl From<TcpFrontend> for RequestTcpFrontend {
@@ -156,6 +160,7 @@ impl From<TcpFrontend> for RequestTcpFrontend {
             cluster_id: val.cluster_id,
             address: val.address.to_string(),
             tags: val.tags,
+            deny_traffic: val.deny_traffic,
         }
     }
 }

--- a/e2e/src/sozu/worker.rs
+++ b/e2e/src/sozu/worker.rs
@@ -301,7 +301,7 @@ impl Worker {
         address: SocketAddr,
     ) -> RequestHttpFrontend {
         RequestHttpFrontend {
-            cluster_id: Some(cluster_id.into()),
+            cluster_id: cluster_id.into(),
             address: address.to_string(),
             hostname: String::from("localhost"),
             path: PathRule::prefix(String::from("/")),

--- a/lib/examples/main.rs
+++ b/lib/examples/main.rs
@@ -60,7 +60,7 @@ fn main() -> anyhow::Result<()> {
     });
 
     let http_front = RequestHttpFrontend {
-        cluster_id: Some(String::from("cluster_1")),
+        cluster_id: String::from("cluster_1"),
         address: "127.0.0.1:8080".to_string(),
         hostname: String::from("lolcatho.st"),
         path: PathRule::prefix(String::from("/")),
@@ -122,7 +122,7 @@ fn main() -> anyhow::Result<()> {
     });
 
     let tls_front = RequestHttpFrontend {
-        cluster_id: Some(String::from("cluster_1")),
+        cluster_id: String::from("cluster_1"),
         address: "127.0.0.1:8443".to_string(),
         hostname: String::from("lolcatho.st"),
         path: PathRule::prefix(String::from("/")),
@@ -171,7 +171,7 @@ fn main() -> anyhow::Result<()> {
     });
 
     let tls_front2 = RequestHttpFrontend {
-        cluster_id: Some(String::from("cluster_2")),
+        cluster_id: String::from("cluster_2"),
         address: "127.0.0.1:8443".to_string(),
         hostname: String::from("test.local"),
         path: PathRule::prefix(String::from("/")),

--- a/lib/examples/minimal.rs
+++ b/lib/examples/minimal.rs
@@ -65,7 +65,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     let http_front = RequestHttpFrontend {
-        cluster_id: Some("my-cluster".to_string()),
+        cluster_id: "my-cluster".to_string(),
         address: "127.0.0.1:8080".to_string(),
         hostname: "example.com".to_string(),
         path: PathRule::prefix(String::from("/")),

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -1148,7 +1148,7 @@ mod tests {
         });
 
         let front = RequestHttpFrontend {
-            cluster_id: Some(String::from("cluster_1")),
+            cluster_id: String::from("cluster_1"),
             address: "127.0.0.1:1024".to_string(),
             hostname: String::from("localhost"),
             path: PathRule::prefix(String::from("/")),
@@ -1234,7 +1234,7 @@ mod tests {
             address: "127.0.0.1:1031".to_string(),
             hostname: String::from("localhost"),
             path: PathRule::prefix(String::from("/")),
-            cluster_id: Some(String::from("cluster_1")),
+            cluster_id: String::from("cluster_1"),
             ..Default::default()
         };
         command
@@ -1356,7 +1356,7 @@ mod tests {
             address: "127.0.0.1:1041".to_string(),
             hostname: String::from("localhost"),
             path: PathRule::prefix(String::from("/")),
-            cluster_id: Some(String::from("cluster_1")),
+            cluster_id: String::from("cluster_1"),
             ..Default::default()
         };
         command
@@ -1463,8 +1463,9 @@ mod tests {
                 method: None,
                 path: PathRule::prefix(uri1),
                 position: RulePosition::Tree,
-                cluster_id: Some(cluster_id1),
+                cluster_id: cluster_id1,
                 tags: None,
+                deny_traffic: false,
             })
             .expect("Could not add http frontend");
         fronts
@@ -1474,8 +1475,9 @@ mod tests {
                 method: None,
                 path: PathRule::prefix(uri2),
                 position: RulePosition::Tree,
-                cluster_id: Some(cluster_id2),
+                cluster_id: cluster_id2,
                 tags: None,
+                deny_traffic: false,
             })
             .expect("Could not add http frontend");
         fronts
@@ -1485,19 +1487,21 @@ mod tests {
                 method: None,
                 path: PathRule::prefix(uri3),
                 position: RulePosition::Tree,
-                cluster_id: Some(cluster_id3),
+                cluster_id: cluster_id3,
                 tags: None,
+                deny_traffic: false,
             })
             .expect("Could not add http frontend");
         fronts
             .add_http_front(&HttpFrontend {
                 address: "0.0.0.0:80".parse().unwrap(),
                 hostname: "other.domain".to_owned(),
-                method: None,
                 path: PathRule::prefix("/test".to_owned()),
                 position: RulePosition::Tree,
-                cluster_id: Some("cluster_1".to_owned()),
+                cluster_id: "cluster_1".to_owned(),
+                method: None,
                 tags: None,
+                deny_traffic: false,
             })
             .expect("Could not add http frontend");
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -123,7 +123,7 @@
 //!  use sozu_command_lib::proto::command::{PathRule, RequestHttpFrontend, RulePosition};
 //!
 //! let http_front = RequestHttpFrontend {
-//!     cluster_id: Some("my-cluster".to_string()),
+//!     cluster_id: "my-cluster".to_string(),
 //!     address: "127.0.0.1:8080".to_string(),
 //!     hostname: "example.com".to_string(),
 //!     path: PathRule::prefix(String::from("/")),
@@ -274,7 +274,7 @@
 //!     };
 //!
 //!     let http_front = RequestHttpFrontend {
-//!         cluster_id: Some("my-cluster".to_string()),
+//!         cluster_id: "my-cluster".to_string(),
 //!         address: "127.0.0.1:8080".to_string(),
 //!         hostname: "example.com".to_string(),
 //!         path: PathRule::prefix(String::from("/")),

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -116,9 +116,9 @@ impl Router {
 
         let method_rule = MethodRule::new(front.method.clone());
 
-        let route = match &front.cluster_id {
-            Some(cluster_id) => Route::ClusterId(cluster_id.clone()),
-            None => Route::Deny,
+        let route = match &front.deny_traffic {
+            false => Route::ClusterId(front.cluster_id.clone()),
+            true => Route::Deny,
         };
 
         let success = match front.position {


### PR DESCRIPTION
This field `deny_traffic` replaces cluster_id being an option, when None meant DENY.

Related to #997 and #996 