### PR TITLE
fix worker status command

### DIFF
--- a/bin/config.toml
+++ b/bin/config.toml
@@ -57,6 +57,12 @@ worker_count = 2
 # defaults to true
 worker_automatic_restart = true
 
+# maximum time to wait for a worker to respond, until it is deemed NotAnswering (10 seconds).
+# Beware that if this duration is bigger than ctl_command timeout (that defaults to 1 second),
+# and if a worker is not responding,
+# you may not receive a reply from Sōzu at all when doing "sozu status"
+worker_timeout = 10
+
 # indicates if worker process will be pinned on a core. If you activate this, be sure
 # that you do not have more workers than CPU cores (and leave at least one core for
 # the kernel and the main process)

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -897,7 +897,7 @@ impl CommandServer {
                 self.in_flight
                     .insert(worker_request_id.clone(), (status_tx.clone(), 1));
             }
-            worker_info_map.insert(worker_request_id, worker.info());
+            worker_info_map.insert(worker_request_id, worker.querying_info());
         }
 
         let command_tx = self.command_tx.clone();

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -902,7 +902,7 @@ impl CommandServer {
 
         let command_tx = self.command_tx.clone();
         let thread_client_id = client_id.clone();
-
+        let worker_timeout = self.config.worker_timeout;
         let now = Instant::now();
 
         smol::spawn(async move {
@@ -923,7 +923,7 @@ impl CommandServer {
                     .and_modify(|worker_info| worker_info.run_state = new_run_state as i32);
 
                 i += 1;
-                if i == count || now.elapsed() > Duration::from_secs(10) {
+                if i == count || now.elapsed() > Duration::from_secs(worker_timeout as u64) {
                     break;
                 }
             }

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -99,11 +99,18 @@ impl Worker {
         kill(Pid::from_raw(self.pid), None).is_ok()
     }
 
-    pub fn info(&self) -> WorkerInfo {
+    /// get info about a worker, with a NotAnswering run state by default,
+    /// to be updated when the worker responds
+    pub fn querying_info(&self) -> WorkerInfo {
+        let run_state = match self.run_state {
+            RunState::Stopping => RunState::Stopping,
+            RunState::Stopped => RunState::Stopped,
+            RunState::Running | RunState::NotAnswering => RunState::NotAnswering,
+        };
         WorkerInfo {
             id: self.id,
             pid: self.pid,
-            run_state: self.run_state as i32,
+            run_state: run_state as i32,
         }
     }
 

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -123,6 +123,9 @@ pub const DEFAULT_CONNECT_TIMEOUT: u32 = 3;
 /// maximum time to receive a request since the connection started (10 seconds)
 pub const DEFAULT_REQUEST_TIMEOUT: u32 = 10;
 
+/// maximum time to wait for a worker to respond, until it is deemed NotAnswering (10 seconds)
+pub const DEFAULT_WORKER_TIMEOUT: u32 = 10;
+
 /// a name applied to sticky sessions ("SOZUBALANCEID")
 pub const DEFAULT_STICKY_NAME: &str = "SOZUBALANCEID";
 
@@ -1142,6 +1145,8 @@ pub struct FileConfig {
     pub accept_queue_timeout: Option<u32>,
     #[serde(default)]
     pub request_timeout: Option<u32>,
+    #[serde(default)]
+    pub worker_timeout: Option<u32>,
 }
 
 impl FileConfig {
@@ -1266,6 +1271,7 @@ impl ConfigBuilder {
             zombie_check_interval: file_config
                 .zombie_check_interval
                 .unwrap_or(DEFAULT_ZOMBIE_CHECK_INTERVAL),
+            worker_timeout: file_config.worker_timeout.unwrap_or(DEFAULT_WORKER_TIMEOUT),
             ..Default::default()
         };
 
@@ -1505,6 +1511,8 @@ pub struct Config {
     pub accept_queue_timeout: u32,
     #[serde(default = "default_request_timeout")]
     pub request_timeout: u32,
+    #[serde(default = "default_worker_timeout")]
+    pub worker_timeout: u32,
 }
 
 fn default_front_timeout() -> u32 {
@@ -1533,6 +1541,10 @@ fn default_accept_queue_timeout() -> u32 {
 
 fn default_disable_cluster_metrics() -> bool {
     DEFAULT_DISABLE_CLUSTER_METRICS
+}
+
+fn default_worker_timeout() -> u32 {
+    DEFAULT_WORKER_TIMEOUT
 }
 
 impl Config {


### PR DESCRIPTION
Until now, querying the status of the workers would not show a non-answering worker. This PR fixes it.