### PR TITLE
CI: Adding a benchmark framework

### DIFF
--- a/.github/workflows/bench.py
+++ b/.github/workflows/bench.py
@@ -1,0 +1,43 @@
+import subprocess
+import logging
+import time
+
+def run(url: str, bombardierduration: str):
+    logging.info("🎯 Initalize environnment")
+    try:
+        lagging_server = subprocess.Popen(
+            ["./lagging_server", "-w", "4", "-p", "4444"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        sozu = subprocess.Popen(
+            ["./sozu", "start", "-c", "bench.toml"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        time.sleep(3)
+    except subprocess.CalledProcessError as e:
+        logging.error(f"🚨 Command failed with return code {e.returncode}")
+
+    try:
+        subprocess.run(["./bombardier", "-c", "400", "-p", "intro,result", "--fasthttp", "-l", "-t", "10s", "-d", bombardierduration, url])
+
+    except subprocess.CalledProcessError as e:
+        logging.error(f"🚨 Failed to run benchmark {e.returncode}")
+
+    logging.info("🪓 Destroy environment")
+    try:
+        subprocess.run(["kill", str(lagging_server.pid)])
+        subprocess.run(["kill", str(sozu.pid)])
+    except subprocess.CalledProcessError as e:
+        logging.error(f"🚨 Failed to destroy environnement {e.returncode}")
+
+logging.basicConfig(encoding='utf-8', level=logging.INFO)
+logging.info("💣 Launching benchmark")
+
+run("http://sozu.io:8080/api", "1m")
+run("https://rsa-2048.sozu.io:8443/api", "1m")
+run("https://rsa-4096.sozu.io:8443/api", "1m")
+run("https://ecdsa.sozu.io:8443/api", "1m")

--- a/.github/workflows/bench.toml
+++ b/.github/workflows/bench.toml
@@ -1,0 +1,49 @@
+log_level = "error"
+log_target = "stdout"
+command_socket = "./sozu.sock"
+command_buffer_size = 16384
+max_command_buffer_size = 163840
+worker_count = 1
+worker_automatic_restart = true
+handle_process_affinity = false
+max_connections = 500
+buffer_size = 16393
+activate_listeners = true
+
+[[listeners]]
+protocol = "http"
+# listening address
+address = "0.0.0.0:8080"
+
+[[listeners]]
+protocol = "https"
+address = "0.0.0.0:8443"
+tls_versions = ["TLS_V12", "TLS_V13"]
+cipher_list = [
+    # TLS 1.3 cipher suites
+    "TLS13_AES_256_GCM_SHA384",
+    "TLS13_AES_128_GCM_SHA256",
+    "TLS13_CHACHA20_POLY1305_SHA256",
+    # TLS 1.2 cipher suites
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+]
+
+[clusters]
+[clusters.BenchCluster]
+
+protocol = "http"
+load_balancing = "ROUND_ROBIN"
+frontends = [
+    { address = "0.0.0.0:8080", hostname = "sozu.io"},
+    { address = "0.0.0.0:8443", hostname = "rsa-2048.sozu.io", certificate = "rsa-2048.pem", certificate_chain = "rsa-2048.pem", key = "rsa-2048.key"},
+    { address = "0.0.0.0:8443", hostname = "rsa-4096.sozu.io", certificate = "rsa-4096.pem", certificate_chain = "rsa-4096.pem", key = "rsa-4096.key"},
+    { address = "0.0.0.0:8443", hostname = "ecdsa.sozu.io", certificate = "ecdsa.pem", certificate_chain = "ecdsa.pem", key = "ecdsa.key"},
+]
+backends = [
+    { address = "0.0.0.0:4444"}
+]

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,161 @@
+---
+name: Benchmark
+
+on: [ push, pull_request ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-bombardier:
+    name: Build Bombardier 💣️
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone bombardier
+        uses: actions/checkout@v4
+        with:
+          repository: codesenberg/bombardier
+          path: .
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.18'
+          check-latest: false
+
+      - name: Build bombardier
+        run: go build -o bombardier
+
+      - name: 📤 Upload bombardier
+        uses: actions/upload-artifact@v4
+        with:
+          name: bombardier
+          path: bombardier
+
+  build-lagging_server:
+    name: Build Lagging_Server ⚡️
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ""
+
+      - name: Clone lagging_server
+        uses: actions/checkout@v4
+        with:
+          repository: CleverCloud/lagging_server
+          path: .
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+          prefix-key: "lagging_server"
+      
+      - name: Build lagging_server
+        run: cargo build --release
+    
+      - name: 📤 Upload lagging_server
+        uses: actions/upload-artifact@v4
+        with:
+          name: lagging_server
+          path: target/release/lagging_server
+
+  build-sozu:
+    name: Build Sozu 🦀
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install protobuf compiler
+        run:  sudo apt-get install -y protobuf-compiler
+      
+      - name: Install rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ""
+
+      - uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+          prefix-key: "sozu"
+
+      - name: Build Sozu
+        run: cargo build --release
+
+      - name: 📤 Upload sozu
+        uses: actions/upload-artifact@v4
+        with:
+          name: sozu
+          path: target/release/sozu
+      
+  bench:
+      name: Benchmark 🎯
+      runs-on: ubuntu-latest
+      needs: [build-bombardier, build-lagging_server, build-sozu]
+      steps:
+      - uses: actions/checkout@v4
+
+      - name: 📥 Download bombardier
+        uses: actions/download-artifact@v4
+        with:
+          name: bombardier
+          path: .github/workflows
+      - name: 📥 Download lagging_server
+        uses: actions/download-artifact@v4
+        with:
+          name: lagging_server
+          path: .github/workflows
+      - name: 📥 Download sozu
+        uses: actions/download-artifact@v4
+        with:
+          name: sozu
+          path: .github/workflows
+
+      - name: Host mapping sozu.io domains
+        run: |
+          sudo echo "0.0.0.0 sozu.io" | sudo tee -a /etc/hosts
+          sudo echo "0.0.0.0 rsa-2048.sozu.io" | sudo tee -a /etc/hosts
+          sudo echo "0.0.0.0 rsa-4096.sozu.io" | sudo tee -a /etc/hosts
+          sudo echo "0.0.0.0 ecdsa.sozu.io" | sudo tee -a /etc/hosts
+
+      - name: Generate TLS key rsa 2048
+        working-directory: .github/workflows
+        run: |
+          openssl req -newkey rsa:2048 -nodes -keyout rsa-2048.key -out rsa-2048.csr -config rsa-2048.cnf
+          openssl x509 -req -days 365 -in rsa-2048.csr -signkey rsa-2048.key -out rsa-2048.pem -extensions req_ext -extfile rsa-2048.cnf
+          sudo cp rsa-2048.pem /usr/local/share/ca-certificates/rsa-2048.crt
+          sudo update-ca-certificates
+      
+      - name: Generate TLS key rsa 4096
+        working-directory: .github/workflows
+        run: |
+          openssl req -newkey rsa:4096 -nodes -keyout rsa-4096.key -out rsa-4096.csr -config rsa-4096.cnf
+          openssl x509 -req -days 365 -in rsa-4096.csr -signkey rsa-4096.key -out rsa-4096.pem -extensions req_ext -extfile rsa-4096.cnf
+          sudo cp rsa-4096.pem /usr/local/share/ca-certificates/rsa-4096.crt
+          sudo update-ca-certificates
+      
+      - name: Generate TLS key ecdsa
+        working-directory: .github/workflows
+        run: |
+          openssl ecparam -name prime256v1 -genkey -out ecdsa.key
+          openssl req -new -key ecdsa.key -out ecdsa.csr -config ecdsa.cnf
+          openssl x509 -req -days 365 -in ecdsa.csr -signkey ecdsa.key -out ecdsa.pem -extensions req_ext -extfile ecdsa.cnf
+          sudo cp ecdsa.pem /usr/local/share/ca-certificates/ecdsa.crt
+          sudo update-ca-certificates
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Fix rights
+        working-directory: .github/workflows
+        run: |
+          chmod +x bombardier
+          chmod +x lagging_server
+          chmod +x sozu
+      
+      - name: ⚡ Launch bench
+        working-directory: .github/workflows
+        run:
+          python bench.py

--- a/.github/workflows/ecdsa.cnf
+++ b/.github/workflows/ecdsa.cnf
@@ -1,0 +1,15 @@
+[ req ]
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+
+[ dn ]
+CN = sozu.io
+
+[ req_ext ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = sozu.io
+DNS.2 = ecdsa.sozu.io

--- a/.github/workflows/rsa-2048.cnf
+++ b/.github/workflows/rsa-2048.cnf
@@ -1,0 +1,15 @@
+[ req ]
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+
+[ dn ]
+CN = sozu.io
+
+[ req_ext ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = sozu.io
+DNS.2 = ecdsa.sozu.io

--- a/.github/workflows/rsa-4096.cnf
+++ b/.github/workflows/rsa-4096.cnf
@@ -1,0 +1,16 @@
+[ req ]
+default_bits = 4096
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+
+[ dn ]
+CN = sozu.io
+
+[ req_ext ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = sozu.io
+DNS.2 = rsa-4096.sozu.io


### PR DESCRIPTION
Hi,

As sozu need strong performances, we need a simple way to benchmark sozu regularly.

I create a complete sozu benchmark script using python who's in charge of booting a sozu with lagging_server, load certificates with a complete configuration and run a stressing tool. At the end, we collect all the results in a log file archive as an artifact.

It's automated with a CI called benchmark.yml to automate the build and the benchmarking tool. For now, I use bombardier, but we can easily add new testing tools.

This setup test sozu performances with following settings :

- 1 Minute duration
- 400 connections at max
- HTTP1 (HTTP2 can be support if needed)
- HTTP Plain text
  - HTTPS with the following encryption settings
    - RSA 2048
    - RSA 4096
    - ECDSA

The aim is not to get some reliable results, but to get a simple methodology that we can reuse in the future to track sozu performances.

