### PR TITLE
Socket address in protobuf

### DIFF
--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -47,8 +47,6 @@ pub enum CtlError {
     ArgsNeeded(String, String),
     #[error("could not load certificate")]
     LoadCertificate(CertificateError),
-    #[error("wrong address {0}: {1}")]
-    WrongAddress(String, UtilError),
     #[error("wrong input to create listener")]
     CreateListener(ConfigError),
     #[error("domain can not be empty")]
@@ -161,19 +159,13 @@ impl CommandManager {
                     key,
                     address,
                     tls_versions,
-                } => self.add_certificate(
-                    address.to_string(),
-                    &certificate,
-                    &chain,
-                    &key,
-                    tls_versions,
-                ),
+                } => self.add_certificate(address.into(), &certificate, &chain, &key, tls_versions),
                 CertificateCmd::Remove {
                     certificate,
                     address,
                     fingerprint,
                 } => self.remove_certificate(
-                    address.to_string(),
+                    address.into(),
                     certificate.as_deref(),
                     fingerprint.as_deref(),
                 ),
@@ -186,7 +178,7 @@ impl CommandManager {
                     old_fingerprint,
                     tls_versions,
                 } => self.replace_certificate(
-                    address.to_string(),
+                    address.into(),
                     &certificate,
                     &chain,
                     &key,

--- a/bin/src/util.rs
+++ b/bin/src/util.rs
@@ -2,7 +2,6 @@ use std::{
     ffi::OsString,
     fs::{read_link, File},
     io::{Error as IoError, Write},
-    net::{AddrParseError, SocketAddr},
     os::unix::io::RawFd,
     path::PathBuf,
 };
@@ -45,8 +44,6 @@ pub enum UtilError {
     or use the SOZU_CONFIG environment variable when building sozu."
     )]
     GetConfigFilePath,
-    #[error("could not parse socket address: {0}")]
-    ParseSocketAddress(AddrParseError),
 }
 
 /// FD_CLOEXEC is set by default on every fd in Rust standard lib,
@@ -115,12 +112,6 @@ pub fn get_config_file_path(args: &cli::Args) -> Result<&str, UtilError> {
         Some(config_file) => Ok(config_file.as_str()),
         None => option_env!("SOZU_CONFIG").ok_or(UtilError::GetConfigFilePath),
     }
-}
-
-pub fn parse_socket_address(address: &str) -> Result<SocketAddr, UtilError> {
-    address
-        .parse::<SocketAddr>()
-        .map_err(UtilError::ParseSocketAddress)
 }
 
 #[cfg(target_os = "freebsd")]

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -115,8 +115,8 @@ message CountRequests {}
 
 // details of an HTTP listener
 message HttpListenerConfig {
-    required string address = 1;
-    optional string public_address = 2;
+    required SocketAddress address = 1;
+    optional SocketAddress public_address = 2;
     required string answer_404 = 3;
     required string answer_503 = 4;
     required bool expect_proxy = 5 [default = false];
@@ -135,8 +135,8 @@ message HttpListenerConfig {
 
 // details of an HTTPS listener
 message HttpsListenerConfig {
-    required string address = 1;
-    optional string public_address = 2;
+    required SocketAddress address = 1;
+    optional SocketAddress public_address = 2;
     required string answer_404 = 3;
     required string answer_503 = 4;
     required bool expect_proxy = 5 [default = false];
@@ -168,8 +168,8 @@ message HttpsListenerConfig {
 
 // details of an TCP listener
 message TcpListenerConfig {
-    required string address = 1;
-    optional string public_address = 2;
+    required SocketAddress address = 1;
+    optional SocketAddress public_address = 2;
     required bool expect_proxy = 3 [default = false];
     // client inactive time, in seconds
     required uint32 front_timeout = 4 [default = 60];
@@ -182,19 +182,19 @@ message TcpListenerConfig {
 }
 
 message ActivateListener {
-    required string address = 1;
+    required SocketAddress address = 1;
     required ListenerType proxy = 2;
     required bool from_scm = 3;
 }
 
 message DeactivateListener {
-    required string address = 1;
+    required SocketAddress address = 1;
     required ListenerType proxy = 2;
     required bool to_scm = 3;
 }
 
 message RemoveListener {
-    required string address = 1;
+    required SocketAddress address = 1;
     required ListenerType proxy = 2;
 }
 
@@ -217,7 +217,7 @@ message ListenersList {
 // An HTTP or HTTPS frontend, as order to, or received from, Sōzu
 message RequestHttpFrontend {
     optional string cluster_id = 1;
-    required string address = 2;
+    required SocketAddress address = 2;
     required string hostname = 3;
     required PathRule path = 4;
     optional string method = 5;
@@ -229,7 +229,7 @@ message RequestHttpFrontend {
 message RequestTcpFrontend {
     required string cluster_id = 1;
     // the socket address on which to listen for incoming traffic
-    required string address = 2;
+    required SocketAddress address = 2;
     // custom tags to identify the frontend in the access logs
     map<string, string> tags = 3;
 }
@@ -269,20 +269,20 @@ enum RulePosition {
 
 // Add a new TLS certificate to an HTTPs listener
 message AddCertificate {
-    required string address = 1;
+    required SocketAddress address = 1;
     required CertificateAndKey certificate = 2;
     // A unix timestamp. Overrides certificate expiration.
     optional int64 expired_at = 3;
 }
 
 message RemoveCertificate {
-    required string address = 1;
+    required SocketAddress address = 1;
     // a hex-encoded TLS fingerprint to identify the certificate to remove
     required string fingerprint = 2;
 }
 
 message ReplaceCertificate {
-    required string address = 1;
+    required SocketAddress address = 1;
     required CertificateAndKey new_certificate = 2;
     // a hex-encoded TLS fingerprint to identify the old certificate
     required string old_fingerprint = 3;
@@ -323,7 +323,7 @@ message ListOfCertificatesByAddress {
 
 // Summaries of certificates for a given address
 message CertificatesByAddress {
-    required string address = 1;
+    required SocketAddress address = 1;
     repeated CertificateSummary certificate_summaries = 2;
 }
 
@@ -382,7 +382,7 @@ message AddBackend {
     required string cluster_id = 1;
     required string backend_id = 2;
     // the socket address of the backend
-    required string address = 3;
+    required SocketAddress address = 3;
     optional string sticky_id = 4;
     optional LoadBalancingParams load_balancing_parameters = 5;
     optional bool backup = 6;
@@ -393,7 +393,7 @@ message RemoveBackend {
     required string cluster_id = 1;
     required string backend_id = 2;
     // the socket address of the backend
-    required string address = 3 ;
+    required SocketAddress address = 3 ;
 }
 
 message LoadBalancingParams {
@@ -502,7 +502,7 @@ message Event {
     required EventKind kind = 1;
     optional string cluster_id = 2;
     optional string backend_id = 3;
-    optional string address = 4;
+    optional SocketAddress address = 4;
 }
 
 enum EventKind {
@@ -607,4 +607,28 @@ message Percentiles {
 
 message RequestCounts {
     map<string, int32> map = 1;
+}
+
+// matches std::net::SocketAddr in the Rust library
+// beware that the ports are expressed with uint32 here,
+// but they should NOT exceed uint16 value
+message SocketAddress {
+    required IpAddress ip = 1;
+    required uint32 port = 2;
+}
+
+message IpAddress {
+    oneof inner {
+        uint32 v4 = 1;
+        Uint128 v6 = 2;
+    }
+}
+
+// used to represent the 128 bits of an IPv6 address
+message Uint128 {
+    // higher value, first 8 bytes of the ip
+    required uint64 low = 1;
+    // lower value, last 8 bytes of the ip
+    required uint64 high = 2;
+
 }

--- a/command/src/proto/display.rs
+++ b/command/src/proto/display.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fmt::{Display, Formatter},
+    net::SocketAddr,
 };
 
 use prettytable::{cell, row, Row, Table};
@@ -17,6 +18,8 @@ use crate::proto::{
     },
     DisplayError,
 };
+
+use super::command::SocketAddress;
 
 impl Display for CertificateAndKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -939,4 +942,10 @@ fn create_cluster_table(headers: Vec<&str>, data: &BTreeMap<String, ResponseCont
     }
     table.add_row(Row::new(row_header));
     table
+}
+
+impl Display for SocketAddress {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", SocketAddr::from(self.clone()))
+    }
 }

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -49,7 +49,7 @@ impl From<HttpFrontend> for RequestHttpFrontend {
         };
         RequestHttpFrontend {
             cluster_id: val.cluster_id,
-            address: val.address.to_string(),
+            address: val.address.into(),
             hostname: val.hostname,
             path: val.path,
             method: val.method,
@@ -64,7 +64,7 @@ impl From<Backend> for AddBackend {
         AddBackend {
             cluster_id: val.cluster_id,
             backend_id: val.backend_id,
-            address: val.address.to_string(),
+            address: val.address.into(),
             sticky_id: val.sticky_id,
             load_balancing_parameters: val.load_balancing_parameters,
             backup: val.backup,
@@ -154,7 +154,7 @@ impl From<TcpFrontend> for RequestTcpFrontend {
     fn from(val: TcpFrontend) -> Self {
         RequestTcpFrontend {
             cluster_id: val.cluster_id,
-            address: val.address.to_string(),
+            address: val.address.into(),
             tags: val.tags,
         }
     }
@@ -202,7 +202,7 @@ impl Backend {
     pub fn to_add_backend(self) -> AddBackend {
         AddBackend {
             cluster_id: self.cluster_id,
-            address: self.address.to_string(),
+            address: self.address.into(),
             sticky_id: self.sticky_id,
             backend_id: self.backend_id,
             load_balancing_parameters: self.load_balancing_parameters,

--- a/e2e/src/sozu/worker.rs
+++ b/e2e/src/sozu/worker.rs
@@ -282,11 +282,11 @@ impl Worker {
 
     pub fn default_tcp_frontend<S: Into<String>>(
         cluster_id: S,
-        address: String,
+        address: SocketAddr,
     ) -> RequestTcpFrontend {
         RequestTcpFrontend {
             cluster_id: cluster_id.into(),
-            address,
+            address: address.into(),
             ..Default::default()
         }
     }
@@ -297,7 +297,7 @@ impl Worker {
     ) -> RequestHttpFrontend {
         RequestHttpFrontend {
             cluster_id: Some(cluster_id.into()),
-            address: address.to_string(),
+            address: address.into(),
             hostname: String::from("localhost"),
             path: PathRule::prefix(String::from("/")),
             position: RulePosition::Tree.into(),
@@ -308,13 +308,13 @@ impl Worker {
     pub fn default_backend<S1: Into<String>, S2: Into<String>>(
         cluster_id: S1,
         backend_id: S2,
-        address: String,
+        address: SocketAddr,
         sticky_id: Option<String>,
     ) -> AddBackend {
         AddBackend {
             cluster_id: cluster_id.into(),
             backend_id: backend_id.into(),
-            address,
+            address: address.into(),
             load_balancing_parameters: Some(LoadBalancingParams::default()),
             sticky_id,
             backup: None,

--- a/lib/examples/http.rs
+++ b/lib/examples/http.rs
@@ -14,7 +14,7 @@ use sozu_command_lib::{
     logging::setup_logging,
     proto::command::{
         request::RequestType, AddBackend, Cluster, LoadBalancingAlgorithms, LoadBalancingParams,
-        PathRule, RequestHttpFrontend, RulePosition,
+        PathRule, RequestHttpFrontend, RulePosition, SocketAddress,
     },
     request::WorkerRequest,
     response::WorkerResponse,
@@ -25,7 +25,7 @@ fn main() -> anyhow::Result<()> {
 
     info!("starting up");
 
-    let http_listener = ListenerBuilder::new_http("127.0.0.1:8080")
+    let http_listener = ListenerBuilder::new_http(SocketAddress::new_v4(127, 0, 0, 1, 8080))
         .to_http(None)
         .expect("Could not create HTTP listener");
 
@@ -57,7 +57,7 @@ fn main() -> anyhow::Result<()> {
 
     let http_front = RequestHttpFrontend {
         cluster_id: Some("my-cluster".to_string()),
-        address: "127.0.0.1:8080".to_string(),
+        address: SocketAddress::new_v4(127, 0, 0, 1, 8080),
         hostname: "example.com".to_string(),
         path: PathRule::prefix(String::from("/")),
         position: RulePosition::Pre.into(),
@@ -70,7 +70,7 @@ fn main() -> anyhow::Result<()> {
     let http_backend = AddBackend {
         cluster_id: "my-cluster".to_string(),
         backend_id: "test-backend".to_string(),
-        address: "127.0.0.1:8000".to_string(),
+        address: SocketAddress::new_v4(127, 0, 0, 1, 8080),
         load_balancing_parameters: Some(LoadBalancingParams::default()),
         ..Default::default()
     };

--- a/lib/examples/https.rs
+++ b/lib/examples/https.rs
@@ -15,7 +15,7 @@ use sozu_command_lib::{
     logging::setup_logging,
     proto::command::{
         request::RequestType, AddBackend, AddCertificate, CertificateAndKey, LoadBalancingParams,
-        PathRule, RequestHttpFrontend,
+        PathRule, RequestHttpFrontend, SocketAddress,
     },
     request::WorkerRequest,
 };
@@ -26,16 +26,15 @@ fn main() -> anyhow::Result<()> {
     info!("MAIN\tstarting up");
 
     sozu_lib::metrics::setup(
-        &"127.0.0.1:8125"
-            .parse()
-            .with_context(|| "Could not parse address for metrics setup")?,
+        &SocketAddress::new_v4(127, 0, 0, 1, 8125).into(),
         "main",
         false,
         None,
     );
     gauge!("sozu.TEST", 42);
 
-    let http_listener = ListenerBuilder::new_http("127.0.0.1:8080").to_http(None)?;
+    let http_listener =
+        ListenerBuilder::new_http(SocketAddress::new_v4(127, 0, 0, 1, 8080)).to_http(None)?;
 
     let (mut command, channel) =
         Channel::generate(1000, 10000).with_context(|| "should create a channel")?;
@@ -52,7 +51,7 @@ fn main() -> anyhow::Result<()> {
 
     let http_front = RequestHttpFrontend {
         cluster_id: Some(String::from("cluster_1")),
-        address: "127.0.0.1:8080".to_string(),
+        address: SocketAddress::new_v4(127, 0, 0, 1, 8080),
         hostname: String::from("lolcatho.st"),
         path: PathRule::prefix(String::from("/")),
         ..Default::default()
@@ -62,7 +61,7 @@ fn main() -> anyhow::Result<()> {
         cluster_id: String::from("cluster_1"),
         backend_id: String::from("cluster_1-0"),
         sticky_id: None,
-        address: "127.0.0.1:1026".to_string(),
+        address: SocketAddress::new_v4(127, 0, 0, 1, 1026),
         load_balancing_parameters: Some(LoadBalancingParams::default()),
         backup: None,
     };
@@ -80,7 +79,8 @@ fn main() -> anyhow::Result<()> {
     info!("MAIN\tHTTP -> {:?}", command.read_message());
     info!("MAIN\tHTTP -> {:?}", command.read_message());
 
-    let https_listener = ListenerBuilder::new_https("127.0.0.1:8443").to_tls(None)?;
+    let https_listener =
+        ListenerBuilder::new_https(SocketAddress::new_v4(127, 0, 0, 1, 8443)).to_tls(None)?;
 
     let (mut command2, channel2) =
         Channel::generate(1000, 10000).with_context(|| "should create a channel")?;
@@ -108,9 +108,7 @@ fn main() -> anyhow::Result<()> {
     command2.write_message(&WorkerRequest {
         id: String::from("ID_IJKL1"),
         content: RequestType::AddCertificate(AddCertificate {
-            address: "127.0.0.1:8443"
-                .parse()
-                .with_context(|| "Could not parse certificate address")?,
+            address: SocketAddress::new_v4(127, 0, 0, 1, 8443),
             certificate: certificate_and_key,
             expired_at: None,
         })
@@ -119,7 +117,7 @@ fn main() -> anyhow::Result<()> {
 
     let tls_front = RequestHttpFrontend {
         cluster_id: Some(String::from("cluster_1")),
-        address: "127.0.0.1:8443".to_string(),
+        address: SocketAddress::new_v4(127, 0, 0, 1, 8443),
         hostname: String::from("lolcatho.st"),
         path: PathRule::prefix(String::from("/")),
         ..Default::default()
@@ -133,7 +131,7 @@ fn main() -> anyhow::Result<()> {
         cluster_id: String::from("cluster_1"),
         backend_id: String::from("cluster_1-0"),
         sticky_id: None,
-        address: "127.0.0.1:1026".to_string(),
+        address: SocketAddress::new_v4(127, 0, 0, 1, 1026),
         load_balancing_parameters: Some(LoadBalancingParams::default()),
         backup: None,
     };
@@ -157,9 +155,7 @@ fn main() -> anyhow::Result<()> {
     command2.write_message(&WorkerRequest {
         id: String::from("ID_QRST1"),
         content: RequestType::AddCertificate(AddCertificate {
-            address: "127.0.0.1:8443"
-                .parse()
-                .with_context(|| "Could not parse certificate address")?,
+            address: SocketAddress::new_v4(127, 0, 0, 1, 8443),
             certificate: certificate_and_key2,
             expired_at: None,
         })
@@ -168,7 +164,7 @@ fn main() -> anyhow::Result<()> {
 
     let tls_front2 = RequestHttpFrontend {
         cluster_id: Some(String::from("cluster_2")),
-        address: "127.0.0.1:8443".to_string(),
+        address: SocketAddress::new_v4(127, 0, 0, 1, 8443),
         hostname: String::from("test.local"),
         path: PathRule::prefix(String::from("/")),
         ..Default::default()
@@ -183,7 +179,7 @@ fn main() -> anyhow::Result<()> {
         cluster_id: String::from("cluster_2"),
         backend_id: String::from("cluster_2-0"),
         sticky_id: None,
-        address: "127.0.0.1:1026".to_string(),
+        address: SocketAddress::new_v4(127, 0, 0, 1, 1026),
         load_balancing_parameters: Some(LoadBalancingParams::default()),
         backup: None,
     };

--- a/lib/examples/tcp.rs
+++ b/lib/examples/tcp.rs
@@ -11,7 +11,7 @@ use sozu_command_lib::{
     channel::Channel,
     logging::setup_logging,
     proto::command::{
-        request::RequestType, AddBackend, LoadBalancingParams, RequestTcpFrontend,
+        request::RequestType, AddBackend, LoadBalancingParams, RequestTcpFrontend, SocketAddress,
         TcpListenerConfig,
     },
     request::WorkerRequest,
@@ -30,7 +30,7 @@ fn main() -> anyhow::Result<()> {
         let max_buffers = 500;
         let buffer_size = 16384;
         let listener = TcpListenerConfig {
-            address: "127.0.0.1:8080".parse().expect("could not parse address"),
+            address: SocketAddress::new_v4(127, 0, 0, 1, 8080),
             ..Default::default()
         };
         setup_logging("stdout", None, "debug", "TCP");
@@ -39,13 +39,13 @@ fn main() -> anyhow::Result<()> {
 
     let tcp_front = RequestTcpFrontend {
         cluster_id: String::from("test"),
-        address: "127.0.0.1:8080".to_string(),
+        address: SocketAddress::new_v4(127, 0, 0, 1, 8080),
         ..Default::default()
     };
     let tcp_backend = AddBackend {
         cluster_id: String::from("test"),
         backend_id: String::from("test-0"),
-        address: "127.0.0.1:1026".to_string(),
+        address: SocketAddress::new_v4(127, 0, 0, 1, 1026),
         load_balancing_parameters: Some(LoadBalancingParams::default()),
         sticky_id: None,
         backup: None,

--- a/lib/src/backends.rs
+++ b/lib/src/backends.rs
@@ -169,7 +169,7 @@ impl std::ops::Drop for Backend {
         server::push_event(Event {
             kind: EventKind::RemovedBackendHasNoConnections as i32,
             backend_id: Some(self.backend_id.clone()),
-            address: Some(self.address.to_string()),
+            address: Some(self.address.into()),
             cluster_id: None,
         });
     }

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -1409,7 +1409,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
                     push_event(Event {
                         kind: EventKind::BackendUp as i32,
                         backend_id: Some(backend.backend_id.to_owned()),
-                        address: Some(backend.address.to_string()),
+                        address: Some(backend.address.into()),
                         cluster_id: None,
                     });
                 }
@@ -1452,7 +1452,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
                 push_event(Event {
                     kind: EventKind::BackendDown as i32,
                     backend_id: Some(backend.backend_id.to_owned()),
-                    address: Some(backend.address.to_string()),
+                    address: Some(backend.address.into()),
                     cluster_id: None,
                 });
             }

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -1098,7 +1098,7 @@ impl Server {
     fn add_backend(&mut self, req_id: &str, add_backend: &AddBackend) -> WorkerResponse {
         let new_backend = Backend::new(
             &add_backend.backend_id,
-            add_backend.address.parse().unwrap(),
+            add_backend.address.clone().into(),
             add_backend.sticky_id.clone(),
             add_backend.load_balancing_parameters.clone(),
             add_backend.backup,
@@ -1111,7 +1111,7 @@ impl Server {
     }
 
     fn remove_backend(&mut self, req_id: &str, backend: &RemoveBackend) -> WorkerResponse {
-        let address = backend.address.parse().unwrap();
+        let address = backend.address.clone().into();
         self.backends
             .borrow_mut()
             .remove_backend(&backend.cluster_id, &address);
@@ -1232,10 +1232,7 @@ impl Server {
             req_id, activate.proxy, activate
         );
 
-        let address: std::net::SocketAddr = match activate.address.parse() {
-            Ok(a) => a,
-            Err(e) => return WorkerResponse::error(req_id, format!("Wrong socket address: {e}")),
-        };
+        let address: std::net::SocketAddr = activate.address.clone().into();
 
         match ListenerType::try_from(activate.proxy) {
             Ok(ListenerType::Http) => {
@@ -1312,10 +1309,7 @@ impl Server {
             req_id, deactivate.proxy, deactivate
         );
 
-        let address: std::net::SocketAddr = match deactivate.address.parse() {
-            Ok(a) => a,
-            Err(e) => return WorkerResponse::error(req_id, format!("Wrong socket address: {e}")),
-        };
+        let address: std::net::SocketAddr = deactivate.address.clone().into();
 
         match ListenerType::try_from(deactivate.proxy) {
             Ok(ListenerType::Http) => {

--- a/lib/src/tls.rs
+++ b/lib/src/tls.rs
@@ -490,12 +490,12 @@ mod tests {
     use rand::{seq::SliceRandom, thread_rng};
     use sozu_command::{
         certificate::parse_pem,
-        proto::command::{AddCertificate, CertificateAndKey},
+        proto::command::{AddCertificate, CertificateAndKey, SocketAddress},
     };
 
     #[test]
     fn lifecycle() -> Result<(), Box<dyn Error + Send + Sync>> {
-        let address = "127.0.0.1:8080".to_string();
+        let address = SocketAddress::new_v4(127, 0, 0, 1, 8080);
         let mut resolver = CertificateResolver::default();
         let certificate_and_key = CertificateAndKey {
             certificate: String::from(include_str!("../assets/certificate.pem")),
@@ -531,7 +531,7 @@ mod tests {
 
     #[test]
     fn name_override() -> Result<(), Box<dyn Error + Send + Sync>> {
-        let address = "127.0.0.1:8080".to_string();
+        let address = SocketAddress::new_v4(127, 0, 0, 1, 8080);
         let mut resolver = CertificateResolver::default();
         let certificate_and_key = CertificateAndKey {
             certificate: String::from(include_str!("../assets/certificate.pem")),
@@ -576,7 +576,7 @@ mod tests {
 
     #[test]
     fn replacement() -> Result<(), Box<dyn Error + Send + Sync>> {
-        let address = "127.0.0.1:8080".to_string();
+        let address = SocketAddress::new_v4(127, 0, 0, 1, 8080);
         let mut resolver = CertificateResolver::default();
 
         // ---------------------------------------------------------------------
@@ -641,7 +641,7 @@ mod tests {
 
     #[test]
     fn expiration_override() -> Result<(), Box<dyn Error + Send + Sync>> {
-        let address = "127.0.0.1:8080".to_string();
+        let address = SocketAddress::new_v4(127, 0, 0, 1, 8080);
         let mut resolver = CertificateResolver::default();
 
         // ---------------------------------------------------------------------
@@ -758,7 +758,7 @@ mod tests {
 
         // ---------------------------------------------------------------------
         // load certificates in resolver
-        let address = "127.0.0.1:8080".to_string();
+        let address = SocketAddress::new_v4(127, 0, 0, 1, 8080);
         let mut resolver = CertificateResolver::default();
 
         for certificate in &certificates {


### PR DESCRIPTION
two types are used:

- `std::net::SocketAddr` for the whole proxying logic, storing the state, listening on TCP sockets, etc
- `sozu_command_lib::proto::command::SocketAddress` (note the full-word ending here) for *transmitting* socket addresses between clients and main process, between main process and workers