### PR TITLE
Fix fetching of cluster metrics

### DIFF
--- a/bin/config.toml
+++ b/bin/config.toml
@@ -136,6 +136,8 @@ activate_listeners = true
 # tagged_metrics = false
 # metrics key prefix
 # prefix = "sozu"
+# by default, sozu register metrics for clusters, unless you want to spare ressources
+# disable_cluster_metrics = true
 
 # Listeners
 # configuration options specific to a TCP listen socket

--- a/lib/src/metrics/local_drain.rs
+++ b/lib/src/metrics/local_drain.rs
@@ -125,7 +125,7 @@ pub struct LocalDrain {
     cluster_metrics: BTreeMap<String, BTreeMap<String, AggregatedMetric>>,
     use_tagged_metrics: bool,
     origin: String,
-    enabled: bool,
+    disable_cluster_metrics: bool,
 }
 
 impl LocalDrain {
@@ -138,14 +138,14 @@ impl LocalDrain {
             backend_to_cluster: BTreeMap::new(),
             use_tagged_metrics: false,
             origin: String::from("x"),
-            enabled: false,
+            disable_cluster_metrics: false,
         }
     }
 
     pub fn configure(&mut self, config: &MetricsConfiguration) {
         match config {
-            MetricsConfiguration::Enabled => self.enabled = true,
-            MetricsConfiguration::Disabled => self.enabled = false,
+            MetricsConfiguration::Enabled => self.disable_cluster_metrics = false,
+            MetricsConfiguration::Disabled => self.disable_cluster_metrics = true,
             MetricsConfiguration::Clear => self.clear(),
         }
     }
@@ -383,7 +383,7 @@ impl LocalDrain {
         backend_id: Option<&str>,
         metric_value: MetricValue,
     ) {
-        if !self.enabled {
+        if self.disable_cluster_metrics {
             return;
         }
 

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -845,7 +845,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
 
     fn writable_default_answer(&mut self, metrics: &mut SessionMetrics) -> StateResult {
         let res = match self.status {
-            SessionStatus::DefaultAnswer(_, ref buf, mut index) => {
+            SessionStatus::DefaultAnswer(status, ref buf, mut index) => {
                 let len = buf.len();
 
                 let mut sz = 0usize;
@@ -866,6 +866,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
                 }
 
                 if index == len {
+                    save_http_status_metric(Some(status.into()), self.log_context());
                     self.log_default_answer_success(metrics);
                     self.frontend_readiness.reset();
                     self.backend_readiness.reset();


### PR DESCRIPTION
cluster metrics are disabled by default, which is cumbersome. This PR introduces a configurable `enable_cluster_metrics` that is `true` by default.

On top of that, since introduction of Kawa, Sōzu would not register 4xx and 5xx HTTP statuses in worker and cluster metrics. For instance, Sōzu would respond with a default 404 but would NOT register this event in metrics. This is fixed here.