### PR TITLE
fix perf issue when creating new worker

### DIFF
--- a/e2e/src/sozu/worker.rs
+++ b/e2e/src/sozu/worker.rs
@@ -102,11 +102,19 @@ impl Worker {
             .send_listeners(&listeners)
             .expect("could not send listeners");
 
+        let initial_state = state
+            .generate_requests()
+            .into_iter()
+            .map(|request| WorkerRequest {
+                id: "initial_state".to_string(),
+                content: request,
+            })
+            .collect();
         let server = Server::try_new_from_config(
             cmd_worker_to_main,
             scm_worker_to_main,
             config,
-            state,
+            initial_state,
             false,
         )
         .expect("could not create sozu worker");
@@ -139,7 +147,14 @@ impl Worker {
             .expect("could not send listeners");
 
         let thread_config = config.to_owned();
-        let thread_state = state.to_owned();
+        let initial_state = state
+            .generate_requests()
+            .into_iter()
+            .map(|request| WorkerRequest {
+                id: "initial_state".to_string(),
+                content: request,
+            })
+            .collect();
         let thread_name = name.to_owned();
         let thread_scm_worker_to_main = scm_worker_to_main.to_owned();
 
@@ -157,7 +172,7 @@ impl Worker {
                 cmd_worker_to_main,
                 thread_scm_worker_to_main,
                 thread_config,
-                thread_state,
+                initial_state,
                 false,
             )
             .expect("could not create sozu worker");


### PR DESCRIPTION
As pointed out in #1038, creating a new worker involves writing the config state on a file using `serde_json::to_writer`:

https://github.com/sozu-proxy/sozu/blob/757a6f1bde1f1f84d9cce8d7f013b4a45debdb15/bin/src/worker.rs#L308

and conversely, using `serde_json::from_reader` to read the file again, from the new worker process:

https://github.com/sozu-proxy/sozu/blob/757a6f1bde1f1f84d9cce8d7f013b4a45debdb15/bin/src/worker.rs#L220

which leads to performance issues, especially when the state is big.

This PR fixes this issue by using the same logic as in command `sozu state save`: convert the ConfigState to WorkerRequests and write them in a file, using a big buffer. Then parse it using nom to retrieve the requests.

This means changing the signature of functions that create workers. Instead of getting a ConfigState, they get `Vec<WorkerRequest>`.

## Gain in performance

- intel i7-10510U
- 20000 clusters in the state
- 100 000 requests in the state file
- 4 workers
- upgrade command that restarts all 4 workers with the state file

### Sōzu 0.15.17

```
Executed in   15.74 secs      fish           external
   usr time    7.04 millis    0.00 micros    7.04 millis
   sys time    4.32 millis  820.00 micros    3.50 millis
```

### Sōzu 0.15.17 with the fix

```
Executed in    7.66 secs      fish           external
   usr time   29.88 millis   29.88 millis    0.00 millis
   sys time   14.20 millis    3.34 millis   10.85 millis
```

We do observe a doubling of performance, which is nice, but still improvable if we would serialize/parse the requests using protobuf (roughly and additionnal x2 increase in perf).