### PR TITLE
store certificates in parsed form in  CertificateResolver

### DIFF
--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -1253,10 +1253,10 @@ impl ConfigState {
                 .flat_map(|hash_map| hash_map.iter())
                 .flat_map(|(fingerprint, cert)| {
                     if cert.names.is_empty() {
-                        let pem = certificate::parse(cert.certificate.as_bytes()).ok()?;
+                        let pem = certificate::parse_pem(cert.certificate.as_bytes()).ok()?;
                         let mut c = cert.to_owned();
 
-                        c.names = certificate::get_cn_and_san_attributes(&pem)
+                        c.names = certificate::get_cn_and_san_attributes(&pem.contents)
                             .ok()?
                             .into_iter()
                             .collect();
@@ -1276,10 +1276,10 @@ impl ConfigState {
                 .filter(|(fingerprint, _cert)| fingerprint.to_string() == f)
                 .flat_map(|(fingerprint, cert)| {
                     if cert.names.is_empty() {
-                        let pem = certificate::parse(cert.certificate.as_bytes()).ok()?;
+                        let pem = certificate::parse_pem(cert.certificate.as_bytes()).ok()?;
                         let mut c = cert.to_owned();
 
-                        c.names = certificate::get_cn_and_san_attributes(&pem)
+                        c.names = certificate::get_cn_and_san_attributes(&pem.contents)
                             .ok()?
                             .into_iter()
                             .collect();
@@ -1297,10 +1297,10 @@ impl ConfigState {
                 .flat_map(|hash_map| hash_map.iter())
                 .flat_map(|(fingerprint, cert)| {
                     if cert.names.is_empty() {
-                        let pem = certificate::parse(cert.certificate.as_bytes()).ok()?;
+                        let pem = certificate::parse_pem(cert.certificate.as_bytes()).ok()?;
                         let mut c = cert.to_owned();
 
-                        c.names = certificate::get_cn_and_san_attributes(&pem)
+                        c.names = certificate::get_cn_and_san_attributes(&pem.contents)
                             .ok()?
                             .into_iter()
                             .collect();

--- a/e2e/src/tests/tests.rs
+++ b/e2e/src/tests/tests.rs
@@ -390,7 +390,7 @@ pub fn try_tls_endpoint() -> State {
     let certificate_and_key = CertificateAndKey {
         certificate: String::from(include_str!("../../../lib/assets/local-certificate.pem")),
         key: String::from(include_str!("../../../lib/assets/local-key.pem")),
-        certificate_chain: vec![],
+        certificate_chain: vec![], // in config.toml the certificate chain would be the same as the certificate
         versions: vec![],
         names: vec![],
     };

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -62,7 +62,7 @@ use crate::{
     server::{ListenSession, ListenToken, ProxyChannel, Server, SessionManager, SessionToken},
     socket::{server_bind, FrontRustls},
     timer::TimeoutContainer,
-    tls::{CertificateResolver, MutexWrappedCertificateResolver, ParsedCertificateAndKey},
+    tls::{MutexWrappedCertificateResolver, ResolveCertificate, StoredCertificate},
     util::UnwrapLog,
     AcceptError, CachedTags, FrontendFromRequestError, L7ListenerHandler, L7Proxy, ListenerError,
     ListenerHandler, Protocol, ProxyConfiguration, ProxyError, ProxySession, SessionIsToBeClosed,
@@ -597,10 +597,10 @@ impl L7ListenerHandler for HttpsListener {
     }
 }
 
-impl CertificateResolver for HttpsListener {
+impl ResolveCertificate for HttpsListener {
     type Error = ListenerError;
 
-    fn get_certificate(&self, fingerprint: &Fingerprint) -> Option<ParsedCertificateAndKey> {
+    fn get_certificate(&self, fingerprint: &Fingerprint) -> Option<StoredCertificate> {
         let resolver = self
             .resolver
             .0
@@ -641,7 +641,7 @@ impl HttpsListener {
         config: HttpsListenerConfig,
         token: Token,
     ) -> Result<HttpsListener, ListenerError> {
-        let resolver = Arc::new(MutexWrappedCertificateResolver::new());
+        let resolver = Arc::new(MutexWrappedCertificateResolver::default());
 
         let server_config = Arc::new(Self::create_rustls_context(&config, resolver.to_owned())?);
 
@@ -1640,7 +1640,7 @@ mod tests {
 
         let address: StdSocketAddr = FromStr::from_str("127.0.0.1:1032")
             .expect("test address 127.0.0.1:1032 should be parsed");
-        let resolver = Arc::new(MutexWrappedCertificateResolver::new());
+        let resolver = Arc::new(MutexWrappedCertificateResolver::default());
 
         let server_config = ServerConfig::builder()
             .with_safe_default_cipher_suites()

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -371,7 +371,7 @@ use mio::{net::TcpStream, Interest, Token};
 use protocol::http::parser::Method;
 use router::RouterError;
 use time::{Duration, Instant};
-use tls::GenericCertificateResolverError;
+use tls::CertificateResolverError;
 
 use sozu_command::{
     proto::command::{Cluster, ListenerType, RequestHttpFrontend},
@@ -658,7 +658,7 @@ pub enum ListenerError {
     #[error("failed to acquire the lock, {0}")]
     Lock(String),
     #[error("failed to handle certificate request, got a resolver error, {0}")]
-    Resolver(GenericCertificateResolverError),
+    Resolver(CertificateResolverError),
     #[error("failed to parse pem, {0}")]
     PemParse(String),
     #[error("failed to build rustls context, {0}")]

--- a/lib/src/metrics/local_drain.rs
+++ b/lib/src/metrics/local_drain.rs
@@ -359,7 +359,7 @@ impl LocalDrain {
                 .iter()
                 .find(|backend_metrics| backend_metrics.backend_id == backend_id)
             {
-                return Ok(backend_metrics.to_filtered_metrics(metric_names)?);
+                return backend_metrics.to_filtered_metrics(metric_names);
             }
         }
 
@@ -486,7 +486,7 @@ impl LocalDrain {
         match self.cluster_metrics.entry(cluster_id.to_owned()) {
             Entry::Vacant(entry) => {
                 let mut metrics = BTreeMap::new();
-                metrics.insert(metric_name.to_owned(), aggregated_metric.clone());
+                metrics.insert(metric_name.to_owned(), aggregated_metric);
                 let backends = [LocalBackendMetrics {
                     backend_id: backend_id.to_owned(),
                     metrics,
@@ -497,11 +497,10 @@ impl LocalDrain {
                     cluster: BTreeMap::new(),
                     backends,
                 });
-                return;
             }
             Entry::Occupied(mut entry) => {
                 for backend_metrics in &mut entry.get_mut().backends {
-                    if &backend_metrics.backend_id == backend_id {
+                    if backend_metrics.backend_id == backend_id {
                         if let Some(existing_metric) = backend_metrics.metrics.get_mut(metric_name)
                         {
                             existing_metric.update(metric_name, metric);

--- a/lib/src/router/pattern_trie.rs
+++ b/lib/src/router/pattern_trie.rs
@@ -222,11 +222,10 @@ impl<V: Debug + Clone> TrieNode<V> {
                     if pos > 0 {
                         let mut remove_result = RemoveResult::NotFound;
                         for t in self.regexps.iter_mut() {
-                            if t.0.as_str() == s {
-                                if t.1.remove_recursive(&partial_key[..pos - 1]) == RemoveResult::Ok
-                                {
-                                    remove_result = RemoveResult::Ok;
-                                }
+                            if t.0.as_str() == s
+                                && t.1.remove_recursive(&partial_key[..pos - 1]) == RemoveResult::Ok
+                            {
+                                remove_result = RemoveResult::Ok;
                             }
                         }
                         return remove_result;
@@ -257,10 +256,10 @@ impl<V: Debug + Clone> TrieNode<V> {
                     if child.is_empty() {
                         self.children.remove(suffix);
                     }
-                    return RemoveResult::Ok;
+                    RemoveResult::Ok
                 }
             },
-            None => return RemoveResult::NotFound,
+            None => RemoveResult::NotFound,
         }
     }
 

--- a/lib/src/router/trie.rs
+++ b/lib/src/router/trie.rs
@@ -307,6 +307,12 @@ impl<V: Debug + Clone> TrieNode<V> {
     }
 }
 
+impl<T: Clone + Debug> Default for TrieNode<T> {
+    fn default() -> Self {
+        Self::root()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/src/socket.rs
+++ b/lib/src/socket.rs
@@ -333,7 +333,7 @@ impl SocketHandler for FrontRustls {
         let mut is_error = false;
         let mut is_closed = false;
 
-        match self.session.writer().write_vectored(&bufs) {
+        match self.session.writer().write_vectored(bufs) {
             Ok(0) => {}
             Ok(sz) => {
                 buffered_size += sz;


### PR DESCRIPTION
The GenericCertificateResolver would store certs
in a ParsedCertificateAndKey form, after parsing and checking, but this form had to be re-parsed into `rustls::sign::CertifiedKey` at every handshake, diminishing performance.
This commit comes back to the feature of 0.13.6: storing CertifiedKey directly in the certificate resolver.

- rename trait CertificateResolver to ResolveCertificate
- rename GenericCertificateResolver to CertificateResolver
-  create type StoredCertificate (wraps CertifiedKey)
- remove trait GenericCertificateResolverHelper
- additional parse functions in command::certificate module
- add documenting comments
- apply clippy suggestions