### PR TITLE
Fix certificate insertion

### DIFF
--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -295,7 +295,8 @@ message CertificateAndKey {
     repeated string certificate_chain = 2;
     required string key = 3;
     repeated TlsVersion versions = 4;
-    // hostnames linked to the certificate
+    // a list of domain names. Override certificate names
+    // if empty, the names of the certificate will be used
     repeated string names = 5;
 }
 

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -522,7 +522,7 @@ impl HttpProxy {
 
     pub fn remove_listener(&mut self, remove: RemoveListener) -> Result<(), ProxyError> {
         let len = self.listeners.len();
-        let remove_address = remove.address.clone().into();
+        let remove_address = remove.address.into();
         self.listeners
             .retain(|_, l| l.borrow().address != remove_address);
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -351,6 +351,7 @@ use std::{
 };
 
 use backends::BackendError;
+use hex::FromHexError;
 use mio::{net::TcpStream, Interest, Token};
 use protocol::http::parser::Method;
 use router::RouterError;
@@ -637,8 +638,6 @@ pub enum AcceptError {
 /// returned by the HTTP, HTTPS and TCP listeners
 #[derive(thiserror::Error, Debug)]
 pub enum ListenerError {
-    #[error("failed to acquire the lock, {0}")]
-    Lock(String),
     #[error("failed to handle certificate request, got a resolver error, {0}")]
     Resolver(CertificateResolverError),
     #[error("failed to parse pem, {0}")]
@@ -689,15 +688,17 @@ pub enum ProxyError {
     #[error("could not remove frontend: {0}")]
     RemoveFrontend(ListenerError),
     #[error("could not add certificate: {0}")]
-    AddCertificate(ListenerError),
+    AddCertificate(CertificateResolverError),
     #[error("could not remove certificate: {0}")]
-    RemoveCertificate(ListenerError),
+    RemoveCertificate(CertificateResolverError),
     #[error("could not replace certificate: {0}")]
-    ReplaceCertificate(ListenerError),
+    ReplaceCertificate(CertificateResolverError),
     #[error("wrong certificate fingerprint: {0}")]
-    WrongCertificateFingerprint(String),
+    WrongCertificateFingerprint(FromHexError),
     #[error("this request is not supported by the proxy")]
     UnsupportedMessage,
+    #[error("failed to acquire the lock, {0}")]
+    Lock(String),
 }
 
 use self::server::ListenToken;

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -909,7 +909,7 @@ impl Server {
                     ContentType::Clusters(ClusterInformations {
                         vec: self
                             .config_state
-                            .cluster_state(&cluster_id)
+                            .cluster_state(cluster_id)
                             .map_or(vec![], |ci| vec![ci]),
                     })
                     .into(),

--- a/lib/src/tls.rs
+++ b/lib/src/tls.rs
@@ -25,7 +25,7 @@ use sozu_command::{
     certificate::{
         get_cn_and_san_attributes, parse_pem, parse_x509, CertificateError, Fingerprint,
     },
-    proto::command::{AddCertificate, CertificateAndKey, ReplaceCertificate},
+    proto::command::{AddCertificate, CertificateAndKey, ReplaceCertificate, SocketAddress},
 };
 
 use crate::router::trie::{Key, KeyValue, TrieNode};
@@ -34,98 +34,19 @@ use crate::router::trie::{Key, KeyValue, TrieNode};
 // Default ParsedCertificateAndKey
 
 static DEFAULT_CERTIFICATE: Lazy<Option<Arc<CertifiedKey>>> = Lazy::new(|| {
-    let certificate_and_key = CertificateAndKey {
-        certificate: include_str!("../assets/certificate.pem").to_string(),
-        certificate_chain: vec![include_str!("../assets/certificate_chain.pem").to_string()],
-        key: include_str!("../assets/key.pem").to_string(),
-        versions: vec![],
-        names: vec![],
+    let add = AddCertificate {
+        certificate: CertificateAndKey {
+            certificate: include_str!("../assets/certificate.pem").to_string(),
+            certificate_chain: vec![include_str!("../assets/certificate_chain.pem").to_string()],
+            key: include_str!("../assets/key.pem").to_string(),
+            versions: vec![],
+            names: vec![],
+        },
+        address: SocketAddress::new_v4(0, 0, 0, 0, 8080), // not used anyway
+        expired_at: None,
     };
-
-    CertificateResolver::parse(&certificate_and_key)
-        .ok()
-        .map(|c| c.inner)
+    CertifiedKeyWrapper::try_from(&add).ok().map(|c| c.inner)
 });
-
-// -----------------------------------------------------------------------------
-// CertificateResolver trait
-
-pub trait ResolveCertificate {
-    type Error;
-
-    /// return the certificate in both a Rustls-usable form, and the pem format
-    fn get_certificate(&self, fingerprint: &Fingerprint) -> Option<CertifiedKeyWrapper>;
-
-    /// persist a certificate, after ensuring validity, and checking if it can replace another certificate
-    fn add_certificate(&mut self, opts: &AddCertificate) -> Result<Fingerprint, Self::Error>;
-
-    /// Delete a certificate from the resolver. May fail if there is no alternative for
-    // a domain name
-    fn remove_certificate(&mut self, opts: &Fingerprint) -> Result<(), Self::Error>;
-
-    /// Short-hand for `add_certificate` and then `remove_certificate`.
-    /// It is possible that the certificate will not be replaced, if the
-    /// new certificate does not match `add_certificate` rules.
-    fn replace_certificate(
-        &mut self,
-        opts: &ReplaceCertificate,
-    ) -> Result<Fingerprint, Self::Error> {
-        match Fingerprint::from_str(&opts.old_fingerprint) {
-            Ok(old_fingerprint) => self.remove_certificate(&old_fingerprint)?,
-            Err(err) => {
-                error!("failed to parse fingerprint, {}", err);
-            }
-        }
-
-        self.add_certificate(&AddCertificate {
-            address: opts.address.to_owned(),
-            certificate: opts.new_certificate.to_owned(),
-            expired_at: opts.new_expired_at.to_owned(),
-        })
-    }
-}
-
-// -----------------------------------------------------------------------------
-// CertificateOverride struct
-
-/// Enables use of certificates for more domain names
-#[derive(Clone, Debug)]
-pub struct CertificateOverride {
-    pub names: Option<HashSet<String>>,
-    pub expiration: Option<i64>,
-}
-
-impl From<&AddCertificate> for CertificateOverride {
-    fn from(opts: &AddCertificate) -> Self {
-        let mut names = None;
-        if !opts.certificate.names.is_empty() {
-            names = Some(opts.certificate.names.iter().cloned().collect())
-        }
-
-        Self {
-            names,
-            expiration: opts.expired_at.to_owned(),
-        }
-    }
-}
-
-/// A wrapper around the Rustls
-/// [`CertifiedKey` type](https://docs.rs/rustls/latest/rustls/sign/struct.CertifiedKey.html),
-/// stored and returned by the certificate resolver.
-#[derive(Clone)]
-pub struct CertifiedKeyWrapper {
-    inner: Arc<CertifiedKey>,
-}
-
-impl CertifiedKeyWrapper {
-    /// bytes of the pem formatted certificate, first of the chain
-    fn pem_bytes(&self) -> &[u8] {
-        self.inner.cert[0].as_ref()
-    }
-}
-
-// -----------------------------------------------------------------------------
-// CertificateResolverError enum
 
 #[derive(thiserror::Error, Debug)]
 pub enum CertificateResolverError {
@@ -135,21 +56,95 @@ pub enum CertificateResolverError {
     InvalidPrivateKey(String),
     #[error("empty key")]
     EmptyKeys,
-    #[error("certificate error: {0}")]
-    CertificateError(CertificateError),
+    #[error("error parsing x509 cert from bytes: {0}")]
+    ParseX509(CertificateError),
+    #[error("error parsing pem formated certificate from bytes: {0}")]
+    ParsePem(CertificateError),
+    #[error("error parsing overriding names in new certificate: {0}")]
+    ParseOverridingNames(CertificateError),
 }
 
-impl From<CertificateError> for CertificateResolverError {
-    fn from(value: CertificateError) -> Self {
-        Self::CertificateError(value)
+/// A wrapper around the Rustls
+/// [`CertifiedKey` type](https://docs.rs/rustls/latest/rustls/sign/struct.CertifiedKey.html),
+/// stored and returned by the certificate resolver.
+#[derive(Clone, Debug)]
+pub struct CertifiedKeyWrapper {
+    inner: Arc<CertifiedKey>,
+    /// domain names, override what can be found in the cert
+    names: Vec<String>,
+    expiration: i64,
+    fingerprint: Fingerprint,
+}
+
+/// Convert an AddCertificate request into the Rustls format.
+/// Support RSA and ECDSA certificates.
+impl TryFrom<&AddCertificate> for CertifiedKeyWrapper {
+    type Error = CertificateResolverError;
+
+    fn try_from(add: &AddCertificate) -> Result<Self, Self::Error> {
+        let cert = add.certificate.clone();
+
+        let pem =
+            parse_pem(cert.certificate.as_bytes()).map_err(CertificateResolverError::ParsePem)?;
+
+        let x509 = parse_x509(&pem.contents).map_err(CertificateResolverError::ParseX509)?;
+
+        let overriding_names = if add.certificate.names.is_empty() {
+            get_cn_and_san_attributes(&x509)
+        } else {
+            add.certificate.names.clone()
+        };
+
+        let expiration = add
+            .expired_at
+            .unwrap_or(x509.validity().not_after.timestamp());
+
+        let fingerprint = Fingerprint(Sha256::digest(&pem.contents).iter().cloned().collect());
+
+        let mut chain = vec![CertificateDer::from(pem.contents)];
+        for cert in &cert.certificate_chain {
+            let chain_link = parse_pem(cert.as_bytes())
+                .map_err(CertificateResolverError::ParsePem)?
+                .contents;
+
+            chain.push(CertificateDer::from(chain_link));
+        }
+
+        let mut key_reader = BufReader::new(cert.key.as_bytes());
+
+        let item = match rustls_pemfile::read_one(&mut key_reader)
+            .map_err(|_| CertificateResolverError::EmptyKeys)?
+        {
+            Some(item) => item,
+            None => return Err(CertificateResolverError::EmptyKeys),
+        };
+
+        let private_key = match item {
+            rustls_pemfile::Item::Pkcs1Key(rsa_key) => PrivateKeyDer::from(rsa_key),
+            rustls_pemfile::Item::Pkcs8Key(pkcs8_key) => PrivateKeyDer::from(pkcs8_key),
+            rustls_pemfile::Item::Sec1Key(ec_key) => PrivateKeyDer::from(ec_key),
+            _ => return Err(CertificateResolverError::EmptyKeys),
+        };
+
+        match any_supported_type(&private_key) {
+            Ok(signing_key) => {
+                let stored_certificate = CertifiedKeyWrapper {
+                    inner: Arc::new(CertifiedKey::new(chain, signing_key)),
+                    names: overriding_names,
+                    expiration,
+                    fingerprint,
+                };
+                Ok(stored_certificate)
+            }
+            Err(sign_error) => Err(CertificateResolverError::InvalidPrivateKey(
+                sign_error.to_string(),
+            )),
+        }
     }
 }
 
-// -----------------------------------------------------------------------------
-// CertificateResolver struct
-
 /// Parses and stores TLS certificates, makes them available to Rustls for TLS handshakes
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct CertificateResolver {
     /// all fingerprints of all
     pub domains: TrieNode<Fingerprint>,
@@ -157,80 +152,76 @@ pub struct CertificateResolver {
     certificates: HashMap<Fingerprint, CertifiedKeyWrapper>,
     /// map of domain_name -> all fingerprints linked to this domain name
     name_fingerprint_idx: HashMap<String, HashSet<Fingerprint>>,
-    /// map of fingerprint -> domain names to override
-    overrides: HashMap<Fingerprint, CertificateOverride>,
 }
 
-impl ResolveCertificate for CertificateResolver {
-    type Error = CertificateResolverError;
-
-    fn get_certificate(&self, fingerprint: &Fingerprint) -> Option<CertifiedKeyWrapper> {
+impl CertificateResolver {
+    /// return the certificate in the Rustls-usable form
+    pub fn get_certificate(&self, fingerprint: &Fingerprint) -> Option<CertifiedKeyWrapper> {
         self.certificates.get(fingerprint).map(ToOwned::to_owned)
     }
 
-    fn add_certificate(&mut self, opts: &AddCertificate) -> Result<Fingerprint, Self::Error> {
-        // Check if we could parse the certificate, chain and private key, if not just throw an
-        // error.
-        let certificate_to_add = Self::parse(&opts.certificate)?;
-        let fingerprint = fingerprint(certificate_to_add.pem_bytes());
-        if !opts.certificate.names.is_empty() || opts.expired_at.is_some() {
-            self.overrides
-                .insert(fingerprint.to_owned(), CertificateOverride::from(opts));
-        } else {
-            self.overrides.remove(&fingerprint);
-        }
+    /// persist a certificate, after ensuring validity, and checking if it can replace another certificate
+    pub fn add_certificate(
+        &mut self,
+        add: &AddCertificate,
+    ) -> Result<Fingerprint, CertificateResolverError> {
+        let cert_to_add = CertifiedKeyWrapper::try_from(add)?;
 
-        let (should_insert, certificates_to_remove) =
-            self.should_insert(&fingerprint, &certificate_to_add)?;
+        let (should_insert, outdated_certs) = self.should_insert(&cert_to_add)?;
+
         if !should_insert {
             // if we do not need to insert the fingerprint just return the fingerprint
-            return Ok(fingerprint);
+            return Ok(cert_to_add.fingerprint);
         }
 
-        let new_names = match self.get_names_override(&fingerprint) {
-            Some(names) => names,
-            None => self.certificate_names(certificate_to_add.pem_bytes())?,
-        };
+        for new_name in &cert_to_add.names {
+            self.domains.remove(&new_name.to_owned().into_bytes());
 
-        self.certificates
-            .insert(fingerprint.to_owned(), certificate_to_add);
-
-        for new_name in new_names {
-            self.domains
-                .insert(new_name.to_owned().into_bytes(), fingerprint.to_owned());
+            self.domains.insert(
+                new_name.to_owned().into_bytes(),
+                cert_to_add.fingerprint.to_owned(),
+            );
 
             self.name_fingerprint_idx
-                .entry(new_name)
+                .entry(new_name.to_owned())
                 .or_insert_with(HashSet::new)
-                .insert(fingerprint.to_owned());
+                .insert(cert_to_add.fingerprint.to_owned());
         }
 
-        for (fingerprint, names) in &certificates_to_remove {
-            for name in names {
-                if let Some(fingerprints) = self.name_fingerprint_idx.get_mut(name) {
-                    fingerprints.remove(fingerprint);
+        for name in &cert_to_add.names {
+            if let Some(fingerprints) = self.name_fingerprint_idx.get_mut(name) {
+                for outdated in &outdated_certs {
+                    fingerprints.remove(outdated);
                 }
             }
-
-            self.certificates.remove(fingerprint);
         }
 
-        Ok(fingerprint.to_owned())
+        for outdated in &outdated_certs {
+            self.certificates.remove(outdated);
+        }
+
+        self.certificates
+            .insert(cert_to_add.fingerprint.to_owned(), cert_to_add.clone());
+
+        Ok(cert_to_add.fingerprint.to_owned())
     }
 
-    fn remove_certificate(&mut self, fingerprint: &Fingerprint) -> Result<(), Self::Error> {
+    /// Delete a certificate from the resolver. May fail if there is no alternative for
+    // a domain name
+    pub fn remove_certificate(
+        &mut self,
+        fingerprint: &Fingerprint,
+    ) -> Result<(), CertificateResolverError> {
         if let Some(certificate_to_remove) = self.get_certificate(fingerprint) {
-            let names = match self.get_names_override(fingerprint) {
-                Some(names) => names,
-                None => self.certificate_names(certificate_to_remove.pem_bytes())?,
-            };
-
-            for name in &names {
-                if let Some(fingerprints) = self.name_fingerprint_idx.get_mut(name) {
+            for name in certificate_to_remove.names {
+                if let Some(fingerprints) = self.name_fingerprint_idx.get_mut(&name) {
                     fingerprints.remove(fingerprint);
 
-                    if fingerprints.is_empty() {
-                        self.domains.domain_remove(&name.to_owned().into_bytes());
+                    self.domains.domain_remove(&name.clone().into_bytes());
+
+                    if let Some(fingerprint) = fingerprints.iter().next() {
+                        self.domains
+                            .insert(name.into_bytes(), fingerprint.to_owned());
                     }
                 }
             }
@@ -240,15 +231,31 @@ impl ResolveCertificate for CertificateResolver {
 
         Ok(())
     }
-}
 
-/// hashes bytes of the pem-formatted certificate for storage in the hashmap
-fn fingerprint(bytes: &[u8]) -> Fingerprint {
-    Fingerprint(Sha256::digest(bytes).iter().cloned().collect())
-}
+    /// Short-hand for `add_certificate` and then `remove_certificate`.
+    /// It is possible that the certificate will not be replaced, if the
+    /// new certificate does not match `add_certificate` rules.
+    pub fn replace_certificate(
+        &mut self,
+        replace: &ReplaceCertificate,
+    ) -> Result<Fingerprint, CertificateResolverError> {
+        match Fingerprint::from_str(&replace.old_fingerprint) {
+            Ok(old_fingerprint) => self.remove_certificate(&old_fingerprint)?,
+            Err(err) => {
+                error!("failed to parse fingerprint, {}", err);
+            }
+        }
 
-impl CertificateResolver {
-    /// return all fingerprints that are available, provided at least one name is given
+        self.add_certificate(&AddCertificate {
+            address: replace.address.to_owned(),
+            certificate: replace.new_certificate.to_owned(),
+            expired_at: replace.new_expired_at.to_owned(),
+        })
+    }
+
+    /// return all fingerprints that are available for these domain names,
+    /// provided at least one name is given
+    #[cfg(test)]
     fn find_certificates_by_names(
         &self,
         names: &HashSet<String>,
@@ -265,148 +272,63 @@ impl CertificateResolver {
         Ok(fingerprints)
     }
 
-    /// return the hashset of subjects that the certificate is able to handle, by
-    /// parsing the pem file and scrapping the information
+    /// return the hashset of subjects that the certificate is able to handle
+    #[cfg(test)]
     fn certificate_names(
         &self,
-        pem_bytes: &[u8],
+        fingerprint: &Fingerprint,
     ) -> Result<HashSet<String>, CertificateResolverError> {
-        let fingerprint = fingerprint(pem_bytes);
-        if let Some(certificate_override) = self.overrides.get(&fingerprint) {
-            if let Some(names) = &certificate_override.names {
-                return Ok(names.to_owned());
-            }
+        if let Some(cert) = self.certificates.get(fingerprint) {
+            return Ok(cert.names.iter().cloned().collect());
         }
-
-        get_cn_and_san_attributes(pem_bytes)
-            .map_err(CertificateResolverError::InvalidCommonNameAndSubjectAlternateNames)
+        Ok(HashSet::new())
     }
 
-    /// Parse a raw certificate into the Rustls format.
-    /// Parses RSA and ECDSA certificates.
-    fn parse(
-        certificate_and_key: &CertificateAndKey,
-    ) -> Result<CertifiedKeyWrapper, CertificateResolverError> {
-        let certificate_pem =
-            sozu_command::certificate::parse_pem(certificate_and_key.certificate.as_bytes())?;
-
-        let mut chain = vec![CertificateDer::from(certificate_pem.contents)];
-        for cert in &certificate_and_key.certificate_chain {
-            let chain_link = parse_pem(cert.as_bytes())?.contents;
-
-            chain.push(CertificateDer::from(chain_link));
-        }
-
-        let mut key_reader = BufReader::new(certificate_and_key.key.as_bytes());
-
-        let item = match rustls_pemfile::read_one(&mut key_reader)
-            .map_err(|_| CertificateResolverError::EmptyKeys)?
-        {
-            Some(item) => item,
-            None => return Err(CertificateResolverError::EmptyKeys),
-        };
-
-        let private_key = match item {
-            rustls_pemfile::Item::Pkcs1Key(rsa_key) => PrivateKeyDer::from(rsa_key),
-            rustls_pemfile::Item::Pkcs8Key(pkcs8_key) => PrivateKeyDer::from(pkcs8_key),
-            rustls_pemfile::Item::Sec1Key(ec_key) => PrivateKeyDer::from(ec_key),
-            _ => return Err(CertificateResolverError::EmptyKeys),
-        };
-        match any_supported_type(&private_key) {
-            Ok(signing_key) => {
-                let stored_certificate = CertifiedKeyWrapper {
-                    inner: Arc::new(CertifiedKey::new(chain, signing_key)),
-                };
-                Ok(stored_certificate)
-            }
-            Err(sign_error) => Err(CertificateResolverError::InvalidPrivateKey(
-                sign_error.to_string(),
-            )),
-        }
-    }
-}
-
-impl CertificateResolver {
+    /// check the certificate expiration and related certificates,
+    /// return a list of outdated certificates that should be removed
     fn should_insert(
         &self,
-        fingerprint: &Fingerprint,
         candidate_cert: &CertifiedKeyWrapper,
-    ) -> Result<(bool, HashMap<Fingerprint, HashSet<String>>), CertificateResolverError> {
-        let x509 = parse_x509(candidate_cert.pem_bytes())?;
+    ) -> Result<(bool, Vec<Fingerprint>), CertificateResolverError> {
+        let mut should_insert = false;
 
-        // We need to know if the new certificate can replace an already existing one.
-        let new_names = match self.get_names_override(fingerprint) {
-            Some(names) => names,
-            None => self.certificate_names(candidate_cert.pem_bytes())?,
-        };
+        let mut related_certificates = HashSet::new();
 
-        let expiration = self
-            .get_expiration_override(fingerprint)
-            .unwrap_or_else(|| x509.validity().not_after.timestamp());
-
-        let fingerprints = self.find_certificates_by_names(&new_names)?;
-        let mut certificates = HashMap::new();
-        for fingerprint in &fingerprints {
-            if let Some(cert) = self.get_certificate(fingerprint) {
-                certificates.insert(fingerprint, cert);
+        for name in &candidate_cert.names {
+            match self.name_fingerprint_idx.get(name) {
+                None => should_insert = true,
+                Some(fingerprints) if fingerprints.is_empty() => should_insert = true,
+                Some(fingerprints) => related_certificates.extend(fingerprints),
             }
         }
 
-        let mut should_insert = false;
-        let mut certificates_to_remove = HashMap::new();
-        let mut certificates_names = HashSet::new();
-        for (fingerprint, stored_certificate) in certificates {
-            let x509 = parse_x509(stored_certificate.pem_bytes())?;
+        let mut outdated_certificates = Vec::new();
 
-            let certificate_names = match self.get_names_override(fingerprint) {
-                Some(names) => names,
-                None => self.certificate_names(stored_certificate.pem_bytes())?,
+        for fingerprint in related_certificates {
+            let related_certificate = match self.certificates.get(fingerprint) {
+                Some(cert) => cert,
+                None => {
+                    error!("certificates and fingerprint hashmaps are desynchronized");
+                    continue;
+                }
             };
 
-            let certificate_expiration = self
-                .get_expiration_override(fingerprint)
-                .unwrap_or_else(|| x509.validity().not_after.timestamp());
-
-            let extra_names = certificate_names
-                .difference(&new_names)
-                .collect::<HashSet<_>>();
-
-            // if the certificate has at least the same name or less and the expiration date
-            // is closer than the new one. We could remove it and allow the new insertion.
-            if extra_names.is_empty() && certificate_expiration < expiration {
-                certificates_to_remove.insert(fingerprint.to_owned(), certificate_names.to_owned());
-                should_insert = true;
+            if related_certificate.expiration > candidate_cert.expiration {
+                continue;
             }
 
-            // We keep a track of all name of certificates that match our query to
-            // check, if the new certificate provide an extra domain which is not
-            // already exposed
-            for name in certificate_names {
-                certificates_names.insert(name);
+            for name in &related_certificate.names {
+                if !candidate_cert.names.contains(name) {
+                    continue;
+                }
             }
+
+            should_insert = true;
+
+            outdated_certificates.push(fingerprint.clone());
         }
 
-        // In the case where we do not insert the certificate, because there is
-        // no additional value, we have to check whether it provides an extra domain
-        // name not registered yet.
-        let diff: HashSet<&String> = new_names.difference(&certificates_names).collect();
-        if !should_insert && diff.is_empty() {
-            // We already have all domain names registered and there is no update
-            // for expiration date of certificate. So, skipping the update.
-            return Ok((false, certificates_to_remove));
-        }
-
-        Ok((true, certificates_to_remove))
-    }
-
-    fn get_expiration_override(&self, fingerprint: &Fingerprint) -> Option<i64> {
-        self.overrides.get(fingerprint).and_then(|co| co.expiration)
-    }
-
-    fn get_names_override(&self, fingerprint: &Fingerprint) -> Option<HashSet<String>> {
-        self.overrides
-            .get(fingerprint)
-            .and_then(|co| co.names.to_owned())
+        Ok((should_insert, outdated_certificates))
     }
 
     pub fn domain_lookup(
@@ -422,9 +344,9 @@ impl CertificateResolver {
 // MutexWrappedCertificateResolver struct
 
 #[derive(Default)]
-pub struct MutexWrappedCertificateResolver(pub Mutex<CertificateResolver>);
+pub struct MutexCertificateResolver(pub Mutex<CertificateResolver>);
 
-impl ResolvesServerCert for MutexWrappedCertificateResolver {
+impl ResolvesServerCert for MutexCertificateResolver {
     fn resolve(&self, client_hello: ClientHello) -> Option<Arc<CertifiedKey>> {
         let server_name = client_hello.server_name();
         let sigschemes = client_hello.signature_schemes();
@@ -468,7 +390,7 @@ impl ResolvesServerCert for MutexWrappedCertificateResolver {
     }
 }
 
-impl Debug for MutexWrappedCertificateResolver {
+impl Debug for MutexCertificateResolver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("MutexWrappedCertificateResolver")
     }
@@ -485,13 +407,10 @@ mod tests {
         time::{Duration, SystemTime},
     };
 
-    use super::{fingerprint, CertificateResolver, ResolveCertificate};
+    use super::CertificateResolver;
 
     use rand::{seq::SliceRandom, thread_rng};
-    use sozu_command::{
-        certificate::parse_pem,
-        proto::command::{AddCertificate, CertificateAndKey, SocketAddress},
-    };
+    use sozu_command::proto::command::{AddCertificate, CertificateAndKey, SocketAddress};
 
     #[test]
     fn lifecycle() -> Result<(), Box<dyn Error + Send + Sync>> {
@@ -503,13 +422,13 @@ mod tests {
             ..Default::default()
         };
 
-        let pem = parse_pem(certificate_and_key.certificate.as_bytes())?;
-
-        let fingerprint = resolver.add_certificate(&AddCertificate {
-            address,
-            certificate: certificate_and_key,
-            expired_at: None,
-        })?;
+        let fingerprint = resolver
+            .add_certificate(&AddCertificate {
+                address,
+                certificate: certificate_and_key,
+                expired_at: None,
+            })
+            .expect("could not add certificate");
 
         if resolver.get_certificate(&fingerprint).is_none() {
             return Err("failed to retrieve certificate".into());
@@ -519,7 +438,7 @@ mod tests {
             return Err(format!("the certificate must not been removed, {err}").into());
         }
 
-        let names = resolver.certificate_names(&pem.contents)?;
+        let names = resolver.certificate_names(&fingerprint)?;
         if !resolver.find_certificates_by_names(&names)?.is_empty()
             && resolver.get_certificate(&fingerprint).is_some()
         {
@@ -540,8 +459,6 @@ mod tests {
             ..Default::default()
         };
 
-        let pem = parse_pem(certificate_and_key.certificate.as_bytes())?;
-
         let fingerprint = resolver.add_certificate(&AddCertificate {
             address,
             certificate: certificate_and_key,
@@ -561,14 +478,76 @@ mod tests {
         }
 
         if let Err(err) = resolver.remove_certificate(&fingerprint) {
-            return Err(format!("the certificate must not been removed, {err}").into());
+            return Err(format!("the certificate could not be removed, {err}").into());
         }
 
-        let names = resolver.certificate_names(&pem.contents)?;
+        let names = resolver.certificate_names(&fingerprint)?;
         if !resolver.find_certificates_by_names(&names)?.is_empty()
             && resolver.get_certificate(&fingerprint).is_some()
         {
-            return Err("We have retrieve the certificate that should be deleted".into());
+            return Err("We have retrieved the certificate that should be deleted".into());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn properly_replace_outdated_cert() -> Result<(), Box<dyn Error + Send + Sync>> {
+        let address = SocketAddress::new_v4(127, 0, 0, 1, 8080);
+        let mut resolver = CertificateResolver::default();
+
+        let first_certificate = CertificateAndKey {
+            certificate: String::from(include_str!("../assets/tests/certificate-1y.pem")),
+            key: String::from(include_str!("../assets/tests/key.pem")),
+            names: vec!["localhost".into()],
+            ..Default::default()
+        };
+        let first = resolver.add_certificate(&AddCertificate {
+            address: address.clone(),
+            certificate: first_certificate,
+            expired_at: None,
+        })?;
+        if resolver.get_certificate(&first).is_none() {
+            return Err("failed to retrieve first certificate".into());
+        }
+        match resolver.domain_lookup("localhost".as_bytes(), true) {
+            Some((_, fingerprint)) if fingerprint == &first => {}
+            Some((domain, fingerprint)) => {
+                return Err(format!(
+                    "failed to lookup first inserted certificate. domain: {:?}, fingerprint: {}",
+                    domain, fingerprint
+                )
+                .into())
+            }
+            _ => return Err("failed to lookup first inserted certificate".into()),
+        }
+
+        let second_certificate = CertificateAndKey {
+            certificate: String::from(include_str!("../assets/tests/certificate-2y.pem")),
+            key: String::from(include_str!("../assets/tests/key.pem")),
+            names: vec!["localhost".into(), "lolcatho.st".into()],
+            ..Default::default()
+        };
+        let second = resolver.add_certificate(&AddCertificate {
+            address,
+            certificate: second_certificate,
+            expired_at: None,
+        })?;
+
+        if resolver.get_certificate(&second).is_none() {
+            return Err("failed to retrieve second certificate".into());
+        }
+
+        match resolver.domain_lookup("localhost".as_bytes(), true) {
+            Some((_, fingerprint)) if fingerprint == &second => {}
+            Some((domain, fingerprint)) => {
+                return Err(format!(
+                    "failed to lookup second inserted certificate. domain: {:?}, fingerprint: {}",
+                    domain, fingerprint
+                )
+                .into())
+            }
+            _ => return Err("the former certificate has not been overriden by the new one".into()),
         }
 
         Ok(())
@@ -586,14 +565,13 @@ mod tests {
             key: String::from(include_str!("../assets/tests/key-1y.pem")),
             ..Default::default()
         };
-        let pem = parse_pem(certificate_and_key_1y.certificate.as_bytes())?;
 
-        let names_1y = resolver.certificate_names(&pem.contents)?;
         let fingerprint_1y = resolver.add_certificate(&AddCertificate {
             address: address.clone(),
             certificate: certificate_and_key_1y,
             expired_at: None,
         })?;
+        let names_1y = resolver.certificate_names(&fingerprint_1y)?;
 
         if resolver.get_certificate(&fingerprint_1y).is_none() {
             return Err("failed to retrieve certificate".into());
@@ -652,9 +630,6 @@ mod tests {
             ..Default::default()
         };
 
-        let pem = parse_pem(certificate_and_key_1y.certificate.as_bytes())?;
-
-        let names_1y = resolver.certificate_names(&pem.contents)?;
         let fingerprint_1y = resolver.add_certificate(&AddCertificate {
             address: address.clone(),
             certificate: certificate_and_key_1y,
@@ -664,6 +639,7 @@ mod tests {
                 .as_secs() as i64,
             ),
         })?;
+        let names_1y = resolver.certificate_names(&fingerprint_1y)?;
 
         if resolver.get_certificate(&fingerprint_1y).is_none() {
             return Err("failed to retrieve certificate".into());
@@ -747,11 +723,6 @@ mod tests {
         ];
 
         let mut fingerprints = vec![];
-        for certificate in &certificates {
-            let pem = parse_pem(certificate.certificate.as_bytes())?;
-
-            fingerprints.push(fingerprint(&pem.contents));
-        }
 
         // randomize entries
         certificates.shuffle(&mut thread_rng());
@@ -762,11 +733,11 @@ mod tests {
         let mut resolver = CertificateResolver::default();
 
         for certificate in &certificates {
-            resolver.add_certificate(&AddCertificate {
+            fingerprints.push(resolver.add_certificate(&AddCertificate {
                 address: address.clone(),
                 certificate: certificate.to_owned(),
                 expired_at: None,
-            })?;
+            })?);
         }
 
         let mut names = HashSet::new();


### PR DESCRIPTION
In production, Sōzu would fail when handling the AddCertificate command, in case a certificate with a concurrent domain name was present. The candidate certificate did not overwrite the outdated certificate in the TrieNode structure that maps domain names to certificate fingerprints.

This PR operates an vast rewrite of the CertificateResolver, its types and methods, and fixes the issue. On top of that, a rare and highly unlikely bug have been prevented, in case one domain name has two valid certificates bound to it.

todo:

- [x] squash & co-author commits