### PR TITLE
Fix early connect trials

### DIFF
--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -285,6 +285,11 @@ impl ProxySession for HttpSession {
         }
 
         if self.state.failed() {
+            match self.state.marker() {
+                StateMarker::Expect => incr!("http.upgrade.expect.failed"),
+                StateMarker::Http => incr!("http.upgrade.http.failed"),
+                StateMarker::WebSocket => incr!("http.upgrade.ws.failed"),
+            }
             return;
         }
 

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -427,6 +427,13 @@ impl ProxySession for HttpsSession {
         }
 
         if self.state.failed() {
+            match self.state.marker() {
+                StateMarker::Expect => incr!("https.upgrade.expect.failed"),
+                StateMarker::Handshake => incr!("https.upgrade.handshake.failed"),
+                StateMarker::Http => incr!("https.upgrade.http.failed"),
+                StateMarker::WebSocket => incr!("https.upgrade.wss.failed"),
+                StateMarker::Http2 => incr!("https.upgrade.http2.failed"),
+            }
             return;
         }
 

--- a/lib/src/protocol/pipe.rs
+++ b/lib/src/protocol/pipe.rs
@@ -221,8 +221,8 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
 
     pub fn log_request_error(&self, metrics: &SessionMetrics, message: &str) {
         incr!("pipe.errors");
-        warn!("could not process request properly got: {}", message);
-        self.print_state(&self.log_context().to_string());
+        error!("{} Could not process request properly got: {}", self.log_context(), message);
+        self.print_state(self.protocol_string());
         self.log_request(metrics, Some(message));
     }
 
@@ -712,7 +712,7 @@ impl<Front: SocketHandler, L: ListenerHandler> SessionState for Pipe<Front, L> {
             );
             incr!("http.infinite_loop.error");
 
-            self.print_state(&format!("{:?}", self.protocol));
+            self.print_state(self.protocol_string());
 
             return SessionResult::Close;
         }

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -930,6 +930,12 @@ impl ProxySession for TcpSession {
         }
 
         if self.state.failed() {
+            match self.state.marker() {
+                StateMarker::Pipe => incr!("tcp.upgrade.pipe.failed"),
+                StateMarker::SendProxyProtocol => incr!("tcp.upgrade.send.failed"),
+                StateMarker::RelayProxyProtocol => incr!("tcp.upgrade.relay.failed"),
+                StateMarker::ExpectProxyProtocol => incr!("tcp.upgrade.expect.failed"),
+            }
             return;
         }
 


### PR DESCRIPTION
- Wait for all headers before connecting
- Use kawa consumed flag to know if we can safely send a default answer
- Add metrics for failed upgrades
- Add log and metric for early response termination
- Add log on HTTP(s) log_resquest_error
- Fix some print_state formats