### PR TITLE
Fix tunneling related behaviors

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -51,6 +51,7 @@ socket2 = { version = "^0.5.4", features = ["all"] }
 thiserror = "^1.0.49"
 time = "^0.3.29"
 x509-parser = "^0.15.1"
+once_cell = "1.18.0"
 
 sozu-command-lib = { path = "../command", version = "^0.15.10" }
 

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -1,7 +1,7 @@
 use std::{
     cell::RefCell,
     collections::{hash_map::Entry, BTreeMap, HashMap},
-    io::{ErrorKind, Read},
+    io::ErrorKind,
     net::{Shutdown, SocketAddr as StdSocketAddr},
     os::unix::{io::AsRawFd, net::UnixStream},
     rc::{Rc, Weak},
@@ -394,7 +394,7 @@ impl ProxySession for HttpsSession {
             return;
         }
 
-        debug!("Closing HTTPS session");
+        trace!("Closing HTTPS session");
         self.metrics.service_stop();
 
         // Restore gauges

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -141,10 +141,10 @@ impl HttpContext {
                         }
                     } else if compare_no_case(key, b"X-Forwarded-Proto") {
                         has_x_proto = true;
-                        header.val = kawa::Store::Static(proto.as_bytes());
+                        // header.val = kawa::Store::Static(proto.as_bytes());
                     } else if compare_no_case(key, b"X-Forwarded-Port") {
                         has_x_port = true;
-                        header.val = kawa::Store::from_string(public_port.to_string());
+                        // header.val = kawa::Store::from_string(public_port.to_string());
                     } else if compare_no_case(key, b"X-Forwarded-For") {
                         x_for = Some(header);
                     } else if compare_no_case(key, b"Forwarded") {

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -918,7 +918,7 @@ impl ProxySession for TcpSession {
         }
 
         // TODO: the state should handle the timeouts
-        info!("Closing TCP session");
+        trace!("Closing TCP session");
         self.metrics.service_stop();
 
         // Restore gauges


### PR DESCRIPTION
This PR implements two behaviors:

- trust `X-Forwarded-Proto` and `X-Forwarded-Port` headers
- return a default certificate when none are found for a host

> note: I suspect those features to open the door to misleading unsafe architectures from users