### PR TITLE
workers return only one response when dispatching a request

### DIFF
--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -294,6 +294,10 @@ impl WorkerResponse {
             content: None,
         }
     }
+
+    pub fn is_failure(&self) -> bool {
+        self.status == ResponseStatus::Failure
+    }
 }
 
 impl fmt::Display for WorkerResponse {


### PR DESCRIPTION
In a Sōzu worker, there are 3 proxies: an HTTP, HTTPS and TCP one. Some requests, like `AddCluster`, are dispatched to all of them, which causes *three distinct WorkerResponses* to be sent back to the main process. Only one of those is recognized by the main process, while the others get logged as:

```
2023-12-12T09:20:17.927059Z 1702372817927059726 38782 MAIN DEBUG	sozu::command	unknown response id: CONFIG-5
2023-12-12T09:20:17.927098Z 1702372817927098916 38782 MAIN DEBUG	sozu::command	unknown response id: CONFIG-5
```

Which confuses the user, pollutes the logs and takes up ressources.

This PR fixes it by returning only one response of the two or three available. A Failure response will override an OK by another proxy.