### PR TITLE
Fix some timeout related issues

### DIFF
--- a/bin/src/util.rs
+++ b/bin/src/util.rs
@@ -162,7 +162,6 @@ pub unsafe fn get_executable_path() -> Result<String, UtilError> {
     Ok(path_str)
 }
 
-
 #[cfg(target_os = "macos")]
 extern "C" {
     pub fn _NSGetExecutablePath(buf: *mut libc::c_char, size: *mut u32) -> i32;

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -95,6 +95,10 @@ impl HttpContext {
                 .map(ToOwned::to_owned);
         }
 
+        if self.method == Some(Method::Get) && request.body_size == kawa::BodySize::Empty {
+            request.parsing_phase = kawa::ParsingPhase::Terminated;
+        }
+
         let public_ip = self.public_address.ip();
         let public_port = self.public_address.port();
         let proto = match self.protocol {
@@ -336,5 +340,17 @@ impl HttpContext {
             key: kawa::Store::Static(b"Sozu-Id"),
             val: kawa::Store::from_string(self.id.to_string()),
         }));
+    }
+
+    pub fn reset(&mut self) {
+        self.keep_alive_backend = true;
+        self.keep_alive_frontend = true;
+        self.sticky_session_found = None;
+        self.method = None;
+        self.authority = None;
+        self.path = None;
+        self.status = None;
+        self.reason = None;
+        self.user_agent = None;
     }
 }


### PR DESCRIPTION
- Explicitely use the frontend timeout on keep-alive (may introduce a specific one later)
- Put timeout responsibility on the backend whenever we read the first bytes
- Mark as terminated GET requests with no length (we assume no body)
- Properly reset the HttpContext of the session