### PR TITLE
Add 507 default answer

### DIFF
--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -1145,7 +1145,6 @@ impl ConfigState {
             })
             .collect();
 
-            
         for front in self.http_fronts.values() {
             if let Some(cluster_id) = &front.cluster_id {
                 if let Some(hasher) = hm.get_mut(cluster_id) {

--- a/lib/src/protocol/kawa_h1/answers.rs
+++ b/lib/src/protocol/kawa_h1/answers.rs
@@ -20,6 +20,8 @@ pub struct DefaultAnswers {
     pub ServiceUnavailable: Rc<Vec<u8>>,
     /// 504
     pub GatewayTimeout: Rc<Vec<u8>>,
+    /// 507
+    pub InsufficientStorage: Rc<Vec<u8>>,
 }
 
 #[allow(non_snake_case)]
@@ -56,6 +58,9 @@ impl HttpAnswers {
                 GatewayTimeout: Rc::new(Vec::from(
                     &b"HTTP/1.1 504 Gateway Timeout\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"[..]
                 )),
+                InsufficientStorage: Rc::new(Vec::from(
+                    &b"HTTP/1.1 507 Insufficient Storage\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"[..]
+                )),
             },
             custom: HashMap::new(),
         }
@@ -89,6 +94,7 @@ impl HttpAnswers {
                 .and_then(|c| c.ServiceUnavailable.clone())
                 .unwrap_or_else(|| self.default.ServiceUnavailable.clone()),
             DefaultAnswerStatus::Answer504 => self.default.GatewayTimeout.clone(),
+            DefaultAnswerStatus::Answer507 => self.default.InsufficientStorage.clone(),
         }
     }
 }

--- a/lib/src/protocol/pipe.rs
+++ b/lib/src/protocol/pipe.rs
@@ -221,7 +221,11 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
 
     pub fn log_request_error(&self, metrics: &SessionMetrics, message: &str) {
         incr!("pipe.errors");
-        error!("{} Could not process request properly got: {}", self.log_context(), message);
+        error!(
+            "{} Could not process request properly got: {}",
+            self.log_context(),
+            message
+        );
         self.print_state(self.protocol_string());
         self.log_request(metrics, Some(message));
     }

--- a/lib/src/socket.rs
+++ b/lib/src/socket.rs
@@ -225,7 +225,7 @@ impl SocketHandler for FrontRustls {
                     Ok(sz) => {
                         size += sz;
                         can_read = true;
-                    },
+                    }
                     Err(e) => match e.kind() {
                         ErrorKind::WouldBlock => {
                             break;


### PR DESCRIPTION
Add default answer for 507 Insufficient Storage (used when headers don't fit in a single Buffer).
Reduce the number of `http.early_response_close`.