### PR TITLE
Reduce syscalls for performance

### DIFF
--- a/bin/config.toml
+++ b/bin/config.toml
@@ -218,6 +218,12 @@ cipher_list = [
 #key = "../lib/assets/key_test.pem"
 #certificate_chain = "../lib/assets/certificate_chain.pem"
 
+# Number of TLS 1.3 tickets to send to a client when establishing a connection.
+# The tickets allow the client to resume a session. This protects the client
+# agains session tracking. Increases the number of getrandom syscalls,
+# with little influence on performance. Defaults to 4.
+# send_tls13_tickets = 4
+
 # options specific to a TCP proxy listener
 #[[listeners]]
 # protocol = "tcp"

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -157,6 +157,10 @@ message HttpsListenerConfig {
     optional string certificate = 17;
     repeated string certificate_chain = 18;
     optional string key = 19;
+    // Number of TLS 1.3 tickets to send to a client when establishing a connection.
+    // The tickets allow the client to resume a session. This protects the client
+    // agains session tracking. Defaults to 4.
+    required uint64 send_tls13_tickets = 20;
 }
 
 // details of an TCP listener

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -159,6 +159,12 @@ pub const DEFAULT_MAX_COMMAND_BUFFER_SIZE: usize = 2_000_000;
 /// wether to avoid register cluster metrics in the local drain
 pub const DEFAULT_DISABLE_CLUSTER_METRICS: bool = false;
 
+/// Number of TLS 1.3 tickets to send to a client when establishing a connection.
+/// The tickets allow the client to resume a session. This protects the client
+/// agains session tracking. Increases the number of getrandom syscalls,
+/// with little influence on performance. Defaults to 4.
+pub const DEFAULT_SEND_TLS_13_TICKETS: u64 = 4;
+
 #[derive(Debug)]
 pub enum IncompatibilityKind {
     PublicAddress,
@@ -249,6 +255,10 @@ pub struct ListenerBuilder {
     pub request_timeout: Option<u32>,
     /// A [Config] to pull defaults from
     pub config: Option<Config>,
+    /// Number of TLS 1.3 tickets to send to a client when establishing a connection.
+    /// The ticket allow the client to resume a session. This protects the client
+    /// agains session tracking. Defaults to 4.
+    pub send_tls13_tickets: Option<u64>,
 }
 
 pub fn default_sticky_name() -> String {
@@ -550,6 +560,9 @@ impl ListenerBuilder {
             signature_algorithms,
             groups_list,
             active: false,
+            send_tls13_tickets: self
+                .send_tls13_tickets
+                .unwrap_or(DEFAULT_SEND_TLS_13_TICKETS),
         };
 
         Ok(https_listener_config)

--- a/doc/benchmark.md
+++ b/doc/benchmark.md
@@ -1,0 +1,285 @@
+# How to benchmark / observe Sōzu
+
+For debugging and optimization purposes.
+
+## Run Sōzu on your machine, with dummy backends
+
+### Create a config with an HTTP and an HTTPS listener
+
+Most defaults of `bin/config.toml` are sensible, copy them into `bin/my-config.toml`.
+An important value to tweak is `worker_count`. Testing the performance of one
+worker only seems ideal:
+
+```toml
+worker_count = 1
+```
+
+The HTTP and HTTPS listeners should be identical.
+Chose a TLS version and a cipher list for the HTTPS listener, and stick to it.
+
+```toml
+[[listeners]]
+protocol = "http"
+address = "0.0.0.0:8080"
+
+[[listeners]]
+protocol = "https"
+address = "0.0.0.0:8443"
+tls_versions = ["TLS_V13"]
+
+cipher_list = [
+  # "TLS13_AES_128_GCM_SHA256",
+  "TLS13_CHACHA20_POLY1305_SHA256",
+  # ...
+]
+```
+
+Create a cluster (equivalent to an app) that has two frontends:
+one for HTTP requests, one for HTTPS requests.
+
+Make sure you created your own certificate and key for the `localhost` domain.
+
+```toml
+frontends = [
+    { address = "0.0.0.0:8080", hostname = "localhost", path = "/api" },
+    { address = "0.0.0.0:8443", hostname = "localhost", certificate = "/path/to/your/certificate.pem", key = "/path/to/your/key.pem", certificate_chain = "/path/to/your/certificate.pem" },
+]
+```
+
+or use the certificate and key and certificate chain of `config.toml`,
+present in `/lib/assets/`.
+But then you have to use `lolcatho.st` as a local domain,
+and be sure to have this lines in your `/etc/hosts`:
+
+```
+127.0.0.1       lolcatho.st
+::1             lolcatho.st
+```
+
+### Spawn 4 backends
+
+Create four simple HTTP servers that reply each 200 OK when requested
+with HTTP GET on the `/api` path (arbitrarily).
+Use your favorite programming langage, it should be simple.
+It's [8 lines of javascript](https://www.digitalocean.com/community/tutorials/how-to-create-a-web-server-in-node-js-with-the-http-module).
+Make sure that each backend listens on localhost and on a different port,
+for exapmle: 1051, 1052, 1053 1054.
+
+Add those backends to `my-config.toml`, under the frontends:
+
+```toml
+backends = [
+    { address = "127.0.0.1:1051", backend_id = "backend_1" },
+    { address = "127.0.0.1:1052", backend_id = "backend_2" },
+    { address = "127.0.0.1:1053", backend_id = "backend_3" },
+    { address = "127.0.0.1:1054", backend_id = "backend_4" },
+]
+```
+
+### Build and run Sōzu
+
+Build Sōzu in release mode.
+
+```bash
+cargo build --release
+```
+
+Tip: rename the release binary and put it in the cargo path:
+
+```bash
+mv target/release/sozu $HOME/.cargo/bin/sozu-0.15.14
+```
+
+Now you can run Sōzu in release mode:
+
+```bash
+cd bin
+sozu-0.15.14 --config my-config.toml start
+```
+
+Check that Sōzu works by curling the backends through Sōzu:
+
+```bash
+curl https://localhost:8443/api -v
+curl http://localhost:8080/api  -v
+```
+
+
+## Bombardier
+
+[Bombardier](https://github.com/codesenberg/bombardier)
+is an HTTP and HTTPS benchmarking tool written in go.
+It is available as a package in most linux distributions,
+and easy to use in the command line.
+
+### Test a lot of requests on one connection
+
+```bash
+bombardier --connections=1 --requests=10000 https://localhost:8443/api --latencies
+bombardier --connections=1 --requests=10000 http://localhost:8080/api --latencies
+```
+
+### Test concurrent connections
+
+```bash
+bombardier --connections=100 --requests=10000 https://localhost:8443/api --latencies
+bombardier --connections=100 --requests=10000 http://localhost:8080/api --latencies
+```
+
+Increase the number of connections until Sõzu can't take it anymore.
+
+## TLS-perf
+
+[`tls-perf`](https://github.com/tempesta-tech/tls-perf) is a TLS stress-test tool written in C.
+It has no dependencies and is easy to build.
+
+```bash
+git clone git@github.com:tempesta-tech/tls-perf.git
+cd tls-perf
+make
+mv tls-perf $HOME/.local/bin
+```
+
+Assuming `$HOME/.local/bin` is in your path.
+
+This command does:
+- ten thousand TLS handshakes
+- using only one connection
+- using TLS version 1.3
+
+```bash
+tls-perf \
+  -n 10000 \
+  -l 1 \
+  --sni localhost \
+  --tls 1.3 \
+  127.0.0.1 8443
+```
+
+## Find syscalls with `strace`
+
+[`strace`](https://github.com/strace/strace) is a diagnostic tool that can monitor
+interactions between a process (Sōzu) and the linux kernel. It is available as a package
+in most linux distributions.
+
+Once Sōzu runs, find the pid of the worker:
+
+```bash
+ps -aux | grep sozu
+user   13368  0.7  0.1 188132 40344 pts/2    Sl+  11:35   0:00 /path/to/sozu --config my-config.toml start
+user   14157  0.0  0.0  79908 29628 pts/2    S+   11:35   0:00 /path/to/sozu worker --id 0 --fd 5 --scm 7 --configuration-state-fd 3 --command-buffer-size 16384 --max-command-buffer-size 16384
+user   14205  0.0  0.0   6556  2412 pts/3    S+   11:35   0:00 grep --color=auto sozu
+```
+
+That second line is the worker, its pid is `14157`.
+
+Use strace to track this pid. You may need root privileges.
+
+```bash
+strace --attach=14157
+```
+
+You should see regular `epoll_wait` syscalls (system calls), this is Sōzu's main loop.
+
+```
+epoll_wait(3, [], 1024, 1000)           = 0
+epoll_wait(3, [], 1024, 1000)           = 0
+epoll_wait(3, [], 1024, 1000)           = 0
+epoll_wait(3, [], 1024, 318)            = 0
+```
+
+If you perform one of those curls, you will see all syscalls that Sōzu does during
+an HTTP or HTTPS request.
+Here are syscalls occuring during an HTTP GET on a simple backend.
+This is only the accepting of traffic on a listener socket.
+
+```julia
+# main loop waiting for events
+epoll_wait(3, [], 1024, 1000)           = 0
+
+# One readable event (EPOLLIN). A client connected to a listener socket.
+epoll_wait(3, [{events=EPOLLIN, data={u32=3, u64=3}}], 1024, 1000) = 1
+
+# The proxy accepts the connection, by telling a listener to accept
+# incoming connections on the socket
+accept4(9, {sa_family=AF_INET, sin_port=htons(46144), sin_addr=inet_addr("127.0.0.1")}, [128 => 16], SOCK_CLOEXEC|SOCK_NONBLOCK) = 11
+
+# Done! No more connections to accept
+accept4(9, 0x7ffe89e39b98, [128], SOCK_CLOEXEC|SOCK_NONBLOCK) = -1 EAGAIN (Resource temporarily unavailable)
+
+# The HTTP proxy sets NODELAY on the socket
+setsockopt(11, SOL_TCP, TCP_NODELAY, [1], 4) = 0
+
+# Sōzu registers the socket in the accept queue
+# The accept queue is popped in another loop, to create sessions
+
+# When creating a session, the socket is registered in the event loop
+epoll_ctl(6, EPOLL_CTL_ADD, 11, {events=EPOLLIN|EPOLLOUT|EPOLLRDHUP|EPOLLET, data={u32=267, u64=267}}) = 0
+
+# Get the address of the socket (here, the host is the same, but the port is different)
+getpeername(11, {sa_family=AF_INET, sin_port=htons(46144), sin_addr=inet_addr("127.0.0.1")}, [128 => 16]) = 0
+
+# Return to the main event loop
+epoll_wait(3, [{events=EPOLLIN|EPOLLOUT, data={u32=267, u64=267}}], 1024, 1000) = 1
+
+# We are ready for traffic to come through this socket
+
+# Here it comes!
+recvfrom(11, "GET /api HTTP/1.1\r\nHost: localho"..., 16400, 0, NULL, NULL) = 80
+```
+
+### Find which parts of the code cause syscalls
+
+For this kind of digging, Sōzu must run in debug mode, that is:
+*not compiled with the `--release` flag*. Do:
+
+```bash
+cargo run -- --config my-config.toml start
+```
+
+Find the pid as described above, and do:
+
+```bash
+strace --attach=14157 --stack-traces
+# or
+strace -p 14157 -k
+```
+
+Curl Sōzu once, for instance
+
+```bash
+curl http://localhost:8080/api  -v
+```
+
+Now you see what piece of code is responsible for each syscall.
+Here is, for instance, the code responsible for a `connect` syscall on a socket with file descriptor 12.
+We can see it is an HTTP session connecting to its backend:
+
+```
+connect(12, {sa_family=AF_INET, sin_port=htons(1052), sin_addr=inet_addr("127.0.0.1")}, 16) = -1 EINPROGRESS (Operation now in progress)
+ > /usr/lib/libc.so.6(__connect+0x14) [0x112454]
+ > /path/to/sozu/target/debug/sozu(mio::sys::unix::tcp::connect+0x84) [0x17b2ec4]
+ > /path/to/sozu/target/debug/sozu(mio::net::tcp::stream::TcpStream::connect+0x127) [0x17ad9e7]
+ > /path/to/sozu/target/debug/sozu(sozu_lib::backends::Backend::try_connect+0x88) [0xb03898]
+ > /path/to/sozu/target/debug/sozu(sozu_lib::backends::BackendMap::backend_from_cluster_id+0x465) [0xb04145]
+ > /path/to/sozu/target/debug/sozu(sozu_lib::protocol::kawa_h1::Http<Front,L>::get_backend_for_sticky_session+0x5ab) [0xca8beb]
+ > /path/to/sozu/target/debug/sozu(sozu_lib::protocol::kawa_h1::Http<Front,L>::backend_from_request+0x159) [0xca69b9]
+ > /path/to/sozu/target/debug/sozu(sozu_lib::protocol::kawa_h1::Http<Front,L>::connect_to_backend+0xb7a) [0xcaafba]
+ > /path/to/sozu/target/debug/sozu(sozu_lib::protocol::kawa_h1::Http<Front,L>::ready_inner+0x423) [0xcaf3a3]
+ > /path/to/sozu/target/debug/sozu(<sozu_lib::protocol::kawa_h1::Http<Front,L> as sozu_lib::protocol::SessionState>::ready+0x2d) [0xcb040d]
+ > /path/to/sozu/target/debug/sozu(<sozu_lib::http::HttpStateMachine as sozu_lib::protocol::SessionState>::ready+0xf2) [0xdbb9b2]
+ > /path/to/sozu/target/debug/sozu(<sozu_lib::http::HttpSession as sozu_lib::ProxySession>::ready+0x114) [0xdb4b54]
+ > /path/to/sozu/target/debug/sozu(sozu_lib::server::Server::ready+0x746) [0xc95846]
+ > /path/to/sozu/target/debug/sozu(sozu_lib::server::Server::run+0x66d) [0xc8869d]
+ > /path/to/sozu/target/debug/sozu(sozu::worker::begin_worker_process+0x3060) [0x32e480]
+ > /path/to/sozu/target/debug/sozu(sozu::main+0x42e) [0x556afe]
+ > /path/to/sozu/target/debug/sozu(core::ops::function::FnOnce::call_once+0xb) [0x1e453b]
+ > /path/to/sozu/target/debug/sozu(std::sys_common::backtrace::__rust_begin_short_backtrace+0xe) [0x287e6e]
+ > /path/to/sozu/target/debug/sozu(std::rt::lang_start::{{closure}}+0x11) [0x2ff2e1]
+ > /path/to/sozu/target/debug/sozu(std::rt::lang_start_internal+0x42e) [0x18217fe]
+ > /path/to/sozu/target/debug/sozu(std::rt::lang_start+0x3a) [0x2ff2ba]
+ > /path/to/sozu/target/debug/sozu(main+0x1e) [0x556f6e]
+ > /usr/lib/libc.so.6(__libc_init_first+0x90) [0x27cd0]
+ > /usr/lib/libc.so.6(__libc_start_main+0x8a) [0x27d8a]
+ > /path/to/sozu/target/debug/sozu(_start+0x25) [0x17bca5]
+```

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -759,6 +759,7 @@ impl HttpsListener {
             .map_err(|err| ListenerError::BuildRustls(err.to_string()))?
             .with_no_client_auth()
             .with_cert_resolver(resolver);
+        server_config.send_tls13_tickets = config.send_tls13_tickets as usize;
 
         let mut protocols = SERVER_PROTOS
             .iter()

--- a/lib/src/socket.rs
+++ b/lib/src/socket.rs
@@ -50,9 +50,6 @@ pub trait SocketHandler {
     fn socket_write_vectored(&mut self, _buf: &[std::io::IoSlice]) -> (usize, SocketResult) {
         unimplemented!()
     }
-    fn has_vectored_writes(&self) -> bool {
-        false
-    }
     fn socket_ref(&self) -> &TcpStream;
     fn socket_mut(&mut self) -> &mut TcpStream;
     fn protocol(&self) -> TransportProtocol;
@@ -133,10 +130,6 @@ impl SocketHandler for TcpStream {
                 }
             },
         }
-    }
-
-    fn has_vectored_writes(&self) -> bool {
-        true
     }
 
     fn socket_ref(&self) -> &TcpStream {
@@ -339,22 +332,72 @@ impl SocketHandler for FrontRustls {
         }
     }
 
-    fn has_vectored_writes(&self) -> bool {
-        true
-    }
-
     fn socket_write_vectored(&mut self, bufs: &[std::io::IoSlice]) -> (usize, SocketResult) {
-        let mut total_size = 0;
-        let mut socket_state = SocketResult::Continue;
-        let mut size;
-        for buf in bufs {
-            (size, socket_state) = self.socket_write(buf);
-            total_size += size;
-            if socket_state != SocketResult::Continue {
-                break;
+        let mut buffered_size = 0usize;
+        let mut can_write = true;
+        let mut is_error = false;
+        let mut is_closed = false;
+
+        match self.session.writer().write_vectored(&bufs) {
+            Ok(0) => {}
+            Ok(sz) => {
+                buffered_size += sz;
+            }
+            Err(e) => match e.kind() {
+                ErrorKind::WouldBlock => {
+                    // we don't need to do anything, the session will return false in wants_write?
+                    //error!("rustls socket_write wouldblock");
+                }
+                ErrorKind::ConnectionReset
+                | ErrorKind::ConnectionAborted
+                | ErrorKind::BrokenPipe => {
+                    //FIXME: this should probably not happen here
+                    incr!("rustls.write.error");
+                    is_closed = true;
+                }
+                _ => {
+                    error!("could not write data to TLS stream: {:?}", e);
+                    incr!("rustls.write.error");
+                    is_error = true;
+                }
+            },
+        }
+
+        loop {
+            match self.session.write_tls(&mut self.stream) {
+                Ok(0) => {
+                    //can_write = false;
+                    break;
+                }
+                Ok(_sz) => {}
+                Err(e) => match e.kind() {
+                    ErrorKind::WouldBlock => can_write = false,
+                    ErrorKind::ConnectionReset
+                    | ErrorKind::ConnectionAborted
+                    | ErrorKind::BrokenPipe => {
+                        incr!("rustls.write.error");
+                        is_closed = true;
+                        break;
+                    }
+                    _ => {
+                        error!("could not write TLS stream to socket: {:?}", e);
+                        incr!("rustls.write.error");
+                        is_error = true;
+                        break;
+                    }
+                },
             }
         }
-        (total_size, socket_state)
+
+        if is_error {
+            (buffered_size, SocketResult::Error)
+        } else if is_closed {
+            (buffered_size, SocketResult::Closed)
+        } else if !can_write {
+            (buffered_size, SocketResult::WouldBlock)
+        } else {
+            (buffered_size, SocketResult::Continue)
+        }
     }
 
     fn socket_ref(&self) -> &TcpStream {


### PR DESCRIPTION
This is a joint effort with @Wonshtrum to reduce the number of syscalls in Sōzu version 0.15.
When benchmarking version 0.15 against version 0.13.6, we found a disproportionate number of `getrandom` and `writev` syscalls, especially for HTTPS traffic.

## `writev`

Here is the [strace](https://github.com/strace/strace) of how a simple response is sent to the client in a TLS-encrypted form, in Sōzu 0.13:

```
writev(8, [{iov_base="\27\3\3\0[\233\\@IW\323\371o\255y`Z\376b7\362vA\321\207Z\253S\361\177\234\220"..., iov_len=96}], 1) = 96
writev(8, [{iov_base="\27\3\3\0006N\236\375\25\6\233\350\363:\227XUx\376\256\25\337~\27\21\fI\202\2452\236,"..., iov_len=59}], 1) = 59
writev(8, [{iov_base="\27\3\3\0\35|N\346\376k\231\360\34\377\f\27\364\372\6;\373\6)\243\343\260'.r\340\340\342"..., iov_len=34}], 1) = 34
```

It is chunked by a custom `BufferQueue` in three writes.

Here is the same traffic sent to the client in version 0.15.14. There are more headers than in version 0.13, and for each of them, Sōzu performs a writev call:

```
writev(11, [{iov_base="\27\3\3\0\31\201\357\330\261j\24\233\356j\317L\253\366\301\vm;h\220m\334\253w-U", iov_len=30}], 1) = 30
writev(11, [{iov_base="\27\3\3\0\22\275#\6(\260\237:\352\23\241d\263S_\241\351\304\300", iov_len=23}], 1) = 23
writev(11, [{iov_base="\27\3\3\0\24\270\235\334 \241\221\340\230\353p\16\360-\325\376r>\262\7V", iov_len=25}], 1) = 25
writev(11, [{iov_base="\27\3\3\0\22\16\235\323\334\316\231o\3\324^WM\242\373N\270\f\220", iov_len=23}], 1) = 23
writev(11, [{iov_base="\27\3\3\0\23\240\307\311\24Z\353\277\v\322!T\254\267\342\27-\350\246\271", iov_len=24}], 1) = 24
writev(11, [{iov_base="\27\3\3\0\23P>\250{k\35\273\21!dZr\230f5\323\275\227\344", iov_len=24}], 1) = 24
writev(11, [{iov_base="\27\3\3\0\37\250B_%XY&+\250\302.\26\352\n\357\1\313\32vI\301\247\206\304\364h$"..., iov_len=36}], 1) = 36
writev(11, [{iov_base="\27\3\3\0\23\5g9\230\306\210k\336\374@\352\311\253?i\330\255:=", iov_len=24}], 1) = 24
writev(11, [{iov_base="\27\3\3\0\23\302\21\242\354\37\10\203\363\3\10\202#2\317\\:\t\220\252", iov_len=24}], 1) = 24
writev(11, [{iov_base="\27\3\3\0\23 nt!+E\213\301\337K\1\256\\M,\32\265\274\226", iov_len=24}], 1) = 24
writev(11, [{iov_base="\27\3\3\0\258d\314u\244\305\311>F\361\27?\16Z\367\5I\330?yq", iov_len=26}], 1) = 26
writev(11, [{iov_base="\27\3\3\0\23\0\263H\300.U\347H\333}9\320B]\233S\356\371/", iov_len=24}], 1) = 24
writev(11, [{iov_base="\27\3\3\0.:\24\246:c\242G\227s\2358Z-5\200.\362#\16\327uX\310D.)\332"..., iov_len=51}], 1) = 51
writev(11, [{iov_base="\27\3\3\0\23\211`\211H\227L\203im\205my\343\354\211\245\263\327\221", iov_len=24}], 1) = 24
writev(11, [{iov_base="\27\3\3\0\30\271\255\337\fG*\231\3263\374\306\244R1\215\204\365\266,j\212\235~\266", iov_len=29}], 1) = 29
writev(11, [{iov_base="\27\3\3\0\23\274;R\220\244I,\217n\215_\354p!gP\375\334\\", iov_len=24}], 1) = 24
writev(11, [{iov_base="\27\3\3\0+r\340\26yL,\5\17u\223\230\362\331\230\257Z\33MFDck\37!\302\307\376"..., iov_len=48}], 1) = 48
writev(11, [{iov_base="\27\3\3\0\23\204f\276\240\216\340\32\257U\266l\23:\307oZRR\35", iov_len=24}], 1) = 24
writev(11, [{iov_base="\27\3\3\0\23\362\323\261\355pA\2625[p\317\5\31m\32&\17\230\355", iov_len=24}], 1) = 24
writev(11, [{iov_base="\27\3\3\0\33\237G\307}}\300\227M\240\203\220\212#\f\334\16\315\342\330\253\344\277%\227u\214`", iov_len=32}], 1) = 32
```

This is due to the way [Kawa](https://github.com/CleverCloud/kawa) stores data, and this data is passed to Rustls as is. Fortunately, the Rustls API offers a [write_vectored](https://doc.rust-lang.org/nightly/std/io/trait.Write.html#method.write_vectored) method on its Writer, that performs all writes in a single syscall. We opted for it.

```
writev(
    11,
    [
        {iov_base="\27\3\3\0\31\210H\371\252\25w\304\275\346u\27\371\334g\345\244\371\331\203c\302\356\324i\367", iov_len=30},
        {iov_base="\27\3\3\0\22\366IR\236\357\374\37\30\310E\330Xr\3249\24r0", iov_len=23},
        {iov_base="\27\3\3\0\24\326\337\223\356R\360\37\215\343a\2L\236\30\24D\31\10\363\16", iov_len=25},
        {iov_base="\27\3\3\0\22\347\305\255\371?\224\6\212\325\345\250*a\250\321i\366\266", iov_len=23},
        {iov_base="\27\3\3\0\23\37\24Ex\334\vHp\2758\207\27G\306\16\226\253\320\240", iov_len=24},
        {iov_base="\27\3\3\0\23\23\362q\352\307\303\364\312]\361(\227<\17\334Y\333g\310", iov_len=24},
        {iov_base="\27\3\3\0\37\216\332\374\376\303H\206\35f\334\310\252\375\341\366\224\261*\367\30mg\\\230dbh"..., iov_len=36},
        {iov_base="\27\3\3\0\23-\312\31\v\353\212\303\265\231H\371\356%\317JX\32Tg", iov_len=24},
        {iov_base="\27\3\3\0\23d\356\0276\3236\252\206^5\346=\234F\2\200\33\314>", iov_len=24},
        {iov_base="\27\3\3\0\23U\30\37x7\5d\304/ZY\274\25\17;\276t]\216", iov_len=24},
        {iov_base="\27\3\3\0\25\240\371q\2416Z\202\6\35\311|\203Bai-\20\217=\3516", iov_len=26},
        {iov_base="\27\3\3\0\23\220\350\323\321bx\321\21:\35\203?\257\313)\200\364E\377", iov_len=24},
        {iov_base="\27\3\3\0.\226\254\30\240\315\307o\250\243b`Q\n\17\226\333\347\256[\331\324#~/\240\206,"..., iov_len=51},
        {iov_base="\27\3\3\0\23\251\207:\350?/\252Z\317\322\0017\24E\256\5*\342\224", iov_len=24},
        {iov_base="\27\3\3\0\30$w0!\205\310\276\372k\204?\375k\334\334\363\314\\!\355\266\0\362\33", iov_len=29},
        {iov_base="\27\3\3\0\23\257\277rj;\3\376\251\10\310\37\265\365\303\216\260\345\361\366", iov_len=24},
        {iov_base="\27\3\3\0+\341\0313\277'\223\3\272W&\316\306\360BYI9\225Vh\347t\3}\303\321\343"..., iov_len=48},
        {iov_base="\27\3\3\0\23\247\33\26M\255%\351\214F\254\177\250+z\253]\17F\325", iov_len=24},
        {iov_base="\27\3\3\0\23fm\262t\334\271>\226\225ITia\250,\31^\37\f", iov_len=24},
        {iov_base="\27\3\3\0\33S\25/zM'\343\302L/l\\\1\22\250M\0AL\357\304\36\227\317\322Q\365", iov_len=32}
    ],
    20
) = 563
```

This improves performance significantly.

## Performance improvement

- On a single worker
- 4 HTTP backends that reply a simple 200 with a 10 bytes body "Hey there!"
- tls version: `TLS v1.3`
- cipher_list: only `TLS13_CHACHA20_POLY1305_SHA256`
- CPU: Intel i7-2600K (8) @ 3.800GHz
- 1 worker
- 200 simultaneous connections
- 100_000 requests

### Sōzu 0.13.6

```
bombardier -c 200 -n 100000 https://localhost:8443/api -l
Bombarding https://localhost:8443/api with 100000 request(s) using 200 connection(s)
 100000 / 100000 [=====================================================================================================] 100.00% 7784/s 12s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec      7837.35    1514.08   14001.32
  Latency       25.58ms    18.76ms   458.92ms
  Latency Distribution
     50%    24.37ms
     75%    25.99ms
     90%    28.25ms
     95%    29.65ms
     99%    32.85ms
  HTTP codes:
    1xx - 0, 2xx - 100000, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     2.10MB/s
```

### Sōzu 0.15.14 without fixes

```
bombardier -c 200 -n 100000 https://localhost:8443/api -l   
Bombarding https://localhost:8443/api with 100000 request(s) using 200 connection(s)
 100000 / 100000 [=====================================================================================================] 100.00% 3193/s 31s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec      3200.75     737.90    5135.83
  Latency       62.43ms    26.44ms   667.69ms
  Latency Distribution
     50%    60.10ms
     75%    63.60ms
     90%    68.29ms
     95%    71.33ms
     99%    87.74ms
  HTTP codes:
    1xx - 0, 2xx - 100000, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     2.00MB/s
```

### Sōzu 0.15.14 with both fixes of this pull request

```
bombardier -c 200 -n 100000 https://localhost:8443/api -l                                                                   12.862s 18:06
Bombarding https://localhost:8443/api with 100000 request(s) using 200 connection(s)
 100000 / 100000 [=====================================================================================================] 100.00% 7661/s 13s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec      7785.59    1285.38   13644.94
  Latency       25.73ms    25.89ms   618.15ms
  Latency Distribution
     50%    24.09ms
     75%    26.02ms
     90%    28.26ms
     95%    29.76ms
     99%    34.26ms
  HTTP codes:
    1xx - 0, 2xx - 100000, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     4.86MB/s
```

As you can see, the fixes restore the performance of Sōzu (in this somewhat limited usecase) back to 0.13.6 levels. The 0.15.14 version still struggles when confronted with many concurrent TLS handshakes, when compared with the 0.13.6, but we're getting there.
Note that the throughput has augmented, that's because headers are more numerous since the introduction of Kawa.


## `getrandom`, it's all about TLS 1.3 resumption tickets

We found that Sōzu 0.15.14 would create four times more `getrandom` syscalls during a TLS handshake than the 0.13.6 version:

```
// 0.13.6
getrandom("\x03\x81\x50\x75....", 32, 0) = 32
getrandom("\x49\x7d\x38\x98....", 32, 0) = 32
getrandom("\xd3\xde\xb1\x6e", 4, 0)     = 4
```

```
// 0.15.14
getrandom("\x73\x30\x04\x5b...", 32, 0) = 32
getrandom("\xc6\xb6\xe5\x7b", 4, 0)     = 4
getrandom("\x4f\xe0\xd1\xe4...", 32, 0) = 32
getrandom("\x13\x7e\xa1\xf5...", 32, 0) = 32
getrandom("\x3c\x5d\x3c\xc9", 4, 0)     = 4
getrandom("\x71\xd1\x73\x76...", 32, 0) = 32
getrandom("\x97\x18\x1a\xb5...", 32, 0) = 32
getrandom("\x7e\x92\xbf\x14", 4, 0)     = 4
getrandom("\xaf\x1f\xb8\x53...", 32, 0) = 32
getrandom("\x20\xef\x36\xad...", 32, 0) = 32
getrandom("\xcd\xe0\x96\xd0", 4, 0)     = 4
getrandom("\x33\xd0\x99\x85...", 32, 0) = 32
```

After a lot of digging, we found that Rustls 0.19, used in Sōzu 0.13.6, seems to produce  *one* TLS 1.3 ticket (used by a client to resume a TLS session). Producing a ticket needs 3 `getrandom` syscalls, as far as we understand.

Sōzu 0.15.14 does 4 times as many `getrandom` calls at this step of the TLS handshake. That is because Rustls 0.21.8, used in Sōzu 0.15, produces *four* TLS 1.3 tickets by default, since [this commit](https://github.com/rustls/rustls/commit/d780790329164d46ec6e641ba6e0ef292413fefe) in [this PR](https://github.com/rustls/rustls/pull/1145), meant to resolve [this issue](https://github.com/rustls/rustls/issues/466), and I quote the issue since it seems relevant:

> RFC8446 [section 4.6.1](https://tools.ietf.org/html/rfc8446#section-4.6.1) **recommends that TLS 1.3 servers send multiple session resumption tickets to clients. In [appendix C.4](https://tools.ietf.org/html/rfc8446#appendix-C.4), it's subsequently recommended that clients use tickets at most once to avoid session tracking**. The current implementation of ClientSessionMemoryCache does not do this, and some properties of StoresClientSession (and use of the cache in general) make doing so difficult.

The number of tickets is accessible in [this public field of the Rustls Configuration](https://docs.rs/rustls/latest/rustls/server/struct.ServerConfig.html#structfield.send_tls13_tickets) of Rustls. It does default to 4. Resetting it to 1 may improve the performance of Sōzu's TLS handshake for intense traffic with a lot of simultaneous TLS handshakes.

A default 1 ticket production seems appropriate for Sōzu for some users, but we may still want to make this number configurable in the Sōzu configuration file, so that any Sōzu user can trade security and performance to its liking. What do you think @FlorentinDUBOIS and @Wonshtrum ?

EDIT: benchmarking this change with [tls-perf](https://github.com/tempesta-tech/tls-perf) does NOT seem to improve performance in any relevant way. We may keep the line of code with a set value of 4, and an explanating comment, for future generations of developers.

Comments welcome!
