### PR TITLE
Do not set RUST_LOG on logger setup

### DIFF
--- a/command/src/logging.rs
+++ b/command/src/logging.rs
@@ -512,8 +512,6 @@ pub fn setup_logging(
     if let Ok(env_log_level) = env::var("RUST_LOG") {
         Logger::init(tag.to_string(), &env_log_level, backend, access_backend);
     } else {
-        // We set the env variable so every worker can access it
-        env::set_var("RUST_LOG", log_level);
         Logger::init(tag.to_string(), log_level, backend, access_backend);
     }
 }


### PR DESCRIPTION
Setting RUST_LOG increased the log level of all loggers in e2e tests which is not wanted.
I'm not sure why this line was here, the comment seems out of date since the workers get the wanted log level just fine.