### PR TITLE
return histograms for time metrics

### DIFF
--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -555,6 +555,11 @@ impl GatheringTask for QueryMetricsTask {
                     summed_cluster_metrics.append(&mut listed_cluster_metrics.clone());
                 }
             }
+            summed_proxy_metrics.sort();
+            summed_cluster_metrics.sort();
+            summed_proxy_metrics.dedup();
+            summed_cluster_metrics.dedup();
+
             return client.finish_ok_with_content(
                 ContentType::AvailableMetrics(AvailableMetrics {
                     proxy_metrics: summed_proxy_metrics,

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -614,6 +614,7 @@ message BackendMetrics {
     map<string, FilteredMetrics> metrics = 2;
 }
 
+// A metric, in a "filtered" format, which means: sendable to outside programs.
 message FilteredMetrics {
     oneof inner {
         // increases or decrease depending on the state
@@ -624,6 +625,7 @@ message FilteredMetrics {
         uint64 time = 3;
         Percentiles percentiles = 4;
         FilteredTimeSerie time_serie = 5;
+        FilteredHistogram histogram = 6;
     }
 }
 
@@ -632,7 +634,6 @@ message FilteredTimeSerie {
     repeated uint32 last_minute = 2;
     repeated uint32 last_hour = 3;
 }
-
 
 message Percentiles {
     required uint64 samples = 1;
@@ -644,6 +645,20 @@ message Percentiles {
     required uint64 p_99_999 = 7;
     required uint64 p_100 = 8;
     required uint64 sum = 9;
+}
+
+// a histogram meant to be translated to prometheus
+message FilteredHistogram {
+    required uint64 sum = 1;
+    required uint64 count = 2;
+    repeated Bucket buckets = 3;
+}
+
+// a prometheus histogram bucket
+message Bucket {
+    required uint64 count = 1;
+    // upper range of the bucket (le = less or equal)
+    required uint64 le = 2;
 }
 
 message RequestCounts {


### PR DESCRIPTION
Up until now, time metrics were returned by Sōzu, and rendered in the CLI, as percentiles:

```
┌────────────────────────┬─────────┬──────┬──────┬──────┬───────┬────────┬─────────┬──────┐
│ Percentiles            │ samples │ p50  │ p90  │ p99  │ p99.9 │ p99.99 │ p99.999 │ p100 │
├────────────────────────┼─────────┼──────┼──────┼──────┼───────┼────────┼─────────┼──────┤
│ accept_queue.wait_time │ 6       │ 0    │ 0    │ 0    │ 0     │ 0      │ 0       │ 0    │
├────────────────────────┼─────────┼──────┼──────┼──────┼───────┼────────┼─────────┼──────┤
│ epoll_time             │ 40      │ 1000 │ 1001 │ 1001 │ 1001  │ 1001   │ 1001    │ 1001 │
├────────────────────────┼─────────┼──────┼──────┼──────┼───────┼────────┼─────────┼──────┤
│ event_loop_time        │ 40      │ 0    │ 0    │ 4    │ 4     │ 4      │ 4       │ 4    │
├────────────────────────┼─────────┼──────┼──────┼──────┼───────┼────────┼─────────┼──────┤
│ response_time          │ 6       │ 0    │ 0    │ 0    │ 0     │ 0      │ 0       │ 0    │
├────────────────────────┼─────────┼──────┼──────┼──────┼───────┼────────┼─────────┼──────┤
│ service_time           │ 6       │ 0    │ 0    │ 0    │ 0     │ 0      │ 0       │ 0    │
└────────────────────────┴─────────┴──────┴──────┴──────┴───────┴────────┴─────────┴──────┘

```

These percentiles are not convertible for a prometheus layer, however. 

Since the time metrics are collected by sozu_lib's LocalDrain as [hdrhistograms](https://docs.rs/hdrhistogram/latest/hdrhistogram/index.html), why not return them in a histogram form as well? This would allow the [Sozu prometheus connector](https://github.com/clevercloud/sozu-prometheus-connector) to convert them to prometheus metrics.

This PR creates the protobuf type `FilteredHistogram`. Now, for each time metric:
1. a `Percentiles` metric is produced, for instance `response_time`
2. a `FilteredHistogram` is produced, named `response_time_hist`