### PR TITLE
Retry connection with the backend of access logs 

### DIFF
--- a/bin/src/command/mod.rs
+++ b/bin/src/command/mod.rs
@@ -11,7 +11,7 @@ use mio::net::UnixListener;
 
 use sozu_command_lib::{
     config::{Config, ConfigError},
-    logging::setup_logging_with_config,
+    logging::{setup_logging_with_config, LogError},
 };
 
 use crate::{
@@ -52,6 +52,8 @@ pub enum StartError {
     SetPermissions(IoError),
     #[error("could not launch new worker: {0}")]
     LaunchWorker(ServerError),
+    #[error("could not setup the logger: {0}")]
+    SetupLogging(LogError),
 }
 
 pub fn begin_main_process(args: &Args) -> Result<(), StartError> {
@@ -59,7 +61,7 @@ pub fn begin_main_process(args: &Args) -> Result<(), StartError> {
 
     let config = Config::load_from_path(config_file_path).map_err(StartError::LoadConfig)?;
 
-    setup_logging_with_config(&config, "MAIN");
+    setup_logging_with_config(&config, "MAIN").map_err(StartError::SetupLogging)?;
     info!("Starting up");
     setup_metrics(&config).map_err(StartError::SetupMetrics)?;
     write_pid_file(&config).map_err(StartError::WritePidFile)?;

--- a/bin/src/ctl/command.rs
+++ b/bin/src/ctl/command.rs
@@ -162,7 +162,11 @@ impl CommandManager {
             let config = self.config.clone();
 
             upgrade_jobs.push(std::thread::spawn(move || {
-                setup_logging_with_config(&config, &format!("UPGRADE-WRK-{}", worker.id));
+                if let Err(e) =
+                    setup_logging_with_config(&config, &format!("UPGRADE-WRK-{}", worker.id))
+                {
+                    error!("Could not setup logging: {}", e);
+                }
 
                 info!("creating channel to upgrade worker {}", worker.id);
                 let channel = match create_channel(&config) {

--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -7,7 +7,7 @@ use sozu_command_lib::{
     certificate::CertificateError,
     channel::{Channel, ChannelError},
     config::{Config, ConfigError},
-    logging::setup_logging_with_config,
+    logging::{setup_logging_with_config, LogError},
     proto::{
         command::{Request, Response},
         DisplayError,
@@ -53,6 +53,8 @@ pub enum CtlError {
     NeedClusterDomain,
     #[error("wrong response from Sōzu: {0:?}")]
     WrongResponse(Response),
+    #[error("could not setup the logger: {0}")]
+    SetupLogging(LogError),
 }
 
 pub struct CommandManager {
@@ -70,7 +72,7 @@ pub fn ctl(args: cli::Args) -> Result<(), CtlError> {
 
     // prevent logging for json responses for a clean output
     if !args.json {
-        setup_logging_with_config(&config, "CTL");
+        setup_logging_with_config(&config, "CTL").map_err(CtlError::SetupLogging)?;
     }
 
     // If the command is `config check` then exit because if we are here, the configuration is valid

--- a/bin/src/upgrade.rs
+++ b/bin/src/upgrade.rs
@@ -18,7 +18,7 @@ use tempfile::tempfile;
 
 use sozu_command_lib::{
     channel::{Channel, ChannelError},
-    logging::setup_logging_with_config,
+    logging::{setup_logging_with_config, LogError},
 };
 
 use crate::{
@@ -69,6 +69,8 @@ pub enum UpgradeError {
     CreateHub(HubError),
     #[error("could not enable cloexec after upgrade: {0}")]
     EnableCloexec(ServerError),
+    #[error("could not setup the logger: {0}")]
+    SetupLogging(LogError),
 }
 
 /// unix-forks the main process
@@ -180,7 +182,7 @@ pub fn begin_new_main_process(
 
     println!("Setting up logging");
 
-    setup_logging_with_config(&config, "MAIN");
+    setup_logging_with_config(&config, "MAIN").map_err(UpgradeError::SetupLogging)?;
     util::setup_metrics(&config).map_err(UpgradeError::SetupMetrics)?;
 
     let mut command_hub =

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -22,7 +22,7 @@ use tempfile::tempfile;
 use sozu_command_lib::{
     channel::{Channel, ChannelError},
     config::Config,
-    logging::{setup_logging, AccessLogFormat},
+    logging::{setup_logging, AccessLogFormat, LogError},
     proto::command::{ServerConfig, WorkerRequest, WorkerResponse},
     ready::Ready,
     request::{read_initial_state_from_file, RequestError},
@@ -74,6 +74,8 @@ pub enum WorkerError {
         state: String,
         channel_err: ChannelError,
     },
+    #[error("could not setup the logger: {0}")]
+    SetupLogging(LogError),
 }
 
 /// called within a worker process, this starts the actual proxy
@@ -117,7 +119,8 @@ pub fn begin_worker_process(
         Some(worker_config.log_colored),
         &worker_config.log_level,
         &worker_id,
-    );
+    )
+    .map_err(WorkerError::SetupLogging)?;
 
     trace!(
         "Creating worker {} with config: {:#?}",

--- a/command/examples/bench_logger.rs
+++ b/command/examples/bench_logger.rs
@@ -53,7 +53,9 @@ fn main() {
     eprintln!(
         "n={n}, pre_generate={pre_generate}, target={target}, colored={colored}, filter={filter}"
     );
-    setup_logging(&target, colored, None, None, None, &filter, "WRK-01");
+    if let Err(e) = setup_logging(&target, colored, None, None, None, &filter, "WRK-01") {
+        println!("could not setup logging: {}", e);
+    }
 
     let mut pre_generated_log_iterator;
     let mut log_iterator = std::iter::repeat(())

--- a/command/examples/bench_logger.rs
+++ b/command/examples/bench_logger.rs
@@ -53,8 +53,8 @@ fn main() {
     eprintln!(
         "n={n}, pre_generate={pre_generate}, target={target}, colored={colored}, filter={filter}"
     );
-    if let Err(e) = setup_logging(&target, colored, None, None, None, &filter, "WRK-01") {
-        println!("could not setup logging: {}", e);
+    if let Err(e) = setup_logging(&target, colored, None, None, None, &filter, "BENCH") {
+        println!("Could not setup logging: {}", e);
     }
 
     let mut pre_generated_log_iterator;

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -172,6 +172,7 @@ pub const MAX_LOOP_ITERATIONS: usize = 100000;
 /// with little influence on performance. Defaults to 4.
 pub const DEFAULT_SEND_TLS_13_TICKETS: u64 = 4;
 
+/// for both logs and access logs
 pub const DEFAULT_LOG_TARGET: &str = "stdout";
 
 #[derive(Debug)]

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -172,6 +172,8 @@ pub const MAX_LOOP_ITERATIONS: usize = 100000;
 /// with little influence on performance. Defaults to 4.
 pub const DEFAULT_SEND_TLS_13_TICKETS: u64 = 4;
 
+pub const DEFAULT_LOG_TARGET: &str = "stdout";
+
 #[derive(Debug)]
 pub enum IncompatibilityKind {
     PublicAddress,

--- a/command/src/logging/mod.rs
+++ b/command/src/logging/mod.rs
@@ -8,13 +8,25 @@ pub mod display;
 #[macro_use]
 pub mod logs;
 
+use std::net::AddrParseError;
+
 pub use crate::logging::access_logs::*;
 pub use crate::logging::logs::*;
 
 #[derive(thiserror::Error, Debug)]
 pub enum LogError {
     #[error("invalid log target {0}: {1}")]
-    InvalidLogTarget(String, String),
+    InvalidLogTarget(String, &'static str),
+    #[error("invalid log target {0}: {1}")]
+    InvalidSocketAddress(String, AddrParseError),
+    #[error("could not open log file {0}: {1}")]
+    OpenFile(String, std::io::Error),
     #[error("could not connect to TCP socket {0}: {1}")]
     TcpConnect(String, std::io::Error),
+    #[error("could not create unbound UNIX datagram: {0}")]
+    CreateUnixSocket(std::io::Error),
+    #[error("could not connect to UNIX datagram {0}: {1}")]
+    ConnectToUnixSocket(String, std::io::Error),
+    #[error("could not bind to UDP socket: {0}")]
+    UdpBind(std::io::Error),
 }

--- a/command/src/logging/mod.rs
+++ b/command/src/logging/mod.rs
@@ -10,3 +10,11 @@ pub mod logs;
 
 pub use crate::logging::access_logs::*;
 pub use crate::logging::logs::*;
+
+#[derive(thiserror::Error, Debug)]
+pub enum LogError {
+    #[error("invalid log target {0}: {1}")]
+    InvalidLogTarget(String, String),
+    #[error("could not connect to TCP socket {0}: {1}")]
+    TcpConnect(String, std::io::Error),
+}

--- a/e2e/src/sozu/worker.rs
+++ b/e2e/src/sozu/worker.rs
@@ -133,7 +133,9 @@ impl Worker {
         println!("Setting up logging");
 
         let server_job = thread::spawn(move || {
-            setup_default_logging(false, "error", &thread_name);
+            if let Err(e) = setup_default_logging(false, "error", &thread_name) {
+                println!("could not setup logging: {e}");
+            }
             let mut server = Server::try_new_from_config(
                 cmd_worker_to_main,
                 thread_scm_worker_to_main,

--- a/e2e/src/tests/tests.rs
+++ b/e2e/src/tests/tests.rs
@@ -629,7 +629,9 @@ pub fn try_hard_or_soft_stop(soft: bool) -> State {
 }
 
 fn try_http_behaviors() -> State {
-    setup_default_logging(false, "debug", "BEHAVE-OUT");
+    if let Err(e) = setup_default_logging(false, "debug", "BEHAVE-OUT") {
+        println!("could not setup default logging: {e}");
+    }
 
     info!("starting up");
 
@@ -1121,7 +1123,9 @@ pub fn try_blue_geen() -> State {
 }
 
 pub fn try_keep_alive() -> State {
-    setup_default_logging(false, "debug", "KA-OUT");
+    if let Err(e) = setup_default_logging(false, "debug", "KA-OUT") {
+        println!("could not setup default logging: {e}");
+    }
 
     let front_address = create_local_address();
 

--- a/lib/examples/http.rs
+++ b/lib/examples/http.rs
@@ -15,7 +15,7 @@ use sozu_command_lib::{
 };
 
 fn main() -> anyhow::Result<()> {
-    setup_default_logging(true, "info", "EXAMPLE");
+    setup_default_logging(true, "info", "EXAMPLE").with_context(|| "could not setup logging")?;
 
     info!("starting up");
 

--- a/lib/examples/https.rs
+++ b/lib/examples/https.rs
@@ -18,7 +18,7 @@ use sozu_command_lib::{
 };
 
 fn main() -> anyhow::Result<()> {
-    setup_default_logging(true, "info", "EXAMPLE");
+    setup_default_logging(true, "info", "EXAMPLE").with_context(|| "could not setup logging")?;
 
     info!("MAIN\tstarting up");
 

--- a/lib/examples/tcp.rs
+++ b/lib/examples/tcp.rs
@@ -16,7 +16,7 @@ use sozu_command_lib::{
 };
 
 fn main() -> anyhow::Result<()> {
-    setup_default_logging(true, "info", "EXAMPLE");
+    setup_default_logging(true, "info", "EXAMPLE").with_context(|| "could not setup logging")?;
 
     info!("starting up");
 
@@ -30,7 +30,9 @@ fn main() -> anyhow::Result<()> {
             address: SocketAddress::new_v4(127, 0, 0, 1, 8080),
             ..Default::default()
         };
-        setup_default_logging(true, "debug", "TCP");
+        if let Err(e) = setup_default_logging(true, "debug", "TCP") {
+            println!("could not setup logging: {e}");
+        }
         sozu_lib::tcp::testing::start_tcp_worker(listener, max_buffers, buffer_size, channel);
     });
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -226,7 +226,7 @@
 //! };
 //!
 //! fn main() -> anyhow::Result<()> {
-//!     setup_default_logging(true, "info", "EXAMPLE");
+//!     setup_default_logging(true, "info", "EXAMPLE").with_context(|| "could not setup logging")?;
 //!
 //!     info!("starting up");
 //!

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -930,6 +930,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
 
         log_access! {
             error,
+            on_failure: { incr!("unsent-access-logs") },
             message: message,
             context,
             session_address: self.get_session_address(),

--- a/lib/src/protocol/pipe.rs
+++ b/lib/src/protocol/pipe.rs
@@ -236,6 +236,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
         metrics.register_end_of_session(&context);
         log_access!(
             error,
+            on_failure: { incr!("unsent-access-logs") },
             message,
             context,
             session_address: self.get_session_address(),

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -214,6 +214,7 @@ impl TcpSession {
         let context = self.log_context();
         self.metrics.register_end_of_session(&context);
         info_access!(
+            on_failure: { incr!("unsent-access-logs") },
             message: None,
             context,
             session_address: self.frontend_address,


### PR DESCRIPTION
Until now, a failure in transmitting access logs (e.g. a UNIX socket not responding/existing) would mean that Sōzu would not emit access logs anymore.

This pull request:
- adds a `revive_backend` function
- makes Sōzu startup **impossible** if the backend of access logs does not exist (note: if no `access_logs_target` is given in `config.toml`, it will still default to stdout)

Additionally, this PR adds error types and propagation.