### PR TITLE
sort cluster information alphabetically when displaying

### DIFF
--- a/command/src/proto/display.rs
+++ b/command/src/proto/display.rs
@@ -611,11 +611,11 @@ fn print_cluster_infos(worker_responses: &WorkerResponses) -> Result<(), Display
 
     let worker_ids: HashSet<&String> = worker_responses.map.keys().collect();
 
-    let mut cluster_infos = HashMap::new();
-    let mut http_frontends = HashMap::new();
-    let mut https_frontends = HashMap::new();
-    let mut tcp_frontends = HashMap::new();
-    let mut backends = HashMap::new();
+    let mut cluster_infos = BTreeMap::new();
+    let mut http_frontends = BTreeMap::new();
+    let mut https_frontends = BTreeMap::new();
+    let mut tcp_frontends = BTreeMap::new();
+    let mut backends = BTreeMap::new();
 
     for (worker_id, response_content) in worker_responses.map.iter() {
         if let Some(ContentType::Clusters(clusters)) = &response_content.content_type {


### PR DESCRIPTION
Using BTreeMaps instead of HashMaps suffices to sort items alphabetically. For instance, this list of backends in a `config.toml` for a given cluster:

```yaml
backends = [
    { address = "127.0.0.1:1051", backend_id = "a_backend_1" },
    { address = "127.0.0.1:1052", backend_id = "c_backend_2" },
    { address = "127.0.0.1:1053", backend_id = "b_backend_3" },
    { address = "127.0.0.1:1054", backend_id = "aa_backend_4" },
]
```

will be displayed like this:

```
backends configuration:

┌──────────────┬────────────────┬────────┬───┬───┬──────┐
│ backend id   │ IP address     │ Backup │ 0 │ 1 │ main │
├──────────────┼────────────────┼────────┼───┼───┼──────┤
│ a_backend_1  │ 127.0.0.1:1051 │        │ X │ X │ X    │
├──────────────┼────────────────┼────────┼───┼───┼──────┤
│ aa_backend_4 │ 127.0.0.1:1054 │        │ X │ X │ X    │
├──────────────┼────────────────┼────────┼───┼───┼──────┤
│ b_backend_3  │ 127.0.0.1:1053 │        │ X │ X │ X    │
├──────────────┼────────────────┼────────┼───┼───┼──────┤
│ c_backend_2  │ 127.0.0.1:1052 │        │ X │ X │ X    │
└──────────────┴────────────────┴────────┴───┴───┴──────┘
```

In the same way, the frontends of a cluster will be sorted by hostname:

```
┌───────────┬─────────────────┬───────────────┬───┬───┬──────┐
│ id        │ hostname        │ path          │ 0 │ 1 │ main │
├───────────┼─────────────────┼───────────────┼───┼───┼──────┤
│ MyCluster │ abracadabra.com │ prefix '/api' │ X │ X │ X    │
├───────────┼─────────────────┼───────────────┼───┼───┼──────┤
│ MyCluster │ blabla.com      │ prefix '/api' │ X │ X │ X    │
├───────────┼─────────────────┼───────────────┼───┼───┼──────┤
│ MyCluster │ localhost       │ prefix '/api' │ X │ X │ X    │
└───────────┴─────────────────┴───────────────┴───┴───┴──────┘
```