### PR TITLE
Draft: introduce multiplexed SessionState to handle heterogeneous HTTP Sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,14 +804,23 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd69211b9b519e98303c015e21a007e293db403b6c85b9b124e133d25e242cdd"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
- "smallvec",
- "utf8_iter",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -43,43 +43,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "ascii"
@@ -99,7 +100,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.64",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -111,7 +112,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -123,7 +124,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -155,9 +156,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "block-buffer"
@@ -176,15 +177,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.1.30"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "shlex",
 ]
@@ -209,9 +210,9 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "clap"
-version = "4.5.20"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -219,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.20"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -231,27 +232,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "cookie-factory"
@@ -264,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
@@ -282,18 +283,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -307,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
 name = "der-parser"
@@ -373,7 +374,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -394,7 +395,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
- "log 0.4.22",
+ "log 0.4.25",
  "regex",
 ]
 
@@ -406,19 +407,19 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fixedbitset"
@@ -428,9 +429,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -498,7 +499,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -647,9 +648,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -677,7 +678,7 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "log 0.4.22",
+ "log 0.4.25",
  "rustls 0.21.12",
  "tokio",
  "tokio-rustls",
@@ -799,7 +800,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -825,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -861,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jemalloc-sys"
@@ -902,9 +903,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libredox"
@@ -919,15 +920,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -945,14 +946,14 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.22",
+ "log 0.4.25",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "memchr"
@@ -977,22 +978,21 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi 0.3.9",
  "libc",
- "log 0.4.22",
+ "log 0.4.25",
  "wasi",
  "windows-sys 0.52.0",
 ]
@@ -1078,9 +1078,9 @@ checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -1162,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -1204,12 +1204,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1227,18 +1227,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1246,14 +1246,13 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
+checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
- "bytes",
  "heck",
  "itertools",
- "log 0.4.22",
+ "log 0.4.25",
  "multimap",
  "once_cell",
  "petgraph",
@@ -1261,28 +1260,28 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.87",
+ "syn 2.0.96",
  "tempfile",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
+checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
 dependencies = [
  "prost",
 ]
@@ -1294,15 +1293,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
  "env_logger",
- "log 0.4.22",
+ "log 0.4.25",
  "rand",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1339,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags",
 ]
@@ -1360,14 +1359,14 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror 1.0.64",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1377,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1424,15 +1423,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1441,7 +1440,7 @@ version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
- "log 0.4.22",
+ "log 0.4.25",
  "ring",
  "rustls-webpki 0.101.7",
  "sct",
@@ -1449,11 +1448,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.14"
+version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
- "log 0.4.22",
+ "log 0.4.25",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1473,9 +1472,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 
 [[package]]
 name = "rustls-webpki"
@@ -1500,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "rusty_ulid"
@@ -1523,9 +1522,9 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "scc"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "553f8299af7450cda9a52d3a370199904e7a46b5ffd1bef187c4a6af3bb6db69"
+checksum = "28e1c91382686d21b5ac7959341fcb9780fa7c03773646995a87c950fa7be640"
 dependencies = [
  "sdd",
 ]
@@ -1548,35 +1547,35 @@ dependencies = [
 
 [[package]]
 name = "sdd"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c1eeaf4b6a87c7479688c6d52b9f1153cedd3c489300564f932b065c6eab95"
+checksum = "478f121bb72bbf63c52c93011ea1791dca40140dfe13f8336c4c5ac952c33aa9"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
@@ -1595,12 +1594,12 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.1.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
 dependencies = [
  "futures",
- "log 0.4.22",
+ "log 0.4.25",
  "once_cell",
  "parking_lot",
  "scc",
@@ -1609,13 +1608,13 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.1.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1652,9 +1651,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1662,12 +1661,12 @@ dependencies = [
 
 [[package]]
 name = "sozu"
-version = "1.0.6"
+version = "1.1.0-rc.0"
 dependencies = [
  "clap",
  "jemallocator",
  "libc",
- "log 0.4.22",
+ "log 0.4.25",
  "mio",
  "nix",
  "nom",
@@ -1680,16 +1679,16 @@ dependencies = [
  "sozu-lib",
  "tempfile",
  "termion",
- "thiserror 2.0.3",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "sozu-command-lib"
-version = "1.0.6"
+version = "1.1.0-rc.0"
 dependencies = [
  "hex",
  "libc",
- "log 0.4.22",
+ "log 0.4.25",
  "memchr",
  "mio",
  "nix",
@@ -1704,7 +1703,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror 2.0.3",
+ "thiserror 2.0.11",
  "time",
  "toml",
  "trailer",
@@ -1729,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "sozu-lib"
-version = "1.0.6"
+version = "1.1.0-rc.0"
 dependencies = [
  "anyhow",
  "cookie-factory",
@@ -1746,7 +1745,7 @@ dependencies = [
  "quickcheck",
  "rand",
  "regex",
- "rustls 0.23.14",
+ "rustls 0.23.21",
  "rustls-pemfile",
  "rusty_ulid",
  "serial_test",
@@ -1754,7 +1753,7 @@ dependencies = [
  "slab",
  "socket2",
  "sozu-command-lib",
- "thiserror 2.0.3",
+ "thiserror 2.0.11",
  "time",
  "tiny_http",
 ]
@@ -1796,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1813,17 +1812,18 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -1854,49 +1854,49 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.64",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
@@ -1915,9 +1915,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1932,7 +1932,7 @@ dependencies = [
  "ascii",
  "chunked_transfer",
  "httpdate",
- "log 0.4.22",
+ "log 0.4.25",
 ]
 
 [[package]]
@@ -1947,9 +1947,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "libc",
@@ -2011,9 +2011,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-core",
@@ -2021,9 +2021,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
@@ -2048,9 +2048,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-width"
@@ -2215,9 +2215,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]
@@ -2247,15 +2247,15 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 1.0.64",
+ "thiserror 1.0.69",
  "time",
 ]
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -2265,13 +2265,13 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -2293,27 +2293,27 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -2342,5 +2342,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.96",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "sozu"
-version = "1.1.0-rc.0"
+version = "1.1.0-rc.1"
 dependencies = [
  "clap",
  "jemallocator",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "sozu-command-lib"
-version = "1.1.0-rc.0"
+version = "1.1.0-rc.1"
 dependencies = [
  "hex",
  "libc",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "sozu-lib"
-version = "1.1.0-rc.0"
+version = "1.1.0-rc.1"
 dependencies = [
  "anyhow",
  "cookie-factory",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "sozu"
-version = "1.1.0-rc.1"
+version = "1.1.0-rc.2"
 dependencies = [
  "clap",
  "jemallocator",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "sozu-command-lib"
-version = "1.1.0-rc.1"
+version = "1.1.0-rc.2"
 dependencies = [
  "hex",
  "libc",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "sozu-lib"
-version = "1.1.0-rc.1"
+version = "1.1.0-rc.2"
 dependencies = [
  "anyhow",
  "cookie-factory",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/sozu-proxy/sozu"
 readme = "README.md"
 documentation = "https://docs.rs/sozu"
 homepage = "https://sozu.io"
-version = "1.0.6"
+version = "1.1.0-rc.0"
 license = "AGPL-3.0"
 authors = [
   "Geoffroy Couprie <geo.couprie@gmail.com>",
@@ -42,8 +42,8 @@ tempfile = "^3.13.0"
 termion = "^4.0.3"
 thiserror = "^2.0.3"
 
-sozu-command-lib = { path = "../command", version = "^1.0.6" }
-sozu-lib = { path = "../lib", version = "^1.0.6" }
+sozu-command-lib = { path = "../command", version = "^1.1.0-rc.0" }
+sozu-lib = { path = "../lib", version = "1.1.0-rc.0" }
 
 [target.'cfg(target_os="linux")'.dependencies]
 num_cpus = "^1.16.0"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/sozu-proxy/sozu"
 readme = "README.md"
 documentation = "https://docs.rs/sozu"
 homepage = "https://sozu.io"
-version = "1.1.0-rc.1"
+version = "1.1.0-rc.2"
 license = "AGPL-3.0"
 authors = [
   "Geoffroy Couprie <geo.couprie@gmail.com>",
@@ -42,8 +42,8 @@ tempfile = "^3.13.0"
 termion = "^4.0.3"
 thiserror = "^2.0.3"
 
-sozu-command-lib = { path = "../command", version = "^1.1.0-rc.1" }
-sozu-lib = { path = "../lib", version = "1.1.0-rc.1" }
+sozu-command-lib = { path = "../command", version = "^1.1.0-rc.2" }
+sozu-lib = { path = "../lib", version = "1.1.0-rc.2" }
 
 [target.'cfg(target_os="linux")'.dependencies]
 num_cpus = "^1.16.0"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/sozu-proxy/sozu"
 readme = "README.md"
 documentation = "https://docs.rs/sozu"
 homepage = "https://sozu.io"
-version = "1.1.0-rc.0"
+version = "1.1.0-rc.1"
 license = "AGPL-3.0"
 authors = [
   "Geoffroy Couprie <geo.couprie@gmail.com>",
@@ -42,8 +42,8 @@ tempfile = "^3.13.0"
 termion = "^4.0.3"
 thiserror = "^2.0.3"
 
-sozu-command-lib = { path = "../command", version = "^1.1.0-rc.0" }
-sozu-lib = { path = "../lib", version = "1.1.0-rc.0" }
+sozu-command-lib = { path = "../command", version = "^1.1.0-rc.1" }
+sozu-lib = { path = "../lib", version = "1.1.0-rc.1" }
 
 [target.'cfg(target_os="linux")'.dependencies]
 num_cpus = "^1.16.0"

--- a/bin/config.toml
+++ b/bin/config.toml
@@ -324,7 +324,8 @@ frontends = [
 # - weight: weight used by the load balancing algorithm
 # - sticky-id: sticky session identifier
 backends = [
-    { address = "127.0.0.1:1026", backend_id = "the-backend-to-my-app" }
+    { address = "127.0.0.1:1026", backend_id = "back26" },
+    { address = "127.0.0.1:1027", backend_id = "back27" }
 ]
 
 # this is an example of a routing configuration for the TCP proxy

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -425,6 +425,8 @@ pub enum HttpFrontendCmd {
         method: Option<String>,
         #[clap(long = "tags", help = "Specify tag (key-value pair) to apply on front-end (example: 'key=value, other-key=other-value')", value_parser = parse_tags)]
         tags: Option<BTreeMap<String, String>>,
+        #[clap(help = "the frontend uses http2 with prio-knowledge")]
+        h2: Option<bool>,
     },
     #[clap(name = "remove")]
     Remove {

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -299,6 +299,11 @@ pub enum ClusterCmd {
             help = "Configures the load balancing policy. Possible values are 'roundrobin', 'random' or 'leastconnections'"
         )]
         load_balancing_policy: LoadBalancingAlgorithms,
+        #[clap(
+            long = "http2",
+            help = "the backends of this cluster use http2 prio-knowledge"
+        )]
+        h2: bool,
     },
 }
 
@@ -425,8 +430,6 @@ pub enum HttpFrontendCmd {
         method: Option<String>,
         #[clap(long = "tags", help = "Specify tag (key-value pair) to apply on front-end (example: 'key=value, other-key=other-value')", value_parser = parse_tags)]
         tags: Option<BTreeMap<String, String>>,
-        #[clap(help = "the frontend uses http2 with prio-knowledge")]
-        h2: Option<bool>,
     },
     #[clap(name = "remove")]
     Remove {

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -150,6 +150,7 @@ impl CommandManager {
                 send_proxy,
                 expect_proxy,
                 load_balancing_policy,
+                h2,
             } => {
                 let proxy_protocol = match (send_proxy, expect_proxy) {
                     (true, true) => Some(ProxyProtocolConfig::RelayHeader),
@@ -164,7 +165,9 @@ impl CommandManager {
                         https_redirect,
                         proxy_protocol: proxy_protocol.map(|pp| pp as i32),
                         load_balancing: load_balancing_policy as i32,
-                        ..Default::default()
+                        http2: h2,
+                        load_metric: None,
+                        answer_503: None,
                     })
                     .into(),
                 )
@@ -238,7 +241,6 @@ impl CommandManager {
                 method,
                 cluster_id: route,
                 tags,
-                h2,
             } => self.send_request(
                 RequestType::AddHttpFrontend(RequestHttpFrontend {
                     cluster_id: route.into(),
@@ -287,7 +289,6 @@ impl CommandManager {
                 method,
                 cluster_id: route,
                 tags,
-                h2,
             } => self.send_request(
                 RequestType::AddHttpsFrontend(RequestHttpFrontend {
                     cluster_id: route.into(),

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -251,7 +251,6 @@ impl CommandManager {
                         Some(tags) => tags,
                         None => BTreeMap::new(),
                     },
-                    h2: h2.unwrap_or(false),
                 })
                 .into(),
             ),
@@ -301,7 +300,6 @@ impl CommandManager {
                         Some(tags) => tags,
                         None => BTreeMap::new(),
                     },
-                    h2: h2.unwrap_or(false),
                 })
                 .into(),
             ),

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -238,6 +238,7 @@ impl CommandManager {
                 method,
                 cluster_id: route,
                 tags,
+                h2,
             } => self.send_request(
                 RequestType::AddHttpFrontend(RequestHttpFrontend {
                     cluster_id: route.into(),
@@ -250,6 +251,7 @@ impl CommandManager {
                         Some(tags) => tags,
                         None => BTreeMap::new(),
                     },
+                    h2: h2.unwrap_or(false),
                 })
                 .into(),
             ),
@@ -286,6 +288,7 @@ impl CommandManager {
                 method,
                 cluster_id: route,
                 tags,
+                h2,
             } => self.send_request(
                 RequestType::AddHttpsFrontend(RequestHttpFrontend {
                     cluster_id: route.into(),
@@ -298,6 +301,7 @@ impl CommandManager {
                         Some(tags) => tags,
                         None => BTreeMap::new(),
                     },
+                    h2: h2.unwrap_or(false),
                 })
                 .into(),
             ),

--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/sozu-proxy/sozu"
 readme = "README.md"
 documentation = "https://docs.rs/sozu-command-lib"
 homepage = "https://sozu.io"
-version = "1.1.0-rc.1"
+version = "1.1.0-rc.2"
 license = "LGPL-3.0"
 authors = [
   "Geoffroy Couprie <geo.couprie@gmail.com>",

--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/sozu-proxy/sozu"
 readme = "README.md"
 documentation = "https://docs.rs/sozu-command-lib"
 homepage = "https://sozu.io"
-version = "1.1.0-rc.0"
+version = "1.1.0-rc.1"
 license = "LGPL-3.0"
 authors = [
   "Geoffroy Couprie <geo.couprie@gmail.com>",

--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/sozu-proxy/sozu"
 readme = "README.md"
 documentation = "https://docs.rs/sozu-command-lib"
 homepage = "https://sozu.io"
-version = "1.0.6"
+version = "1.1.0-rc.0"
 license = "LGPL-3.0"
 authors = [
   "Geoffroy Couprie <geo.couprie@gmail.com>",

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -248,6 +248,7 @@ message RequestHttpFrontend {
     required RulePosition position = 6 [default = TREE];
     // custom tags to identify the frontend in the access logs
     map<string, string> tags = 7;
+    required bool h2 = 8;
 }
 
 message RequestTcpFrontend {

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -162,6 +162,7 @@ message HttpsListenerConfig {
     // agains session tracking. Defaults to 4.
     required uint64 send_tls13_tickets = 20;
     optional CustomHttpAnswers http_answers = 21;
+    repeated AlpnProtocol alpn = 22;
 }
 
 // details of an TCP listener
@@ -364,6 +365,11 @@ enum TlsVersion {
     TLS_V1_1 = 3;
     TLS_V1_2 = 4;
     TLS_V1_3 = 5;
+}
+
+enum AlpnProtocol {
+    Http11 = 0;
+    H2 = 1;
 }
 
 // A cluster is what binds a frontend to backends with routing rules

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -248,7 +248,6 @@ message RequestHttpFrontend {
     required RulePosition position = 6 [default = TREE];
     // custom tags to identify the frontend in the access logs
     map<string, string> tags = 7;
-    required bool h2 = 8;
 }
 
 message RequestTcpFrontend {
@@ -383,6 +382,7 @@ message Cluster {
     required LoadBalancingAlgorithms load_balancing = 5 [default = ROUND_ROBIN];
     optional string answer_503 = 6;
     optional LoadMetric load_metric = 7;
+    required bool http2 = 8;
 }
 
 enum LoadBalancingAlgorithms {

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -679,6 +679,7 @@ pub struct FileClusterFrontendConfig {
     #[serde(default)]
     pub position: RulePosition,
     pub tags: Option<BTreeMap<String, String>>,
+    pub h2: Option<bool>,
 }
 
 impl FileClusterFrontendConfig {
@@ -764,6 +765,7 @@ impl FileClusterFrontendConfig {
             path,
             method: self.method.clone(),
             tags: self.tags.clone(),
+            h2: self.h2.unwrap_or(false),
         })
     }
 }
@@ -789,6 +791,7 @@ pub struct FileClusterConfig {
     pub frontends: Vec<FileClusterFrontendConfig>,
     pub backends: Vec<BackendConfig>,
     pub protocol: FileClusterProtocolConfig,
+    pub http_version: Option<u8>,
     pub sticky_session: Option<bool>,
     pub https_redirect: Option<bool>,
     #[serde(default)]
@@ -914,6 +917,7 @@ pub struct HttpFrontendConfig {
     #[serde(default)]
     pub position: RulePosition,
     pub tags: Option<BTreeMap<String, String>>,
+    pub h2: bool,
 }
 
 impl HttpFrontendConfig {
@@ -950,6 +954,7 @@ impl HttpFrontendConfig {
                     path: self.path.clone(),
                     method: self.method.clone(),
                     position: self.position.into(),
+                    h2: self.h2,
                     tags,
                 })
                 .into(),
@@ -964,6 +969,7 @@ impl HttpFrontendConfig {
                     path: self.path.clone(),
                     method: self.method.clone(),
                     position: self.position.into(),
+                    h2: self.h2,
                     tags,
                 })
                 .into(),
@@ -1299,13 +1305,13 @@ impl ConfigBuilder {
         Ok(())
     }
 
-    fn push_http_listener(&mut self, mut listener: ListenerBuilder) -> Result<(), ConfigError> {
+    fn push_http_listener(&mut self, listener: ListenerBuilder) -> Result<(), ConfigError> {
         let listener = listener.to_http(Some(&self.built))?;
         self.built.http_listeners.push(listener);
         Ok(())
     }
 
-    fn push_tcp_listener(&mut self, mut listener: ListenerBuilder) -> Result<(), ConfigError> {
+    fn push_tcp_listener(&mut self, listener: ListenerBuilder) -> Result<(), ConfigError> {
         let listener = listener.to_tcp(Some(&self.built))?;
         self.built.tcp_listeners.push(listener);
         Ok(())

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -661,6 +661,11 @@ pub enum PathRuleType {
     Equals,
 }
 
+/// Congruent with command.proto
+fn default_rule_position() -> RulePosition {
+    RulePosition::Tree
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FileClusterFrontendConfig {
@@ -676,7 +681,7 @@ pub struct FileClusterFrontendConfig {
     pub certificate_chain: Option<String>,
     #[serde(default)]
     pub tls_versions: Vec<TlsVersion>,
-    #[serde(default)]
+    #[serde(default = "default_rule_position")]
     pub position: RulePosition,
     pub tags: Option<BTreeMap<String, String>>,
     pub h2: Option<bool>,

--- a/command/src/proto/display.rs
+++ b/command/src/proto/display.rs
@@ -152,7 +152,7 @@ impl Response {
 }
 
 impl ResponseContent {
-    fn display(&self, json: bool) -> Result<(), DisplayError> {
+    pub fn display(&self, json: bool) -> Result<(), DisplayError> {
         let content_type = match &self.content_type {
             Some(content_type) => content_type,
             None => return Ok(println!("No content")),

--- a/command/src/proto/display.rs
+++ b/command/src/proto/display.rs
@@ -54,9 +54,9 @@ impl Display for CertificateSummary {
 impl Display for QueryCertificatesFilters {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         if let Some(d) = self.domain.clone() {
-            write!(f, "domain:{}", d)
+            write!(f, "domain:{d}")
         } else if let Some(fp) = self.fingerprint.clone() {
-            write!(f, "domain:{}", fp)
+            write!(f, "domain:{fp}")
         } else {
             write!(f, "all certificates")
         }

--- a/command/src/request.rs
+++ b/command/src/request.rs
@@ -173,6 +173,7 @@ impl RequestHttpFrontend {
                 }
             })?,
             tags: Some(self.tags),
+            h2: self.h2,
         })
     }
 }

--- a/command/src/request.rs
+++ b/command/src/request.rs
@@ -173,7 +173,6 @@ impl RequestHttpFrontend {
                 }
             })?,
             tags: Some(self.tags),
-            h2: self.h2,
         })
     }
 }

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -39,6 +39,7 @@ pub struct HttpFrontend {
     #[serde(default)]
     pub position: RulePosition,
     pub tags: Option<BTreeMap<String, String>>,
+    pub h2: bool,
 }
 
 impl From<HttpFrontend> for RequestHttpFrontend {
@@ -51,6 +52,7 @@ impl From<HttpFrontend> for RequestHttpFrontend {
             method: val.method,
             position: val.position.into(),
             tags: val.tags.unwrap_or_default(),
+            h2: val.h2,
         }
     }
 }

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -39,7 +39,6 @@ pub struct HttpFrontend {
     #[serde(default)]
     pub position: RulePosition,
     pub tags: Option<BTreeMap<String, String>>,
-    pub h2: bool,
 }
 
 impl From<HttpFrontend> for RequestHttpFrontend {
@@ -52,7 +51,6 @@ impl From<HttpFrontend> for RequestHttpFrontend {
             method: val.method,
             position: val.position.into(),
             tags: val.tags.unwrap_or_default(),
-            h2: val.h2,
         }
     }
 }

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -462,7 +462,7 @@ impl ConfigState {
         if tcp_frontends.contains(&tcp_frontend) {
             return Err(StateError::Exists {
                 kind: ObjectKind::TcpFrontend,
-                id: format!("{:?}", tcp_frontend),
+                id: format!("{tcp_frontend:?}"),
             });
         }
 
@@ -479,7 +479,7 @@ impl ConfigState {
                 .get_mut(&front_to_remove.cluster_id)
                 .ok_or(StateError::NotFound {
                     kind: ObjectKind::TcpFrontend,
-                    id: format!("{:?}", front_to_remove),
+                    id: format!("{front_to_remove:?}"),
                 })?;
 
         let len = tcp_frontends.len();

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -14,5 +14,5 @@ rustls = { version = "^0.21.10", features = ["dangerous_configuration"] }
 time = "^0.3.36"
 tokio = { version = "1.40.0", features = ["net", "rt-multi-thread"] }
 
-sozu-command-lib = { path = "../command", version = "^1.1.0-rc.1" }
-sozu-lib = { path = "../lib", version = "^1.1.0-rc.1" }
+sozu-command-lib = { path = "../command", version = "^1.1.0-rc.2" }
+sozu-lib = { path = "../lib", version = "^1.1.0-rc.2" }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -14,5 +14,5 @@ rustls = { version = "^0.21.10", features = ["dangerous_configuration"] }
 time = "^0.3.36"
 tokio = { version = "1.40.0", features = ["net", "rt-multi-thread"] }
 
-sozu-command-lib = { path = "../command", version = "^1.1.0-rc.0" }
-sozu-lib = { path = "../lib", version = "^1.1.0-rc.0" }
+sozu-command-lib = { path = "../command", version = "^1.1.0-rc.1" }
+sozu-lib = { path = "../lib", version = "^1.1.0-rc.1" }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -14,5 +14,5 @@ rustls = { version = "^0.21.10", features = ["dangerous_configuration"] }
 time = "^0.3.36"
 tokio = { version = "1.40.0", features = ["net", "rt-multi-thread"] }
 
-sozu-command-lib = { path = "../command", version = "^1.0.6" }
-sozu-lib = { path = "../lib", version = "^1.0.6" }
+sozu-command-lib = { path = "../command", version = "^1.1.0-rc.0" }
+sozu-lib = { path = "../lib", version = "^1.1.0-rc.0" }

--- a/e2e/src/http_utils/mod.rs
+++ b/e2e/src/http_utils/mod.rs
@@ -26,10 +26,14 @@ pub fn http_request<S1: Into<String>, S2: Into<String>, S3: Into<String>, S4: In
 
 pub fn immutable_answer(status: u16) -> String {
     match status {
-        400 => String::from("HTTP/1.1 400 Bad Request\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"),
-        404 => String::from("HTTP/1.1 404 Not Found\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"),
-        502 => String::from("HTTP/1.1 502 Bad Gateway\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"),
-        503 => String::from("HTTP/1.1 503 Service Unavailable\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"),
+        // 400 => String::from("HTTP/1.1 400 Bad Request\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"),
+        400 => String::from("HTTP/1.1 400 Sozu Default Answer\r\nCache-Control: no-cache\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"),
+        // 404 => String::from("HTTP/1.1 404 Not Found\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"),
+        404 => String::from("HTTP/1.1 404 Sozu Default Answer\r\nCache-Control: no-cache\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"),
+        // 502 => String::from("HTTP/1.1 502 Bad Gateway\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"),
+        502 => String::from("HTTP/1.1 502 Sozu Default Answer\r\nCache-Control: no-cache\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"),
+        // 503 => String::from("HTTP/1.1 503 Service Unavailable\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"),
+        503 => String::from("HTTP/1.1 503 Sozu Default Answer\r\nCache-Control: no-cache\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"),
         _ => unimplemented!()
     }
 }

--- a/e2e/src/http_utils/mod.rs
+++ b/e2e/src/http_utils/mod.rs
@@ -33,3 +33,21 @@ pub fn immutable_answer(status: u16) -> String {
         _ => unimplemented!()
     }
 }
+
+// use std::io::Write;
+// use kawa;
+
+// /// the default kawa answer for the error code provided, converted to HTTP/1.1
+// pub fn default_answer(code: u16) -> String {
+//     let mut kawa_answer = kawa::Kawa::new(
+//         kawa::Kind::Response,
+//         kawa::Buffer::new(kawa::SliceBuffer(&mut [])),
+//     );
+//     sozu_lib::protocol::mux::fill_default_answer(&mut kawa_answer, code);
+//     kawa_answer.prepare(&mut kawa::h1::converter::H1BlockConverter);
+//     let out = kawa_answer.as_io_slice();
+//     let mut writer = std::io::BufWriter::new(Vec::new());
+//     writer.write_vectored(&out).expect("WRITE");
+//     let result = unsafe { std::str::from_utf8_unchecked(writer.buffer()) };
+//     result.to_string()
+// }

--- a/e2e/src/mock/async_backend.rs
+++ b/e2e/src/mock/async_backend.rs
@@ -35,7 +35,7 @@ impl<A: Aggregator + Send + Sync + 'static> BackendHandle<A> {
         let name = name.into();
         let (stop_tx, mut stop_rx) = mpsc::channel::<()>(1);
         let (mut aggregator_tx, aggregator_rx) = mpsc::channel::<A>(1);
-        let listener = TcpListener::bind(address).expect("could not bind");
+        let listener = TcpListener::bind(address).expect(&format!("could not bind on: {address}"));
         let mut clients = Vec::new();
         let thread_name = name.to_owned();
 

--- a/e2e/src/mock/client.rs
+++ b/e2e/src/mock/client.rs
@@ -39,7 +39,7 @@ impl Client {
     /// Establish a TCP connection with its address,
     /// register the yielded TCP stream, apply timeouts
     pub fn connect(&mut self) {
-        let stream = TcpStream::connect(self.address).expect("could not connect");
+        let stream = TcpStream::connect(self.address).expect(&format!("could not connect to: {}", self.address));
         stream
             .set_read_timeout(Some(Duration::from_millis(100)))
             .expect("could not set read timeout");

--- a/e2e/src/mock/sync_backend.rs
+++ b/e2e/src/mock/sync_backend.rs
@@ -44,7 +44,7 @@ impl Backend {
 
     /// Binds itself to its address, stores the yielded TCP listener
     pub fn connect(&mut self) {
-        let listener = TcpListener::bind(self.address).expect("could not bind");
+        let listener = TcpListener::bind(self.address).expect(&format!("could not bind on: {}", self.address));
         let timeout = Duration::from_millis(100);
         let timeout = libc::timeval {
             tv_sec: 0,

--- a/e2e/src/tests/tests.rs
+++ b/e2e/src/tests/tests.rs
@@ -776,7 +776,8 @@ fn try_http_behaviors() -> State {
             && response.ends_with(&expected_response_end)
     );
 
-    info!("server closes, expecting 503");
+    // FIXME: do we want 502 or 503???
+    info!("server closes, expecting 502");
     // TODO: what if the client continue to use the closed stream
     client.connect();
     client.send();
@@ -1242,7 +1243,9 @@ pub fn try_stick() -> State {
     backend1.send(0);
     let response = client.receive();
     println!("response: {response:?}");
-    assert!(request.unwrap().starts_with("GET /api HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nCookie: foo=bar\r\nX-Forwarded-For:"));
+    assert!(request.unwrap().starts_with(
+        "GET /api HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nCookie: foo=bar\r\n"
+    ));
     assert!(response.unwrap().starts_with("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nSet-Cookie: SOZUBALANCEID=sticky_cluster_0-0; Path=/\r\nSozu-Id:"));
 
     // invalid sticky_session
@@ -1255,7 +1258,9 @@ pub fn try_stick() -> State {
     backend2.send(0);
     let response = client.receive();
     println!("response: {response:?}");
-    assert!(request.unwrap().starts_with("GET /api HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nCookie: foo=bar\r\nX-Forwarded-For:"));
+    assert!(request.unwrap().starts_with(
+        "GET /api HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nCookie: foo=bar\r\n"
+    ));
     assert!(response.unwrap().starts_with("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nSet-Cookie: SOZUBALANCEID=sticky_cluster_0-1; Path=/\r\nSozu-Id:"));
 
     // good sticky_session (force use backend2, round-robin would have chosen backend1)
@@ -1268,7 +1273,9 @@ pub fn try_stick() -> State {
     backend2.send(0);
     let response = client.receive();
     println!("response: {response:?}");
-    assert!(request.unwrap().starts_with("GET /api HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nCookie: foo=bar\r\nX-Forwarded-For:"));
+    assert!(request.unwrap().starts_with(
+        "GET /api HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nCookie: foo=bar\r\n"
+    ));
     assert!(response
         .unwrap()
         .starts_with("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nSozu-Id:"));

--- a/e2e/src/tests/tests.rs
+++ b/e2e/src/tests/tests.rs
@@ -788,7 +788,7 @@ fn try_http_behaviors() -> State {
     let response = client.receive();
     println!("request: {request:?}");
     println!("response: {response:?}");
-    assert_eq!(response, Some(immutable_answer(503)));
+    assert_eq!(response, Some(immutable_answer(502)));
     assert_eq!(client.receive(), None);
 
     worker.send_proxy_request_type(RequestType::RemoveBackend(RemoveBackend {
@@ -988,7 +988,7 @@ fn try_https_redirect() -> State {
     client.connect();
     client.send();
     let answer = client.receive();
-    let expected_answer = format!("{answer_301_prefix}https://example.com/redirected?true\r\n\r\n");
+    let expected_answer = format!("{answer_301_prefix}https://example.com/redirected?true\r\nContent-Length: 0\r\n\r\n");
     assert_eq!(answer, Some(expected_answer));
 
     State::Success

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -33,7 +33,7 @@ cookie-factory = "^0.3.3"
 hdrhistogram = "^7.5.4"
 hex = "^0.4.3"
 hpack = "^0.3.0"
-idna = "^1.0.2"
+idna = "^1.0.3"
 kawa = { version = "^0.6.7", default-features = false }
 libc = "^0.2.159"
 memchr = "^2.7.4"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/sozu-proxy/sozu"
 readme = "README.md"
 documentation = "https://docs.rs/sozu-lib"
 homepage = "https://sozu.io"
-version = "1.1.0-rc.1"
+version = "1.1.0-rc.2"
 license = "AGPL-3.0"
 authors = [
   "Clément Delafargue <clement@delafargue.name>",
@@ -56,7 +56,7 @@ socket2 = { version = "^0.5.7", features = ["all"] }
 thiserror = "^2.0.3"
 time = "^0.3.36"
 
-sozu-command-lib = { path = "../command", version = "1.1.0-rc.1" }
+sozu-command-lib = { path = "../command", version = "1.1.0-rc.2" }
 
 [dev-dependencies]
 quickcheck = "^1.0.3"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/sozu-proxy/sozu"
 readme = "README.md"
 documentation = "https://docs.rs/sozu-lib"
 homepage = "https://sozu.io"
-version = "1.1.0-rc.0"
+version = "1.1.0-rc.1"
 license = "AGPL-3.0"
 authors = [
   "Clément Delafargue <clement@delafargue.name>",
@@ -56,7 +56,7 @@ socket2 = { version = "^0.5.7", features = ["all"] }
 thiserror = "^2.0.3"
 time = "^0.3.36"
 
-sozu-command-lib = { path = "../command", version = "1.1.0-rc.0" }
+sozu-command-lib = { path = "../command", version = "1.1.0-rc.1" }
 
 [dev-dependencies]
 quickcheck = "^1.0.3"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/sozu-proxy/sozu"
 readme = "README.md"
 documentation = "https://docs.rs/sozu-lib"
 homepage = "https://sozu.io"
-version = "1.0.6"
+version = "1.1.0-rc.0"
 license = "AGPL-3.0"
 authors = [
   "Clément Delafargue <clement@delafargue.name>",
@@ -56,7 +56,7 @@ socket2 = { version = "^0.5.7", features = ["all"] }
 thiserror = "^2.0.3"
 time = "^0.3.36"
 
-sozu-command-lib = { path = "../command", version = "^1.0.6" }
+sozu-command-lib = { path = "../command", version = "1.1.0-rc.0" }
 
 [dev-dependencies]
 quickcheck = "^1.0.3"

--- a/lib/src/backends.rs
+++ b/lib/src/backends.rs
@@ -297,7 +297,8 @@ impl BackendMap {
         })?;
         self.available = true;
 
-        Ok((next_backend.clone(), tcp_stream))
+        drop(borrowed_backend);
+        Ok((next_backend, tcp_stream))
     }
 
     pub fn backend_from_sticky_session(

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -472,7 +472,7 @@ impl L7ListenerHandler for HttpListener {
 
         let now = Instant::now();
 
-        if let Route::ClusterId(cluster) = &route {
+        if let Route::Cluster { id: cluster, .. } = &route {
             time!("frontend_matching_time", cluster, (now - start).as_millis());
         }
 
@@ -688,7 +688,7 @@ impl HttpProxy {
         if !socket_errors.is_empty() {
             return Err(ProxyError::SoftStop {
                 proxy_protocol: "HTTP".to_string(),
-                error: format!("Error deregistering listen sockets: {:?}", socket_errors),
+                error: format!("Error deregistering listen sockets: {socket_errors:?}"),
             });
         }
 
@@ -711,7 +711,7 @@ impl HttpProxy {
         if !socket_errors.is_empty() {
             return Err(ProxyError::HardStop {
                 proxy_protocol: "HTTP".to_string(),
-                error: format!("Error deregistering listen sockets: {:?}", socket_errors),
+                error: format!("Error deregistering listen sockets: {socket_errors:?}"),
             });
         }
 
@@ -1326,6 +1326,7 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some(cluster_id1),
                 tags: None,
+                h2: false,
             })
             .expect("Could not add http frontend");
         fronts
@@ -1337,6 +1338,7 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some(cluster_id2),
                 tags: None,
+                h2: false,
             })
             .expect("Could not add http frontend");
         fronts
@@ -1348,6 +1350,7 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some(cluster_id3),
                 tags: None,
+                h2: false,
             })
             .expect("Could not add http frontend");
         fronts
@@ -1359,6 +1362,7 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some("cluster_1".to_owned()),
                 tags: None,
+                h2: false,
             })
             .expect("Could not add http frontend");
 
@@ -1388,19 +1392,31 @@ mod tests {
         let frontend5 = listener.frontend_from_request("domain", "/", &Method::Get);
         assert_eq!(
             frontend1.expect("should find frontend"),
-            Route::ClusterId("cluster_1".to_string())
+            Route::Cluster {
+                id: "cluster_1".to_string(),
+                h2: false
+            }
         );
         assert_eq!(
             frontend2.expect("should find frontend"),
-            Route::ClusterId("cluster_1".to_string())
+            Route::Cluster {
+                id: "cluster_1".to_string(),
+                h2: false
+            }
         );
         assert_eq!(
             frontend3.expect("should find frontend"),
-            Route::ClusterId("cluster_2".to_string())
+            Route::Cluster {
+                id: "cluster_2".to_string(),
+                h2: false
+            }
         );
         assert_eq!(
             frontend4.expect("should find frontend"),
-            Route::ClusterId("cluster_3".to_string())
+            Route::Cluster {
+                id: "cluster_3".to_string(),
+                h2: false
+            }
         );
         assert!(frontend5.is_err());
     }

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -520,7 +520,7 @@ impl L7ListenerHandler for HttpListener {
 
         let now = Instant::now();
 
-        if let Route::Cluster { id: cluster, .. } = &route {
+        if let Route::Cluster(cluster) = &route {
             time!("frontend_matching_time", cluster, (now - start).as_millis());
         }
 
@@ -1374,7 +1374,6 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some(cluster_id1),
                 tags: None,
-                h2: false,
             })
             .expect("Could not add http frontend");
         fronts
@@ -1386,7 +1385,6 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some(cluster_id2),
                 tags: None,
-                h2: false,
             })
             .expect("Could not add http frontend");
         fronts
@@ -1398,7 +1396,6 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some(cluster_id3),
                 tags: None,
-                h2: false,
             })
             .expect("Could not add http frontend");
         fronts
@@ -1410,7 +1407,6 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some("cluster_1".to_owned()),
                 tags: None,
-                h2: false,
             })
             .expect("Could not add http frontend");
 
@@ -1440,31 +1436,19 @@ mod tests {
         let frontend5 = listener.frontend_from_request("domain", "/", &Method::Get);
         assert_eq!(
             frontend1.expect("should find frontend"),
-            Route::Cluster {
-                id: "cluster_1".to_string(),
-                h2: false
-            }
+            Route::Cluster("cluster_1".to_string())
         );
         assert_eq!(
             frontend2.expect("should find frontend"),
-            Route::Cluster {
-                id: "cluster_1".to_string(),
-                h2: false
-            }
+            Route::Cluster("cluster_1".to_string())
         );
         assert_eq!(
             frontend3.expect("should find frontend"),
-            Route::Cluster {
-                id: "cluster_2".to_string(),
-                h2: false
-            }
+            Route::Cluster("cluster_2".to_string())
         );
         assert_eq!(
             frontend4.expect("should find frontend"),
-            Route::Cluster {
-                id: "cluster_3".to_string(),
-                h2: false
-            }
+            Route::Cluster("cluster_3".to_string())
         );
         assert!(frontend5.is_err());
     }

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -38,7 +38,7 @@ use crate::{
         },
         mux::{self, Mux},
         proxy_protocol::expect::ExpectProxyProtocol,
-        Http, Pipe, SessionState,
+        Pipe, SessionState,
     },
     router::{Route, Router},
     server::{ListenToken, SessionManager},
@@ -123,15 +123,21 @@ impl HttpSession {
             gauge_add!("protocol.http", 1);
             let session_address = sock.peer_addr().ok();
 
+            let frontend = mux::Connection::new_h1_server(sock, container_frontend_timeout);
+            let router = mux::Router::new(
+                configured_backend_timeout,
+                configured_connect_timeout,
+                listener.clone(),
+            );
             let mut context = mux::Context::new(pool.clone());
             context
                 .create_stream(request_id, 1 << 16)
                 .ok_or(AcceptError::BufferCapacityReached)?;
-            let frontend = mux::Connection::new_h1_server(sock);
             HttpStateMachine::Mux(Mux {
+                configured_frontend_timeout,
                 frontend_token: token,
                 frontend,
-                router: mux::Router::new(listener.clone()),
+                router,
                 public_address,
                 peer_address: session_address,
                 sticky_name: sticky_name.clone(),
@@ -204,130 +210,91 @@ impl HttpSession {
             .map(|add| (add.destination(), add.source()))
         {
             Some((Some(public_address), Some(session_address))) => {
-                let mut http = Http::new(
-                    self.answers.clone(),
+                let frontend = mux::Connection::new_h1_server(
+                    expect.frontend,
+                    expect.container_frontend_timeout,
+                );
+                let router = mux::Router::new(
                     self.configured_backend_timeout,
                     self.configured_connect_timeout,
-                    self.configured_frontend_timeout,
-                    expect.container_frontend_timeout,
-                    expect.frontend,
-                    expect.frontend_token,
                     self.listener.clone(),
-                    self.pool.clone(),
-                    Protocol::HTTP,
+                );
+                let mut context = mux::Context::new(self.pool.clone());
+                context.create_stream(expect.request_id, 1 << 16)?;
+                let mut mux = Mux {
+                    configured_frontend_timeout: self.configured_frontend_timeout,
+                    frontend_token: self.frontend_token,
+                    frontend,
+                    router,
                     public_address,
-                    expect.request_id,
-                    Some(session_address),
-                    self.sticky_name.clone(),
-                )
-                .ok()?;
-                http.frontend_readiness.event = expect.frontend_readiness.event;
+                    peer_address: Some(session_address),
+                    sticky_name: self.sticky_name.clone(),
+                    context,
+                };
+                mux.frontend.readiness_mut().event = expect.frontend_readiness.event;
 
                 gauge_add!("protocol.proxy.expect", -1);
                 gauge_add!("protocol.http", 1);
-                unimplemented!();
-                // Some(HttpStateMachine::Http(http))
+                Some(HttpStateMachine::Mux(mux))
             }
             _ => None,
         }
-    }
-
-    fn upgrade_http(&mut self, http: Http<TcpStream, HttpListener>) -> Option<HttpStateMachine> {
-        debug!("http switching to ws");
-        let front_token = self.frontend_token;
-        let back_token = match http.backend_token {
-            Some(back_token) => back_token,
-            None => {
-                warn!(
-                    "Could not upgrade http request on cluster '{:?}' ({:?}) using backend '{:?}' into websocket for request '{}'",
-                    http.context.cluster_id, self.frontend_token, http.context.backend_id, http.context.id
-                );
-                return None;
-            }
-        };
-        let ws_context = http.context.websocket_context();
-
-        let mut container_frontend_timeout = http.container_frontend_timeout;
-        let mut container_backend_timeout = http.container_backend_timeout;
-        container_frontend_timeout.reset();
-        container_backend_timeout.reset();
-
-        let backend_buffer = if let ResponseStream::BackendAnswer(kawa) = http.response_stream {
-            kawa.storage.buffer
-        } else {
-            return None;
-        };
-
-        let mut pipe = Pipe::new(
-            backend_buffer,
-            http.context.backend_id,
-            http.backend_socket,
-            http.backend,
-            Some(container_backend_timeout),
-            Some(container_frontend_timeout),
-            http.context.cluster_id,
-            http.request_stream.storage.buffer,
-            front_token,
-            http.frontend_socket,
-            self.listener.clone(),
-            Protocol::HTTP,
-            http.context.id,
-            http.context.session_address,
-            ws_context,
-        );
-
-        pipe.frontend_readiness.event = http.frontend_readiness.event;
-        pipe.backend_readiness.event = http.backend_readiness.event;
-        pipe.set_back_token(back_token);
-
-        gauge_add!("protocol.http", -1);
-        gauge_add!("protocol.ws", 1);
-        gauge_add!("http.active_requests", -1);
-        gauge_add!("websocket.active_requests", 1);
-        Some(HttpStateMachine::WebSocket(pipe))
     }
 
     fn upgrade_mux(&mut self, mut mux: Mux<TcpStream>) -> Option<HttpStateMachine> {
         debug!("mux switching to ws");
         let stream = mux.context.streams.pop().unwrap();
 
-        let (frontend_readiness, frontend_socket) = match mux.frontend {
-            mux::Connection::H1(mux::ConnectionH1 {
-                readiness, socket, ..
-            }) => (readiness, socket),
-            // only h1<->h1 connections can upgrade to websocket
-            mux::Connection::H2(_) => unreachable!(),
-        };
+        let (frontend_readiness, frontend_socket, mut container_frontend_timeout) =
+            match mux.frontend {
+                mux::Connection::H1(mux::ConnectionH1 {
+                    readiness,
+                    socket,
+                    timeout_container,
+                    ..
+                }) => (readiness, socket, timeout_container),
+                mux::Connection::H2(_) => {
+                    error!("Only h1<->h1 connections can upgrade to websocket");
+                    return None;
+                }
+            };
 
-        let mux::StreamState::Linked(back_token) = stream.state else { unreachable!() };
-        let backend = mux.router.backends.remove(&back_token).unwrap();
-        let (cluster_id, backend_readiness, backend_socket) = match backend {
-            mux::Connection::H1(mux::ConnectionH1 {
-                position: mux::Position::Client(mux::BackendStatus::Connected(cluster_id)),
-                readiness,
-                socket,
-                ..
-            }) => (cluster_id, readiness, socket),
-            // the backend disconnected just after upgrade, abort
-            mux::Connection::H1(_) => return None,
-            // only h1<->h1 connections can upgrade to websocket
-            mux::Connection::H2(_) => unreachable!(),
+        let mux::StreamState::Linked(back_token) = stream.state else {
+            error!("Upgrading stream should be linked to a backend");
+            return None;
         };
+        let backend = mux.router.backends.remove(&back_token).unwrap();
+        let (cluster_id, backend_readiness, backend_socket, mut container_backend_timeout) =
+            match backend {
+                mux::Connection::H1(mux::ConnectionH1 {
+                    position: mux::Position::Client(mux::BackendStatus::Connected(cluster_id)),
+                    readiness,
+                    socket,
+                    timeout_container,
+                    ..
+                }) => (cluster_id, readiness, socket, timeout_container),
+                mux::Connection::H1(_) => {
+                    error!("The backend disconnected just after upgrade, abort");
+                    return None;
+                }
+                mux::Connection::H2(_) => {
+                    error!("Only h1<->h1 connections can upgrade to websocket");
+                    return None;
+                }
+            };
 
         let ws_context = stream.context.websocket_context();
 
-        // let mut container_frontend_timeout = http.container_frontend_timeout;
-        // let mut container_backend_timeout = http.container_backend_timeout;
-        // container_frontend_timeout.reset();
-        // container_backend_timeout.reset();
+        container_frontend_timeout.reset();
+        container_backend_timeout.reset();
 
         let mut pipe = Pipe::new(
             stream.back.storage.buffer,
             None,
             Some(backend_socket),
             None,
-            None,
-            None,
+            Some(container_backend_timeout),
+            Some(container_frontend_timeout),
             Some(cluster_id),
             stream.front.storage.buffer,
             self.frontend_token,
@@ -369,7 +336,6 @@ impl ProxySession for HttpSession {
         // Restore gauges
         match self.state.marker() {
             StateMarker::Expect => gauge_add!("protocol.proxy.expect", -1),
-            // StateMarker::Http => gauge_add!("protocol.http", -1),
             StateMarker::Mux => gauge_add!("protocol.http", -1),
             StateMarker::WebSocket => {
                 gauge_add!("protocol.ws", -1);

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -463,18 +463,23 @@ impl ProxySession for HttpsSession {
             token,
             super::ready_to_string(events)
         );
+        println!("EVENT: {token:?}->{events:?}");
         self.last_event = Instant::now();
         self.metrics.wait_start();
         self.state.update_readiness(token, events);
     }
 
     fn ready(&mut self, session: Rc<RefCell<dyn ProxySession>>) -> SessionIsToBeClosed {
-        println!("READY");
+        let start = std::time::Instant::now();
+        println!("READY {start:?}");
         self.metrics.service_start();
 
         let session_result =
             self.state
                 .ready(session.clone(), self.proxy.clone(), &mut self.metrics);
+
+        let end = std::time::Instant::now();
+        println!("READY END {end:?} -> {:?}", end.duration_since(start));
 
         let to_be_closed = match session_result {
             SessionResult::Close => true,

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -607,7 +607,7 @@ impl L7ListenerHandler for HttpsListener {
 
         let now = Instant::now();
 
-        if let Route::Cluster { id: cluster, .. } = &route {
+        if let Route::Cluster(cluster) = &route {
             time!("frontend_matching_time", cluster, (now - start).as_millis());
         }
 
@@ -1558,37 +1558,25 @@ mod tests {
             "lolcatho.st".as_bytes(),
             &PathRule::Prefix(uri1),
             &MethodRule::new(None),
-            &Route::Cluster {
-                id: cluster_id1.clone(),
-                h2: false
-            }
+            &Route::Cluster(cluster_id1.clone())
         ));
         assert!(fronts.add_tree_rule(
             "lolcatho.st".as_bytes(),
             &PathRule::Prefix(uri2),
             &MethodRule::new(None),
-            &Route::Cluster {
-                id: cluster_id2,
-                h2: false
-            }
+            &Route::Cluster(cluster_id2)
         ));
         assert!(fronts.add_tree_rule(
             "lolcatho.st".as_bytes(),
             &PathRule::Prefix(uri3),
             &MethodRule::new(None),
-            &Route::Cluster {
-                id: cluster_id3,
-                h2: false
-            }
+            &Route::Cluster(cluster_id3)
         ));
         assert!(fronts.add_tree_rule(
             "other.domain".as_bytes(),
             &PathRule::Prefix("test".to_string()),
             &MethodRule::new(None),
-            &Route::Cluster {
-                id: cluster_id1,
-                h2: false
-            }
+            &Route::Cluster(cluster_id1)
         ));
 
         let address = SocketAddress::new_v4(127, 0, 0, 1, 1032);
@@ -1629,37 +1617,25 @@ mod tests {
         let frontend1 = listener.frontend_from_request("lolcatho.st", "/", &Method::Get);
         assert_eq!(
             frontend1.expect("should find a frontend"),
-            Route::Cluster {
-                id: "cluster_1".to_string(),
-                h2: false
-            }
+            Route::Cluster("cluster_1".to_string())
         );
         println!("TEST {}", line!());
         let frontend2 = listener.frontend_from_request("lolcatho.st", "/test", &Method::Get);
         assert_eq!(
             frontend2.expect("should find a frontend"),
-            Route::Cluster {
-                id: "cluster_1".to_string(),
-                h2: false
-            }
+            Route::Cluster("cluster_1".to_string())
         );
         println!("TEST {}", line!());
         let frontend3 = listener.frontend_from_request("lolcatho.st", "/yolo/test", &Method::Get);
         assert_eq!(
             frontend3.expect("should find a frontend"),
-            Route::Cluster {
-                id: "cluster_2".to_string(),
-                h2: false
-            }
+            Route::Cluster("cluster_2".to_string())
         );
         println!("TEST {}", line!());
         let frontend4 = listener.frontend_from_request("lolcatho.st", "/yolo/swag", &Method::Get);
         assert_eq!(
             frontend4.expect("should find a frontend"),
-            Route::Cluster {
-                id: "cluster_3".to_string(),
-                h2: false
-            }
+            Route::Cluster("cluster_3".to_string())
         );
         println!("TEST {}", line!());
         let frontend5 = listener.frontend_from_request("domain", "/", &Method::Get);

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -59,6 +59,7 @@ use crate::{
             parser::{hostname_and_port, Method},
             ResponseStream,
         },
+        mux::Mux,
         proxy_protocol::expect::ExpectProxyProtocol,
         rustls::TlsHandshake,
         Http, Pipe, SessionState,
@@ -70,8 +71,8 @@ use crate::{
     tls::MutexCertificateResolver,
     util::UnwrapLog,
     AcceptError, CachedTags, FrontendFromRequestError, L7ListenerHandler, L7Proxy, ListenerError,
-    ListenerHandler, Protocol, ProxyConfiguration, ProxyError, ProxySession, SessionIsToBeClosed,
-    SessionMetrics, SessionResult, StateMachineBuilder, StateResult,
+    ListenerHandler, Protocol, ProxyConfiguration, ProxyError, ProxySession, Readiness,
+    SessionIsToBeClosed, SessionMetrics, SessionResult, StateMachineBuilder, StateResult,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -91,6 +92,7 @@ StateMachineBuilder! {
     enum HttpsStateMachine impl SessionState {
         Expect(ExpectProxyProtocol<MioTcpStream>, ServerConnection),
         Handshake(TlsHandshake),
+        Mux(Mux),
         Http(Http<FrontRustls, HttpsListener>),
         WebSocket(Pipe<FrontRustls, HttpsListener>),
         Http2(Http2<FrontRustls>) -> todo!("H2"),
@@ -189,6 +191,7 @@ impl HttpsSession {
             HttpsStateMachine::Expect(expect, ssl) => self.upgrade_expect(expect, ssl),
             HttpsStateMachine::Handshake(handshake) => self.upgrade_handshake(handshake),
             HttpsStateMachine::Http(http) => self.upgrade_http(http),
+            HttpsStateMachine::Mux(mux) => unimplemented!(),
             HttpsStateMachine::Http2(_) => self.upgrade_http2(),
             HttpsStateMachine::WebSocket(wss) => self.upgrade_websocket(wss),
             HttpsStateMachine::FailedUpgrade(_) => unreachable!(),
@@ -276,6 +279,7 @@ impl HttpsSession {
             // Some client don't fill in the ALPN protocol, in this case we default to Http/1.1
             None => AlpnProtocol::Http11,
         };
+        println!("ALPN: {alpn:?}");
 
         if let Some(version) = handshake.session.protocol_version() {
             incr!(rustls_version_str(version));
@@ -290,6 +294,50 @@ impl HttpsSession {
         };
 
         gauge_add!("protocol.tls.handshake", -1);
+        // return Some(HttpsStateMachine::Mux(Mux::new(
+        //     self.frontend_token,
+        //     handshake.request_id,
+        //     self.listener.clone(),
+        //     self.pool.clone(),
+        //     self.public_address,
+        //     self.peer_address,
+        //     self.sticky_name.clone(),
+        // )));
+        use crate::protocol::mux;
+        let frontend = match alpn {
+            AlpnProtocol::Http11 => mux::Connection::H1(mux::ConnectionH1 {
+                socket: front_stream,
+                position: mux::Position::Server,
+                readiness: Readiness {
+                    interest: Ready::READABLE | Ready::HUP | Ready::ERROR,
+                    event: handshake.frontend_readiness.event,
+                },
+                stream: 0,
+            }),
+            AlpnProtocol::H2 => mux::Connection::H2(mux::ConnectionH2 {
+                socket: front_stream,
+                position: mux::Position::Server,
+                readiness: Readiness {
+                    interest: Ready::READABLE | Ready::HUP | Ready::ERROR,
+                    event: handshake.frontend_readiness.event,
+                },
+                streams: HashMap::new(),
+                state: mux::H2State::ClientPreface,
+            }),
+        };
+        let mut mux = Mux {
+            frontend_token: self.frontend_token,
+            frontend,
+            backends: HashMap::new(),
+            streams: Vec::new(),
+            listener: self.listener.clone(),
+            pool: self.pool.clone(),
+            public_address: self.public_address,
+            peer_address: self.peer_address,
+            sticky_name: self.sticky_name.clone(),
+        };
+        mux.create_stream(handshake.request_id).ok()?;
+        return Some(HttpsStateMachine::Mux(mux));
         match alpn {
             AlpnProtocol::Http11 => {
                 let mut http = Http::new(
@@ -416,6 +464,7 @@ impl ProxySession for HttpsSession {
             StateMarker::Expect => gauge_add!("protocol.proxy.expect", -1),
             StateMarker::Handshake => gauge_add!("protocol.tls.handshake", -1),
             StateMarker::Http => gauge_add!("protocol.https", -1),
+            StateMarker::Mux => gauge_add!("protocol.https", -1),
             StateMarker::WebSocket => {
                 gauge_add!("protocol.wss", -1);
                 gauge_add!("websocket.active_requests", -1);
@@ -485,6 +534,7 @@ impl ProxySession for HttpsSession {
     }
 
     fn ready(&mut self, session: Rc<RefCell<dyn ProxySession>>) -> SessionIsToBeClosed {
+        println!("READY");
         self.metrics.service_start();
 
         let session_result =

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -600,7 +600,7 @@ impl L7ListenerHandler for HttpsListener {
 
         let now = Instant::now();
 
-        if let Route::ClusterId(cluster) = &route {
+        if let Route::Cluster { id: cluster, .. } = &route {
             time!("frontend_matching_time", cluster, (now - start).as_millis());
         }
 
@@ -849,7 +849,7 @@ impl HttpsProxy {
         if !socket_errors.is_empty() {
             return Err(ProxyError::SoftStop {
                 proxy_protocol: "HTTPS".to_string(),
-                error: format!("Error deregistering listen sockets: {:?}", socket_errors),
+                error: format!("Error deregistering listen sockets: {socket_errors:?}"),
             });
         }
 
@@ -872,7 +872,7 @@ impl HttpsProxy {
         if !socket_errors.is_empty() {
             return Err(ProxyError::HardStop {
                 proxy_protocol: "HTTPS".to_string(),
-                error: format!("Error deregistering listen sockets: {:?}", socket_errors),
+                error: format!("Error deregistering listen sockets: {socket_errors:?}"),
             });
         }
 
@@ -1551,25 +1551,37 @@ mod tests {
             "lolcatho.st".as_bytes(),
             &PathRule::Prefix(uri1),
             &MethodRule::new(None),
-            &Route::ClusterId(cluster_id1.clone())
+            &Route::Cluster {
+                id: cluster_id1.clone(),
+                h2: false
+            }
         ));
         assert!(fronts.add_tree_rule(
             "lolcatho.st".as_bytes(),
             &PathRule::Prefix(uri2),
             &MethodRule::new(None),
-            &Route::ClusterId(cluster_id2)
+            &Route::Cluster {
+                id: cluster_id2,
+                h2: false
+            }
         ));
         assert!(fronts.add_tree_rule(
             "lolcatho.st".as_bytes(),
             &PathRule::Prefix(uri3),
             &MethodRule::new(None),
-            &Route::ClusterId(cluster_id3)
+            &Route::Cluster {
+                id: cluster_id3,
+                h2: false
+            }
         ));
         assert!(fronts.add_tree_rule(
             "other.domain".as_bytes(),
             &PathRule::Prefix("test".to_string()),
             &MethodRule::new(None),
-            &Route::ClusterId(cluster_id1)
+            &Route::Cluster {
+                id: cluster_id1,
+                h2: false
+            }
         ));
 
         let address = SocketAddress::new_v4(127, 0, 0, 1, 1032);
@@ -1610,25 +1622,37 @@ mod tests {
         let frontend1 = listener.frontend_from_request("lolcatho.st", "/", &Method::Get);
         assert_eq!(
             frontend1.expect("should find a frontend"),
-            Route::ClusterId("cluster_1".to_string())
+            Route::Cluster {
+                id: "cluster_1".to_string(),
+                h2: false
+            }
         );
         println!("TEST {}", line!());
         let frontend2 = listener.frontend_from_request("lolcatho.st", "/test", &Method::Get);
         assert_eq!(
             frontend2.expect("should find a frontend"),
-            Route::ClusterId("cluster_1".to_string())
+            Route::Cluster {
+                id: "cluster_1".to_string(),
+                h2: false
+            }
         );
         println!("TEST {}", line!());
         let frontend3 = listener.frontend_from_request("lolcatho.st", "/yolo/test", &Method::Get);
         assert_eq!(
             frontend3.expect("should find a frontend"),
-            Route::ClusterId("cluster_2".to_string())
+            Route::Cluster {
+                id: "cluster_2".to_string(),
+                h2: false
+            }
         );
         println!("TEST {}", line!());
         let frontend4 = listener.frontend_from_request("lolcatho.st", "/yolo/swag", &Method::Get);
         assert_eq!(
             frontend4.expect("should find a frontend"),
-            Route::ClusterId("cluster_3".to_string())
+            Route::Cluster {
+                id: "cluster_3".to_string(),
+                h2: false
+            }
         );
         println!("TEST {}", line!());
         let frontend5 = listener.frontend_from_request("domain", "/", &Method::Get);

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -272,7 +272,7 @@ impl HttpsSession {
             // Some client don't fill in the ALPN protocol, in this case we default to Http/1.1
             None => AlpnProtocol::Http11,
         };
-        println!("ALPN: {alpn:?}");
+        // println!("ALPN: {alpn:?}");
 
         if let Some(version) = handshake.session.protocol_version() {
             incr!(rustls_version_str(version));
@@ -481,23 +481,23 @@ impl ProxySession for HttpsSession {
             token,
             super::ready_to_string(events)
         );
-        println!("EVENT: {token:?}->{events:?}");
+        // println!("EVENT: {token:?}->{events:?}");
         self.last_event = Instant::now();
         self.metrics.wait_start();
         self.state.update_readiness(token, events);
     }
 
     fn ready(&mut self, session: Rc<RefCell<dyn ProxySession>>) -> SessionIsToBeClosed {
-        let start = std::time::Instant::now();
-        println!("READY {start:?}");
+        // let start = std::time::Instant::now();
+        // println!("READY {start:?}");
         self.metrics.service_start();
 
         let session_result =
             self.state
                 .ready(session.clone(), self.proxy.clone(), &mut self.metrics);
 
-        let end = std::time::Instant::now();
-        println!("READY END {end:?} -> {:?}", end.duration_since(start));
+        // let end = std::time::Instant::now();
+        // println!("READY END {end:?} -> {:?}", end.duration_since(start));
 
         let to_be_closed = match session_result {
             SessionResult::Close => true,

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -56,9 +56,8 @@ use crate::{
         http::{
             answers::HttpAnswers,
             parser::{hostname_and_port, Method},
-            ResponseStream,
         },
-        mux::{self, Mux},
+        mux::{self, Mux, MuxTls},
         proxy_protocol::expect::ExpectProxyProtocol,
         rustls::TlsHandshake,
         Pipe, SessionState,
@@ -91,7 +90,7 @@ StateMachineBuilder! {
     enum HttpsStateMachine impl SessionState {
         Expect(ExpectProxyProtocol<MioTcpStream>, ServerConnection),
         Handshake(TlsHandshake),
-        Mux(Mux<FrontRustls>),
+        Mux(MuxTls),
         // Http(Http<FrontRustls, HttpsListener>),
         WebSocket(Pipe<FrontRustls, HttpsListener>),
         // Http2(Http2<FrontRustls>) -> todo!("H2"),
@@ -291,9 +290,8 @@ impl HttpsSession {
         let router = mux::Router::new(
             self.configured_backend_timeout,
             self.configured_connect_timeout,
-            self.listener.clone(),
         );
-        let mut context = mux::Context::new(self.pool.clone());
+        let mut context = mux::Context::new(self.pool.clone(), self.listener.clone());
         let mut frontend = match alpn {
             AlpnProtocol::Http11 => {
                 context.create_stream(handshake.request_id, 1 << 16)?;
@@ -320,7 +318,7 @@ impl HttpsSession {
         }))
     }
 
-    fn upgrade_mux(&self, mut mux: Mux<FrontRustls>) -> Option<HttpsStateMachine> {
+    fn upgrade_mux(&self, mut mux: MuxTls) -> Option<HttpsStateMachine> {
         debug!("mux switching to wss");
         let stream = mux.context.streams.pop().unwrap();
 
@@ -547,8 +545,20 @@ pub struct HttpsListener {
 }
 
 impl ListenerHandler for HttpsListener {
-    fn get_addr(&self) -> &StdSocketAddr {
+    fn protocol(&self) -> Protocol {
+        Protocol::HTTPS
+    }
+
+    fn address(&self) -> &StdSocketAddr {
         &self.address
+    }
+
+    fn public_address(&self) -> StdSocketAddr {
+        self.config
+            .public_address
+            .as_ref()
+            .map(|addr| addr.clone().into())
+            .unwrap_or(self.address.clone())
     }
 
     fn get_tags(&self, key: &str) -> Option<&CachedTags> {
@@ -564,11 +574,11 @@ impl ListenerHandler for HttpsListener {
 }
 
 impl L7ListenerHandler for HttpsListener {
-    fn get_sticky_name(&self) -> &str {
+    fn sticky_name(&self) -> &str {
         &self.config.sticky_name
     }
 
-    fn get_connect_timeout(&self) -> u32 {
+    fn connect_timeout(&self) -> u32 {
         self.config.connect_timeout
     }
 

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -291,7 +291,12 @@ impl HttpsSession {
             self.configured_backend_timeout,
             self.configured_connect_timeout,
         );
-        let mut context = mux::Context::new(self.pool.clone(), self.listener.clone());
+        let mut context = mux::Context::new(
+            self.pool.clone(),
+            self.listener.clone(),
+            self.peer_address,
+            self.public_address,
+        );
         let mut frontend = match alpn {
             AlpnProtocol::Http11 => {
                 context.create_stream(handshake.request_id, 1 << 16)?;
@@ -312,9 +317,6 @@ impl HttpsSession {
             frontend,
             context,
             router,
-            public_address: self.public_address,
-            peer_address: self.peer_address,
-            sticky_name: self.sticky_name.clone(),
         }))
     }
 

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -53,7 +53,6 @@ use crate::{
     backends::BackendMap,
     pool::Pool,
     protocol::{
-        h2::Http2,
         http::{
             answers::HttpAnswers,
             parser::{hostname_and_port, Method},
@@ -62,7 +61,7 @@ use crate::{
         mux::{self, Mux},
         proxy_protocol::expect::ExpectProxyProtocol,
         rustls::TlsHandshake,
-        Http, Pipe, SessionState,
+        Pipe, SessionState,
     },
     router::{Route, Router},
     server::{ListenToken, SessionManager},
@@ -93,9 +92,9 @@ StateMachineBuilder! {
         Expect(ExpectProxyProtocol<MioTcpStream>, ServerConnection),
         Handshake(TlsHandshake),
         Mux(Mux<FrontRustls>),
-        Http(Http<FrontRustls, HttpsListener>),
+        // Http(Http<FrontRustls, HttpsListener>),
         WebSocket(Pipe<FrontRustls, HttpsListener>),
-        Http2(Http2<FrontRustls>) -> todo!("H2"),
+        // Http2(Http2<FrontRustls>) -> todo!("H2"),
     }
 }
 
@@ -190,9 +189,9 @@ impl HttpsSession {
         let new_state = match self.state.take() {
             HttpsStateMachine::Expect(expect, ssl) => self.upgrade_expect(expect, ssl),
             HttpsStateMachine::Handshake(handshake) => self.upgrade_handshake(handshake),
-            HttpsStateMachine::Http(http) => self.upgrade_http(http),
-            HttpsStateMachine::Mux(_) => unimplemented!(),
-            HttpsStateMachine::Http2(_) => self.upgrade_http2(),
+            // HttpsStateMachine::Http(http) => self.upgrade_http(http),
+            HttpsStateMachine::Mux(mux) => self.upgrade_mux(mux),
+            // HttpsStateMachine::Http2(_) => self.upgrade_http2(),
             HttpsStateMachine::WebSocket(wss) => self.upgrade_websocket(wss),
             HttpsStateMachine::FailedUpgrade(_) => unreachable!(),
         };
@@ -289,74 +288,105 @@ impl HttpsSession {
 
         gauge_add!("protocol.tls.handshake", -1);
 
+        let router = mux::Router::new(
+            self.configured_backend_timeout,
+            self.configured_connect_timeout,
+            self.listener.clone(),
+        );
         let mut context = mux::Context::new(self.pool.clone());
         let mut frontend = match alpn {
             AlpnProtocol::Http11 => {
                 context.create_stream(handshake.request_id, 1 << 16)?;
-                mux::Connection::new_h1_server(front_stream)
+                mux::Connection::new_h1_server(front_stream, handshake.container_frontend_timeout)
             }
-            AlpnProtocol::H2 => mux::Connection::new_h2_server(front_stream, self.pool.clone())?,
+            AlpnProtocol::H2 => mux::Connection::new_h2_server(
+                front_stream,
+                self.pool.clone(),
+                handshake.container_frontend_timeout,
+            )?,
         };
         frontend.readiness_mut().event = handshake.frontend_readiness.event;
 
         gauge_add!("protocol.https", 1);
         Some(HttpsStateMachine::Mux(Mux {
+            configured_frontend_timeout: self.configured_frontend_timeout,
             frontend_token: self.frontend_token,
             frontend,
             context,
-            router: mux::Router::new(self.listener.clone()),
+            router,
             public_address: self.public_address,
             peer_address: self.peer_address,
             sticky_name: self.sticky_name.clone(),
         }))
     }
 
-    fn upgrade_http(&self, http: Http<FrontRustls, HttpsListener>) -> Option<HttpsStateMachine> {
-        debug!("https switching to wss");
-        let front_token = self.frontend_token;
-        let back_token = match http.backend_token {
-            Some(back_token) => back_token,
-            None => {
-                warn!(
-                    "Could not upgrade https request on cluster '{:?}' ({:?}) using backend '{:?}' into secure websocket for request '{}'",
-                    http.context.cluster_id, self.frontend_token, http.context.backend_id, http.context.id
-                );
-                return None;
-            }
-        };
-        let ws_context = http.context.websocket_context();
+    fn upgrade_mux(&self, mut mux: Mux<FrontRustls>) -> Option<HttpsStateMachine> {
+        debug!("mux switching to wss");
+        let stream = mux.context.streams.pop().unwrap();
 
-        let mut container_frontend_timeout = http.container_frontend_timeout;
-        let mut container_backend_timeout = http.container_backend_timeout;
+        let (frontend_readiness, frontend_socket, mut container_frontend_timeout) =
+            match mux.frontend {
+                mux::Connection::H1(mux::ConnectionH1 {
+                    readiness,
+                    socket,
+                    timeout_container,
+                    ..
+                }) => (readiness, socket, timeout_container),
+                mux::Connection::H2(_) => {
+                    error!("Only h1<->h1 connections can upgrade to websocket");
+                    return None;
+                }
+            };
+
+        let mux::StreamState::Linked(back_token) = stream.state else {
+            error!("Upgrading stream should be linked to a backend");
+            return None;
+        };
+        let backend = mux.router.backends.remove(&back_token).unwrap();
+        let (cluster_id, backend_readiness, backend_socket, mut container_backend_timeout) =
+            match backend {
+                mux::Connection::H1(mux::ConnectionH1 {
+                    position: mux::Position::Client(mux::BackendStatus::Connected(cluster_id)),
+                    readiness,
+                    socket,
+                    timeout_container,
+                    ..
+                }) => (cluster_id, readiness, socket, timeout_container),
+                mux::Connection::H1(_) => {
+                    error!("The backend disconnected just after upgrade, abort");
+                    return None;
+                }
+                mux::Connection::H2(_) => {
+                    error!("Only h1<->h1 connections can upgrade to websocket");
+                    return None;
+                }
+            };
+
+        let ws_context = stream.context.websocket_context();
+
         container_frontend_timeout.reset();
         container_backend_timeout.reset();
 
-        let backend_buffer = if let ResponseStream::BackendAnswer(kawa) = http.response_stream {
-            kawa.storage.buffer
-        } else {
-            return None;
-        };
-
         let mut pipe = Pipe::new(
-            backend_buffer,
-            http.context.backend_id,
-            http.backend_socket,
-            http.backend,
+            stream.back.storage.buffer,
+            None,
+            Some(backend_socket),
+            None,
             Some(container_backend_timeout),
             Some(container_frontend_timeout),
-            http.context.cluster_id,
-            http.request_stream.storage.buffer,
-            front_token,
-            http.frontend_socket,
+            Some(cluster_id),
+            stream.front.storage.buffer,
+            self.frontend_token,
+            frontend_socket,
             self.listener.clone(),
-            Protocol::HTTP,
-            http.context.id,
-            http.context.session_address,
+            Protocol::HTTPS,
+            stream.context.id,
+            stream.context.session_address,
             ws_context,
         );
 
-        pipe.frontend_readiness.event = http.frontend_readiness.event;
-        pipe.backend_readiness.event = http.backend_readiness.event;
+        pipe.frontend_readiness.event = frontend_readiness.event;
+        pipe.backend_readiness.event = backend_readiness.event;
         pipe.set_back_token(back_token);
 
         gauge_add!("protocol.https", -1);
@@ -364,10 +394,6 @@ impl HttpsSession {
         gauge_add!("http.active_requests", -1);
         gauge_add!("websocket.active_requests", 1);
         Some(HttpsStateMachine::WebSocket(pipe))
-    }
-
-    fn upgrade_http2(&self) -> Option<HttpsStateMachine> {
-        todo!()
     }
 
     fn upgrade_websocket(
@@ -393,23 +419,19 @@ impl ProxySession for HttpsSession {
         match self.state.marker() {
             StateMarker::Expect => gauge_add!("protocol.proxy.expect", -1),
             StateMarker::Handshake => gauge_add!("protocol.tls.handshake", -1),
-            StateMarker::Http => gauge_add!("protocol.https", -1),
             StateMarker::Mux => gauge_add!("protocol.https", -1),
             StateMarker::WebSocket => {
                 gauge_add!("protocol.wss", -1);
                 gauge_add!("websocket.active_requests", -1);
             }
-            StateMarker::Http2 => gauge_add!("protocol.http2", -1),
         }
 
         if self.state.failed() {
             match self.state.marker() {
                 StateMarker::Expect => incr!("https.upgrade.expect.failed"),
                 StateMarker::Handshake => incr!("https.upgrade.handshake.failed"),
-                StateMarker::Http => incr!("https.upgrade.http.failed"),
-                StateMarker::WebSocket => incr!("https.upgrade.wss.failed"),
-                StateMarker::Http2 => incr!("https.upgrade.http2.failed"),
                 StateMarker::Mux => incr!("https.upgrade.mux.failed"),
+                StateMarker::WebSocket => incr!("https.upgrade.wss.failed"),
             }
             return;
         }

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -323,6 +323,7 @@ impl HttpsSession {
                 },
                 streams: HashMap::new(),
                 state: mux::H2State::ClientPreface,
+                expect: Some((0, 24 + 9)),
             }),
         };
         let mut mux = Mux {
@@ -479,6 +480,7 @@ impl ProxySession for HttpsSession {
                 StateMarker::Http => incr!("https.upgrade.http.failed"),
                 StateMarker::WebSocket => incr!("https.upgrade.wss.failed"),
                 StateMarker::Http2 => incr!("https.upgrade.http2.failed"),
+                StateMarker::Mux => incr!("https.upgrade.mux.failed"),
             }
             return;
         }

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -298,9 +298,11 @@ impl HttpsSession {
         let mux = Mux {
             frontend_token: self.frontend_token,
             frontend,
-            backends: HashMap::new(),
             context: mux::Context::new(self.pool.clone(), handshake.request_id, 1 << 16).ok()?,
-            listener: self.listener.clone(),
+            router: mux::Router {
+                listener: self.listener.clone(),
+                backends: HashMap::new(),
+            },
             public_address: self.public_address,
             peer_address: self.peer_address,
             sticky_name: self.sticky_name.clone(),
@@ -553,7 +555,6 @@ impl L7ListenerHandler for HttpsListener {
         let (remaining_input, (hostname, _)) = match hostname_and_port(host.as_bytes()) {
             Ok(tuple) => tuple,
             Err(parse_error) => {
-                // parse_error contains a slice of given_host, which should NOT escape this scope
                 return Err(FrontendFromRequestError::HostParse {
                     host: host.to_owned(),
                     error: parse_error.to_string(),

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -585,6 +585,8 @@ pub enum BackendConnectionError {
     MaxConnectionRetries(Option<String>),
     #[error("the sessions slab has reached maximum capacity")]
     MaxSessionsMemory,
+    #[error("the checkout pool has reached maximum capacity")]
+    MaxBuffers,
     #[error("error from the backend: {0}")]
     Backend(BackendError),
     #[error("failed to retrieve the cluster: {0}")]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -604,6 +604,8 @@ pub enum RetrieveClusterError {
     UnauthorizedRoute,
     #[error("{0}")]
     RetrieveFrontend(FrontendFromRequestError),
+    #[error("https redirect")]
+    HttpsRedirect,
 }
 
 /// Used in sessions

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -495,9 +495,7 @@ macro_rules! StateMachineBuilder {
             /// leaving a FailedUpgrade in its place.
             /// The FailedUpgrade retains the marker of the previous State.
             fn take(&mut self) -> $state_name {
-                let mut owned_state = $state_name::FailedUpgrade(self.marker());
-                std::mem::swap(&mut owned_state, self);
-                owned_state
+                std::mem::replace(self, $state_name::FailedUpgrade(self.marker()))
             }
             _fn_impl!{front_socket(&, self) -> &mio::net::TcpStream}
         }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -583,7 +583,7 @@ pub enum BackendConnectAction {
 pub enum BackendConnectionError {
     #[error("Not found: {0:?}")]
     NotFound(ObjectKind),
-    #[error("Too many connections on cluster {0:?}")]
+    #[error("Too many failed attemps on cluster {0:?}")]
     MaxConnectionRetries(Option<String>),
     #[error("the sessions slab has reached maximum capacity")]
     MaxSessionsMemory,

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -38,7 +38,7 @@ pub struct HttpContext {
     pub user_agent: Option<String>,
 
     // ========== Read only
-    /// signals wether Kawa should write a "Connection" header with a "close" value (request and response)
+    /// signals whether Kawa should write a "Connection" header with a "close" value (request and response)
     pub closing: bool,
     /// the value of the custom header, named "Sozu-Id", that Kawa should write (request and response)
     pub id: Ulid,

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -74,16 +74,16 @@ impl HttpContext {
     pub fn new(
         id: Ulid,
         protocol: Protocol,
+        sticky_name: String,
         public_address: SocketAddr,
         session_address: Option<SocketAddr>,
-        sticky_name: String,
     ) -> Self {
         Self {
             id,
             protocol,
+            sticky_name,
             public_address,
             session_address,
-            sticky_name,
 
             cluster_id: None,
             backend_id: None,

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -45,8 +45,9 @@ pub struct HttpContext {
     pub closing: bool,
     /// the value of the custom header, named "Sozu-Id", that Kawa should write (request and response)
     pub id: Ulid,
-    pub backend_id: Option<String>,
     pub cluster_id: Option<String>,
+    pub backend_id: Option<String>,
+    pub backend_address: Option<SocketAddr>,
     /// the value of the protocol Kawa should write in the Forwarded headers of the request
     pub protocol: Protocol,
     /// the value of the public address Kawa should write in the Forwarded headers of the request
@@ -70,6 +71,36 @@ impl kawa::h1::ParserCallbacks<Checkout> for HttpContext {
 }
 
 impl HttpContext {
+    pub fn new(
+        id: Ulid,
+        protocol: Protocol,
+        public_address: SocketAddr,
+        session_address: Option<SocketAddr>,
+        sticky_name: String,
+    ) -> Self {
+        Self {
+            id,
+            protocol,
+            public_address,
+            session_address,
+            sticky_name,
+
+            cluster_id: None,
+            backend_id: None,
+            backend_address: None,
+            keep_alive_backend: true,
+            keep_alive_frontend: true,
+            sticky_session_found: None,
+            method: None,
+            authority: None,
+            path: None,
+            status: None,
+            reason: None,
+            user_agent: None,
+            closing: false,
+            sticky_session: None,
+        }
+    }
     /// Callback for request:
     ///
     /// - edit headers (connection, forwarded, sticky cookie, sozu-id)

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -7,7 +7,10 @@ use rusty_ulid::Ulid;
 
 use crate::{
     pool::Checkout,
-    protocol::http::{parser::compare_no_case, GenericHttpStream, Method},
+    protocol::{
+        http::{parser::compare_no_case, GenericHttpStream, Method},
+        pipe::WebSocketContext,
+    },
     Protocol, RetrieveClusterError,
 };
 
@@ -390,5 +393,15 @@ impl HttpContext {
             return format!("{method}");
         }
         String::new()
+    }
+
+    pub fn websocket_context(&self) -> WebSocketContext {
+        WebSocketContext::Http {
+            method: self.method.clone(),
+            authority: self.authority.clone(),
+            path: self.path.clone(),
+            reason: self.reason.clone(),
+            status: self.status,
+        }
     }
 }

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -356,6 +356,7 @@ impl HttpContext {
         self.status = None;
         self.reason = None;
         self.user_agent = None;
+        self.id = Ulid::generate();
     }
 
     pub fn log_context(&self) -> LogContext {

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -1279,8 +1279,8 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             }
         };
 
-        let cluster_id = match route {
-            Route::ClusterId(cluster_id) => cluster_id,
+        let (cluster_id, _) = match route {
+            Route::Cluster { id, h2 } => (id, h2),
             Route::Deny => {
                 self.set_answer(DefaultAnswer::Answer401 {});
                 return Err(RetrieveClusterError::UnauthorizedRoute);

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -916,17 +916,6 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         }
     }
 
-    /// Format the context of the websocket into a loggable String
-    pub fn websocket_context(&self) -> WebSocketContext {
-        WebSocketContext::Http {
-            method: self.context.method.clone(),
-            authority: self.context.authority.clone(),
-            path: self.context.path.clone(),
-            reason: self.context.reason.clone(),
-            status: self.context.status,
-        }
-    }
-
     pub fn log_request(&self, metrics: &SessionMetrics, error: bool, message: Option<&str>) {
         let listener = self.listener.borrow();
         let tags = self.context.authority.as_ref().and_then(|host| {

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -274,7 +274,6 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             _ => return,
         };
 
-        self.context.id = Ulid::generate();
         self.context.reset();
 
         self.request_stream.clear();

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -1279,8 +1279,8 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             }
         };
 
-        let (cluster_id, _) = match route {
-            Route::Cluster { id, h2 } => (id, h2),
+        let cluster_id = match route {
+            Route::Cluster { id, .. } => id,
             Route::Deny => {
                 self.set_answer(DefaultAnswer::Answer401 {});
                 return Err(RetrieveClusterError::UnauthorizedRoute);

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -1234,7 +1234,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         };
 
         let cluster_id = match route {
-            Route::Cluster { id, .. } => id,
+            Route::Cluster(id) => id,
             Route::Deny => {
                 self.set_answer(DefaultAnswer::Answer401 {});
                 return Err(RetrieveClusterError::UnauthorizedRoute);

--- a/lib/src/protocol/mod.rs
+++ b/lib/src/protocol/mod.rs
@@ -1,5 +1,6 @@
 pub mod h2;
 pub mod kawa_h1;
+pub mod mux;
 pub mod pipe;
 pub mod proxy_protocol;
 pub mod rustls;

--- a/lib/src/protocol/mod.rs
+++ b/lib/src/protocol/mod.rs
@@ -24,17 +24,17 @@ pub trait SessionState {
     /// if a session received an event or can still execute, the event loop will
     /// call this method. Its result indicates if it can still execute or if the
     /// session can be closed
-    fn ready(
+    fn ready<P: L7Proxy>(
         &mut self,
         session: Rc<RefCell<dyn ProxySession>>,
-        proxy: Rc<RefCell<dyn L7Proxy>>,
+        proxy: Rc<RefCell<P>>,
         metrics: &mut SessionMetrics,
     ) -> SessionResult;
     /// if the event loop got an event for a token associated with the session,
     /// it will call this method
     fn update_readiness(&mut self, token: Token, events: Ready);
     /// close the state
-    fn close(&mut self, _proxy: Rc<RefCell<dyn L7Proxy>>, _metrics: &mut SessionMetrics) {}
+    fn close<P: L7Proxy>(&mut self, _proxy: Rc<RefCell<P>>, _metrics: &mut SessionMetrics) {}
     /// if a timeout associated with the session triggers, the event loop will
     /// call this method with the timeout's token
     fn timeout(&mut self, token: Token, metrics: &mut SessionMetrics) -> StateResult;

--- a/lib/src/protocol/mux/converter.rs
+++ b/lib/src/protocol/mux/converter.rs
@@ -7,12 +7,11 @@ use crate::protocol::http::parser::compare_no_case;
 use super::{
     parser::{FrameHeader, FrameType, H2Error},
     serializer::{gen_frame_header, gen_rst_stream},
-    StreamId, StreamState,
+    StreamId,
 };
 
 pub struct H2BlockConverter<'a> {
     pub stream_id: StreamId,
-    pub state: StreamState,
     pub encoder: &'a mut hpack::Encoder<'static>,
     pub out: Vec<u8>,
 }

--- a/lib/src/protocol/mux/converter.rs
+++ b/lib/src/protocol/mux/converter.rs
@@ -150,7 +150,7 @@ impl<'a, T: AsBuffer> BlockConverter<T> for H2BlockConverter<'a> {
                 .unwrap();
                 kawa.push_out(Store::from_slice(&header));
                 kawa.push_out(data);
-                kawa.push_delimiter();
+                // kawa.push_delimiter();
                 return can_continue;
             }
             Block::Flags(Flags {
@@ -189,7 +189,7 @@ impl<'a, T: AsBuffer> BlockConverter<T> for H2BlockConverter<'a> {
                     kawa.push_out(Store::from_slice(&header));
                 }
                 if end_header || end_stream {
-                    kawa.push_delimiter()
+                    // kawa.push_delimiter()
                 }
             }
         }

--- a/lib/src/protocol/mux/converter.rs
+++ b/lib/src/protocol/mux/converter.rs
@@ -124,7 +124,7 @@ impl<'a, T: AsBuffer> BlockConverter<T> for H2BlockConverter<'a> {
                 ..
             }) => {
                 if end_header {
-                    let payload = std::mem::replace(&mut self.out, Vec::new());
+                    let payload = std::mem::take(&mut self.out);
                     let mut header = [0; 9];
                     let flags = if end_stream { 1 } else { 0 } | if end_header { 4 } else { 0 };
                     gen_frame_header(

--- a/lib/src/protocol/mux/converter.rs
+++ b/lib/src/protocol/mux/converter.rs
@@ -125,8 +125,7 @@ impl<'a, T: AsBuffer> BlockConverter<T> for H2BlockConverter<'a> {
                 ..
             }) => {
                 if end_header {
-                    let mut payload = Vec::new();
-                    std::mem::swap(&mut self.out, &mut payload);
+                    let payload = std::mem::replace(&mut self.out, Vec::new());
                     let mut header = [0; 9];
                     let flags = if end_stream { 1 } else { 0 } | if end_header { 4 } else { 0 };
                     gen_frame_header(

--- a/lib/src/protocol/mux/converter.rs
+++ b/lib/src/protocol/mux/converter.rs
@@ -1,5 +1,3 @@
-use std::str::from_utf8_unchecked;
-
 use kawa::{
     AsBuffer, Block, BlockConverter, Chunk, Flags, Kawa, Pair, ParsingErrorKind, ParsingPhase,
     StatusLine, Store,
@@ -107,7 +105,6 @@ impl<'a, T: AsBuffer> BlockConverter<T> for H2BlockConverter<'a> {
                         || compare_no_case(key, b"transfer-encoding")
                         || compare_no_case(key, b"upgrade")
                     {
-                        println!("Elided H2 header: {}", unsafe { from_utf8_unchecked(key) });
                         return true;
                     }
                 }

--- a/lib/src/protocol/mux/converter.rs
+++ b/lib/src/protocol/mux/converter.rs
@@ -1,3 +1,5 @@
+use std::cmp::min;
+
 use kawa::{
     AsBuffer, Block, BlockConverter, Chunk, Flags, Kawa, Pair, ParsingErrorKind, ParsingPhase,
     StatusLine, Store,
@@ -13,6 +15,7 @@ use crate::protocol::{
 };
 
 pub struct H2BlockConverter<'a> {
+    pub max_frame_size: usize,
     pub window: i32,
     pub stream_id: StreamId,
     pub encoder: &'a mut hpack::Encoder<'static>,
@@ -121,19 +124,25 @@ impl<'a, T: AsBuffer> BlockConverter<T> for H2BlockConverter<'a> {
             Block::Chunk(Chunk { data }) => {
                 let mut header = [0; 9];
                 let payload_len = data.len();
-                let (data, payload_len, can_continue) = if self.window >= payload_len as i32 {
-                    // the window is wide enought to send the entire chunk
-                    (data, payload_len as u32, true)
-                } else if self.window > 0 {
-                    // we split the chunk to fit in the window
-                    let (before, after) = data.split(self.window as usize);
-                    kawa.blocks.push_front(Block::Chunk(Chunk { data: after }));
-                    (before, self.window as u32, false)
-                } else {
-                    // the window can't take any more bytes, return the chunk to the blocks
-                    kawa.blocks.push_front(Block::Chunk(Chunk { data }));
-                    return false;
-                };
+                let (data, payload_len, can_continue) =
+                    if self.window >= payload_len as i32 && self.max_frame_size >= payload_len {
+                        // the window is wide enought to send the entire chunk
+                        (data, payload_len as u32, true)
+                    } else if self.window > 0 {
+                        // we split the chunk to fit in the window
+                        let payload_len = min(self.max_frame_size, self.window as usize);
+                        let (before, after) = data.split(payload_len);
+                        kawa.blocks.push_front(Block::Chunk(Chunk { data: after }));
+                        (
+                            before,
+                            payload_len as u32,
+                            self.max_frame_size < self.window as usize,
+                        )
+                    } else {
+                        // the window can't take any more bytes, return the chunk to the blocks
+                        kawa.blocks.push_front(Block::Chunk(Chunk { data }));
+                        return false;
+                    };
                 self.window -= payload_len as i32;
                 gen_frame_header(
                     &mut header,
@@ -158,19 +167,37 @@ impl<'a, T: AsBuffer> BlockConverter<T> for H2BlockConverter<'a> {
                 if end_header {
                     let payload = std::mem::take(&mut self.out);
                     let mut header = [0; 9];
-                    let flags = if end_stream { 1 } else { 0 } | if end_header { 4 } else { 0 };
-                    gen_frame_header(
-                        &mut header,
-                        &FrameHeader {
-                            payload_len: payload.len() as u32,
-                            frame_type: FrameType::Headers,
-                            flags,
-                            stream_id: self.stream_id,
-                        },
-                    )
-                    .unwrap();
-                    kawa.push_out(Store::from_slice(&header));
-                    kawa.push_out(Store::Alloc(payload.into_boxed_slice(), 0));
+                    let chunks = payload.chunks(self.max_frame_size);
+                    let n_chunks = chunks.len();
+                    for (i, chunk) in chunks.enumerate() {
+                        let flags = if i == 0 && end_stream { 1 } else { 0 }
+                            | if i + 1 == n_chunks { 4 } else { 0 };
+                        if i == 0 {
+                            gen_frame_header(
+                                &mut header,
+                                &FrameHeader {
+                                    payload_len: chunk.len() as u32,
+                                    frame_type: FrameType::Headers,
+                                    flags,
+                                    stream_id: self.stream_id,
+                                },
+                            )
+                            .unwrap();
+                        } else {
+                            gen_frame_header(
+                                &mut header,
+                                &FrameHeader {
+                                    payload_len: chunk.len() as u32,
+                                    frame_type: FrameType::Continuation,
+                                    flags,
+                                    stream_id: self.stream_id,
+                                },
+                            )
+                            .unwrap();
+                        }
+                        kawa.push_out(Store::from_slice(&header));
+                        kawa.push_out(Store::from_slice(chunk));
+                    }
                 } else if end_stream {
                     let mut header = [0; 9];
                     gen_frame_header(

--- a/lib/src/protocol/mux/converter.rs
+++ b/lib/src/protocol/mux/converter.rs
@@ -17,7 +17,7 @@ pub struct H2BlockConverter<'a> {
 }
 
 impl<'a, T: AsBuffer> BlockConverter<T> for H2BlockConverter<'a> {
-    fn call(&mut self, block: Block, kawa: &mut Kawa<T>) {
+    fn call(&mut self, block: Block, kawa: &mut Kawa<T>) -> bool {
         let buffer = kawa.storage.buffer();
         match block {
             Block::StatusLine => match kawa.detached.status_line.pop() {
@@ -49,7 +49,7 @@ impl<'a, T: AsBuffer> BlockConverter<T> for H2BlockConverter<'a> {
             },
             Block::Cookies => {
                 if kawa.detached.jar.is_empty() {
-                    return;
+                    return true;
                 }
                 for cookie in kawa
                     .detached
@@ -83,7 +83,7 @@ impl<'a, T: AsBuffer> BlockConverter<T> for H2BlockConverter<'a> {
                         || compare_no_case(key, b"upgrade")
                     {
                         println!("Elided H2 header: {}", unsafe { from_utf8_unchecked(key) });
-                        return;
+                        return true;
                     }
                 }
                 self.encoder
@@ -164,6 +164,7 @@ impl<'a, T: AsBuffer> BlockConverter<T> for H2BlockConverter<'a> {
                 }
             }
         }
+        true
     }
     fn finalize(&mut self, _kawa: &mut Kawa<T>) {
         assert!(self.out.is_empty());

--- a/lib/src/protocol/mux/converter.rs
+++ b/lib/src/protocol/mux/converter.rs
@@ -1,0 +1,159 @@
+use kawa::{AsBuffer, Block, BlockConverter, Chunk, Flags, Kawa, Pair, StatusLine, Store};
+
+use super::{
+    parser::{FrameHeader, FrameType},
+    serializer::gen_frame_header,
+    StreamId,
+};
+
+pub struct H2BlockConverter<'a> {
+    pub stream_id: StreamId,
+    pub encoder: &'a mut hpack::Encoder<'static>,
+    pub out: Vec<u8>,
+}
+
+impl<'a, T: AsBuffer> BlockConverter<T> for H2BlockConverter<'a> {
+    fn call(&mut self, block: Block, kawa: &mut Kawa<T>) {
+        let buffer = kawa.storage.mut_buffer();
+        match block {
+            Block::StatusLine => match kawa.detached.status_line.pop() {
+                StatusLine::Request {
+                    method,
+                    authority,
+                    path,
+                    ..
+                } => {
+                    self.encoder
+                        .encode_header_into((b":method", method.data(buffer)), &mut self.out)
+                        .unwrap();
+                    self.encoder
+                        .encode_header_into((b":authority", authority.data(buffer)), &mut self.out)
+                        .unwrap();
+                    self.encoder
+                        .encode_header_into((b":path", path.data(buffer)), &mut self.out)
+                        .unwrap();
+                    self.encoder
+                        .encode_header_into((b":scheme", b"https"), &mut self.out)
+                        .unwrap();
+                }
+                StatusLine::Response { status, .. } => {
+                    self.encoder
+                        .encode_header_into((b":status", status.data(buffer)), &mut self.out)
+                        .unwrap();
+                }
+                StatusLine::Unknown => unreachable!(),
+            },
+            Block::Cookies => {
+                if kawa.detached.jar.is_empty() {
+                    return;
+                }
+                for cookie in kawa
+                    .detached
+                    .jar
+                    .drain(..)
+                    .filter(|cookie| !cookie.is_elided())
+                {
+                    let cookie = [cookie.key.data(buffer), b"=", cookie.val.data(buffer)].concat();
+                    self.encoder
+                        .encode_header_into((b"cookie", &cookie), &mut self.out)
+                        .unwrap();
+                }
+            }
+            Block::Header(Pair {
+                key: Store::Empty, ..
+            }) => {
+                // elided header
+            }
+            Block::Header(Pair { key, val }) => {
+                {
+                    // let key = key.data(kawa.storage.buffer());
+                    // let val = val.data(kawa.storage.buffer());
+                    // if compare_no_case(key, b"connection")
+                    //     || compare_no_case(key, b"host")
+                    //     || compare_no_case(key, b"http2-settings")
+                    //     || compare_no_case(key, b"keep-alive")
+                    //     || compare_no_case(key, b"proxy-connection")
+                    //     || compare_no_case(key, b"te") && !compare_no_case(val, b"trailers")
+                    //     || compare_no_case(key, b"trailer")
+                    //     || compare_no_case(key, b"transfer-encoding")
+                    //     || compare_no_case(key, b"upgrade")
+                    // {
+                    //     return;
+                    // }
+                }
+                self.encoder
+                    .encode_header_into((key.data(buffer), val.data(buffer)), &mut self.out)
+                    .unwrap();
+            }
+            Block::ChunkHeader(_) => {
+                // this converter doesn't align H1 chunks on H2 data frames
+            }
+            Block::Chunk(Chunk { data }) => {
+                let mut header = [0; 9];
+                let payload_len = match &data {
+                    Store::Empty => 0,
+                    Store::Detached(s) | Store::Slice(s) => s.len,
+                    Store::Static(s) => s.len() as u32,
+                    Store::Alloc(a, i) => a.len() as u32 - i,
+                };
+                gen_frame_header(
+                    &mut header,
+                    &FrameHeader {
+                        payload_len,
+                        frame_type: FrameType::Data,
+                        flags: 0,
+                        stream_id: self.stream_id,
+                    },
+                )
+                .unwrap();
+                kawa.push_out(Store::from_slice(&header));
+                kawa.push_out(data);
+                kawa.push_delimiter()
+            }
+            Block::Flags(Flags {
+                end_header,
+                end_stream,
+                ..
+            }) => {
+                if end_header {
+                    let mut payload = Vec::new();
+                    std::mem::swap(&mut self.out, &mut payload);
+                    let mut header = [0; 9];
+                    let flags = if end_stream { 1 } else { 0 } | if end_header { 4 } else { 0 };
+                    gen_frame_header(
+                        &mut header,
+                        &FrameHeader {
+                            payload_len: payload.len() as u32,
+                            frame_type: FrameType::Headers,
+                            flags,
+                            stream_id: self.stream_id,
+                        },
+                    )
+                    .unwrap();
+                    kawa.push_out(Store::from_slice(&header));
+                    kawa.push_out(Store::Alloc(payload.into_boxed_slice(), 0));
+                }
+                if end_stream {
+                    let mut header = [0; 9];
+                    gen_frame_header(
+                        &mut header,
+                        &FrameHeader {
+                            payload_len: 0,
+                            frame_type: FrameType::Data,
+                            flags: 1,
+                            stream_id: self.stream_id,
+                        },
+                    )
+                    .unwrap();
+                    kawa.push_out(Store::from_slice(&header));
+                }
+                if end_header || end_stream {
+                    kawa.push_delimiter()
+                }
+            }
+        }
+    }
+    fn finalize(&mut self, _kawa: &mut Kawa<T>) {
+        assert!(self.out.is_empty());
+    }
+}

--- a/lib/src/protocol/mux/converter.rs
+++ b/lib/src/protocol/mux/converter.rs
@@ -82,7 +82,10 @@ impl<'a, T: AsBuffer> BlockConverter<T> for H2BlockConverter<'a> {
                     // }
                 }
                 self.encoder
-                    .encode_header_into((key.data(buffer), val.data(buffer)), &mut self.out)
+                    .encode_header_into(
+                        (&key.data(buffer).to_ascii_lowercase(), val.data(buffer)),
+                        &mut self.out,
+                    )
                     .unwrap();
             }
             Block::ChunkHeader(_) => {

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -17,7 +17,7 @@ pub struct ConnectionH1<Front: SocketHandler> {
 }
 
 impl<Front: SocketHandler> ConnectionH1<Front> {
-    pub fn readable<E>(&mut self, context: &mut Context, endpoint: E) -> MuxResult
+    pub fn readable<E>(&mut self, context: &mut Context, mut endpoint: E) -> MuxResult
     where
         E: UpdateReadiness,
     {
@@ -44,6 +44,12 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         }
         if kawa.is_terminated() {
             self.readiness.interest.remove(Ready::READABLE);
+        }
+        if kawa.is_main_phase() {
+            endpoint
+                .readiness_mut(stream.token.unwrap())
+                .interest
+                .insert(Ready::WRITABLE)
         }
         MuxResult::Continue
     }

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -6,6 +6,8 @@ use crate::{
     Readiness,
 };
 
+use super::UpdateReadiness;
+
 pub struct ConnectionH1<Front: SocketHandler> {
     pub position: Position,
     pub readiness: Readiness,
@@ -15,7 +17,10 @@ pub struct ConnectionH1<Front: SocketHandler> {
 }
 
 impl<Front: SocketHandler> ConnectionH1<Front> {
-    pub fn readable(&mut self, context: &mut Context) -> MuxResult {
+    pub fn readable<E>(&mut self, context: &mut Context, endpoint: E) -> MuxResult
+    where
+        E: UpdateReadiness,
+    {
         println!("======= MUX H1 READABLE");
         let stream = &mut context.streams[self.stream];
         let kawa = stream.rbuffer(self.position);
@@ -42,7 +47,10 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         }
         MuxResult::Continue
     }
-    pub fn writable(&mut self, context: &mut Context) -> MuxResult {
+    pub fn writable<E>(&mut self, context: &mut Context, endpoint: E) -> MuxResult
+    where
+        E: UpdateReadiness,
+    {
         println!("======= MUX H1 WRITABLE");
         let stream = &mut context.streams[self.stream];
         let kawa = stream.wbuffer(self.position);

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -49,7 +49,7 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
             return MuxResult::Continue;
         }
 
-        let was_initial = kawa.is_initial();
+        let was_main_phase = kawa.is_main_phase();
         kawa::h1::parse(kawa, parts.context);
         debug_kawa(kawa);
         if kawa.is_error() {
@@ -80,7 +80,7 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
             }
             match self.position {
                 Position::Server => {
-                    if was_initial {
+                    if !was_main_phase {
                         self.requests += 1;
                         println_!("REQUESTS: {}", self.requests);
                         stream.state = StreamState::Link
@@ -153,9 +153,9 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
                     let old_state = std::mem::replace(&mut stream.state, StreamState::Unlinked);
                     if stream.context.keep_alive_frontend {
                         self.timeout_container.reset();
-                        println!("{old_state:?} {:?}", self.readiness);
+                        // println!("{old_state:?} {:?}", self.readiness);
                         if let StreamState::Linked(token) = old_state {
-                            println!("{:?}", endpoint.readiness(token));
+                            // println!("{:?}", endpoint.readiness(token));
                             endpoint.end_stream(token, self.stream, context);
                         }
                         self.readiness.interest.insert(Ready::READABLE);

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -30,7 +30,7 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
     where
         E: Endpoint,
     {
-        println!("======= MUX H1 READABLE");
+        println!("======= MUX H1 READABLE {:?}", self.position);
         let stream = &mut context.streams[self.stream];
         let parts = stream.split(&self.position);
         let kawa = parts.rbuffer;
@@ -72,7 +72,7 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
     where
         E: Endpoint,
     {
-        println!("======= MUX H1 WRITABLE");
+        println!("======= MUX H1 WRITABLE {:?}", self.position);
         let stream = &mut context.streams[self.stream];
         let kawa = stream.wbuffer(&self.position);
         kawa.prepare(&mut kawa::h1::BlockConverter);
@@ -122,7 +122,7 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         )
     }
 
-    pub fn end_stream(&mut self, stream: usize, context: &mut Context) {
+    pub fn end_stream(&mut self, stream: GlobalStreamId, context: &mut Context) {
         assert_eq!(stream, self.stream);
         let stream_context = &mut context.streams[stream].context;
         println!("end H1 stream {stream}: {stream_context:#?}");
@@ -144,8 +144,8 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         }
     }
 
-    pub fn start_stream(&mut self, stream: usize, context: &mut Context) {
-        println!("start H1 stream {stream}");
+    pub fn start_stream(&mut self, stream: GlobalStreamId, context: &mut Context) {
+        println!("start H1 stream {stream} {:?}", self.readiness);
         self.stream = stream;
         let mut owned_position = Position::Server;
         std::mem::swap(&mut owned_position, &mut self.position);

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -18,10 +18,7 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
     pub fn readable(&mut self, context: &mut Context) -> MuxResult {
         println!("======= MUX H1 READABLE");
         let stream = &mut context.streams.get(self.stream);
-        let kawa = match self.position {
-            Position::Client => &mut stream.front,
-            Position::Server => &mut stream.back,
-        };
+        let kawa = stream.rbuffer(self.position);
         let (size, status) = self.socket.socket_read(kawa.storage.space());
         println!("  size: {size}, status: {status:?}");
         if size > 0 {
@@ -37,6 +34,9 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         }
         kawa::h1::parse(kawa, &mut kawa::h1::NoCallbacks);
         kawa::debug_kawa(kawa);
+        if kawa.is_error() {
+            return MuxResult::Close(self.stream);
+        }
         if kawa.is_terminated() {
             self.readiness.interest.remove(Ready::READABLE);
         }
@@ -45,11 +45,9 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
     pub fn writable(&mut self, context: &mut Context) -> MuxResult {
         println!("======= MUX H1 WRITABLE");
         let stream = &mut context.streams.get(self.stream);
-        let kawa = match self.position {
-            Position::Client => &mut stream.back,
-            Position::Server => &mut stream.front,
-        };
+        let kawa = stream.wbuffer(self.position);
         kawa.prepare(&mut kawa::h1::BlockConverter);
+        kawa::debug_kawa(kawa);
         let bufs = kawa.as_io_slice();
         if bufs.is_empty() {
             self.readiness.interest.remove(Ready::WRITABLE);
@@ -62,6 +60,9 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
             // self.backend_readiness.interest.insert(Ready::READABLE);
         } else {
             self.readiness.event.remove(Ready::WRITABLE);
+        }
+        if kawa.is_terminated() && kawa.is_completed() {
+            self.readiness.interest.insert(Ready::READABLE);
         }
         MuxResult::Continue
     }

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -1,7 +1,7 @@
 use sozu_command::ready::Ready;
 
 use crate::{
-    protocol::mux::{Context, GlobalStreamId, MuxResult, Position, UpdateReadiness},
+    protocol::mux::{BackendStatus, Context, Endpoint, GlobalStreamId, MuxResult, Position},
     socket::SocketHandler,
     Readiness,
 };
@@ -14,14 +14,25 @@ pub struct ConnectionH1<Front: SocketHandler> {
     pub stream: GlobalStreamId,
 }
 
+impl<Front: SocketHandler> std::fmt::Debug for ConnectionH1<Front> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConnectionH1")
+            .field("position", &self.position)
+            .field("readiness", &self.readiness)
+            .field("socket", &self.socket.socket_ref())
+            .field("stream", &self.stream)
+            .finish()
+    }
+}
+
 impl<Front: SocketHandler> ConnectionH1<Front> {
     pub fn readable<E>(&mut self, context: &mut Context, mut endpoint: E) -> MuxResult
     where
-        E: UpdateReadiness,
+        E: Endpoint,
     {
         println!("======= MUX H1 READABLE");
         let stream = &mut context.streams[self.stream];
-        let parts = stream.split(self.position);
+        let parts = stream.split(&self.position);
         let kawa = parts.rbuffer;
         let (size, status) = self.socket.socket_read(kawa.storage.space());
         println!("  size: {size}, status: {status:?}");
@@ -48,7 +59,7 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         }
         if was_initial && kawa.is_main_phase() {
             match self.position {
-                Position::Client => endpoint
+                Position::Client(_) => endpoint
                     .readiness_mut(stream.token.unwrap())
                     .interest
                     .insert(Ready::WRITABLE),
@@ -57,13 +68,13 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         }
         MuxResult::Continue
     }
-    pub fn writable<E>(&mut self, context: &mut Context, endpoint: E) -> MuxResult
+    pub fn writable<E>(&mut self, context: &mut Context, mut endpoint: E) -> MuxResult
     where
-        E: UpdateReadiness,
+        E: Endpoint,
     {
         println!("======= MUX H1 WRITABLE");
         let stream = &mut context.streams[self.stream];
-        let kawa = stream.wbuffer(self.position);
+        let kawa = stream.wbuffer(&self.position);
         kawa.prepare(&mut kawa::h1::BlockConverter);
         kawa::debug_kawa(kawa);
         let bufs = kawa.as_io_slice();
@@ -80,8 +91,72 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
             self.readiness.event.remove(Ready::WRITABLE);
         }
         if kawa.is_terminated() && kawa.is_completed() {
-            self.readiness.interest.insert(Ready::READABLE);
+            match self.position {
+                Position::Client(_) => self.readiness.interest.insert(Ready::READABLE),
+                Position::Server => {
+                    endpoint.end_stream(stream.token.unwrap(), self.stream, context)
+                }
+            }
         }
         MuxResult::Continue
+    }
+
+    pub fn close<E>(&mut self, context: &mut Context, mut endpoint: E)
+    where
+        E: Endpoint,
+    {
+        match self.position {
+            Position::Client(BackendStatus::KeepAlive(_))
+            | Position::Client(BackendStatus::Disconnecting) => {
+                println!("close detached client ConnectionH1");
+                return;
+            }
+            Position::Client(BackendStatus::Connecting(_)) => todo!("reconnect"),
+            Position::Client(_) => {}
+            Position::Server => unreachable!(),
+        }
+        endpoint.end_stream(
+            context.streams[self.stream].token.unwrap(),
+            self.stream,
+            context,
+        )
+    }
+
+    pub fn end_stream(&mut self, stream: usize, context: &mut Context) {
+        assert_eq!(stream, self.stream);
+        let stream_context = &mut context.streams[stream].context;
+        println!("end H1 stream {stream}: {stream_context:#?}");
+        self.stream = usize::MAX;
+        let mut owned_position = Position::Server;
+        std::mem::swap(&mut owned_position, &mut self.position);
+        match owned_position {
+            Position::Client(BackendStatus::Connected(cluster_id))
+            | Position::Client(BackendStatus::Connecting(cluster_id)) => {
+                self.position = if stream_context.keep_alive_backend {
+                    Position::Client(BackendStatus::KeepAlive(cluster_id))
+                } else {
+                    Position::Client(BackendStatus::Disconnecting)
+                }
+            }
+            Position::Client(BackendStatus::KeepAlive(_))
+            | Position::Client(BackendStatus::Disconnecting) => unreachable!(),
+            Position::Server => todo!(),
+        }
+    }
+
+    pub fn start_stream(&mut self, stream: usize, context: &mut Context) {
+        println!("start H1 stream {stream}");
+        self.stream = stream;
+        let mut owned_position = Position::Server;
+        std::mem::swap(&mut owned_position, &mut self.position);
+        match owned_position {
+            Position::Client(BackendStatus::KeepAlive(cluster_id)) => {
+                self.position = Position::Client(BackendStatus::Connecting(cluster_id))
+            }
+            Position::Server => unreachable!(),
+            _ => {
+                self.position = owned_position;
+            }
+        }
     }
 }

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -1,0 +1,66 @@
+use sozu_command::ready::Ready;
+
+use crate::{
+    protocol::mux::{Context, GlobalStreamId, Position},
+    socket::{SocketHandler, SocketResult},
+    Readiness,
+};
+
+pub struct ConnectionH1<Front: SocketHandler> {
+    pub position: Position,
+    pub readiness: Readiness,
+    pub socket: Front,
+    /// note: a Server H1 will always reference stream 0, but a client can reference any stream
+    pub stream: GlobalStreamId,
+}
+
+impl<Front: SocketHandler> ConnectionH1<Front> {
+    pub fn readable(&mut self, context: &mut Context) {
+        println!("======= MUX H1 READABLE");
+        let stream = &mut context.streams.get(self.stream);
+        let kawa = match self.position {
+            Position::Client => &mut stream.front,
+            Position::Server => &mut stream.back,
+        };
+        let (size, status) = self.socket.socket_read(kawa.storage.space());
+        println!("  size: {size}, status: {status:?}");
+        if size > 0 {
+            kawa.storage.fill(size);
+        } else {
+            self.readiness.event.remove(Ready::READABLE);
+        }
+        match status {
+            SocketResult::Continue => {}
+            SocketResult::Closed => todo!(),
+            SocketResult::Error => todo!(),
+            SocketResult::WouldBlock => self.readiness.event.remove(Ready::READABLE),
+        }
+        kawa::h1::parse(kawa, &mut kawa::h1::NoCallbacks);
+        kawa::debug_kawa(kawa);
+        if kawa.is_terminated() {
+            self.readiness.interest.remove(Ready::READABLE);
+        }
+    }
+    pub fn writable(&mut self, context: &mut Context) {
+        println!("======= MUX H1 WRITABLE");
+        let stream = &mut context.streams.get(self.stream);
+        let kawa = match self.position {
+            Position::Client => &mut stream.back,
+            Position::Server => &mut stream.front,
+        };
+        kawa.prepare(&mut kawa::h1::BlockConverter);
+        let bufs = kawa.as_io_slice();
+        if bufs.is_empty() {
+            self.readiness.interest.remove(Ready::WRITABLE);
+            return;
+        }
+        let (size, status) = self.socket.socket_write_vectored(&bufs);
+        println!("  size: {size}, status: {status:?}");
+        if size > 0 {
+            kawa.consume(size);
+            // self.backend_readiness.interest.insert(Ready::READABLE);
+        } else {
+            self.readiness.event.remove(Ready::WRITABLE);
+        }
+    }
+}

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -8,16 +8,18 @@ use crate::{
         Position, StreamState,
     },
     socket::SocketHandler,
+    timer::TimeoutContainer,
     Readiness,
 };
 
 pub struct ConnectionH1<Front: SocketHandler> {
     pub position: Position,
     pub readiness: Readiness,
+    pub requests: usize,
     pub socket: Front,
     /// note: a Server H1 will always reference stream 0, but a client can reference any stream
     pub stream: GlobalStreamId,
-    pub requests: usize,
+    pub timeout_container: TimeoutContainer,
 }
 
 impl<Front: SocketHandler> std::fmt::Debug for ConnectionH1<Front> {

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -17,7 +17,7 @@ pub struct ConnectionH1<Front: SocketHandler> {
 impl<Front: SocketHandler> ConnectionH1<Front> {
     pub fn readable(&mut self, context: &mut Context) -> MuxResult {
         println!("======= MUX H1 READABLE");
-        let stream = &mut context.streams.get(self.stream);
+        let stream = &mut context.streams[self.stream];
         let kawa = stream.rbuffer(self.position);
         let (size, status) = self.socket.socket_read(kawa.storage.space());
         println!("  size: {size}, status: {status:?}");
@@ -44,7 +44,7 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
     }
     pub fn writable(&mut self, context: &mut Context) -> MuxResult {
         println!("======= MUX H1 WRITABLE");
-        let stream = &mut context.streams.get(self.stream);
+        let stream = &mut context.streams[self.stream];
         let kawa = stream.wbuffer(self.position);
         kawa.prepare(&mut kawa::h1::BlockConverter);
         kawa::debug_kawa(kawa);

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -595,6 +595,7 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                 }
 
                 let mut converter = converter::H2BlockConverter {
+                    max_frame_size: self.peer_settings.settings_max_frame_size as usize,
                     window: 0,
                     stream_id: 0,
                     encoder: &mut self.encoder,

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -50,6 +50,7 @@ impl Default for H2Settings {
 
 pub struct ConnectionH2<Front: SocketHandler> {
     pub decoder: hpack::Decoder<'static>,
+    pub encoder: hpack::Encoder<'static>,
     pub expect: Option<(H2StreamId, usize)>,
     pub position: Position,
     pub readiness: Readiness,
@@ -263,7 +264,7 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             (_, _) => {
                 let mut converter = converter::H2BlockConverter {
                     stream_id: 0,
-                    encoder: unsafe { std::mem::transmute(&mut self.decoder) },
+                    encoder: &mut self.encoder,
                     out: Vec::new(),
                 };
                 let mut want_write = false;

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -745,13 +745,16 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         println_!("{frame:#?}");
         match frame {
             Frame::Data(data) => {
-                let mut slice = data.payload;
                 // can this fail? yes
                 let Some(global_stream_id) = self.streams.get(&data.stream_id).copied() else {
-                    error!("Handling Data frame with no attached stream {:#?}", self);
+                    error!(
+                        "Handling Data frame with no attached stream: {:?} | {:?} | {:?} | {:?}",
+                        data, context.streams, self, endpoint,
+                    );
                     incr!("h2.data_no_stream.error");
                     return self.force_disconnect();
                 };
+                let mut slice = data.payload;
                 let stream = &mut context.streams[global_stream_id];
                 let parts = stream.split(&self.position);
                 let kawa = parts.rbuffer;

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -12,7 +12,7 @@ use crate::{
     Readiness,
 };
 
-use super::GenericHttpStream;
+use super::{GenericHttpStream, UpdateReadiness};
 
 #[derive(Debug)]
 pub enum H2State {
@@ -66,7 +66,10 @@ pub enum H2StreamId {
 }
 
 impl<Front: SocketHandler> ConnectionH2<Front> {
-    pub fn readable(&mut self, context: &mut Context) -> MuxResult {
+    pub fn readable<E>(&mut self, context: &mut Context, endpoint: E) -> MuxResult
+    where
+        E: UpdateReadiness,
+    {
         println!("======= MUX H2 READABLE");
         let (stream_id, kawa) = if let Some((stream_id, amount)) = self.expect {
             let kawa = match stream_id {
@@ -230,7 +233,10 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         MuxResult::Continue
     }
 
-    pub fn writable(&mut self, context: &mut Context) -> MuxResult {
+    pub fn writable<E>(&mut self, context: &mut Context, endpoint: E) -> MuxResult
+    where
+        E: UpdateReadiness,
+    {
         println!("======= MUX H2 WRITABLE");
         match (&self.state, &self.position) {
             (H2State::ClientPreface, Position::Client) => todo!("Send PRI + client Settings"),

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -59,7 +59,7 @@ impl Default for H2Settings {
     fn default() -> Self {
         Self {
             settings_header_table_size: 4096,
-            settings_enable_push: true,
+            settings_enable_push: false,
             settings_max_concurrent_streams: 100,
             settings_initial_window_size: (1 << 16) - 1,
             settings_max_frame_size: 1 << 14,

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -13,6 +13,7 @@ use crate::{
         GlobalStreamId, MuxResult, Position, StreamId, StreamState,
     },
     socket::SocketHandler,
+    timer::TimeoutContainer,
     Readiness,
 };
 
@@ -94,6 +95,7 @@ pub struct ConnectionH2<Front: SocketHandler> {
     pub socket: Front,
     pub state: H2State,
     pub streams: HashMap<StreamId, GlobalStreamId>,
+    pub timeout_container: TimeoutContainer,
     pub window: u32,
     pub zero: GenericHttpStream,
 }

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -1,0 +1,274 @@
+use std::collections::HashMap;
+
+use kawa::h1::ParserCallbacks;
+use rusty_ulid::Ulid;
+use sozu_command::ready::Ready;
+
+use crate::{
+    protocol::mux::{
+        parser::{self, error_code_to_str, FrameHeader},
+        pkawa, serializer, Context, GlobalStreamId, Position, StreamId,
+    },
+    socket::SocketHandler,
+    Readiness,
+};
+
+#[derive(Debug)]
+pub enum H2State {
+    ClientPreface,
+    ClientSettings,
+    ServerSettings,
+    Header,
+    Frame(FrameHeader),
+    Error,
+}
+
+#[derive(Debug)]
+pub struct H2Settings {
+    settings_header_table_size: u32,
+    settings_enable_push: bool,
+    settings_max_concurrent_streams: u32,
+    settings_initial_window_size: u32,
+    settings_max_frame_size: u32,
+    settings_max_header_list_size: u32,
+}
+
+impl Default for H2Settings {
+    fn default() -> Self {
+        Self {
+            settings_header_table_size: 4096,
+            settings_enable_push: true,
+            settings_max_concurrent_streams: u32::MAX,
+            settings_initial_window_size: (1 << 16) - 1,
+            settings_max_frame_size: 1 << 14,
+            settings_max_header_list_size: u32::MAX,
+        }
+    }
+}
+
+pub struct ConnectionH2<Front: SocketHandler> {
+    // pub decoder: hpack::Decoder<'static>,
+    pub expect: Option<(GlobalStreamId, usize)>,
+    pub position: Position,
+    pub readiness: Readiness,
+    pub settings: H2Settings,
+    pub socket: Front,
+    pub state: H2State,
+    pub streams: HashMap<StreamId, GlobalStreamId>,
+}
+
+impl<Front: SocketHandler> ConnectionH2<Front> {
+    pub fn readable(&mut self, context: &mut Context) {
+        println!("======= MUX H2 READABLE");
+        let kawa = if let Some((stream_id, amount)) = self.expect {
+            let kawa = context.streams.get(stream_id).front(self.position);
+            let (size, status) = self.socket.socket_read(&mut kawa.storage.space()[..amount]);
+            println!("{:?}({stream_id}, {amount}) {size} {status:?}", self.state);
+            if size > 0 {
+                kawa.storage.fill(size);
+                if size == amount {
+                    self.expect = None;
+                } else {
+                    self.expect = Some((stream_id, amount - size));
+                    return;
+                }
+            } else {
+                self.readiness.event.remove(Ready::READABLE);
+                return;
+            }
+            kawa
+        } else {
+            self.readiness.event.remove(Ready::READABLE);
+            return;
+        };
+        match (&self.state, &self.position) {
+            (H2State::ClientPreface, Position::Client) => {
+                error!("Waiting for ClientPreface to finish writing")
+            }
+            (H2State::ClientPreface, Position::Server) => {
+                let i = kawa.storage.data();
+                let i = match parser::preface(i) {
+                    Ok((i, _)) => i,
+                    Err(e) => panic!("{e:?}"),
+                };
+                match parser::frame_header(i) {
+                    Ok((
+                        _,
+                        parser::FrameHeader {
+                            payload_len,
+                            frame_type: parser::FrameType::Settings,
+                            flags: 0,
+                            stream_id: 0,
+                        },
+                    )) => {
+                        kawa.storage.clear();
+                        self.state = H2State::ClientSettings;
+                        self.expect = Some((0, payload_len as usize));
+                    }
+                    _ => todo!(),
+                };
+            }
+            (H2State::ClientSettings, Position::Server) => {
+                let i = kawa.storage.data();
+                match parser::settings_frame(i, i.len()) {
+                    Ok((_, settings)) => {
+                        kawa.storage.clear();
+                        self.handle(settings, context);
+                    }
+                    Err(e) => panic!("{e:?}"),
+                }
+                let kawa = &mut context.streams.zero.back;
+                self.state = H2State::ServerSettings;
+                match serializer::gen_frame_header(
+                    kawa.storage.space(),
+                    &parser::FrameHeader {
+                        payload_len: 6 * 2,
+                        frame_type: parser::FrameType::Settings,
+                        flags: 0,
+                        stream_id: 0,
+                    },
+                ) {
+                    Ok((_, size)) => kawa.storage.fill(size),
+                    Err(e) => panic!("could not serialize HeaderFrame: {e:?}"),
+                };
+                // kawa.storage
+                //     .write(&[1, 3, 0, 0, 0, 100, 0, 4, 0, 1, 0, 0])
+                //     .unwrap();
+                match serializer::gen_frame_header(
+                    kawa.storage.space(),
+                    &parser::FrameHeader {
+                        payload_len: 0,
+                        frame_type: parser::FrameType::Settings,
+                        flags: 1,
+                        stream_id: 0,
+                    },
+                ) {
+                    Ok((_, size)) => kawa.storage.fill(size),
+                    Err(e) => panic!("could not serialize HeaderFrame: {e:?}"),
+                };
+                self.readiness.interest.insert(Ready::WRITABLE);
+                self.readiness.interest.remove(Ready::READABLE);
+            }
+            (H2State::ServerSettings, Position::Client) => todo!("Receive server Settings"),
+            (H2State::ServerSettings, Position::Server) => {
+                error!("waiting for ServerPreface to finish writing")
+            }
+            (H2State::Header, Position::Server) => {
+                let i = kawa.storage.data();
+                println!("  header: {i:?}");
+                match parser::frame_header(i) {
+                    Ok((_, header)) => {
+                        println!("{header:?}");
+                        kawa.storage.clear();
+                        let stream_id = if let Some(stream_id) = self.streams.get(&header.stream_id)
+                        {
+                            *stream_id
+                        } else {
+                            self.create_stream(header.stream_id, context)
+                        };
+                        let stream_id = if header.frame_type == parser::FrameType::Data {
+                            stream_id
+                        } else {
+                            0
+                        };
+                        println!("{} {} {:#?}", header.stream_id, stream_id, self.streams);
+                        self.expect = Some((stream_id as usize, header.payload_len as usize));
+                        self.state = H2State::Frame(header);
+                    }
+                    Err(e) => panic!("{e:?}"),
+                };
+            }
+            (H2State::Frame(header), Position::Server) => {
+                let i = kawa.storage.data();
+                println!("  data: {i:?}");
+                match parser::frame_body(i, header, self.settings.settings_max_frame_size) {
+                    Ok((_, frame)) => {
+                        kawa.storage.clear();
+                        self.handle(frame, context);
+                    }
+                    Err(e) => panic!("{e:?}"),
+                }
+                self.state = H2State::Header;
+                self.expect = Some((0, 9));
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn writable(&mut self, context: &mut Context) {
+        println!("======= MUX H2 WRITABLE");
+        match (&self.state, &self.position) {
+            (H2State::ClientPreface, Position::Client) => todo!("Send PRI + client Settings"),
+            (H2State::ClientPreface, Position::Server) => unreachable!(),
+            (H2State::ServerSettings, Position::Client) => unreachable!(),
+            (H2State::ServerSettings, Position::Server) => {
+                let kawa = &mut context.streams.zero.back;
+                println!("{:?}", kawa.storage.data());
+                let (size, status) = self.socket.socket_write(kawa.storage.data());
+                println!("  size: {size}, status: {status:?}");
+                let size = kawa.storage.available_data();
+                kawa.storage.consume(size);
+                if kawa.storage.is_empty() {
+                    self.readiness.interest.remove(Ready::WRITABLE);
+                    self.readiness.interest.insert(Ready::READABLE);
+                    self.state = H2State::Header;
+                    self.expect = Some((0, 9));
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn create_stream(&mut self, stream_id: StreamId, context: &mut Context) -> GlobalStreamId {
+        match context.create_stream(Ulid::generate(), self.settings.settings_initial_window_size) {
+            Ok(global_stream_id) => {
+                self.streams.insert(stream_id, global_stream_id);
+                global_stream_id
+            }
+            Err(e) => panic!("{e:?}"),
+        }
+    }
+
+    fn handle(&mut self, frame: parser::Frame, context: &mut Context) {
+        println!("{frame:?}");
+        match frame {
+            parser::Frame::Data(_) => todo!(),
+            parser::Frame::Headers(headers) => {
+                // if !headers.end_headers {
+                //     self.state = H2State::Continuation
+                // }
+                let global_stream_id = self.streams.get(&headers.stream_id).unwrap();
+                let kawa = context.streams.zero.front(self.position);
+                let buffer = headers.header_block_fragment.data(kawa.storage.buffer());
+                let stream = &mut context.streams.others[*global_stream_id - 1];
+                let kawa = &mut stream.front;
+                pkawa::handle_header(kawa, buffer, &mut context.decoder);
+                stream.context.on_headers(kawa);
+            }
+            parser::Frame::Priority(priority) => (),
+            parser::Frame::RstStream(_) => todo!(),
+            parser::Frame::Settings(settings) => {
+                for setting in settings.settings {
+                    match setting.identifier {
+                        1 => self.settings.settings_header_table_size = setting.value,
+                        2 => self.settings.settings_enable_push = setting.value == 1,
+                        3 => self.settings.settings_max_concurrent_streams = setting.value,
+                        4 => self.settings.settings_initial_window_size = setting.value,
+                        5 => self.settings.settings_max_frame_size = setting.value,
+                        6 => self.settings.settings_max_header_list_size = setting.value,
+                        other => panic!("setting_id: {other}"),
+                    }
+                }
+                println!("{:#?}", self.settings);
+            }
+            parser::Frame::PushPromise(_) => todo!(),
+            parser::Frame::Ping(_) => todo!(),
+            parser::Frame::GoAway(goaway) => panic!("{}", error_code_to_str(goaway.error_code)),
+            parser::Frame::WindowUpdate(update) => {
+                let global_stream_id = *self.streams.get(&update.stream_id).unwrap();
+                context.streams.get(global_stream_id).window += update.increment as i32;
+            }
+            parser::Frame::Continuation(_) => todo!(),
+        }
+    }
+}

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -251,14 +251,11 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                 println!("{:?}", kawa.storage.data());
                 let (size, status) = self.socket.socket_write(kawa.storage.data());
                 println!("  size: {size}, status: {status:?}");
-                let size = kawa.storage.available_data();
-                kawa.storage.consume(size);
-                if kawa.storage.is_empty() {
-                    self.readiness.interest.remove(Ready::WRITABLE);
-                    self.readiness.interest.insert(Ready::READABLE);
-                    self.state = H2State::Header;
-                    self.expect = Some((H2StreamId::Zero, 9));
-                }
+                kawa.storage.clear();
+                self.readiness.interest.remove(Ready::WRITABLE);
+                self.readiness.interest.insert(Ready::READABLE);
+                self.state = H2State::Header;
+                self.expect = Some((H2StreamId::Zero, 9));
                 MuxResult::Continue
             }
             (H2State::Error, _) => unreachable!(),

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -1,0 +1,446 @@
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    io::Write,
+    net::SocketAddr,
+    rc::{Rc, Weak},
+};
+
+use mio::{net::TcpStream, Token};
+use rusty_ulid::Ulid;
+use sozu_command::ready::Ready;
+
+mod parser;
+mod serializer;
+
+use crate::{
+    https::HttpsListener,
+    pool::{Checkout, Pool},
+    protocol::SessionState,
+    socket::{FrontRustls, SocketHandler, SocketResult},
+    AcceptError, L7Proxy, ProxySession, Readiness, SessionMetrics, SessionResult, StateResult,
+};
+
+/// Generic Http representation using the Kawa crate using the Checkout of Sozu as buffer
+type GenericHttpStream = kawa::Kawa<Checkout>;
+type StreamId = usize;
+type GlobalStreamId = usize;
+
+pub enum Position {
+    Client,
+    Server,
+}
+
+pub struct ConnectionH1<Front: SocketHandler> {
+    pub socket: Front,
+    pub position: Position,
+    pub readiness: Readiness,
+    pub stream: GlobalStreamId,
+}
+
+pub enum H2State {
+    ClientPreface,
+    ServerPreface,
+    Connected,
+    Error,
+}
+pub struct ConnectionH2<Front: SocketHandler> {
+    pub socket: Front,
+    pub position: Position,
+    pub readiness: Readiness,
+    pub state: H2State,
+    pub streams: HashMap<StreamId, GlobalStreamId>,
+    // context_hpack: HpackContext,
+    // settings: SettiongsH2,
+}
+pub struct Stream {
+    pub request_id: Ulid,
+    pub front: GenericHttpStream,
+    pub back: GenericHttpStream,
+}
+
+pub enum Connection<Front: SocketHandler> {
+    H1(ConnectionH1<Front>),
+    H2(ConnectionH2<Front>),
+}
+impl<Front: SocketHandler> Connection<Front> {
+    fn readiness(&self) -> &Readiness {
+        match self {
+            Connection::H1(c) => &c.readiness,
+            Connection::H2(c) => &c.readiness,
+        }
+    }
+    fn readiness_mut(&mut self) -> &mut Readiness {
+        match self {
+            Connection::H1(c) => &mut c.readiness,
+            Connection::H2(c) => &mut c.readiness,
+        }
+    }
+    fn readable(&mut self, streams: &mut [Stream]) {
+        match self {
+            Connection::H1(c) => c.readable(streams),
+            Connection::H2(c) => c.readable(streams),
+        }
+    }
+    fn writable(&mut self, streams: &mut [Stream]) {
+        match self {
+            Connection::H1(c) => c.writable(streams),
+            Connection::H2(c) => c.writable(streams),
+        }
+    }
+}
+
+pub struct Mux {
+    pub frontend_token: Token,
+    pub frontend: Connection<FrontRustls>,
+    pub backends: HashMap<Token, Connection<TcpStream>>,
+    pub streams: Vec<Stream>,
+    pub listener: Rc<RefCell<HttpsListener>>,
+    pub pool: Weak<RefCell<Pool>>,
+    pub public_address: SocketAddr,
+    pub peer_address: Option<SocketAddr>,
+    pub sticky_name: String,
+}
+
+impl SessionState for Mux {
+    fn ready(
+        &mut self,
+        session: Rc<RefCell<dyn ProxySession>>,
+        proxy: Rc<RefCell<dyn L7Proxy>>,
+        metrics: &mut SessionMetrics,
+    ) -> SessionResult {
+        let mut counter = 0;
+        let max_loop_iterations = 100000;
+
+        if self.frontend.readiness().event.is_hup() {
+            return SessionResult::Close;
+        }
+
+        let streams = &mut self.streams;
+        while counter < max_loop_iterations {
+            let mut dirty = false;
+
+            if self.frontend.readiness().filter_interest().is_readable() {
+                self.frontend.readable(streams);
+                dirty = true;
+            }
+
+            for (_, backend) in self.backends.iter_mut() {
+                if backend.readiness().filter_interest().is_writable() {
+                    backend.writable(streams);
+                    dirty = true;
+                }
+
+                if backend.readiness().filter_interest().is_readable() {
+                    backend.readable(streams);
+                    dirty = true;
+                }
+            }
+
+            if self.frontend.readiness().filter_interest().is_writable() {
+                self.frontend.writable(streams);
+                dirty = true;
+            }
+
+            for backend in self.backends.values() {
+                if backend.readiness().filter_interest().is_hup()
+                    || backend.readiness().filter_interest().is_error()
+                {
+                    return SessionResult::Close;
+                }
+            }
+
+            if !dirty {
+                break;
+            }
+
+            counter += 1;
+        }
+
+        if counter == max_loop_iterations {
+            incr!("http.infinite_loop.error");
+            return SessionResult::Close;
+        }
+
+        SessionResult::Continue
+    }
+
+    fn update_readiness(&mut self, token: Token, events: sozu_command::ready::Ready) {
+        if token == self.frontend_token {
+            self.frontend.readiness_mut().event |= events;
+        } else if let Some(c) = self.backends.get_mut(&token) {
+            c.readiness_mut().event |= events;
+        }
+    }
+
+    fn timeout(&mut self, token: Token, metrics: &mut SessionMetrics) -> StateResult {
+        println!("MuxState::timeout({token:?})");
+        StateResult::CloseSession
+    }
+
+    fn cancel_timeouts(&mut self) {
+        println!("MuxState::cancel_timeouts");
+    }
+
+    fn print_state(&self, context: &str) {
+        error!(
+            "\
+{} Session(Mux)
+\tFrontend:
+\t\ttoken: {:?}\treadiness: {:?}",
+            context,
+            self.frontend_token,
+            self.frontend.readiness()
+        );
+    }
+    fn close(&mut self, _proxy: Rc<RefCell<dyn L7Proxy>>, _metrics: &mut SessionMetrics) {
+        let s = match &mut self.frontend {
+            Connection::H1(c) => &mut c.socket,
+            Connection::H2(c) => &mut c.socket,
+        };
+        let mut b = [0; 1024];
+        let (size, status) = s.socket_read(&mut b);
+        println!("{size} {status:?} {:?}", &b[..size]);
+    }
+}
+
+impl Mux {
+    // pub fn new(
+    //     frontend_token: Token,
+    //     request_id: Ulid,
+    //     listener: Rc<RefCell<HttpsListener>>,
+    //     pool: Weak<RefCell<Pool>>,
+    //     public_address: SocketAddr,
+    //     peer_address: Option<SocketAddr>,
+    //     sticky_name: String,
+    // ) -> Self {
+    //     Self {
+    //         frontend_token,
+    //         frontend: todo!(),
+    //         backends: todo!(),
+    //         streams: todo!(),
+    //     }
+    // }
+    pub fn front_socket(&self) -> &TcpStream {
+        match &self.frontend {
+            Connection::H1(c) => &c.socket.stream,
+            Connection::H2(c) => &c.socket.stream,
+        }
+    }
+
+    pub fn create_stream(&mut self, request_id: Ulid) -> Result<GlobalStreamId, AcceptError> {
+        let (front_buffer, back_buffer) = match self.pool.upgrade() {
+            Some(pool) => {
+                let mut pool = pool.borrow_mut();
+                match (pool.checkout(), pool.checkout()) {
+                    (Some(front_buffer), Some(back_buffer)) => (front_buffer, back_buffer),
+                    _ => return Err(AcceptError::BufferCapacityReached),
+                }
+            }
+            None => return Err(AcceptError::BufferCapacityReached),
+        };
+        self.streams.push(Stream {
+            request_id,
+            front: GenericHttpStream::new(kawa::Kind::Request, kawa::Buffer::new(front_buffer)),
+            back: GenericHttpStream::new(kawa::Kind::Request, kawa::Buffer::new(back_buffer)),
+        });
+        Ok(self.streams.len() - 1)
+    }
+}
+
+impl<Front: SocketHandler> ConnectionH2<Front> {
+    fn readable(&mut self, streams: &mut [Stream]) {
+        println!("======= MUX H2 READABLE");
+        match (&self.state, &self.position) {
+            (H2State::ClientPreface, Position::Client) => {
+                error!("Waiting for ClientPreface to finish writing")
+            }
+            (H2State::ClientPreface, Position::Server) => {
+                let stream = &mut streams[0];
+                let kawa = &mut stream.front;
+                let mut i = [0; 33];
+
+                // let (size, status) = self.socket.socket_read(kawa.storage.space());
+                // println!("{:02x?}", &kawa.storage.buffer()[..size]);
+                // unreachable!();
+
+                let (size, status) = self.socket.socket_read(&mut i);
+
+                println!("{size} {status:?} {i:02x?}");
+                let i = match parser::preface(&i) {
+                    Ok((i, _)) => i,
+                    Err(_) => todo!(),
+                };
+                let header = match parser::frame_header(&i) {
+                    Ok((
+                        _,
+                        header @ parser::FrameHeader {
+                            payload_len: _,
+                            frame_type: parser::FrameType::Settings,
+                            flags: 0,
+                            stream_id: 0,
+                        },
+                    )) => header,
+                    _ => todo!(),
+                };
+                let (size, status) = self
+                    .socket
+                    .socket_read(&mut kawa.storage.space()[..header.payload_len as usize]);
+                kawa.storage.fill(size);
+                let i = kawa.storage.data();
+                println!("  {size} {status:?} {i:02x?}");
+                match parser::settings_frame(i, &header) {
+                    Ok((_, settings)) => println!("{settings:?}"),
+                    Err(_) => todo!(),
+                }
+                let kawa = &mut stream.back;
+                self.state = H2State::ServerPreface;
+                match serializer::gen_frame_header(
+                    kawa.storage.space(),
+                    &parser::FrameHeader {
+                        payload_len: 6 * 2,
+                        frame_type: parser::FrameType::Settings,
+                        flags: 0,
+                        stream_id: 0,
+                    },
+                ) {
+                    Ok((_, size)) => kawa.storage.fill(size),
+                    Err(e) => panic!("could not serialize HeaderFrame: {e:?}"),
+                };
+                // kawa.storage
+                //     .write(&[1, 3, 0, 0, 0, 100, 0, 4, 0, 1, 0, 0])
+                //     .unwrap();
+                match serializer::gen_frame_header(
+                    kawa.storage.space(),
+                    &parser::FrameHeader {
+                        payload_len: 0,
+                        frame_type: parser::FrameType::Settings,
+                        flags: 1,
+                        stream_id: 0,
+                    },
+                ) {
+                    Ok((_, size)) => kawa.storage.fill(size),
+                    Err(e) => panic!("could not serialize HeaderFrame: {e:?}"),
+                };
+                self.readiness.interest.insert(Ready::WRITABLE);
+                self.readiness.interest.remove(Ready::READABLE);
+            }
+            (H2State::ServerPreface, Position::Client) => todo!("Receive server Settings"),
+            (H2State::ServerPreface, Position::Server) => {
+                error!("waiting for ServerPreface to finish writing")
+            }
+            (H2State::Connected, Position::Server) => {
+                let mut header = [0; 9];
+                let (size, status) = self.socket.socket_read(&mut header);
+                println!("  size: {size}, status: {status:?}");
+                if size == 0 {
+                    self.readiness.event.remove(Ready::READABLE);
+                    return;
+                }
+                println!("{:?}", &header[..size]);
+                let len = match parser::frame_header(&header) {
+                    Ok((_, h)) => {
+                        println!("{h:?}");
+                        h.payload_len as usize
+                    }
+                    Err(_) => {
+                        self.state = H2State::Error;
+                        return;
+                    }
+                };
+                let kawa = &mut streams[0].front;
+                kawa.storage.clear();
+                let (size, status) = self.socket.socket_read(&mut kawa.storage.space()[..len]);
+                kawa.storage.fill(size);
+                let i = kawa.storage.data();
+                println!("  {size} {status:?} {i:?}");
+            }
+            _ => unreachable!(),
+        }
+    }
+    fn writable(&mut self, streams: &mut [Stream]) {
+        println!("======= MUX H2 WRITABLE");
+        match (&self.state, &self.position) {
+            (H2State::ClientPreface, Position::Client) => todo!("Send PRI + client Settings"),
+            (H2State::ClientPreface, Position::Server) => unreachable!(),
+            (H2State::ServerPreface, Position::Client) => unreachable!(),
+            (H2State::Connected, Position::Server) | (H2State::ServerPreface, Position::Server) => {
+                let stream = &mut streams[0];
+                let kawa = &mut stream.back;
+                println!("{:?}", kawa.storage.data());
+                let (size, status) = self.socket.socket_write(kawa.storage.data());
+                println!("  size: {size}, status: {status:?}");
+                let size = kawa.storage.available_data();
+                kawa.storage.consume(size);
+                if kawa.storage.is_empty() {
+                    self.readiness.interest.remove(Ready::WRITABLE);
+                    self.readiness.interest.insert(Ready::READABLE);
+                    self.state = H2State::Connected;
+                }
+            }
+            _ => unreachable!(),
+        }
+        // for global_stream_id in self.streams.values() {
+        //     let stream = &mut streams[*global_stream_id];
+        //     let kawa = match self.position {
+        //         Position::Client => &mut stream.back,
+        //         Position::Server => &mut stream.front,
+        //     };
+        //     kawa.prepare(&mut kawa::h2::BlockConverter);
+        //     let (size, status) = self.socket.socket_write_vectored(&kawa.as_io_slice());
+        //     println!("  size: {size}, status: {status:?}");
+        //     kawa.consume(size);
+        // }
+    }
+}
+
+impl<Front: SocketHandler> ConnectionH1<Front> {
+    fn readable(&mut self, streams: &mut [Stream]) {
+        println!("======= MUX H1 READABLE");
+        let stream = &mut streams[self.stream];
+        let kawa = match self.position {
+            Position::Client => &mut stream.front,
+            Position::Server => &mut stream.back,
+        };
+        let (size, status) = self.socket.socket_read(kawa.storage.space());
+        println!("  size: {size}, status: {status:?}");
+        if size > 0 {
+            kawa.storage.fill(size);
+        } else {
+            self.readiness.event.remove(Ready::READABLE);
+        }
+        match status {
+            SocketResult::Continue => {}
+            SocketResult::Closed => todo!(),
+            SocketResult::Error => todo!(),
+            SocketResult::WouldBlock => self.readiness.event.remove(Ready::READABLE),
+        }
+        kawa::h1::parse(kawa, &mut kawa::h1::NoCallbacks);
+        kawa::debug_kawa(kawa);
+        if kawa.is_terminated() {
+            self.readiness.interest.remove(Ready::READABLE);
+        }
+    }
+    fn writable(&mut self, streams: &mut [Stream]) {
+        println!("======= MUX H1 WRITABLE");
+        let stream = &mut streams[self.stream];
+        let kawa = match self.position {
+            Position::Client => &mut stream.back,
+            Position::Server => &mut stream.front,
+        };
+        kawa.prepare(&mut kawa::h1::BlockConverter);
+        let bufs = kawa.as_io_slice();
+        if bufs.is_empty() {
+            self.readiness.interest.remove(Ready::WRITABLE);
+            return;
+        }
+        let (size, status) = self.socket.socket_write_vectored(&bufs);
+        println!("  size: {size}, status: {status:?}");
+        if size > 0 {
+            kawa.consume(size);
+            // self.backend_readiness.interest.insert(Ready::READABLE);
+        } else {
+            self.readiness.event.remove(Ready::WRITABLE);
+        }
+    }
+}

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -1,7 +1,7 @@
 use std::{
     cell::RefCell,
     collections::HashMap,
-    io::{ErrorKind, Write},
+    io::ErrorKind,
     net::{Shutdown, SocketAddr},
     rc::{Rc, Weak},
     time::Duration,
@@ -42,7 +42,7 @@ use self::h2::Prioriser;
 macro_rules! println_ {
     ($($t:expr),*) => {
         // print!("{}:{} ", file!(), line!());
-        println!($($t),*)
+        // println!($($t),*)
         // $(let _ = &$t;)*
     };
 }
@@ -942,7 +942,7 @@ impl<Front: SocketHandler + std::fmt::Debug> SessionState for Mux<Front> {
                 let mut dead_backends = Vec::new();
                 for (token, backend) in self.router.backends.iter_mut() {
                     let readiness = backend.readiness_mut();
-                    println!("{token:?} -> {readiness:?}");
+                    // println!("{token:?} -> {readiness:?}");
                     let dead = readiness.filter_interest().is_hup()
                         || readiness.filter_interest().is_error();
                     if dead {
@@ -1011,7 +1011,7 @@ impl<Front: SocketHandler + std::fmt::Debug> SessionState for Mux<Front> {
                         if !proxy_borrow.remove_session(*token) {
                             error!("session {:?} was already removed!", token);
                         } else {
-                            println!("SUCCESS: session {token:?} was removed!");
+                            // println!("SUCCESS: session {token:?} was removed!");
                         }
                     }
                     println_!("FRONTEND: {:#?}", self.frontend);
@@ -1257,7 +1257,7 @@ impl<Front: SocketHandler + std::fmt::Debug> SessionState for Mux<Front> {
             if !proxy_borrow.remove_session(*token) {
                 error!("session {:?} was already removed!", token);
             } else {
-                println!("SUCCESS: session {token:?} was removed!");
+                // println!("SUCCESS: session {token:?} was removed!");
             }
         }
         // let s = match &mut self.frontend {

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -41,8 +41,8 @@ use self::h2::Prioriser;
 #[macro_export]
 macro_rules! println_ {
     ($($t:expr),*) => {
-        // print!("{}:{} ", file!(), line!());
-        // println!($($t),*)
+        print!("{}:{} ", file!(), line!());
+        println!($($t),*)
         // $(let _ = &$t;)*
     };
 }
@@ -1260,26 +1260,27 @@ impl<Front: SocketHandler + std::fmt::Debug> SessionState for Mux<Front> {
                 // println!("SUCCESS: session {token:?} was removed!");
             }
         }
-        // let s = match &mut self.frontend {
-        //     Connection::H1(c) => &mut c.socket,
-        //     Connection::H2(c) => &mut c.socket,
-        // };
-        // let mut b = [0; 1024];
-        // let (size, status) = s.socket_read(&mut b);
-        // println_!("{size} {status:?} {:?}", &b[..size]);
-        // for stream in &mut self.context.streams {
-        //     for kawa in [&mut stream.front, &mut stream.back] {
-        //         debug_kawa(kawa);
-        //         kawa.prepare(&mut kawa::h1::BlockConverter);
-        //         let out = kawa.as_io_slice();
-        //         let mut writer = std::io::BufWriter::new(Vec::new());
-        //         let amount = writer.write_vectored(&out).unwrap();
-        //         println_!(
-        //             "amount: {amount}\n{}",
-        //             String::from_utf8_lossy(writer.buffer())
-        //         );
-        //     }
-        // }
+        use std::io::Write;
+        let s = match &mut self.frontend {
+            Connection::H1(c) => &mut c.socket,
+            Connection::H2(c) => &mut c.socket,
+        };
+        let mut b = [0; 1024];
+        let (size, status) = s.socket_read(&mut b);
+        println_!("{size} {status:?} {:?}", &b[..size]);
+        for stream in &mut self.context.streams {
+            for kawa in [&mut stream.front, &mut stream.back] {
+                debug_kawa(kawa);
+                kawa.prepare(&mut kawa::h1::BlockConverter);
+                let out = kawa.as_io_slice();
+                let mut writer = std::io::BufWriter::new(Vec::new());
+                let amount = writer.write_vectored(&out).unwrap();
+                println_!(
+                    "amount: {amount}\n{}",
+                    String::from_utf8_lossy(writer.buffer())
+                );
+            }
+        }
     }
 
     fn shutting_down(&mut self) -> SessionIsToBeClosed {

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -27,11 +27,11 @@ use crate::{
     },
     router::Route,
     socket::{FrontRustls, SocketHandler},
-    AcceptError, BackendConnectionError, L7ListenerHandler, L7Proxy, ProxySession, Readiness,
+    BackendConnectionError, L7ListenerHandler, L7Proxy, ProxySession, Readiness,
     RetrieveClusterError, SessionMetrics, SessionResult, StateResult,
 };
 
-use self::h2::{H2Settings, H2State};
+use self::h2::{H2Settings, H2State, H2StreamId};
 
 /// Generic Http representation using the Kawa crate using the Checkout of Sozu as buffer
 type GenericHttpStream = kawa::Kawa<Checkout>;
@@ -80,33 +80,49 @@ impl<Front: SocketHandler> Connection<Front> {
         })
     }
 
-    pub fn new_h2_server(front_stream: Front) -> Connection<Front> {
-        Connection::H2(ConnectionH2 {
+    pub fn new_h2_server(
+        front_stream: Front,
+        pool: Weak<RefCell<Pool>>,
+    ) -> Option<Connection<Front>> {
+        let buffer = pool
+            .upgrade()
+            .and_then(|pool| pool.borrow_mut().checkout())?;
+        Some(Connection::H2(ConnectionH2 {
             socket: front_stream,
             position: Position::Server,
             readiness: Readiness {
                 interest: Ready::READABLE | Ready::HUP | Ready::ERROR,
                 event: Ready::EMPTY,
             },
-            streams: HashMap::from([(0, 0)]),
+            streams: HashMap::new(),
             state: H2State::ClientPreface,
-            expect: Some((0, 24 + 9)),
+            expect: Some((H2StreamId::Zero, 24 + 9)),
             settings: H2Settings::default(),
-        })
+            zero: kawa::Kawa::new(kawa::Kind::Request, kawa::Buffer::new(buffer)),
+            window: 1 << 16,
+        }))
     }
-    pub fn new_h2_client(front_stream: Front) -> Connection<Front> {
-        Connection::H2(ConnectionH2 {
+    pub fn new_h2_client(
+        front_stream: Front,
+        pool: Weak<RefCell<Pool>>,
+    ) -> Option<Connection<Front>> {
+        let buffer = pool
+            .upgrade()
+            .and_then(|pool| pool.borrow_mut().checkout())?;
+        Some(Connection::H2(ConnectionH2 {
             socket: front_stream,
             position: Position::Client,
             readiness: Readiness {
                 interest: Ready::WRITABLE | Ready::HUP | Ready::ERROR,
                 event: Ready::EMPTY,
             },
-            streams: HashMap::from([(0, 0)]),
+            streams: HashMap::new(),
             state: H2State::ClientPreface,
             expect: None,
             settings: H2Settings::default(),
-        })
+            zero: kawa::Kawa::new(kawa::Kind::Request, kawa::Buffer::new(buffer)),
+            window: 1 << 16,
+        }))
     }
 
     pub fn readiness(&self) -> &Readiness {
@@ -123,8 +139,8 @@ impl<Front: SocketHandler> Connection<Front> {
     }
     pub fn socket(&self) -> &TcpStream {
         match self {
-            Connection::H1(c) => &c.socket.socket_ref(),
-            Connection::H2(c) => &c.socket.socket_ref(),
+            Connection::H1(c) => c.socket.socket_ref(),
+            Connection::H2(c) => c.socket.socket_ref(),
         }
     }
     fn readable(&mut self, context: &mut Context) -> MuxResult {
@@ -149,59 +165,27 @@ pub struct Stream {
     pub context: HttpContext,
 }
 
+/// This struct allows to mutably borrow the read and write buffers (dependant on the position)
+/// as well as the context of a Stream at the same time
+pub struct StreamParts<'a> {
+    pub rbuffer: &'a mut GenericHttpStream,
+    pub wbuffer: &'a mut GenericHttpStream,
+    pub context: &'a mut HttpContext,
+}
+
 impl Stream {
-    pub fn rbuffer(&mut self, position: Position) -> &mut GenericHttpStream {
-        match position {
-            Position::Client => &mut self.back,
-            Position::Server => &mut self.front,
-        }
-    }
-    pub fn wbuffer(&mut self, position: Position) -> &mut GenericHttpStream {
-        match position {
-            Position::Client => &mut self.front,
-            Position::Server => &mut self.back,
-        }
-    }
-}
-
-pub struct Streams {
-    zero: Stream,
-    others: Vec<Stream>,
-}
-
-impl Streams {
-    pub fn get(&mut self, stream_id: GlobalStreamId) -> &mut Stream {
-        if stream_id == 0 {
-            &mut self.zero
-        } else {
-            &mut self.others[stream_id - 1]
-        }
-    }
-}
-
-pub struct Context {
-    pub streams: Streams,
-    pub pool: Weak<RefCell<Pool>>,
-    pub decoder: hpack::Decoder<'static>,
-}
-
-impl Context {
-    pub fn new_stream(
-        pool: Weak<RefCell<Pool>>,
-        request_id: Ulid,
-        window: u32,
-    ) -> Result<Stream, AcceptError> {
+    pub fn new(pool: Weak<RefCell<Pool>>, request_id: Ulid, window: u32) -> Option<Self> {
         let (front_buffer, back_buffer) = match pool.upgrade() {
             Some(pool) => {
                 let mut pool = pool.borrow_mut();
                 match (pool.checkout(), pool.checkout()) {
                     (Some(front_buffer), Some(back_buffer)) => (front_buffer, back_buffer),
-                    _ => return Err(AcceptError::BufferCapacityReached),
+                    _ => return None,
                 }
             }
-            None => return Err(AcceptError::BufferCapacityReached),
+            None => return None,
         };
-        Ok(Stream {
+        Some(Self {
             window: window as i32,
             front: GenericHttpStream::new(kawa::Kind::Request, kawa::Buffer::new(front_buffer)),
             back: GenericHttpStream::new(kawa::Kind::Response, kawa::Buffer::new(back_buffer)),
@@ -227,31 +211,53 @@ impl Context {
             },
         })
     }
+    pub fn split(&mut self, position: Position) -> StreamParts<'_> {
+        match position {
+            Position::Client => StreamParts {
+                rbuffer: &mut self.back,
+                wbuffer: &mut self.front,
+                context: &mut self.context,
+            },
+            Position::Server => StreamParts {
+                rbuffer: &mut self.front,
+                wbuffer: &mut self.back,
+                context: &mut self.context,
+            },
+        }
+    }
+    pub fn rbuffer(&mut self, position: Position) -> &mut GenericHttpStream {
+        match position {
+            Position::Client => &mut self.back,
+            Position::Server => &mut self.front,
+        }
+    }
+    pub fn wbuffer(&mut self, position: Position) -> &mut GenericHttpStream {
+        match position {
+            Position::Client => &mut self.front,
+            Position::Server => &mut self.back,
+        }
+    }
+}
 
-    pub fn create_stream(
-        &mut self,
-        request_id: Ulid,
-        window: u32,
-    ) -> Result<GlobalStreamId, AcceptError> {
+pub struct Context {
+    pub streams: Vec<Stream>,
+    pub pool: Weak<RefCell<Pool>>,
+    pub decoder: hpack::Decoder<'static>,
+}
+
+impl Context {
+    pub fn create_stream(&mut self, request_id: Ulid, window: u32) -> Option<GlobalStreamId> {
         self.streams
-            .others
-            .push(Self::new_stream(self.pool.clone(), request_id, window)?);
-        Ok(self.streams.others.len())
+            .push(Stream::new(self.pool.clone(), request_id, window)?);
+        Some(self.streams.len() - 1)
     }
 
-    pub fn new(
-        pool: Weak<RefCell<Pool>>,
-        request_id: Ulid,
-        window: u32,
-    ) -> Result<Context, AcceptError> {
-        Ok(Self {
-            streams: Streams {
-                zero: Context::new_stream(pool.clone(), request_id, window)?,
-                others: Vec::new(),
-            },
+    pub fn new(pool: Weak<RefCell<Pool>>) -> Context {
+        Self {
+            streams: Vec::new(),
             pool,
             decoder: hpack::Decoder::new(),
-        })
+        }
     }
 }
 
@@ -269,7 +275,7 @@ impl Router {
         proxy: Rc<RefCell<dyn L7Proxy>>,
         metrics: &mut SessionMetrics,
     ) -> Result<(), BackendConnectionError> {
-        let context = &mut context.streams.others[stream_id - 1].context;
+        let context = &mut context.streams[stream_id].context;
         // we should get if the route is H2 or not here
         // for now we assume it's H1
         let cluster_id = self
@@ -319,7 +325,7 @@ impl Router {
     fn cluster_id_from_request(
         &mut self,
         context: &mut HttpContext,
-        proxy: Rc<RefCell<dyn L7Proxy>>,
+        _proxy: Rc<RefCell<dyn L7Proxy>>,
     ) -> Result<String, RetrieveClusterError> {
         let (host, uri, method) = match context.extract_route() {
             Ok(tuple) => tuple,
@@ -362,7 +368,7 @@ impl Router {
         frontend_should_stick: bool,
         context: &mut HttpContext,
         proxy: Rc<RefCell<dyn L7Proxy>>,
-        metrics: &mut SessionMetrics,
+        _metrics: &mut SessionMetrics,
     ) -> Result<TcpStream, BackendConnectionError> {
         let (backend, conn) = self
             .get_backend_for_sticky_session(
@@ -569,7 +575,7 @@ impl SessionState for Mux {
         let mut b = [0; 1024];
         let (size, status) = s.socket_read(&mut b);
         println!("{size} {status:?} {:?}", &b[..size]);
-        for stream in &mut self.context.streams.others {
+        for stream in &mut self.context.streams {
             for kawa in [&mut stream.front, &mut stream.back] {
                 kawa::debug_kawa(kawa);
                 kawa.prepare(&mut kawa::h1::BlockConverter);

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -79,7 +79,7 @@ impl<Front: SocketHandler> Connection<Front> {
             socket: front_stream,
             position: Position::Client,
             readiness: Readiness {
-                interest: Ready::WRITABLE | Ready::HUP | Ready::ERROR,
+                interest: Ready::WRITABLE | Ready::READABLE | Ready::HUP | Ready::ERROR,
                 event: Ready::EMPTY,
             },
             stream: stream_id,
@@ -120,7 +120,7 @@ impl<Front: SocketHandler> Connection<Front> {
             socket: front_stream,
             position: Position::Client,
             readiness: Readiness {
-                interest: Ready::WRITABLE | Ready::HUP | Ready::ERROR,
+                interest: Ready::WRITABLE | Ready::READABLE | Ready::HUP | Ready::ERROR,
                 event: Ready::EMPTY,
             },
             streams: HashMap::new(),

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -6,11 +6,12 @@ use std::{
     rc::{Rc, Weak},
 };
 
-use kawa::h1::ParserCallbacks;
 use mio::{net::TcpStream, Token};
 use rusty_ulid::Ulid;
 use sozu_command::ready::Ready;
 
+mod h1;
+mod h2;
 mod parser;
 mod pkawa;
 mod serializer;
@@ -18,12 +19,16 @@ mod serializer;
 use crate::{
     https::HttpsListener,
     pool::{Checkout, Pool},
-    protocol::{mux::parser::error_code_to_str, SessionState},
-    socket::{FrontRustls, SocketHandler, SocketResult},
+    protocol::{
+        http::editor::HttpContext,
+        mux::{h1::ConnectionH1, h2::ConnectionH2},
+        SessionState,
+    },
+    socket::{FrontRustls, SocketHandler},
     AcceptError, L7Proxy, ProxySession, Readiness, SessionMetrics, SessionResult, StateResult,
 };
 
-use super::http::editor::HttpContext;
+use self::h2::{H2State, H2Settings};
 
 /// Generic Http representation using the Kawa crate using the Checkout of Sozu as buffer
 type GenericHttpStream = kawa::Kawa<Checkout>;
@@ -34,81 +39,6 @@ type GlobalStreamId = usize;
 pub enum Position {
     Client,
     Server,
-}
-
-pub struct ConnectionH1<Front: SocketHandler> {
-    pub position: Position,
-    pub readiness: Readiness,
-    pub socket: Front,
-    /// note: a Server H1 will always reference stream 0, but a client can reference any stream
-    pub stream: GlobalStreamId,
-}
-
-#[derive(Debug)]
-pub enum H2State {
-    ClientPreface,
-    ClientSettings,
-    ServerSettings,
-    Header,
-    Frame(parser::FrameHeader),
-    Error,
-}
-
-#[derive(Debug)]
-pub struct H2Settings {
-    settings_header_table_size: u32,
-    settings_enable_push: bool,
-    settings_max_concurrent_streams: u32,
-    settings_initial_window_size: u32,
-    settings_max_frame_size: u32,
-    settings_max_header_list_size: u32,
-}
-
-impl Default for H2Settings {
-    fn default() -> Self {
-        Self {
-            settings_header_table_size: 4096,
-            settings_enable_push: true,
-            settings_max_concurrent_streams: u32::MAX,
-            settings_initial_window_size: (1 << 16) - 1,
-            settings_max_frame_size: 1 << 14,
-            settings_max_header_list_size: u32::MAX,
-        }
-    }
-}
-
-pub struct ConnectionH2<Front: SocketHandler> {
-    // pub decoder: hpack::Decoder<'static>,
-    pub expect: Option<(GlobalStreamId, usize)>,
-    pub position: Position,
-    pub readiness: Readiness,
-    pub settings: H2Settings,
-    pub socket: Front,
-    pub state: H2State,
-    pub streams: HashMap<StreamId, GlobalStreamId>,
-}
-
-pub struct Stream {
-    // pub request_id: Ulid,
-    pub window: i32,
-    pub front: GenericHttpStream,
-    pub back: GenericHttpStream,
-    pub context: HttpContext,
-}
-
-impl Stream {
-    pub fn front(&mut self, position: Position) -> &mut GenericHttpStream {
-        match position {
-            Position::Client => &mut self.back,
-            Position::Server => &mut self.front,
-        }
-    }
-    pub fn back(&mut self, position: Position) -> &mut GenericHttpStream {
-        match position {
-            Position::Client => &mut self.front,
-            Position::Server => &mut self.back,
-        }
-    }
 }
 
 pub enum Connection<Front: SocketHandler> {
@@ -195,26 +125,48 @@ impl<Front: SocketHandler> Connection<Front> {
     }
 }
 
+pub struct Stream {
+    // pub request_id: Ulid,
+    pub window: i32,
+    pub front: GenericHttpStream,
+    pub back: GenericHttpStream,
+    pub context: HttpContext,
+}
+
+impl Stream {
+    pub fn front(&mut self, position: Position) -> &mut GenericHttpStream {
+        match position {
+            Position::Client => &mut self.back,
+            Position::Server => &mut self.front,
+        }
+    }
+    pub fn back(&mut self, position: Position) -> &mut GenericHttpStream {
+        match position {
+            Position::Client => &mut self.front,
+            Position::Server => &mut self.back,
+        }
+    }
+}
+
 pub struct Streams {
     zero: Stream,
     others: Vec<Stream>,
+}
+
+impl Streams {
+    pub fn get(&mut self, stream_id: GlobalStreamId) -> &mut Stream {
+        if stream_id == 0 {
+            &mut self.zero
+        } else {
+            &mut self.others[stream_id - 1]
+        }
+    }
 }
 
 pub struct Context {
     pub streams: Streams,
     pub pool: Weak<RefCell<Pool>>,
     pub decoder: hpack::Decoder<'static>,
-}
-
-pub struct Mux {
-    pub frontend_token: Token,
-    pub frontend: Connection<FrontRustls>,
-    pub backends: HashMap<Token, Connection<TcpStream>>,
-    pub listener: Rc<RefCell<HttpsListener>>,
-    pub public_address: SocketAddr,
-    pub peer_address: Option<SocketAddr>,
-    pub sticky_name: String,
-    pub context: Context,
 }
 
 impl Context {
@@ -285,14 +237,15 @@ impl Context {
     }
 }
 
-impl Streams {
-    pub fn get(&mut self, stream_id: GlobalStreamId) -> &mut Stream {
-        if stream_id == 0 {
-            &mut self.zero
-        } else {
-            &mut self.others[stream_id - 1]
-        }
-    }
+pub struct Mux {
+    pub frontend_token: Token,
+    pub frontend: Connection<FrontRustls>,
+    pub backends: HashMap<Token, Connection<TcpStream>>,
+    pub listener: Rc<RefCell<HttpsListener>>,
+    pub public_address: SocketAddr,
+    pub peer_address: Option<SocketAddr>,
+    pub sticky_name: String,
+    pub context: Context,
 }
 
 impl Mux {
@@ -413,273 +366,6 @@ impl SessionState for Mux {
             println!("amount: {amount}\n{}", unsafe {
                 std::str::from_utf8_unchecked(writer.buffer())
             });
-        }
-    }
-}
-
-impl<Front: SocketHandler> ConnectionH2<Front> {
-    fn readable(&mut self, context: &mut Context) {
-        println!("======= MUX H2 READABLE");
-        let kawa = if let Some((stream_id, amount)) = self.expect {
-            let kawa = context.streams.get(stream_id).front(self.position);
-            let (size, status) = self.socket.socket_read(&mut kawa.storage.space()[..amount]);
-            println!("{:?}({stream_id}, {amount}) {size} {status:?}", self.state);
-            if size > 0 {
-                kawa.storage.fill(size);
-                if size == amount {
-                    self.expect = None;
-                } else {
-                    self.expect = Some((stream_id, amount - size));
-                    return;
-                }
-            } else {
-                self.readiness.event.remove(Ready::READABLE);
-                return;
-            }
-            kawa
-        } else {
-            self.readiness.event.remove(Ready::READABLE);
-            return;
-        };
-        match (&self.state, &self.position) {
-            (H2State::ClientPreface, Position::Client) => {
-                error!("Waiting for ClientPreface to finish writing")
-            }
-            (H2State::ClientPreface, Position::Server) => {
-                let i = kawa.storage.data();
-                let i = match parser::preface(i) {
-                    Ok((i, _)) => i,
-                    Err(e) => panic!("{e:?}"),
-                };
-                match parser::frame_header(i) {
-                    Ok((
-                        _,
-                        parser::FrameHeader {
-                            payload_len,
-                            frame_type: parser::FrameType::Settings,
-                            flags: 0,
-                            stream_id: 0,
-                        },
-                    )) => {
-                        kawa.storage.clear();
-                        self.state = H2State::ClientSettings;
-                        self.expect = Some((0, payload_len as usize));
-                    }
-                    _ => todo!(),
-                };
-            }
-            (H2State::ClientSettings, Position::Server) => {
-                let i = kawa.storage.data();
-                match parser::settings_frame(i, i.len()) {
-                    Ok((_, settings)) => {
-                        kawa.storage.clear();
-                        self.handle(settings, context);
-                    }
-                    Err(e) => panic!("{e:?}"),
-                }
-                let kawa = &mut context.streams.zero.back;
-                self.state = H2State::ServerSettings;
-                match serializer::gen_frame_header(
-                    kawa.storage.space(),
-                    &parser::FrameHeader {
-                        payload_len: 6 * 2,
-                        frame_type: parser::FrameType::Settings,
-                        flags: 0,
-                        stream_id: 0,
-                    },
-                ) {
-                    Ok((_, size)) => kawa.storage.fill(size),
-                    Err(e) => panic!("could not serialize HeaderFrame: {e:?}"),
-                };
-                // kawa.storage
-                //     .write(&[1, 3, 0, 0, 0, 100, 0, 4, 0, 1, 0, 0])
-                //     .unwrap();
-                match serializer::gen_frame_header(
-                    kawa.storage.space(),
-                    &parser::FrameHeader {
-                        payload_len: 0,
-                        frame_type: parser::FrameType::Settings,
-                        flags: 1,
-                        stream_id: 0,
-                    },
-                ) {
-                    Ok((_, size)) => kawa.storage.fill(size),
-                    Err(e) => panic!("could not serialize HeaderFrame: {e:?}"),
-                };
-                self.readiness.interest.insert(Ready::WRITABLE);
-                self.readiness.interest.remove(Ready::READABLE);
-            }
-            (H2State::ServerSettings, Position::Client) => todo!("Receive server Settings"),
-            (H2State::ServerSettings, Position::Server) => {
-                error!("waiting for ServerPreface to finish writing")
-            }
-            (H2State::Header, Position::Server) => {
-                let i = kawa.storage.data();
-                println!("  header: {i:?}");
-                match parser::frame_header(i) {
-                    Ok((_, header)) => {
-                        println!("{header:?}");
-                        kawa.storage.clear();
-                        let stream_id = if let Some(stream_id) = self.streams.get(&header.stream_id)
-                        {
-                            *stream_id
-                        } else {
-                            self.create_stream(header.stream_id, context)
-                        };
-                        let stream_id = if header.frame_type == parser::FrameType::Data {
-                            stream_id
-                        } else {
-                            0
-                        };
-                        println!("{} {} {:#?}", header.stream_id, stream_id, self.streams);
-                        self.expect = Some((stream_id as usize, header.payload_len as usize));
-                        self.state = H2State::Frame(header);
-                    }
-                    Err(e) => panic!("{e:?}"),
-                };
-            }
-            (H2State::Frame(header), Position::Server) => {
-                let i = kawa.storage.data();
-                println!("  data: {i:?}");
-                match parser::frame_body(i, header, self.settings.settings_max_frame_size) {
-                    Ok((_, frame)) => {
-                        kawa.storage.clear();
-                        self.handle(frame, context);
-                    }
-                    Err(e) => panic!("{e:?}"),
-                }
-                self.state = H2State::Header;
-                self.expect = Some((0, 9));
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    fn writable(&mut self, context: &mut Context) {
-        println!("======= MUX H2 WRITABLE");
-        match (&self.state, &self.position) {
-            (H2State::ClientPreface, Position::Client) => todo!("Send PRI + client Settings"),
-            (H2State::ClientPreface, Position::Server) => unreachable!(),
-            (H2State::ServerSettings, Position::Client) => unreachable!(),
-            (H2State::ServerSettings, Position::Server) => {
-                let kawa = &mut context.streams.zero.back;
-                println!("{:?}", kawa.storage.data());
-                let (size, status) = self.socket.socket_write(kawa.storage.data());
-                println!("  size: {size}, status: {status:?}");
-                let size = kawa.storage.available_data();
-                kawa.storage.consume(size);
-                if kawa.storage.is_empty() {
-                    self.readiness.interest.remove(Ready::WRITABLE);
-                    self.readiness.interest.insert(Ready::READABLE);
-                    self.state = H2State::Header;
-                    self.expect = Some((0, 9));
-                }
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn create_stream(&mut self, stream_id: StreamId, context: &mut Context) -> GlobalStreamId {
-        match context.create_stream(Ulid::generate(), self.settings.settings_initial_window_size) {
-            Ok(global_stream_id) => {
-                self.streams.insert(stream_id, global_stream_id);
-                global_stream_id
-            }
-            Err(e) => panic!("{e:?}"),
-        }
-    }
-
-    fn handle(&mut self, frame: parser::Frame, context: &mut Context) {
-        println!("{frame:?}");
-        match frame {
-            parser::Frame::Data(_) => todo!(),
-            parser::Frame::Headers(headers) => {
-                // if !headers.end_headers {
-                //     self.state = H2State::Continuation
-                // }
-                let global_stream_id = self.streams.get(&headers.stream_id).unwrap();
-                let kawa = context.streams.zero.front(self.position);
-                let buffer = headers.header_block_fragment.data(kawa.storage.buffer());
-                let stream = &mut context.streams.others[*global_stream_id - 1];
-                let kawa = &mut stream.front;
-                pkawa::handle_header(kawa, buffer, &mut context.decoder);
-                stream.context.on_headers(kawa);
-            }
-            parser::Frame::Priority(priority) => (),
-            parser::Frame::RstStream(_) => todo!(),
-            parser::Frame::Settings(settings) => {
-                for setting in settings.settings {
-                    match setting.identifier {
-                        1 => self.settings.settings_header_table_size = setting.value,
-                        2 => self.settings.settings_enable_push = setting.value == 1,
-                        3 => self.settings.settings_max_concurrent_streams = setting.value,
-                        4 => self.settings.settings_initial_window_size = setting.value,
-                        5 => self.settings.settings_max_frame_size = setting.value,
-                        6 => self.settings.settings_max_header_list_size = setting.value,
-                        other => panic!("setting_id: {other}"),
-                    }
-                }
-                println!("{:#?}", self.settings);
-            }
-            parser::Frame::PushPromise(_) => todo!(),
-            parser::Frame::Ping(_) => todo!(),
-            parser::Frame::GoAway(goaway) => panic!("{}", error_code_to_str(goaway.error_code)),
-            parser::Frame::WindowUpdate(update) => {
-                let global_stream_id = *self.streams.get(&update.stream_id).unwrap();
-                context.streams.get(global_stream_id).window += update.increment as i32;
-            }
-            parser::Frame::Continuation(_) => todo!(),
-        }
-    }
-}
-
-impl<Front: SocketHandler> ConnectionH1<Front> {
-    fn readable(&mut self, context: &mut Context) {
-        println!("======= MUX H1 READABLE");
-        let stream = &mut context.streams.get(self.stream);
-        let kawa = match self.position {
-            Position::Client => &mut stream.front,
-            Position::Server => &mut stream.back,
-        };
-        let (size, status) = self.socket.socket_read(kawa.storage.space());
-        println!("  size: {size}, status: {status:?}");
-        if size > 0 {
-            kawa.storage.fill(size);
-        } else {
-            self.readiness.event.remove(Ready::READABLE);
-        }
-        match status {
-            SocketResult::Continue => {}
-            SocketResult::Closed => todo!(),
-            SocketResult::Error => todo!(),
-            SocketResult::WouldBlock => self.readiness.event.remove(Ready::READABLE),
-        }
-        kawa::h1::parse(kawa, &mut kawa::h1::NoCallbacks);
-        kawa::debug_kawa(kawa);
-        if kawa.is_terminated() {
-            self.readiness.interest.remove(Ready::READABLE);
-        }
-    }
-    fn writable(&mut self, context: &mut Context) {
-        println!("======= MUX H1 WRITABLE");
-        let stream = &mut context.streams.get(self.stream);
-        let kawa = match self.position {
-            Position::Client => &mut stream.back,
-            Position::Server => &mut stream.front,
-        };
-        kawa.prepare(&mut kawa::h1::BlockConverter);
-        let bufs = kawa.as_io_slice();
-        if bufs.is_empty() {
-            self.readiness.interest.remove(Ready::WRITABLE);
-            return;
-        }
-        let (size, status) = self.socket.socket_write_vectored(&bufs);
-        println!("  size: {size}, status: {status:?}");
-        if size > 0 {
-            kawa.consume(size);
-            // self.backend_readiness.interest.insert(Ready::READABLE);
-        } else {
-            self.readiness.event.remove(Ready::WRITABLE);
         }
     }
 }

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -107,6 +107,7 @@ impl<Front: SocketHandler> Connection<Front> {
             zero: kawa::Kawa::new(kawa::Kind::Request, kawa::Buffer::new(buffer)),
             window: 1 << 16,
             decoder: hpack::Decoder::new(),
+            encoder: hpack::Encoder::new(),
         }))
     }
     pub fn new_h2_client(
@@ -130,6 +131,7 @@ impl<Front: SocketHandler> Connection<Front> {
             zero: kawa::Kawa::new(kawa::Kind::Request, kawa::Buffer::new(buffer)),
             window: 1 << 16,
             decoder: hpack::Decoder::new(),
+            encoder: hpack::Encoder::new(),
         }))
     }
 
@@ -592,7 +594,7 @@ impl SessionState for Mux {
                     || backend.readiness().filter_interest().is_error()
                 {
                     println!("{:?} {:?}", backend.readiness(), backend.socket());
-                    return SessionResult::Close;
+                    // return SessionResult::Close;
                 }
             }
 

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -151,6 +151,7 @@ fn set_default_answer(stream: &mut Stream, readiness: &mut Readiness, code: u16)
         fill_default_301_answer(kawa, host, uri);
     } else {
         fill_default_answer(kawa, code);
+        context.keep_alive_frontend = false;
     }
     context.status = Some(code);
     stream.state = StreamState::Unlinked;
@@ -450,7 +451,7 @@ impl<Front: SocketHandler> Connection<Front> {
                 );
                 println_!("--------------- CONNECTION CLOSE: {backend_borrow:#?}");
             }
-            Position::Server => todo!(),
+            Position::Server => {}
         }
         match self {
             Connection::H1(c) => c.close(context, endpoint),
@@ -1585,6 +1586,8 @@ impl<Front: SocketHandler + std::fmt::Debug, L: ListenerHandler + L7ListenerHand
         debug!("MUX CLOSE");
         println_!("FRONTEND: {:#?}", self.frontend);
         println_!("BACKENDS: {:#?}", self.router.backends);
+
+        self.frontend.close(&mut self.context, EndpointClient(&mut self.router));
 
         for (token, client) in &mut self.router.backends {
             let proxy_borrow = proxy.borrow();

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -31,6 +31,7 @@ use crate::{
         SessionState,
     },
     router::Route,
+    server::CONN_RETRIES,
     socket::{FrontRustls, SocketHandler, SocketResult},
     BackendConnectionError, L7ListenerHandler, L7Proxy, ProxySession, Readiness,
     RetrieveClusterError, SessionMetrics, SessionResult, StateResult,
@@ -39,18 +40,64 @@ use crate::{
 #[macro_export]
 macro_rules! println_ {
     ($($t:expr),*) => {
+        // print!("{}:{} ", file!(), line!());
         println!($($t),*)
         // $(let _ = &$t;)*
     };
 }
 fn debug_kawa(_kawa: &GenericHttpStream) {
-    // kawa::debug_kawa(_kawa);
+    kawa::debug_kawa(_kawa);
 }
 
 /// Generic Http representation using the Kawa crate using the Checkout of Sozu as buffer
 type GenericHttpStream = kawa::Kawa<Checkout>;
 type StreamId = u32;
 type GlobalStreamId = usize;
+
+/// Replace the content of the kawa buffer with a default Sozu answer for a given status code
+fn set_default_answer(kawa: &mut GenericHttpStream, readiness: &mut Readiness, code: u16) {
+    kawa.clear();
+    kawa.storage.clear();
+    kawa.detached.status_line = kawa::StatusLine::Response {
+        version: kawa::Version::V20,
+        code,
+        status: kawa::Store::from_string(code.to_string()),
+        reason: kawa::Store::Static(b"Sozu Default Answer"),
+    };
+    kawa.push_block(kawa::Block::StatusLine);
+    kawa.push_block(kawa::Block::Header(kawa::Pair {
+        key: kawa::Store::Static(b"Cache-Control"),
+        val: kawa::Store::Static(b"no-cache"),
+    }));
+    kawa.push_block(kawa::Block::Header(kawa::Pair {
+        key: kawa::Store::Static(b"Connection"),
+        val: kawa::Store::Static(b"close"),
+    }));
+    kawa.push_block(kawa::Block::Header(kawa::Pair {
+        key: kawa::Store::Static(b"Content-Length"),
+        val: kawa::Store::Static(b"0"),
+    }));
+    kawa.push_block(kawa::Block::Flags(kawa::Flags {
+        end_body: false,
+        end_chunk: false,
+        end_header: true,
+        end_stream: true,
+    }));
+    kawa.parsing_phase = kawa::ParsingPhase::Terminated;
+    readiness.interest.insert(Ready::WRITABLE);
+}
+
+fn forcefully_terminate_answer(kawa: &mut GenericHttpStream, readiness: &mut Readiness) {
+    kawa.push_block(kawa::Block::Flags(kawa::Flags {
+        end_body: false,
+        end_chunk: false,
+        end_header: false,
+        end_stream: true,
+    }));
+    kawa.parsing_phase = kawa::ParsingPhase::Terminated;
+    debug_kawa(kawa);
+    readiness.interest.insert(Ready::WRITABLE);
+}
 
 #[derive(Debug)]
 pub enum Position {
@@ -69,8 +116,6 @@ pub enum BackendStatus {
 pub enum MuxResult {
     Continue,
     CloseSession(H2Error),
-    Close(GlobalStreamId),
-    Connect(GlobalStreamId),
 }
 
 #[derive(Debug)]
@@ -82,7 +127,15 @@ pub enum Connection<Front: SocketHandler> {
 pub trait Endpoint {
     fn readiness(&self, token: Token) -> &Readiness;
     fn readiness_mut(&mut self, token: Token) -> &mut Readiness;
+    /// If end_stream is called on a client it means the stream has PROPERLY finished,
+    /// the server has completed serving the response and informs the endpoint that this stream won't be used anymore.
+    /// If end_stream is called on a server it means the stream was BROKEN, the client was most likely disconnected or encountered an error
+    /// it is for the server to decide if the stream can be retried or an error should be sent. It should be GUARANTEED that all bytes from
+    /// the backend were read. However it is almost certain that all bytes were not already sent to the client.
     fn end_stream(&mut self, token: Token, stream: GlobalStreamId, context: &mut Context);
+    /// If start_stream is called on a client it means the stream should be attached to this endpoint,
+    /// the stream might be recovering from a disconnection, in any case at this point its response MUST be empty.
+    /// If the start_stream is called on a H2 server it means the stream is a server push and its request MUST be empty.
     fn start_stream(&mut self, token: Token, stream: GlobalStreamId, context: &mut Context);
 }
 
@@ -365,11 +418,25 @@ fn update_readiness_after_write(
 //     Closed,
 // }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamState {
+    Idle,
+    /// the Stream is asking for connection, this will trigger a call to connect
+    Link,
+    /// the Stream is linked to a Client (note that the client might not be connected)
+    Linked(Token),
+    /// the Stream was linked to a Client, but the connection closed, the client was removed
+    /// and this Stream could not be retried (it should be terminated)
+    Unlinked,
+    /// the Stream is unlinked and can be reused
+    Recycle,
+}
+
 pub struct Stream {
     // pub request_id: Ulid,
-    pub active: bool,
     pub window: i32,
-    pub token: Option<Token>,
+    pub attempts: u8,
+    pub state: StreamState,
     front: GenericHttpStream,
     back: GenericHttpStream,
     pub context: HttpContext,
@@ -419,9 +486,9 @@ impl Stream {
             None => return None,
         };
         Some(Self {
-            active: true,
+            state: StreamState::Idle,
+            attempts: 0,
             window: window as i32,
-            token: None,
             front: GenericHttpStream::new(kawa::Kind::Request, kawa::Buffer::new(front_buffer)),
             back: GenericHttpStream::new(kawa::Kind::Response, kawa::Buffer::new(back_buffer)),
             context: temporary_http_context(request_id),
@@ -463,16 +530,16 @@ pub struct Context {
 impl Context {
     pub fn create_stream(&mut self, request_id: Ulid, window: u32) -> Option<GlobalStreamId> {
         for (stream_id, stream) in self.streams.iter_mut().enumerate() {
-            if !stream.active {
+            if stream.state == StreamState::Recycle {
                 println_!("Reuse stream: {stream_id}");
+                stream.state = StreamState::Idle;
+                stream.attempts = 0;
                 stream.window = window as i32;
                 stream.context = temporary_http_context(request_id);
                 stream.back.clear();
                 stream.back.storage.clear();
                 stream.front.clear();
                 stream.front.storage.clear();
-                stream.token = None;
-                stream.active = true;
                 return Some(stream_id);
             }
         }
@@ -506,7 +573,12 @@ impl Router {
         let stream = &mut context.streams[stream_id];
         // when reused, a stream should be detached from its old connection, if not we could end
         // with concurrent connections on a single endpoint
-        assert!(stream.token.is_none());
+        assert!(matches!(stream.state, StreamState::Link));
+        if stream.attempts >= CONN_RETRIES {
+            return Err(BackendConnectionError::MaxConnectionRetries(None));
+        }
+        stream.attempts += 1;
+
         let stream_context = &mut stream.context;
         let (cluster_id, h2) = self
             .route_from_request(stream_context, proxy.clone())
@@ -606,7 +678,7 @@ impl Router {
         };
 
         // link stream to backend
-        stream.token = Some(token);
+        stream.state = StreamState::Linked(token);
         // link backend to stream
         self.backends
             .get_mut(&token)
@@ -626,8 +698,6 @@ impl Router {
                 // we are past kawa parsing if it succeeded this can't fail
                 // if the request was malformed it was caught by kawa and we sent a 400
                 panic!("{cluster_error}");
-                // self.set_answer(DefaultAnswerStatus::Answer400, None);
-                // return Err(cluster_error);
             }
         };
 
@@ -757,112 +827,149 @@ impl SessionState for Mux {
 
         let start = std::time::Instant::now();
         println_!("{start:?}");
-        while counter < max_loop_iterations {
-            let mut dirty = false;
+        loop {
+            loop {
+                let context = &mut self.context;
+                if self.frontend.readiness().filter_interest().is_readable() {
+                    match self
+                        .frontend
+                        .readable(context, EndpointClient(&mut self.router))
+                    {
+                        MuxResult::Continue => (),
+                        MuxResult::CloseSession(e) => self.goaway(e),
+                    }
+                }
+
+                let mut all_backends_readiness_are_empty = true;
+                let context = &mut self.context;
+                let mut dead_backends = Vec::new();
+                for (token, backend) in self.router.backends.iter_mut() {
+                    let readiness = backend.readiness_mut();
+                    let dead = readiness.filter_interest().is_hup()
+                        || readiness.filter_interest().is_error();
+                    if dead {
+                        println_!("Backend({token:?}) -> {readiness:?}");
+                        readiness.event.remove(Ready::WRITABLE);
+                    }
+
+                    if backend.readiness().filter_interest().is_writable() {
+                        let mut owned_position = Position::Server;
+                        let position = backend.position_mut();
+                        std::mem::swap(&mut owned_position, position);
+                        match owned_position {
+                            Position::Client(BackendStatus::Connecting(cluster_id)) => {
+                                *position = Position::Client(BackendStatus::Connected(cluster_id));
+                            }
+                            _ => *position = owned_position,
+                        }
+                        match backend.writable(context, EndpointServer(&mut self.frontend)) {
+                            MuxResult::Continue => (),
+                            MuxResult::CloseSession(e) => {
+                                self.goaway(e);
+                                break;
+                            }
+                        }
+                    }
+
+                    if backend.readiness().filter_interest().is_readable() {
+                        match backend.readable(context, EndpointServer(&mut self.frontend)) {
+                            MuxResult::Continue => (),
+                            MuxResult::CloseSession(e) => {
+                                self.goaway(e);
+                                break;
+                            }
+                        }
+                    }
+
+                    if dead && !backend.readiness().filter_interest().is_readable() {
+                        println_!("Closing {:#?}", backend);
+                        backend.close(context, EndpointServer(&mut self.frontend));
+                        dead_backends.push(*token);
+                    }
+
+                    if !backend.readiness().filter_interest().is_empty() {
+                        all_backends_readiness_are_empty = false;
+                    }
+                }
+                if !dead_backends.is_empty() {
+                    for token in &dead_backends {
+                        self.router.backends.remove(token);
+                    }
+                    println_!("FRONTEND: {:#?}", &self.frontend);
+                    println_!("BACKENDS: {:#?}", self.router.backends);
+                }
+
+                let context = &mut self.context;
+                if self.frontend.readiness().filter_interest().is_writable() {
+                    match self
+                        .frontend
+                        .writable(context, EndpointClient(&mut self.router))
+                    {
+                        MuxResult::Continue => (),
+                        MuxResult::CloseSession(e) => self.goaway(e),
+                    }
+                }
+
+                if self.frontend.readiness().filter_interest().is_empty()
+                    && all_backends_readiness_are_empty
+                {
+                    break;
+                }
+
+                counter += 1;
+                if counter >= max_loop_iterations {
+                    incr!("http.infinite_loop.error");
+                    return SessionResult::Close;
+                }
+            }
 
             let context = &mut self.context;
-            if self.frontend.readiness().filter_interest().is_readable() {
-                match self
-                    .frontend
-                    .readable(context, EndpointClient(&mut self.router))
-                {
-                    MuxResult::Continue => (),
-                    MuxResult::CloseSession(e) => self.goaway(e),
-                    MuxResult::Close(_) => todo!(),
-                    MuxResult::Connect(stream_id) => {
-                        match self.router.connect(
-                            stream_id,
-                            context,
-                            session.clone(),
-                            proxy.clone(),
-                            metrics,
-                        ) {
-                            Ok(_) => (),
-                            Err(error) => {
-                                println_!("{error}");
+            let front_readiness = self.frontend.readiness_mut();
+            let mut dirty = false;
+            for stream_id in 0..context.streams.len() {
+                if context.streams[stream_id].state == StreamState::Link {
+                    dirty = true;
+                    match self.router.connect(
+                        stream_id,
+                        context,
+                        session.clone(),
+                        proxy.clone(),
+                        metrics,
+                    ) {
+                        Ok(_) => {}
+                        Err(error) => {
+                            println_!("Connection error: {error}");
+                            let kawa = &mut context.streams[stream_id].back;
+                            use BackendConnectionError as BE;
+                            match error {
+                                BE::Backend(BackendError::NoBackendForCluster(_))
+                                | BE::MaxConnectionRetries(_)
+                                | BE::MaxSessionsMemory
+                                | BE::MaxBuffers => {
+                                    set_default_answer(kawa, front_readiness, 503);
+                                }
+                                BE::RetrieveClusterError(
+                                    RetrieveClusterError::RetrieveFrontend(_),
+                                ) => {
+                                    set_default_answer(kawa, front_readiness, 404);
+                                }
+                                BE::RetrieveClusterError(
+                                    RetrieveClusterError::UnauthorizedRoute,
+                                ) => {
+                                    set_default_answer(kawa, front_readiness, 401);
+                                }
+
+                                BE::Backend(_) => {}
+                                BE::RetrieveClusterError(_) => unreachable!(),
+                                BE::NotFound(_) => unreachable!(),
                             }
                         }
                     }
                 }
-                dirty = true;
             }
-
-            let context = &mut self.context;
-            let mut dead_backends = Vec::new();
-            for (token, backend) in self.router.backends.iter_mut() {
-                let readiness = backend.readiness().filter_interest();
-                if readiness.is_hup() || readiness.is_error() {
-                    println_!("{token:?} -> {:?}", backend);
-                    backend.close(context, EndpointServer(&mut self.frontend));
-                    dead_backends.push(*token);
-                }
-                if readiness.is_writable() {
-                    let mut owned_position = Position::Server;
-                    let position = backend.position_mut();
-                    std::mem::swap(&mut owned_position, position);
-                    match owned_position {
-                        Position::Client(BackendStatus::Connecting(cluster_id)) => {
-                            *position = Position::Client(BackendStatus::Connected(cluster_id));
-                        }
-                        _ => *position = owned_position,
-                    }
-                    match backend.writable(context, EndpointServer(&mut self.frontend)) {
-                        MuxResult::Continue => (),
-                        MuxResult::CloseSession(e) => {
-                            self.goaway(e);
-                            break;
-                        }
-                        MuxResult::Close(_) => todo!(),
-                        MuxResult::Connect(_) => unreachable!(),
-                    }
-                    dirty = true;
-                }
-
-                if readiness.is_readable() {
-                    match backend.readable(context, EndpointServer(&mut self.frontend)) {
-                        MuxResult::Continue => (),
-                        MuxResult::CloseSession(e) => {
-                            self.goaway(e);
-                            break;
-                        }
-                        MuxResult::Close(_) => todo!(),
-                        MuxResult::Connect(_) => unreachable!(),
-                    }
-                    dirty = true;
-                }
-            }
-            if !dead_backends.is_empty() {
-                for token in &dead_backends {
-                    self.router.backends.remove(token);
-                }
-                println_!("FRONTEND: {:#?}", &self.frontend);
-                println_!("BACKENDS: {:#?}", self.router.backends);
-            }
-
-            let context = &mut self.context;
-            if self.frontend.readiness().filter_interest().is_writable() {
-                match self
-                    .frontend
-                    .writable(context, EndpointClient(&mut self.router))
-                {
-                    MuxResult::Continue => (),
-                    MuxResult::CloseSession(e) => self.goaway(e),
-                    MuxResult::Close(_) => todo!(),
-                    MuxResult::Connect(_) => unreachable!(),
-                }
-                dirty = true;
-            }
-
             if !dirty {
                 break;
             }
-
-            counter += 1;
-        }
-
-        if counter == max_loop_iterations {
-            incr!("http.infinite_loop.error");
-            return SessionResult::Close;
         }
 
         SessionResult::Continue

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -4,6 +4,7 @@ use std::{
     io::Write,
     net::SocketAddr,
     rc::{Rc, Weak},
+    time::Duration,
 };
 
 use mio::{net::TcpStream, Interest, Token};
@@ -28,6 +29,7 @@ use crate::{
     router::Route,
     server::CONN_RETRIES,
     socket::{SocketHandler, SocketResult},
+    timer::TimeoutContainer,
     BackendConnectionError, L7ListenerHandler, L7Proxy, ProxySession, Readiness,
     RetrieveClusterError, SessionIsToBeClosed, SessionMetrics, SessionResult, StateResult,
 };
@@ -177,19 +179,27 @@ pub enum Connection<Front: SocketHandler> {
 }
 
 impl<Front: SocketHandler> Connection<Front> {
-    pub fn new_h1_server(front_stream: Front) -> Connection<Front> {
+    pub fn new_h1_server(
+        front_stream: Front,
+        timeout_container: TimeoutContainer,
+    ) -> Connection<Front> {
         Connection::H1(ConnectionH1 {
-            socket: front_stream,
             position: Position::Server,
             readiness: Readiness {
                 interest: Ready::READABLE | Ready::HUP | Ready::ERROR,
                 event: Ready::EMPTY,
             },
-            stream: 0,
             requests: 0,
+            socket: front_stream,
+            stream: 0,
+            timeout_container,
         })
     }
-    pub fn new_h1_client(front_stream: Front, cluster_id: String) -> Connection<Front> {
+    pub fn new_h1_client(
+        front_stream: Front,
+        cluster_id: String,
+        timeout_container: TimeoutContainer,
+    ) -> Connection<Front> {
         Connection::H1(ConnectionH1 {
             socket: front_stream,
             position: Position::Client(BackendStatus::Connecting(cluster_id)),
@@ -199,12 +209,14 @@ impl<Front: SocketHandler> Connection<Front> {
             },
             stream: 0,
             requests: 0,
+            timeout_container,
         })
     }
 
     pub fn new_h2_server(
         front_stream: Front,
         pool: Weak<RefCell<Pool>>,
+        timeout_container: TimeoutContainer,
     ) -> Option<Connection<Front>> {
         let buffer = pool
             .upgrade()
@@ -226,6 +238,7 @@ impl<Front: SocketHandler> Connection<Front> {
             socket: front_stream,
             state: H2State::ClientPreface,
             streams: HashMap::new(),
+            timeout_container,
             window: 1 << 16,
             zero: kawa::Kawa::new(kawa::Kind::Request, kawa::Buffer::new(buffer)),
         }))
@@ -234,6 +247,7 @@ impl<Front: SocketHandler> Connection<Front> {
         front_stream: Front,
         cluster_id: String,
         pool: Weak<RefCell<Pool>>,
+        timeout_container: TimeoutContainer,
     ) -> Option<Connection<Front>> {
         let buffer = pool
             .upgrade()
@@ -255,6 +269,7 @@ impl<Front: SocketHandler> Connection<Front> {
             socket: front_stream,
             state: H2State::ClientPreface,
             streams: HashMap::new(),
+            timeout_container,
             window: 1 << 16,
             zero: kawa::Kawa::new(kawa::Kind::Request, kawa::Buffer::new(buffer)),
         }))
@@ -282,6 +297,12 @@ impl<Front: SocketHandler> Connection<Front> {
         match self {
             Connection::H1(c) => &mut c.position,
             Connection::H2(c) => &mut c.position,
+        }
+    }
+    pub fn timeout_container(&mut self) -> &mut TimeoutContainer {
+        match self {
+            Connection::H1(c) => &mut c.timeout_container,
+            Connection::H2(c) => &mut c.timeout_container,
         }
     }
     pub fn socket(&self) -> &TcpStream {
@@ -596,15 +617,23 @@ impl Context {
 }
 
 pub struct Router {
-    pub listener: Rc<RefCell<dyn L7ListenerHandler>>,
     pub backends: HashMap<Token, Connection<TcpStream>>,
+    pub configured_backend_timeout: Duration,
+    pub configured_connect_timeout: Duration,
+    pub listener: Rc<RefCell<dyn L7ListenerHandler>>,
 }
 
 impl Router {
-    pub fn new(listener: Rc<RefCell<dyn L7ListenerHandler>>) -> Self {
+    pub fn new(
+        configured_backend_timeout: Duration,
+        configured_connect_timeout: Duration,
+        listener: Rc<RefCell<dyn L7ListenerHandler>>,
+    ) -> Self {
         Self {
-            listener,
             backends: HashMap::new(),
+            configured_backend_timeout,
+            configured_connect_timeout,
+            listener,
         }
     }
 
@@ -717,13 +746,19 @@ impl Router {
                 error!("error registering back socket({:?}): {:?}", socket, e);
             }
 
+            let timeout_container = TimeoutContainer::new(self.configured_connect_timeout, token);
             let connection = if h2 {
-                match Connection::new_h2_client(socket, cluster_id, context.pool.clone()) {
+                match Connection::new_h2_client(
+                    socket,
+                    cluster_id,
+                    context.pool.clone(),
+                    timeout_container,
+                ) {
                     Some(connection) => connection,
                     None => return Err(BackendConnectionError::MaxBuffers),
                 }
             } else {
-                Connection::new_h1_client(socket, cluster_id)
+                Connection::new_h1_client(socket, cluster_id, timeout_container)
             };
             self.backends.insert(token, connection);
             token
@@ -844,6 +879,7 @@ impl Router {
 }
 
 pub struct Mux<Front: SocketHandler> {
+    pub configured_frontend_timeout: Duration,
     pub frontend_token: Token,
     pub frontend: Connection<Front>,
     pub router: Router,
@@ -1035,11 +1071,90 @@ impl<Front: SocketHandler + std::fmt::Debug> SessionState for Mux<Front> {
 
     fn timeout(&mut self, token: Token, _metrics: &mut SessionMetrics) -> StateResult {
         println_!("MuxState::timeout({token:?})");
-        StateResult::CloseSession
+        let front_is_h2 = match self.frontend {
+            Connection::H1(_) => false,
+            Connection::H2(_) => true,
+        };
+        let mut is_to_be_closed = true;
+        if self.frontend_token == token {
+            self.frontend.timeout_container().triggered();
+            let front_readiness = self.frontend.readiness_mut();
+            for stream in &mut self.context.streams {
+                match stream.state {
+                    StreamState::Idle => {
+                        // In h1 an Idle stream is always the first request, so we can send a 408
+                        // In h2 an Idle stream doesn't necessarily hold a request yet,
+                        // in most cases it was just reserved, so we can just ignore them.
+                        if !front_is_h2 {
+                            set_default_answer(stream, front_readiness, 408);
+                            is_to_be_closed = false;
+                        }
+                    }
+                    StreamState::Link => {
+                        // This is an unusual case, as we have both a complete request and no
+                        // available backend yet. For now, we answer with 503
+                        set_default_answer(stream, front_readiness, 503);
+                        is_to_be_closed = false;
+                    }
+                    StreamState::Linked(_) => {
+                        // A stream Linked to a backend is waiting for the response, not the answer.
+                        // For streaming or malformed requests, it is possible that the request is not
+                        // terminated at this point. For now, we do nothing and
+                        is_to_be_closed = false;
+                    }
+                    StreamState::Unlinked => {
+                        // A stream Unlinked already has a response and its backend closed.
+                        // In case it hasn't finished proxying we wait. Otherwise it is a stream
+                        // kept alive for a new request, which can be killed.
+                        if !stream.back.is_completed() {
+                            is_to_be_closed = false;
+                        }
+                    }
+                    StreamState::Recycle => {
+                        // A recycled stream is an h2 stream which doesn't hold a request anymore.
+                        // We can ignore it.
+                    }
+                }
+            }
+        } else if let Some(backend) = self.router.backends.get_mut(&token) {
+            backend.timeout_container().triggered();
+            let front_readiness = self.frontend.readiness_mut();
+            for stream_id in 0..self.context.streams.len() {
+                let stream = &mut self.context.streams[stream_id];
+                if let StreamState::Linked(back_token) = stream.state {
+                    if token == back_token {
+                        // This stream is linked to the backend that timedout.
+                        if stream.back.is_terminated() || stream.back.is_error() {
+                            // Nothing to do, simply wait for the remaining bytes to be proxied
+                            if !stream.back.is_completed() {
+                                is_to_be_closed = false;
+                            }
+                        } else if stream.back.is_initial() {
+                            // The response has not started yet
+                            set_default_answer(stream, front_readiness, 504);
+                            is_to_be_closed = false;
+                        } else {
+                            forcefully_terminate_answer(stream, front_readiness);
+                            is_to_be_closed = false;
+                        }
+                        backend.end_stream(0, &mut self.context);
+                    }
+                }
+            }
+        }
+        if is_to_be_closed {
+            StateResult::CloseSession
+        } else {
+            StateResult::Continue
+        }
     }
 
     fn cancel_timeouts(&mut self) {
         println_!("MuxState::cancel_timeouts");
+        self.frontend.timeout_container().cancel();
+        for backend in self.router.backends.values_mut() {
+            backend.timeout_container().cancel();
+        }
     }
 
     fn print_state(&self, context: &str) {

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -1,8 +1,8 @@
 use std::{
     cell::RefCell,
     collections::HashMap,
-    io::Write,
-    net::SocketAddr,
+    io::{ErrorKind, Write},
+    net::{Shutdown, SocketAddr},
     rc::{Rc, Weak},
     time::Duration,
 };
@@ -47,7 +47,7 @@ macro_rules! println_ {
     };
 }
 fn debug_kawa(_kawa: &GenericHttpStream) {
-    kawa::debug_kawa(_kawa);
+    // kawa::debug_kawa(_kawa);
 }
 
 /// Generic Http representation using the Kawa crate using the Checkout of Sozu as buffer
@@ -299,16 +299,22 @@ impl<Front: SocketHandler> Connection<Front> {
             Connection::H2(c) => &mut c.position,
         }
     }
-    pub fn timeout_container(&mut self) -> &mut TimeoutContainer {
-        match self {
-            Connection::H1(c) => &mut c.timeout_container,
-            Connection::H2(c) => &mut c.timeout_container,
-        }
-    }
     pub fn socket(&self) -> &TcpStream {
         match self {
             Connection::H1(c) => c.socket.socket_ref(),
             Connection::H2(c) => c.socket.socket_ref(),
+        }
+    }
+    pub fn socket_mut(&mut self) -> &mut TcpStream {
+        match self {
+            Connection::H1(c) => c.socket.socket_mut(),
+            Connection::H2(c) => c.socket.socket_mut(),
+        }
+    }
+    pub fn timeout_container(&mut self) -> &mut TimeoutContainer {
+        match self {
+            Connection::H1(c) => &mut c.timeout_container,
+            Connection::H2(c) => &mut c.timeout_container,
         }
     }
     fn force_disconnect(&mut self) -> MuxResult {
@@ -951,6 +957,9 @@ impl<Front: SocketHandler + std::fmt::Debug> SessionState for Mux<Front> {
                                 *position = Position::Client(BackendStatus::Connected(
                                     std::mem::take(cluster_id),
                                 ));
+                                backend
+                                    .timeout_container()
+                                    .set_duration(self.router.configured_backend_timeout);
                             }
                             _ => {}
                         }
@@ -981,7 +990,29 @@ impl<Front: SocketHandler + std::fmt::Debug> SessionState for Mux<Front> {
                 }
                 if !dead_backends.is_empty() {
                     for token in &dead_backends {
-                        self.router.backends.remove(token);
+                        let proxy_borrow = proxy.borrow();
+                        if let Some(mut backend) = self.router.backends.remove(token) {
+                            backend.timeout_container().cancel();
+                            let socket = backend.socket_mut();
+                            if let Err(e) = proxy_borrow.deregister_socket(socket) {
+                                error!("error deregistering back socket({:?}): {:?}", socket, e);
+                            }
+                            if let Err(e) = socket.shutdown(Shutdown::Both) {
+                                if e.kind() != ErrorKind::NotConnected {
+                                    error!(
+                                        "error shutting down back socket({:?}): {:?}",
+                                        socket, e
+                                    );
+                                }
+                            }
+                        } else {
+                            error!("session {:?} has no backend!", token);
+                        }
+                        if !proxy_borrow.remove_session(*token) {
+                            error!("session {:?} was already removed!", token);
+                        } else {
+                            println!("SUCCESS: session {token:?} was removed!");
+                        }
                     }
                     println_!("FRONTEND: {:#?}", self.frontend);
                     println_!("BACKENDS: {:#?}", self.router.backends);
@@ -1013,10 +1044,15 @@ impl<Front: SocketHandler + std::fmt::Debug> SessionState for Mux<Front> {
             }
 
             let context = &mut self.context;
-            let front_readiness = self.frontend.readiness_mut();
             let mut dirty = false;
             for stream_id in 0..context.streams.len() {
                 if context.streams[stream_id].state == StreamState::Link {
+                    // Before the first request triggers a stream Link, the frontend timeout is set
+                    // to a shorter request_timeout, here we switch to the longer nominal timeout
+                    self.frontend
+                        .timeout_container()
+                        .set_duration(self.configured_frontend_timeout);
+                    let front_readiness = self.frontend.readiness_mut();
                     dirty = true;
                     match self.router.connect(
                         stream_id,
@@ -1105,9 +1141,9 @@ impl<Front: SocketHandler + std::fmt::Debug> SessionState for Mux<Front> {
                         should_write = true;
                     }
                     StreamState::Linked(_) => {
-                        // A stream Linked to a backend is waiting for the response, not the answer.
+                        // A stream Linked to a backend is waiting for the response, not the request.
                         // For streaming or malformed requests, it is possible that the request is not
-                        // terminated at this point. For now, we do nothing and
+                        // terminated at this point. For now, we do nothing
                         should_close = false;
                     }
                     StreamState::Unlinked => {
@@ -1202,27 +1238,48 @@ impl<Front: SocketHandler + std::fmt::Debug> SessionState for Mux<Front> {
         }
     }
 
-    fn close(&mut self, _proxy: Rc<RefCell<dyn L7Proxy>>, _metrics: &mut SessionMetrics) {
-        let s = match &mut self.frontend {
-            Connection::H1(c) => &mut c.socket,
-            Connection::H2(c) => &mut c.socket,
-        };
-        let mut b = [0; 1024];
-        let (size, status) = s.socket_read(&mut b);
-        println_!("{size} {status:?} {:?}", &b[..size]);
-        for stream in &mut self.context.streams {
-            for kawa in [&mut stream.front, &mut stream.back] {
-                debug_kawa(kawa);
-                kawa.prepare(&mut kawa::h1::BlockConverter);
-                let out = kawa.as_io_slice();
-                let mut writer = std::io::BufWriter::new(Vec::new());
-                let amount = writer.write_vectored(&out).unwrap();
-                println_!(
-                    "amount: {amount}\n{}",
-                    String::from_utf8_lossy(writer.buffer())
-                );
+    fn close(&mut self, proxy: Rc<RefCell<dyn L7Proxy>>, _metrics: &mut SessionMetrics) {
+        println_!("FRONTEND: {:#?}", self.frontend);
+        println_!("BACKENDS: {:#?}", self.router.backends);
+
+        for (token, backend) in &mut self.router.backends {
+            let proxy_borrow = proxy.borrow();
+            backend.timeout_container().cancel();
+            let socket = backend.socket_mut();
+            if let Err(e) = proxy_borrow.deregister_socket(socket) {
+                error!("error deregistering back socket({:?}): {:?}", socket, e);
+            }
+            if let Err(e) = socket.shutdown(Shutdown::Both) {
+                if e.kind() != ErrorKind::NotConnected {
+                    error!("error shutting down back socket({:?}): {:?}", socket, e);
+                }
+            }
+            if !proxy_borrow.remove_session(*token) {
+                error!("session {:?} was already removed!", token);
+            } else {
+                println!("SUCCESS: session {token:?} was removed!");
             }
         }
+        // let s = match &mut self.frontend {
+        //     Connection::H1(c) => &mut c.socket,
+        //     Connection::H2(c) => &mut c.socket,
+        // };
+        // let mut b = [0; 1024];
+        // let (size, status) = s.socket_read(&mut b);
+        // println_!("{size} {status:?} {:?}", &b[..size]);
+        // for stream in &mut self.context.streams {
+        //     for kawa in [&mut stream.front, &mut stream.back] {
+        //         debug_kawa(kawa);
+        //         kawa.prepare(&mut kawa::h1::BlockConverter);
+        //         let out = kawa.as_io_slice();
+        //         let mut writer = std::io::BufWriter::new(Vec::new());
+        //         let amount = writer.write_vectored(&out).unwrap();
+        //         println_!(
+        //             "amount: {amount}\n{}",
+        //             String::from_utf8_lossy(writer.buffer())
+        //         );
+        //     }
+        // }
     }
 
     fn shutting_down(&mut self) -> SessionIsToBeClosed {

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -27,7 +27,7 @@ use crate::{
         SessionState,
     },
     router::Route,
-    socket::{FrontRustls, SocketHandler},
+    socket::{FrontRustls, SocketHandler, SocketResult},
     BackendConnectionError, L7ListenerHandler, L7Proxy, ProxySession, Readiness,
     RetrieveClusterError, SessionMetrics, SessionResult, StateResult,
 };
@@ -83,6 +83,7 @@ impl<Front: SocketHandler> Connection<Front> {
                 event: Ready::EMPTY,
             },
             stream: 0,
+            requests: 0,
         })
     }
     pub fn new_h1_client(front_stream: Front, cluster_id: String) -> Connection<Front> {
@@ -94,6 +95,7 @@ impl<Front: SocketHandler> Connection<Front> {
                 event: Ready::EMPTY,
             },
             stream: 0,
+            requests: 0,
         })
     }
 
@@ -113,7 +115,8 @@ impl<Front: SocketHandler> Connection<Front> {
             },
             streams: HashMap::new(),
             state: H2State::ClientPreface,
-            expect: Some((H2StreamId::Zero, 24 + 9)),
+            expect_read: Some((H2StreamId::Zero, 24 + 9)),
+            expect_write: None,
             settings: H2Settings::default(),
             zero: kawa::Kawa::new(kawa::Kind::Request, kawa::Buffer::new(buffer)),
             window: 1 << 16,
@@ -139,7 +142,8 @@ impl<Front: SocketHandler> Connection<Front> {
             },
             streams: HashMap::new(),
             state: H2State::ClientPreface,
-            expect: None,
+            expect_read: None,
+            expect_write: None,
             settings: H2Settings::default(),
             zero: kawa::Kawa::new(kawa::Kind::Request, kawa::Buffer::new(buffer)),
             window: 1 << 16,
@@ -269,6 +273,52 @@ impl<'a> Endpoint for EndpointClient<'a> {
             .get_mut(&token)
             .unwrap()
             .start_stream(stream, context);
+    }
+}
+
+fn update_readiness_after_read(
+    size: usize,
+    status: SocketResult,
+    readiness: &mut Readiness,
+) -> bool {
+    println!("  size={size}, status={status:?}");
+    match status {
+        SocketResult::Continue => {}
+        SocketResult::Closed | SocketResult::Error => {
+            readiness.event.remove(Ready::ALL);
+        }
+        SocketResult::WouldBlock => {
+            readiness.event.remove(Ready::READABLE);
+        }
+    }
+    if size > 0 {
+        false
+    } else {
+        readiness.event.remove(Ready::READABLE);
+        true
+    }
+}
+fn update_readiness_after_write(
+    size: usize,
+    status: SocketResult,
+    readiness: &mut Readiness,
+) -> bool {
+    println!("  size={size}, status={status:?}");
+    match status {
+        SocketResult::Continue => {}
+        SocketResult::Closed | SocketResult::Error => {
+            // even if the socket closed there might be something left to read
+            readiness.event.remove(Ready::WRITABLE);
+        }
+        SocketResult::WouldBlock => {
+            readiness.event.remove(Ready::WRITABLE);
+        }
+    }
+    if size > 0 {
+        false
+    } else {
+        readiness.event.remove(Ready::WRITABLE);
+        true
     }
 }
 
@@ -711,11 +761,7 @@ impl SessionState for Mux {
             for (token, backend) in self.router.backends.iter_mut() {
                 let readiness = backend.readiness().filter_interest();
                 if readiness.is_hup() || readiness.is_error() {
-                    println!(
-                        "{token:?} -> {:?} {:?}",
-                        backend.readiness(),
-                        backend.socket()
-                    );
+                    println!("{token:?} -> {:?}", backend);
                     backend.close(context, EndpointServer(&mut self.frontend));
                     dead_backends.push(*token);
                 }
@@ -778,6 +824,7 @@ impl SessionState for Mux {
 
         if counter == max_loop_iterations {
             incr!("http.infinite_loop.error");
+            panic!();
             return SessionResult::Close;
         }
 

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -56,6 +56,11 @@ pub enum Connection<Front: SocketHandler> {
     H2(ConnectionH2<Front>),
 }
 
+pub trait UpdateReadiness {
+    fn readiness(&self, token: Token) -> &Readiness;
+    fn readiness_mut(&mut self, token: Token) -> &mut Readiness;
+}
+
 impl<Front: SocketHandler> Connection<Front> {
     pub fn new_h1_server(front_stream: Front) -> Connection<Front> {
         Connection::H1(ConnectionH1 {
@@ -143,17 +148,43 @@ impl<Front: SocketHandler> Connection<Front> {
             Connection::H2(c) => c.socket.socket_ref(),
         }
     }
-    fn readable(&mut self, context: &mut Context) -> MuxResult {
+    fn readable<E>(&mut self, context: &mut Context, endpoint: E) -> MuxResult
+    where
+        E: UpdateReadiness,
+    {
         match self {
-            Connection::H1(c) => c.readable(context),
-            Connection::H2(c) => c.readable(context),
+            Connection::H1(c) => c.readable(context, endpoint),
+            Connection::H2(c) => c.readable(context, endpoint),
         }
     }
-    fn writable(&mut self, context: &mut Context) -> MuxResult {
+    fn writable<E>(&mut self, context: &mut Context, endpoint: E) -> MuxResult
+    where
+        E: UpdateReadiness,
+    {
         match self {
-            Connection::H1(c) => c.writable(context),
-            Connection::H2(c) => c.writable(context),
+            Connection::H1(c) => c.writable(context, endpoint),
+            Connection::H2(c) => c.writable(context, endpoint),
         }
+    }
+}
+
+struct EndpointServer<'a>(&'a mut Connection<FrontRustls>);
+struct EndpointClient<'a>(&'a mut Router);
+
+impl<'a> UpdateReadiness for EndpointServer<'a> {
+    fn readiness(&self, _token: Token) -> &Readiness {
+        self.0.readiness()
+    }
+    fn readiness_mut(&mut self, _token: Token) -> &mut Readiness {
+        self.0.readiness_mut()
+    }
+}
+impl<'a> UpdateReadiness for EndpointClient<'a> {
+    fn readiness(&self, token: Token) -> &Readiness {
+        self.0.backends.get(&token).unwrap().readiness()
+    }
+    fn readiness_mut(&mut self, token: Token) -> &mut Readiness {
+        self.0.backends.get_mut(&token).unwrap().readiness_mut()
     }
 }
 
@@ -461,7 +492,7 @@ impl SessionState for Mux {
             let mut dirty = false;
 
             if self.frontend.readiness().filter_interest().is_readable() {
-                match self.frontend.readable(context) {
+                match self.frontend.readable(context, EndpointClient(&mut self.router)) {
                     MuxResult::Continue => (),
                     MuxResult::CloseSession => return SessionResult::Close,
                     MuxResult::Close(_) => todo!(),
@@ -485,7 +516,7 @@ impl SessionState for Mux {
 
             for (_, backend) in self.router.backends.iter_mut() {
                 if backend.readiness().filter_interest().is_writable() {
-                    match backend.writable(context) {
+                    match backend.writable(context, EndpointServer(&mut self.frontend)) {
                         MuxResult::Continue => (),
                         MuxResult::CloseSession => return SessionResult::Close,
                         MuxResult::Close(_) => todo!(),
@@ -495,7 +526,7 @@ impl SessionState for Mux {
                 }
 
                 if backend.readiness().filter_interest().is_readable() {
-                    match backend.readable(context) {
+                    match backend.readable(context, EndpointServer(&mut self.frontend)) {
                         MuxResult::Continue => (),
                         MuxResult::CloseSession => return SessionResult::Close,
                         MuxResult::Close(_) => todo!(),
@@ -506,7 +537,7 @@ impl SessionState for Mux {
             }
 
             if self.frontend.readiness().filter_interest().is_writable() {
-                match self.frontend.writable(context) {
+                match self.frontend.writable(context, EndpointClient(&mut self.router)) {
                     MuxResult::Continue => (),
                     MuxResult::CloseSession => return SessionResult::Close,
                     MuxResult::Close(_) => todo!(),

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -8,7 +8,7 @@ use std::{
 
 use mio::{net::TcpStream, Interest, Token};
 use rusty_ulid::Ulid;
-use sozu_command::ready::Ready;
+use sozu_command::{proto::command::ListenerType, ready::Ready};
 
 mod converter;
 mod h1;
@@ -19,22 +19,20 @@ mod serializer;
 
 use crate::{
     backends::{Backend, BackendError},
-    https::HttpsListener,
     pool::{Checkout, Pool},
     protocol::{
         http::editor::HttpContext,
-        mux::{
-            h1::ConnectionH1,
-            h2::{ConnectionH2, H2Settings, H2State, H2StreamId},
-        },
+        mux::h2::{H2Settings, H2State, H2StreamId},
         SessionState,
     },
     router::Route,
     server::CONN_RETRIES,
-    socket::{FrontRustls, SocketHandler, SocketResult},
+    socket::{SocketHandler, SocketResult},
     BackendConnectionError, L7ListenerHandler, L7Proxy, ProxySession, Readiness,
-    RetrieveClusterError, SessionMetrics, SessionResult, StateResult,
+    RetrieveClusterError, SessionIsToBeClosed, SessionMetrics, SessionResult, StateResult,
 };
+
+pub use crate::protocol::mux::{h1::ConnectionH1, h2::ConnectionH2};
 
 #[macro_export]
 macro_rules! println_ {
@@ -53,11 +51,22 @@ type GenericHttpStream = kawa::Kawa<Checkout>;
 type StreamId = u32;
 type GlobalStreamId = usize;
 
-/// Replace the content of the kawa message with a default Sozu answer for a given status code
-fn set_default_answer(stream: &mut Stream, readiness: &mut Readiness, code: u16) {
-    let kawa = &mut stream.back;
-    kawa.clear();
-    kawa.storage.clear();
+pub fn fill_default_301_answer<T: kawa::AsBuffer>(kawa: &mut kawa::Kawa<T>, host: &str, uri: &str) {
+    kawa.detached.status_line = kawa::StatusLine::Response {
+        version: kawa::Version::V20,
+        code: 301,
+        status: kawa::Store::Static(b"301"),
+        reason: kawa::Store::Static(b"Moved Permanently"),
+    };
+    kawa.push_block(kawa::Block::StatusLine);
+    kawa.push_block(kawa::Block::Header(kawa::Pair {
+        key: kawa::Store::Static(b"Location"),
+        val: kawa::Store::from_string(format!("https://{host}{uri}")),
+    }));
+    terminate_default_answer(kawa, false);
+}
+
+pub fn fill_default_answer<T: kawa::AsBuffer>(kawa: &mut kawa::Kawa<T>, code: u16) {
     kawa.detached.status_line = kawa::StatusLine::Response {
         version: kawa::Version::V20,
         code,
@@ -65,14 +74,20 @@ fn set_default_answer(stream: &mut Stream, readiness: &mut Readiness, code: u16)
         reason: kawa::Store::Static(b"Sozu Default Answer"),
     };
     kawa.push_block(kawa::Block::StatusLine);
-    kawa.push_block(kawa::Block::Header(kawa::Pair {
-        key: kawa::Store::Static(b"Cache-Control"),
-        val: kawa::Store::Static(b"no-cache"),
-    }));
-    kawa.push_block(kawa::Block::Header(kawa::Pair {
-        key: kawa::Store::Static(b"Connection"),
-        val: kawa::Store::Static(b"close"),
-    }));
+    terminate_default_answer(kawa, true);
+}
+
+pub fn terminate_default_answer<T: kawa::AsBuffer>(kawa: &mut kawa::Kawa<T>, close: bool) {
+    if close {
+        kawa.push_block(kawa::Block::Header(kawa::Pair {
+            key: kawa::Store::Static(b"Cache-Control"),
+            val: kawa::Store::Static(b"no-cache"),
+        }));
+        kawa.push_block(kawa::Block::Header(kawa::Pair {
+            key: kawa::Store::Static(b"Connection"),
+            val: kawa::Store::Static(b"close"),
+        }));
+    }
     kawa.push_block(kawa::Block::Header(kawa::Pair {
         key: kawa::Store::Static(b"Content-Length"),
         val: kawa::Store::Static(b"0"),
@@ -84,6 +99,20 @@ fn set_default_answer(stream: &mut Stream, readiness: &mut Readiness, code: u16)
         end_stream: true,
     }));
     kawa.parsing_phase = kawa::ParsingPhase::Terminated;
+}
+
+/// Replace the content of the kawa message with a default Sozu answer for a given status code
+fn set_default_answer(stream: &mut Stream, readiness: &mut Readiness, code: u16) {
+    let kawa = &mut stream.back;
+    kawa.clear();
+    kawa.storage.clear();
+    if code == 301 {
+        let host = stream.context.authority.as_deref().unwrap();
+        let uri = stream.context.path.as_deref().unwrap();
+        fill_default_301_answer(kawa, host, uri);
+    } else {
+        fill_default_answer(kawa, code);
+    }
     stream.state = StreamState::Unlinked;
     readiness.interest.insert(Ready::WRITABLE);
 }
@@ -98,7 +127,7 @@ fn forcefully_terminate_answer(stream: &mut Stream, readiness: &mut Readiness) {
         end_header: false,
         end_stream: true,
     }));
-    kawa.parsing_phase = kawa::ParsingPhase::Terminated;
+    kawa.parsing_phase.error("Termination".into());
     debug_kawa(kawa);
     stream.state = StreamState::Unlinked;
     readiness.interest.insert(Ready::WRITABLE);
@@ -120,6 +149,7 @@ pub enum BackendStatus {
 
 pub enum MuxResult {
     Continue,
+    Upgrade,
     CloseSession,
 }
 
@@ -238,13 +268,13 @@ impl<Front: SocketHandler> Connection<Front> {
             Connection::H2(c) => &mut c.readiness,
         }
     }
-    fn position(&self) -> &Position {
+    pub fn position(&self) -> &Position {
         match self {
             Connection::H1(c) => &c.position,
             Connection::H2(c) => &c.position,
         }
     }
-    fn position_mut(&mut self) -> &mut Position {
+    pub fn position_mut(&mut self) -> &mut Position {
         match self {
             Connection::H1(c) => &mut c.position,
             Connection::H2(c) => &mut c.position,
@@ -300,12 +330,12 @@ impl<Front: SocketHandler> Connection<Front> {
     }
 }
 
-struct EndpointServer<'a>(&'a mut Connection<FrontRustls>);
+struct EndpointServer<'a, Front: SocketHandler>(&'a mut Connection<Front>);
 struct EndpointClient<'a>(&'a mut Router);
 
 // note: EndpointServer are used by client Connection, they do not know the frontend Token
 // they will use the Stream's Token which is their backend token
-impl<'a> Endpoint for EndpointServer<'a> {
+impl<'a, Front: SocketHandler> Endpoint for EndpointServer<'a, Front> {
     fn readiness(&self, _token: Token) -> &Readiness {
         self.0.readiness()
     }
@@ -442,8 +472,8 @@ pub struct Stream {
     pub window: i32,
     pub attempts: u8,
     pub state: StreamState,
-    front: GenericHttpStream,
-    back: GenericHttpStream,
+    pub front: GenericHttpStream,
+    pub back: GenericHttpStream,
     pub context: HttpContext,
 }
 
@@ -562,11 +592,18 @@ impl Context {
 }
 
 pub struct Router {
-    pub listener: Rc<RefCell<HttpsListener>>,
+    pub listener: Rc<RefCell<dyn L7ListenerHandler>>,
     pub backends: HashMap<Token, Connection<TcpStream>>,
 }
 
 impl Router {
+    pub fn new(listener: Rc<RefCell<dyn L7ListenerHandler>>) -> Self {
+        Self {
+            listener,
+            backends: HashMap::new(),
+        }
+    }
+
     fn connect(
         &mut self,
         stream_id: GlobalStreamId,
@@ -589,12 +626,18 @@ impl Router {
             .route_from_request(stream_context, proxy.clone())
             .map_err(BackendConnectionError::RetrieveClusterError)?;
 
-        let frontend_should_stick = proxy
+        let (frontend_should_stick, frontend_should_redirect_https) = proxy
             .borrow()
             .clusters()
             .get(&cluster_id)
-            .map(|cluster| cluster.sticky_session)
-            .unwrap_or(false);
+            .map(|cluster| (cluster.sticky_session, cluster.https_redirect))
+            .unwrap_or((false, false));
+
+        if frontend_should_redirect_https && matches!(proxy.borrow().kind(), ListenerType::Http) {
+            return Err(BackendConnectionError::RetrieveClusterError(
+                RetrieveClusterError::HttpsRedirect,
+            ));
+        }
 
         let mut reuse_token = None;
         // let mut priority = 0;
@@ -796,9 +839,9 @@ impl Router {
     }
 }
 
-pub struct Mux {
+pub struct Mux<Front: SocketHandler> {
     pub frontend_token: Token,
-    pub frontend: Connection<FrontRustls>,
+    pub frontend: Connection<Front>,
     pub router: Router,
     pub public_address: SocketAddr,
     pub peer_address: Option<SocketAddr>,
@@ -806,13 +849,13 @@ pub struct Mux {
     pub context: Context,
 }
 
-impl Mux {
+impl<Front: SocketHandler> Mux<Front> {
     pub fn front_socket(&self) -> &TcpStream {
         self.frontend.socket()
     }
 }
 
-impl SessionState for Mux {
+impl<Front: SocketHandler + std::fmt::Debug> SessionState for Mux<Front> {
     fn ready(
         &mut self,
         session: Rc<RefCell<dyn ProxySession>>,
@@ -838,6 +881,7 @@ impl SessionState for Mux {
                     {
                         MuxResult::Continue => {}
                         MuxResult::CloseSession => return SessionResult::Close,
+                        MuxResult::Upgrade => return SessionResult::Upgrade,
                     }
                 }
 
@@ -846,6 +890,7 @@ impl SessionState for Mux {
                 let mut dead_backends = Vec::new();
                 for (token, backend) in self.router.backends.iter_mut() {
                     let readiness = backend.readiness_mut();
+                    println!("{token:?} -> {readiness:?}");
                     let dead = readiness.filter_interest().is_hup()
                         || readiness.filter_interest().is_error();
                     if dead {
@@ -865,6 +910,7 @@ impl SessionState for Mux {
                         }
                         match backend.writable(context, EndpointServer(&mut self.frontend)) {
                             MuxResult::Continue => {}
+                            MuxResult::Upgrade => unreachable!(), // only frontend can upgrade
                             MuxResult::CloseSession => return SessionResult::Close,
                         }
                     }
@@ -872,6 +918,7 @@ impl SessionState for Mux {
                     if backend.readiness().filter_interest().is_readable() {
                         match backend.readable(context, EndpointServer(&mut self.frontend)) {
                             MuxResult::Continue => {}
+                            MuxResult::Upgrade => unreachable!(), // only frontend can upgrade
                             MuxResult::CloseSession => return SessionResult::Close,
                         }
                     }
@@ -890,7 +937,7 @@ impl SessionState for Mux {
                     for token in &dead_backends {
                         self.router.backends.remove(token);
                     }
-                    println_!("FRONTEND: {:#?}", &self.frontend);
+                    println_!("FRONTEND: {:#?}", self.frontend);
                     println_!("BACKENDS: {:#?}", self.router.backends);
                 }
 
@@ -902,6 +949,7 @@ impl SessionState for Mux {
                     {
                         MuxResult::Continue => {}
                         MuxResult::CloseSession => return SessionResult::Close,
+                        MuxResult::Upgrade => return SessionResult::Upgrade,
                     }
                 }
 
@@ -953,6 +1001,9 @@ impl SessionState for Mux {
                                 ) => {
                                     set_default_answer(stream, front_readiness, 401);
                                 }
+                                BE::RetrieveClusterError(RetrieveClusterError::HttpsRedirect) => {
+                                    set_default_answer(stream, front_readiness, 301);
+                                }
 
                                 BE::Backend(_) => {}
                                 BE::RetrieveClusterError(_) => unreachable!(),
@@ -998,6 +1049,7 @@ impl SessionState for Mux {
             self.frontend.readiness()
         );
     }
+
     fn close(&mut self, _proxy: Rc<RefCell<dyn L7Proxy>>, _metrics: &mut SessionMetrics) {
         let s = match &mut self.frontend {
             Connection::H1(c) => &mut c.socket,
@@ -1018,5 +1070,33 @@ impl SessionState for Mux {
                 });
             }
         }
+    }
+
+    fn shutting_down(&mut self) -> SessionIsToBeClosed {
+        let mut can_stop = true;
+        for stream in &mut self.context.streams {
+            match stream.state {
+                StreamState::Linked(_) => {
+                    can_stop = false;
+                }
+                StreamState::Unlinked => {
+                    let front = &stream.front;
+                    let back = &stream.back;
+                    kawa::debug_kawa(front);
+                    kawa::debug_kawa(back);
+                    if front.is_initial()
+                        && front.storage.is_empty()
+                        && back.is_initial()
+                        && back.storage.is_empty()
+                    {
+                        continue;
+                    }
+                    stream.context.closing = true;
+                    can_stop = false;
+                }
+                _ => {}
+            }
+        }
+        can_stop
     }
 }

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -10,6 +10,7 @@ use mio::{net::TcpStream, Interest, Token};
 use rusty_ulid::Ulid;
 use sozu_command::ready::Ready;
 
+mod converter;
 mod h1;
 mod h2;
 mod parser;
@@ -105,6 +106,7 @@ impl<Front: SocketHandler> Connection<Front> {
             settings: H2Settings::default(),
             zero: kawa::Kawa::new(kawa::Kind::Request, kawa::Buffer::new(buffer)),
             window: 1 << 16,
+            decoder: hpack::Decoder::new(),
         }))
     }
     pub fn new_h2_client(
@@ -127,6 +129,7 @@ impl<Front: SocketHandler> Connection<Front> {
             settings: H2Settings::default(),
             zero: kawa::Kawa::new(kawa::Kind::Request, kawa::Buffer::new(buffer)),
             window: 1 << 16,
+            decoder: hpack::Decoder::new(),
         }))
     }
 
@@ -305,7 +308,6 @@ impl Stream {
 pub struct Context {
     pub streams: Vec<Stream>,
     pub pool: Weak<RefCell<Pool>>,
-    pub decoder: hpack::Decoder<'static>,
 }
 
 impl Context {
@@ -319,7 +321,6 @@ impl Context {
         Self {
             streams: Vec::new(),
             pool,
-            decoder: hpack::Decoder::new(),
         }
     }
 }
@@ -381,7 +382,7 @@ impl Router {
             error!("error registering back socket({:?}): {:?}", socket, e);
         }
 
-        stream.token.insert(backend_token);
+        stream.token = Some(backend_token);
         self.backends
             .insert(backend_token, Connection::new_h1_client(socket, stream_id));
         Ok(())
@@ -610,7 +611,7 @@ impl SessionState for Mux {
         SessionResult::Continue
     }
 
-    fn update_readiness(&mut self, token: Token, events: sozu_command::ready::Ready) {
+    fn update_readiness(&mut self, token: Token, events: Ready) {
         if token == self.frontend_token {
             self.frontend.readiness_mut().event |= events;
         } else if let Some(c) = self.router.backends.get_mut(&token) {

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -3,6 +3,7 @@ use std::{
     collections::HashMap,
     net::SocketAddr,
     rc::{Rc, Weak},
+    str::from_utf8_unchecked,
 };
 
 use mio::{net::TcpStream, Token};
@@ -22,7 +23,7 @@ use crate::{
 
 /// Generic Http representation using the Kawa crate using the Checkout of Sozu as buffer
 type GenericHttpStream = kawa::Kawa<Checkout>;
-type StreamId = usize;
+type StreamId = u32;
 type GlobalStreamId = usize;
 
 #[derive(Debug, Clone, Copy)]
@@ -32,9 +33,9 @@ pub enum Position {
 }
 
 pub struct ConnectionH1<Front: SocketHandler> {
-    pub socket: Front,
     pub position: Position,
     pub readiness: Readiness,
+    pub socket: Front,
     pub stream: GlobalStreamId,
 }
 
@@ -44,21 +45,47 @@ pub enum H2State {
     ClientSettings,
     ServerSettings,
     Header,
-    Frame,
+    Frame(parser::FrameHeader),
     Error,
 }
+
+#[derive(Debug)]
+pub struct H2Settings {
+    settings_header_table_size: u32,
+    settings_enable_push: bool,
+    settings_max_concurrent_streams: u32,
+    settings_initial_window_size: u32,
+    settings_max_frame_size: u32,
+    settings_max_header_list_size: u32,
+}
+
+impl Default for H2Settings {
+    fn default() -> Self {
+        Self {
+            settings_header_table_size: 4096,
+            settings_enable_push: true,
+            settings_max_concurrent_streams: u32::MAX,
+            settings_initial_window_size: (1 << 16) - 1,
+            settings_max_frame_size: 1 << 14,
+            settings_max_header_list_size: u32::MAX,
+        }
+    }
+}
+
 pub struct ConnectionH2<Front: SocketHandler> {
-    pub socket: Front,
+    pub decoder: hpack::Decoder<'static>,
+    pub expect: Option<(GlobalStreamId, usize)>,
     pub position: Position,
     pub readiness: Readiness,
+    pub settings: H2Settings,
+    pub socket: Front,
     pub state: H2State,
     pub streams: HashMap<StreamId, GlobalStreamId>,
-    pub expect: Option<(GlobalStreamId, usize)>,
-    // context_hpack: HpackContext,
-    // settings: SettiongsH2,
 }
+
 pub struct Stream {
     pub request_id: Ulid,
+    pub window: i32,
     pub front: GenericHttpStream,
     pub back: GenericHttpStream,
 }
@@ -82,26 +109,81 @@ pub enum Connection<Front: SocketHandler> {
     H1(ConnectionH1<Front>),
     H2(ConnectionH2<Front>),
 }
+
 impl<Front: SocketHandler> Connection<Front> {
-    fn readiness(&self) -> &Readiness {
+    pub fn new_h1_server(front_stream: Front) -> Connection<Front> {
+        Connection::H1(ConnectionH1 {
+            socket: front_stream,
+            position: Position::Server,
+            readiness: Readiness {
+                interest: Ready::READABLE | Ready::HUP | Ready::ERROR,
+                event: Ready::EMPTY,
+            },
+            stream: 0,
+        })
+    }
+    pub fn new_h1_client(front_stream: Front) -> Connection<Front> {
+        Connection::H1(ConnectionH1 {
+            socket: front_stream,
+            position: Position::Client,
+            readiness: Readiness {
+                interest: Ready::WRITABLE | Ready::HUP | Ready::ERROR,
+                event: Ready::EMPTY,
+            },
+            stream: 0,
+        })
+    }
+
+    pub fn new_h2_server(front_stream: Front) -> Connection<Front> {
+        Connection::H2(ConnectionH2 {
+            socket: front_stream,
+            position: Position::Server,
+            readiness: Readiness {
+                interest: Ready::READABLE | Ready::HUP | Ready::ERROR,
+                event: Ready::EMPTY,
+            },
+            streams: HashMap::from([(0, 0)]),
+            state: H2State::ClientPreface,
+            expect: Some((0, 24 + 9)),
+            settings: H2Settings::default(),
+            decoder: hpack::Decoder::new(),
+        })
+    }
+    pub fn new_h2_client(front_stream: Front) -> Connection<Front> {
+        Connection::H2(ConnectionH2 {
+            socket: front_stream,
+            position: Position::Client,
+            readiness: Readiness {
+                interest: Ready::WRITABLE | Ready::HUP | Ready::ERROR,
+                event: Ready::EMPTY,
+            },
+            streams: HashMap::from([(0, 0)]),
+            state: H2State::ClientPreface,
+            expect: None,
+            settings: H2Settings::default(),
+            decoder: hpack::Decoder::new(),
+        })
+    }
+
+    pub fn readiness(&self) -> &Readiness {
         match self {
             Connection::H1(c) => &c.readiness,
             Connection::H2(c) => &c.readiness,
         }
     }
-    fn readiness_mut(&mut self) -> &mut Readiness {
+    pub fn readiness_mut(&mut self) -> &mut Readiness {
         match self {
             Connection::H1(c) => &mut c.readiness,
             Connection::H2(c) => &mut c.readiness,
         }
     }
-    fn readable(&mut self, streams: &mut [Stream]) {
+    fn readable(&mut self, streams: &mut Streams) {
         match self {
             Connection::H1(c) => c.readable(streams),
             Connection::H2(c) => c.readable(streams),
         }
     }
-    fn writable(&mut self, streams: &mut [Stream]) {
+    fn writable(&mut self, streams: &mut Streams) {
         match self {
             Connection::H1(c) => c.writable(streams),
             Connection::H2(c) => c.writable(streams),
@@ -109,16 +191,67 @@ impl<Front: SocketHandler> Connection<Front> {
     }
 }
 
+pub struct Streams {
+    pub streams: Vec<Stream>,
+    pub pool: Weak<RefCell<Pool>>,
+}
+
 pub struct Mux {
     pub frontend_token: Token,
     pub frontend: Connection<FrontRustls>,
     pub backends: HashMap<Token, Connection<TcpStream>>,
-    pub streams: Vec<Stream>,
     pub listener: Rc<RefCell<HttpsListener>>,
-    pub pool: Weak<RefCell<Pool>>,
     pub public_address: SocketAddr,
     pub peer_address: Option<SocketAddr>,
     pub sticky_name: String,
+    pub streams: Streams,
+}
+
+impl Streams {
+    pub fn create_stream(
+        &mut self,
+        request_id: Ulid,
+        window: u32,
+    ) -> Result<GlobalStreamId, AcceptError> {
+        let (front_buffer, back_buffer) = match self.pool.upgrade() {
+            Some(pool) => {
+                let mut pool = pool.borrow_mut();
+                match (pool.checkout(), pool.checkout()) {
+                    (Some(front_buffer), Some(back_buffer)) => (front_buffer, back_buffer),
+                    _ => return Err(AcceptError::BufferCapacityReached),
+                }
+            }
+            None => return Err(AcceptError::BufferCapacityReached),
+        };
+        self.streams.push(Stream {
+            request_id,
+            window: window as i32,
+            front: GenericHttpStream::new(kawa::Kind::Request, kawa::Buffer::new(front_buffer)),
+            back: GenericHttpStream::new(kawa::Kind::Response, kawa::Buffer::new(back_buffer)),
+        });
+        Ok(self.streams.len() - 1)
+    }
+}
+
+impl std::ops::Deref for Streams {
+    type Target = [Stream];
+    fn deref(&self) -> &Self::Target {
+        &self.streams
+    }
+}
+impl std::ops::DerefMut for Streams {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.streams
+    }
+}
+
+impl Mux {
+    pub fn front_socket(&self) -> &TcpStream {
+        match &self.frontend {
+            Connection::H1(c) => &c.socket.stream,
+            Connection::H2(c) => &c.socket.stream,
+        }
+    }
 }
 
 impl SessionState for Mux {
@@ -223,36 +356,8 @@ impl SessionState for Mux {
     }
 }
 
-impl Mux {
-    pub fn front_socket(&self) -> &TcpStream {
-        match &self.frontend {
-            Connection::H1(c) => &c.socket.stream,
-            Connection::H2(c) => &c.socket.stream,
-        }
-    }
-
-    pub fn create_stream(&mut self, request_id: Ulid) -> Result<GlobalStreamId, AcceptError> {
-        let (front_buffer, back_buffer) = match self.pool.upgrade() {
-            Some(pool) => {
-                let mut pool = pool.borrow_mut();
-                match (pool.checkout(), pool.checkout()) {
-                    (Some(front_buffer), Some(back_buffer)) => (front_buffer, back_buffer),
-                    _ => return Err(AcceptError::BufferCapacityReached),
-                }
-            }
-            None => return Err(AcceptError::BufferCapacityReached),
-        };
-        self.streams.push(Stream {
-            request_id,
-            front: GenericHttpStream::new(kawa::Kind::Request, kawa::Buffer::new(front_buffer)),
-            back: GenericHttpStream::new(kawa::Kind::Request, kawa::Buffer::new(back_buffer)),
-        });
-        Ok(self.streams.len() - 1)
-    }
-}
-
 impl<Front: SocketHandler> ConnectionH2<Front> {
-    fn readable(&mut self, streams: &mut [Stream]) {
+    fn readable(&mut self, streams: &mut Streams) {
         println!("======= MUX H2 READABLE");
         let kawa = if let Some((stream_id, amount)) = self.expect {
             let kawa = streams[stream_id].front(self.position);
@@ -305,10 +410,12 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             (H2State::ClientSettings, Position::Server) => {
                 let i = kawa.storage.data();
                 match parser::settings_frame(i, i.len()) {
-                    Ok((_, settings)) => println!("{settings:?}"),
+                    Ok((_, settings)) => {
+                        kawa.storage.clear();
+                        self.handle(settings, streams);
+                    }
                     Err(e) => panic!("{e:?}"),
                 }
-                kawa.storage.clear();
                 let kawa = &mut streams[0].back;
                 self.state = H2State::ServerSettings;
                 match serializer::gen_frame_header(
@@ -352,17 +459,34 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                     Ok((_, header)) => {
                         println!("{header:?}");
                         kawa.storage.clear();
-                        self.state = H2State::Frame;
-                        self.expect =
-                            Some((header.stream_id as usize, header.payload_len as usize));
+                        let stream_id = if let Some(stream_id) = self.streams.get(&header.stream_id)
+                        {
+                            *stream_id
+                        } else {
+                            self.create_stream(header.stream_id, streams)
+                        };
+                        let stream_id = if header.frame_type == parser::FrameType::Headers {
+                            0
+                        } else {
+                            stream_id
+                        };
+                        println!("{} {} {:#?}", header.stream_id, stream_id, self.streams);
+                        self.expect = Some((stream_id as usize, header.payload_len as usize));
+                        self.state = H2State::Frame(header);
                     }
                     Err(e) => panic!("{e:?}"),
                 };
             }
-            (H2State::Frame, Position::Server) => {
+            (H2State::Frame(header), Position::Server) => {
                 let i = kawa.storage.data();
                 println!("  data: {i:?}");
-                kawa.storage.clear();
+                match parser::frame_body(i, header, self.settings.settings_max_frame_size) {
+                    Ok((_, frame)) => {
+                        kawa.storage.clear();
+                        self.handle(frame, streams);
+                    }
+                    Err(e) => panic!("{e:?}"),
+                }
                 self.state = H2State::Header;
                 self.expect = Some((0, 9));
             }
@@ -370,7 +494,7 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         }
     }
 
-    fn writable(&mut self, streams: &mut [Stream]) {
+    fn writable(&mut self, streams: &mut Streams) {
         println!("======= MUX H2 WRITABLE");
         match (&self.state, &self.position) {
             (H2State::ClientPreface, Position::Client) => todo!("Send PRI + client Settings"),
@@ -393,22 +517,60 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             }
             _ => unreachable!(),
         }
-        // for global_stream_id in self.streams.values() {
-        //     let stream = &mut streams[*global_stream_id];
-        //     let kawa = match self.position {
-        //         Position::Client => &mut stream.back,
-        //         Position::Server => &mut stream.front,
-        //     };
-        //     kawa.prepare(&mut kawa::h2::BlockConverter);
-        //     let (size, status) = self.socket.socket_write_vectored(&kawa.as_io_slice());
-        //     println!("  size: {size}, status: {status:?}");
-        //     kawa.consume(size);
-        // }
+    }
+
+    pub fn create_stream(&mut self, stream_id: StreamId, streams: &mut Streams) -> GlobalStreamId {
+        match streams.create_stream(Ulid::generate(), self.settings.settings_initial_window_size) {
+            Ok(global_stream_id) => {
+                self.streams.insert(stream_id, global_stream_id);
+                global_stream_id
+            }
+            Err(e) => panic!("{e:?}"),
+        }
+    }
+
+    fn handle(&mut self, frame: parser::Frame, streams: &mut Streams) {
+        println!("{frame:?}");
+        match frame {
+            parser::Frame::Data(_) => todo!(),
+            parser::Frame::Headers(headers) => {
+                let kawa = streams[0].front(self.position);
+                let buffer = headers.header_block_fragment.data(kawa.storage.buffer());
+                println!("{buffer:?}");
+                let result = self.decoder.decode(buffer).unwrap();
+                for (k, v) in result {
+                    unsafe { println!("{} {}", from_utf8_unchecked(&k), from_utf8_unchecked(&v)) };
+                }
+            }
+            parser::Frame::Priority => todo!(),
+            parser::Frame::RstStream(_) => todo!(),
+            parser::Frame::Settings(settings) => {
+                for setting in settings.settings {
+                    match setting.identifier {
+                        1 => self.settings.settings_header_table_size = setting.value,
+                        2 => self.settings.settings_enable_push = setting.value == 1,
+                        3 => self.settings.settings_max_concurrent_streams = setting.value,
+                        4 => self.settings.settings_initial_window_size = setting.value,
+                        5 => self.settings.settings_max_frame_size = setting.value,
+                        6 => self.settings.settings_max_header_list_size = setting.value,
+                        other => panic!("setting_id: {other}"),
+                    }
+                }
+                println!("{:#?}", self.settings);
+            }
+            parser::Frame::PushPromise => todo!(),
+            parser::Frame::Ping(_) => todo!(),
+            parser::Frame::GoAway => todo!(),
+            parser::Frame::WindowUpdate(update) => {
+                streams[update.stream_id as usize].window += update.increment as i32;
+            }
+            parser::Frame::Continuation => todo!(),
+        }
     }
 }
 
 impl<Front: SocketHandler> ConnectionH1<Front> {
-    fn readable(&mut self, streams: &mut [Stream]) {
+    fn readable(&mut self, streams: &mut Streams) {
         println!("======= MUX H1 READABLE");
         let stream = &mut streams[self.stream];
         let kawa = match self.position {
@@ -434,7 +596,7 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
             self.readiness.interest.remove(Ready::READABLE);
         }
     }
-    fn writable(&mut self, streams: &mut [Stream]) {
+    fn writable(&mut self, streams: &mut Streams) {
         println!("======= MUX H1 WRITABLE");
         let stream = &mut streams[self.stream];
         let kawa = match self.position {

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -6,7 +6,7 @@ use std::{
     rc::{Rc, Weak},
 };
 
-use mio::{net::TcpStream, Token};
+use mio::{net::TcpStream, Interest, Token};
 use rusty_ulid::Ulid;
 use sozu_command::ready::Ready;
 
@@ -17,6 +17,7 @@ mod pkawa;
 mod serializer;
 
 use crate::{
+    backends::{Backend, BackendError},
     https::HttpsListener,
     pool::{Checkout, Pool},
     protocol::{
@@ -24,8 +25,10 @@ use crate::{
         mux::{h1::ConnectionH1, h2::ConnectionH2},
         SessionState,
     },
+    router::Route,
     socket::{FrontRustls, SocketHandler},
-    AcceptError, L7Proxy, ProxySession, Readiness, SessionMetrics, SessionResult, StateResult,
+    AcceptError, BackendConnectionError, L7ListenerHandler, L7Proxy, ProxySession, Readiness,
+    RetrieveClusterError, SessionMetrics, SessionResult, StateResult,
 };
 
 use self::h2::{H2Settings, H2State};
@@ -65,7 +68,7 @@ impl<Front: SocketHandler> Connection<Front> {
             stream: 0,
         })
     }
-    pub fn new_h1_client(front_stream: Front) -> Connection<Front> {
+    pub fn new_h1_client(front_stream: Front, stream_id: GlobalStreamId) -> Connection<Front> {
         Connection::H1(ConnectionH1 {
             socket: front_stream,
             position: Position::Client,
@@ -73,7 +76,7 @@ impl<Front: SocketHandler> Connection<Front> {
                 interest: Ready::WRITABLE | Ready::HUP | Ready::ERROR,
                 event: Ready::EMPTY,
             },
-            stream: 0,
+            stream: stream_id,
         })
     }
 
@@ -118,6 +121,12 @@ impl<Front: SocketHandler> Connection<Front> {
             Connection::H2(c) => &mut c.readiness,
         }
     }
+    pub fn socket(&self) -> &TcpStream {
+        match self {
+            Connection::H1(c) => &c.socket.socket_ref(),
+            Connection::H2(c) => &c.socket.socket_ref(),
+        }
+    }
     fn readable(&mut self, context: &mut Context) -> MuxResult {
         match self {
             Connection::H1(c) => c.readable(context),
@@ -141,13 +150,13 @@ pub struct Stream {
 }
 
 impl Stream {
-    pub fn front(&mut self, position: Position) -> &mut GenericHttpStream {
+    pub fn rbuffer(&mut self, position: Position) -> &mut GenericHttpStream {
         match position {
             Position::Client => &mut self.back,
             Position::Server => &mut self.front,
         }
     }
-    pub fn back(&mut self, position: Position) -> &mut GenericHttpStream {
+    pub fn wbuffer(&mut self, position: Position) -> &mut GenericHttpStream {
         match position {
             Position::Client => &mut self.front,
             Position::Server => &mut self.back,
@@ -197,6 +206,8 @@ impl Context {
             front: GenericHttpStream::new(kawa::Kind::Request, kawa::Buffer::new(front_buffer)),
             back: GenericHttpStream::new(kawa::Kind::Response, kawa::Buffer::new(back_buffer)),
             context: HttpContext {
+                backend_id: None,
+                cluster_id: None,
                 keep_alive_backend: false,
                 keep_alive_frontend: false,
                 sticky_session_found: None,
@@ -244,11 +255,175 @@ impl Context {
     }
 }
 
+pub struct Router {
+    pub listener: Rc<RefCell<HttpsListener>>,
+    pub backends: HashMap<Token, Connection<TcpStream>>,
+}
+
+impl Router {
+    fn connect(
+        &mut self,
+        stream_id: GlobalStreamId,
+        context: &mut Context,
+        session: Rc<RefCell<dyn ProxySession>>,
+        proxy: Rc<RefCell<dyn L7Proxy>>,
+        metrics: &mut SessionMetrics,
+    ) -> Result<(), BackendConnectionError> {
+        let context = &mut context.streams.others[stream_id - 1].context;
+        // we should get if the route is H2 or not here
+        // for now we assume it's H1
+        let cluster_id = self
+            .cluster_id_from_request(context, proxy.clone())
+            .map_err(BackendConnectionError::RetrieveClusterError)?;
+        println!("{cluster_id}!!!!!");
+
+        let frontend_should_stick = proxy
+            .borrow()
+            .clusters()
+            .get(&cluster_id)
+            .map(|cluster| cluster.sticky_session)
+            .unwrap_or(false);
+
+        let mut socket = self.backend_from_request(
+            &cluster_id,
+            frontend_should_stick,
+            context,
+            proxy.clone(),
+            metrics,
+        )?;
+
+        if let Err(e) = socket.set_nodelay(true) {
+            error!(
+                "error setting nodelay on back socket({:?}): {:?}",
+                socket, e
+            );
+        }
+        // self.backend_readiness.interest = Ready::WRITABLE | Ready::HUP | Ready::ERROR;
+        // self.backend_connection_status = BackendConnectionStatus::Connecting(Instant::now());
+
+        let backend_token = proxy.borrow().add_session(session);
+
+        if let Err(e) = proxy.borrow().register_socket(
+            &mut socket,
+            backend_token,
+            Interest::READABLE | Interest::WRITABLE,
+        ) {
+            error!("error registering back socket({:?}): {:?}", socket, e);
+        }
+
+        self.backends
+            .insert(backend_token, Connection::new_h1_client(socket, stream_id));
+        Ok(())
+    }
+
+    fn cluster_id_from_request(
+        &mut self,
+        context: &mut HttpContext,
+        proxy: Rc<RefCell<dyn L7Proxy>>,
+    ) -> Result<String, RetrieveClusterError> {
+        let (host, uri, method) = match context.extract_route() {
+            Ok(tuple) => tuple,
+            Err(cluster_error) => {
+                panic!("{}", cluster_error);
+                // self.set_answer(DefaultAnswerStatus::Answer400, None);
+                // return Err(cluster_error);
+            }
+        };
+
+        let route_result = self
+            .listener
+            .borrow()
+            .frontend_from_request(host, uri, method);
+
+        let route = match route_result {
+            Ok(route) => route,
+            Err(frontend_error) => {
+                panic!("{}", frontend_error);
+                // self.set_answer(DefaultAnswerStatus::Answer404, None);
+                // return Err(RetrieveClusterError::RetrieveFrontend(frontend_error));
+            }
+        };
+
+        let cluster_id = match route {
+            Route::Cluster { id, .. } => id,
+            Route::Deny => {
+                panic!("Route::Deny");
+                // self.set_answer(DefaultAnswerStatus::Answer401, None);
+                // return Err(RetrieveClusterError::UnauthorizedRoute);
+            }
+        };
+
+        Ok(cluster_id)
+    }
+
+    pub fn backend_from_request(
+        &mut self,
+        cluster_id: &str,
+        frontend_should_stick: bool,
+        context: &mut HttpContext,
+        proxy: Rc<RefCell<dyn L7Proxy>>,
+        metrics: &mut SessionMetrics,
+    ) -> Result<TcpStream, BackendConnectionError> {
+        let (backend, conn) = self
+            .get_backend_for_sticky_session(
+                cluster_id,
+                frontend_should_stick,
+                context.sticky_session_found.as_deref(),
+                proxy,
+            )
+            .map_err(|backend_error| {
+                panic!("{backend_error}")
+                // self.set_answer(DefaultAnswerStatus::Answer503, None);
+                // BackendConnectionError::Backend(backend_error)
+            })?;
+
+        if frontend_should_stick {
+            // update sticky name in case it changed I guess?
+            context.sticky_name = self.listener.borrow().get_sticky_name().to_string();
+
+            context.sticky_session = Some(
+                backend
+                    .borrow()
+                    .sticky_id
+                    .clone()
+                    .unwrap_or_else(|| backend.borrow().backend_id.clone()),
+            );
+        }
+
+        // metrics.backend_id = Some(backend.borrow().backend_id.clone());
+        // metrics.backend_start();
+        // self.set_backend_id(backend.borrow().backend_id.clone());
+        // self.backend = Some(backend);
+
+        Ok(conn)
+    }
+
+    fn get_backend_for_sticky_session(
+        &self,
+        cluster_id: &str,
+        frontend_should_stick: bool,
+        sticky_session: Option<&str>,
+        proxy: Rc<RefCell<dyn L7Proxy>>,
+    ) -> Result<(Rc<RefCell<Backend>>, TcpStream), BackendError> {
+        match (frontend_should_stick, sticky_session) {
+            (true, Some(sticky_session)) => proxy
+                .borrow()
+                .backends()
+                .borrow_mut()
+                .backend_from_sticky_session(cluster_id, sticky_session),
+            _ => proxy
+                .borrow()
+                .backends()
+                .borrow_mut()
+                .backend_from_cluster_id(cluster_id),
+        }
+    }
+}
+
 pub struct Mux {
     pub frontend_token: Token,
     pub frontend: Connection<FrontRustls>,
-    pub backends: HashMap<Token, Connection<TcpStream>>,
-    pub listener: Rc<RefCell<HttpsListener>>,
+    pub router: Router,
     pub public_address: SocketAddr,
     pub peer_address: Option<SocketAddr>,
     pub sticky_name: String,
@@ -257,19 +432,16 @@ pub struct Mux {
 
 impl Mux {
     pub fn front_socket(&self) -> &TcpStream {
-        match &self.frontend {
-            Connection::H1(c) => &c.socket.stream,
-            Connection::H2(c) => &c.socket.stream,
-        }
+        self.frontend.socket()
     }
 }
 
 impl SessionState for Mux {
     fn ready(
         &mut self,
-        _session: Rc<RefCell<dyn ProxySession>>,
-        _proxy: Rc<RefCell<dyn L7Proxy>>,
-        _metrics: &mut SessionMetrics,
+        session: Rc<RefCell<dyn ProxySession>>,
+        proxy: Rc<RefCell<dyn L7Proxy>>,
+        metrics: &mut SessionMetrics,
     ) -> SessionResult {
         let mut counter = 0;
         let max_loop_iterations = 100000;
@@ -287,19 +459,32 @@ impl SessionState for Mux {
                     MuxResult::Continue => (),
                     MuxResult::CloseSession => return SessionResult::Close,
                     MuxResult::Close(_) => todo!(),
-                    MuxResult::Connect(_) => todo!(),
+                    MuxResult::Connect(stream_id) => {
+                        match self.router.connect(
+                            stream_id,
+                            context,
+                            session.clone(),
+                            proxy.clone(),
+                            metrics,
+                        ) {
+                            Ok(_) => (),
+                            Err(error) => {
+                                println!("{error}");
+                            }
+                        }
+                    }
                 }
                 dirty = true;
             }
 
-            for (_, backend) in self.backends.iter_mut() {
+            for (_, backend) in self.router.backends.iter_mut() {
                 if backend.readiness().filter_interest().is_writable() {
                     match backend.writable(context) {
                         MuxResult::Continue => (),
                         MuxResult::CloseSession => return SessionResult::Close,
                         MuxResult::Close(_) => todo!(),
                         MuxResult::Connect(_) => unreachable!(),
-                        }
+                    }
                     dirty = true;
                 }
 
@@ -309,7 +494,7 @@ impl SessionState for Mux {
                         MuxResult::CloseSession => return SessionResult::Close,
                         MuxResult::Close(_) => todo!(),
                         MuxResult::Connect(_) => unreachable!(),
-                        }
+                    }
                     dirty = true;
                 }
             }
@@ -324,10 +509,11 @@ impl SessionState for Mux {
                 dirty = true;
             }
 
-            for backend in self.backends.values() {
+            for backend in self.router.backends.values() {
                 if backend.readiness().filter_interest().is_hup()
                     || backend.readiness().filter_interest().is_error()
                 {
+                    println!("{:?} {:?}", backend.readiness(), backend.socket());
                     return SessionResult::Close;
                 }
             }
@@ -350,7 +536,7 @@ impl SessionState for Mux {
     fn update_readiness(&mut self, token: Token, events: sozu_command::ready::Ready) {
         if token == self.frontend_token {
             self.frontend.readiness_mut().event |= events;
-        } else if let Some(c) = self.backends.get_mut(&token) {
+        } else if let Some(c) = self.router.backends.get_mut(&token) {
             c.readiness_mut().event |= events;
         }
     }
@@ -384,15 +570,16 @@ impl SessionState for Mux {
         let (size, status) = s.socket_read(&mut b);
         println!("{size} {status:?} {:?}", &b[..size]);
         for stream in &mut self.context.streams.others {
-            let kawa = &mut stream.front;
-            kawa::debug_kawa(kawa);
-            kawa.prepare(&mut kawa::h1::BlockConverter);
-            let out = kawa.as_io_slice();
-            let mut writer = std::io::BufWriter::new(Vec::new());
-            let amount = writer.write_vectored(&out).unwrap();
-            println!("amount: {amount}\n{}", unsafe {
-                std::str::from_utf8_unchecked(writer.buffer())
-            });
+            for kawa in [&mut stream.front, &mut stream.back] {
+                kawa::debug_kawa(kawa);
+                kawa.prepare(&mut kawa::h1::BlockConverter);
+                let out = kawa.as_io_slice();
+                let mut writer = std::io::BufWriter::new(Vec::new());
+                let amount = writer.write_vectored(&out).unwrap();
+                println!("amount: {amount}\n{}", unsafe {
+                    std::str::from_utf8_unchecked(writer.buffer())
+                });
+            }
         }
     }
 }

--- a/lib/src/protocol/mux/parser.rs
+++ b/lib/src/protocol/mux/parser.rs
@@ -139,7 +139,7 @@ impl<'a> ParseError<&'a [u8]> for ParserError<'a> {
         }
     }
 
-    fn append(input: &'a [u8], kind: ErrorKind, other: Self) -> Self {
+    fn append(input: &'a [u8], kind: ErrorKind, _other: Self) -> Self {
         ParserError {
             input,
             kind: ParserErrorKind::Nom(kind),

--- a/lib/src/protocol/mux/parser.rs
+++ b/lib/src/protocol/mux/parser.rs
@@ -250,7 +250,7 @@ pub fn frame<'a>(input: &'a [u8], max_frame_size: u32) -> IResult<&'a [u8], Fram
             if header.payload_len % 6 != 0 {
                 return Err(Err::Failure(Error::new(input, InnerError::FrameSizeError)));
             }
-            settings_frame(i, &header)?
+            settings_frame(i, header.payload_len as usize)?
         }
         FrameType::Ping => {
             if header.payload_len != 8 {
@@ -408,9 +408,9 @@ pub struct Setting {
 
 pub fn settings_frame<'a, 'b>(
     input: &'a [u8],
-    header: &'b FrameHeader,
+    payload_len: usize,
 ) -> IResult<&'a [u8], Frame<'a>, Error<'a>> {
-    let (i, data) = take(header.payload_len)(input)?;
+    let (i, data) = take(payload_len)(input)?;
 
     let (_, settings) = many0(map(
         complete(tuple((be_u16, be_u32))),

--- a/lib/src/protocol/mux/parser.rs
+++ b/lib/src/protocol/mux/parser.rs
@@ -103,7 +103,10 @@ impl<'a> Error<'a> {
         Error { input, error }
     }
     pub fn new_h2(input: &'a [u8], error: H2Error) -> Error<'a> {
-        Error { input, error: InnerError::H2(error) }
+        Error {
+            input,
+            error: InnerError::H2(error),
+        }
     }
 }
 

--- a/lib/src/protocol/mux/parser.rs
+++ b/lib/src/protocol/mux/parser.rs
@@ -391,7 +391,6 @@ pub fn headers_frame<'a>(
             stream_id: header.stream_id,
             stream_dependency,
             weight,
-            // header_block_fragment,
             header_block_fragment: Slice::new(input, header_block_fragment),
             end_stream: header.flags & 0x1 != 0,
             end_headers: header.flags & 0x4 != 0,

--- a/lib/src/protocol/mux/parser.rs
+++ b/lib/src/protocol/mux/parser.rs
@@ -360,18 +360,12 @@ pub fn headers_frame<'a>(
         (i, None)
     };
 
-    let (i, stream_dependency) = if header.flags & 0x20 != 0 {
-        let (i, dep) = stream_dependency(i)?;
-        (i, Some(dep))
-    } else {
-        (i, None)
-    };
-
-    let (i, weight) = if header.flags & 0x20 != 0 {
+    let (i, stream_dependency, weight) = if header.flags & 0x20 != 0 {
+        let (i, stream_dependency) = stream_dependency(i)?;
         let (i, weight) = be_u8(i)?;
-        (i, Some(weight))
+        (i, Some(stream_dependency), Some(weight))
     } else {
-        (i, None)
+        (i, None, None)
     };
 
     if pad_length.is_some() && i.len() <= pad_length.unwrap() as usize {
@@ -521,10 +515,7 @@ pub fn ping_frame<'a>(
     let (i, data) = take(8usize)(input)?;
 
     let mut p = Ping { payload: [0; 8] };
-
-    for i in 0..8 {
-        p.payload[i] = data[i];
-    }
+    p.payload[..8].copy_from_slice(&data[..8]);
 
     Ok((i, Frame::Ping(p)))
 }

--- a/lib/src/protocol/mux/parser.rs
+++ b/lib/src/protocol/mux/parser.rs
@@ -1,0 +1,468 @@
+use std::convert::From;
+
+use nom::{
+    bytes::streaming::{tag, take},
+    combinator::{complete, map, map_opt},
+    error::{ErrorKind, ParseError},
+    multi::many0,
+    number::streaming::{be_u16, be_u24, be_u32, be_u8},
+    sequence::tuple,
+    Err, HexDisplay, IResult, Offset,
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct FrameHeader {
+    pub payload_len: u32,
+    pub frame_type: FrameType,
+    pub flags: u8,
+    pub stream_id: u32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum FrameType {
+    Data,
+    Headers,
+    Priority,
+    RstStream,
+    Settings,
+    PushPromise,
+    Ping,
+    GoAway,
+    WindowUpdate,
+    Continuation,
+}
+
+/*
+const NO_ERROR: u32 = 0x0;
+const PROTOCOL_ERROR: u32 = 0x1;
+const INTERNAL_ERROR: u32 = 0x2;
+const FLOW_CONTROL_ERROR: u32 = 0x3;
+const SETTINGS_TIMEOUT: u32 = 0x4;
+const STREAM_CLOSED: u32 = 0x5;
+const FRAME_SIZE_ERROR: u32 = 0x6;
+const REFUSED_STREAM: u32 = 0x7;
+const CANCEL: u32 = 0x8;
+const COMPRESSION_ERROR: u32 = 0x9;
+const CONNECT_ERROR: u32 = 0xa;
+const ENHANCE_YOUR_CALM: u32 = 0xb;
+const INADEQUATE_SECURITY: u32 = 0xc;
+const HTTP_1_1_REQUIRED: u32 = 0xd;
+*/
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Error<'a> {
+    pub input: &'a [u8],
+    pub error: InnerError,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum InnerError {
+    Nom(ErrorKind),
+    NoError,
+    ProtocolError,
+    InternalError,
+    FlowControlError,
+    SettingsTimeout,
+    StreamClosed,
+    FrameSizeError,
+    RefusedStream,
+    Cancel,
+    CompressionError,
+    ConnectError,
+    EnhanceYourCalm,
+    InadequateSecurity,
+    HTTP11Required,
+}
+
+impl<'a> Error<'a> {
+    pub fn new(input: &'a [u8], error: InnerError) -> Error<'a> {
+        Error { input, error }
+    }
+}
+
+impl<'a> ParseError<&'a [u8]> for Error<'a> {
+    fn from_error_kind(input: &'a [u8], kind: ErrorKind) -> Self {
+        Error {
+            input,
+            error: InnerError::Nom(kind),
+        }
+    }
+
+    fn append(input: &'a [u8], kind: ErrorKind, other: Self) -> Self {
+        Error {
+            input,
+            error: InnerError::Nom(kind),
+        }
+    }
+}
+
+impl<'a> From<(&'a [u8], ErrorKind)> for Error<'a> {
+    fn from((input, kind): (&'a [u8], ErrorKind)) -> Self {
+        Error {
+            input,
+            error: InnerError::Nom(kind),
+        }
+    }
+}
+
+pub fn preface(i: &[u8]) -> IResult<&[u8], &[u8]> {
+    tag(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")(i)
+}
+
+// https://httpwg.org/specs/rfc7540.html#rfc.section.4.1
+/*named!(pub frame_header<FrameHeader>,
+  do_parse!(
+    payload_len: dbg_dmp!(be_u24) >>
+    frame_type: map_opt!(be_u8, convert_frame_type) >>
+    flags: dbg_dmp!(be_u8) >>
+    stream_id: dbg_dmp!(verify!(be_u32, |id| {
+      match frame_type {
+
+      }
+    }) >>
+    (FrameHeader { payload_len, frame_type, flags, stream_id })
+  )
+);
+  */
+
+pub fn frame_header(input: &[u8]) -> IResult<&[u8], FrameHeader, Error> {
+    let (i1, payload_len) = be_u24(input)?;
+    let (i2, frame_type) = map_opt(be_u8, convert_frame_type)(i1)?;
+    let (i3, flags) = be_u8(i2)?;
+    let (i4, stream_id) = be_u32(i3)?;
+
+    Ok((
+        i4,
+        FrameHeader {
+            payload_len,
+            frame_type,
+            flags,
+            stream_id,
+        },
+    ))
+}
+
+fn convert_frame_type(t: u8) -> Option<FrameType> {
+    info!("got frame type: {}", t);
+    match t {
+        0 => Some(FrameType::Data),
+        1 => Some(FrameType::Headers),
+        2 => Some(FrameType::Priority),
+        3 => Some(FrameType::RstStream),
+        4 => Some(FrameType::Settings),
+        5 => Some(FrameType::PushPromise),
+        6 => Some(FrameType::Ping),
+        7 => Some(FrameType::GoAway),
+        8 => Some(FrameType::WindowUpdate),
+        9 => Some(FrameType::Continuation),
+        _ => None,
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Frame<'a> {
+    Data(Data<'a>),
+    Headers(Headers<'a>),
+    Priority,
+    RstStream(RstStream),
+    Settings(Settings),
+    PushPromise,
+    Ping(Ping),
+    GoAway,
+    WindowUpdate(WindowUpdate),
+    Continuation,
+}
+
+impl<'a> Frame<'a> {
+    pub fn is_stream_specific(&self) -> bool {
+        match self {
+            Frame::Data(_)
+            | Frame::Headers(_)
+            | Frame::Priority
+            | Frame::RstStream(_)
+            | Frame::PushPromise
+            | Frame::Continuation => true,
+            Frame::Settings(_) | Frame::Ping(_) | Frame::GoAway => false,
+            Frame::WindowUpdate(w) => w.stream_id != 0,
+        }
+    }
+
+    pub fn stream_id(&self) -> u32 {
+        match self {
+            Frame::Data(d) => d.stream_id,
+            Frame::Headers(h) => h.stream_id,
+            Frame::Priority => unimplemented!(),
+            Frame::RstStream(r) => r.stream_id,
+            Frame::PushPromise => unimplemented!(),
+            Frame::Continuation => unimplemented!(),
+            Frame::Settings(_) | Frame::Ping(_) | Frame::GoAway => 0,
+            Frame::WindowUpdate(w) => w.stream_id,
+        }
+    }
+}
+
+pub fn frame<'a>(input: &'a [u8], max_frame_size: u32) -> IResult<&'a [u8], Frame<'a>, Error<'a>> {
+    let (i, header) = frame_header(input)?;
+
+    info!("got frame header: {:?}", header);
+
+    if header.payload_len > max_frame_size {
+        return Err(Err::Failure(Error::new(input, InnerError::FrameSizeError)));
+    }
+
+    let valid_stream_id = match header.frame_type {
+        FrameType::Data
+        | FrameType::Headers
+        | FrameType::Priority
+        | FrameType::RstStream
+        | FrameType::PushPromise
+        | FrameType::Continuation => header.stream_id != 0,
+        FrameType::Settings | FrameType::Ping | FrameType::GoAway => header.stream_id == 0,
+        FrameType::WindowUpdate => true,
+    };
+
+    if !valid_stream_id {
+        return Err(Err::Failure(Error::new(input, InnerError::ProtocolError)));
+    }
+
+    let f = match header.frame_type {
+        FrameType::Data => data_frame(i, &header)?,
+        FrameType::Headers => headers_frame(i, &header)?,
+        FrameType::Priority => {
+            if header.payload_len != 5 {
+                return Err(Err::Failure(Error::new(input, InnerError::FrameSizeError)));
+            }
+            unimplemented!();
+        }
+        FrameType::RstStream => {
+            if header.payload_len != 4 {
+                return Err(Err::Failure(Error::new(input, InnerError::FrameSizeError)));
+            }
+            rst_stream_frame(i, &header)?
+        }
+        FrameType::PushPromise => {
+            unimplemented!();
+        }
+        FrameType::Continuation => {
+            unimplemented!();
+        }
+        FrameType::Settings => {
+            if header.payload_len % 6 != 0 {
+                return Err(Err::Failure(Error::new(input, InnerError::FrameSizeError)));
+            }
+            settings_frame(i, &header)?
+        }
+        FrameType::Ping => {
+            if header.payload_len != 8 {
+                return Err(Err::Failure(Error::new(input, InnerError::FrameSizeError)));
+            }
+            ping_frame(i, &header)?
+        }
+        FrameType::GoAway => {
+            unimplemented!();
+        }
+        FrameType::WindowUpdate => {
+            if header.payload_len != 4 {
+                return Err(Err::Failure(Error::new(input, InnerError::FrameSizeError)));
+            }
+            window_update_frame(i, &header)?
+        }
+    };
+
+    Ok(f)
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Data<'a> {
+    pub stream_id: u32,
+    pub payload: &'a [u8],
+    pub end_stream: bool,
+}
+
+pub fn data_frame<'a, 'b>(
+    input: &'a [u8],
+    header: &'b FrameHeader,
+) -> IResult<&'a [u8], Frame<'a>, Error<'a>> {
+    let (remaining, i) = take(header.payload_len)(input)?;
+
+    let (i1, pad_length) = if header.flags & 0x8 != 0 {
+        let (i, pad_length) = be_u8(i)?;
+        (i, Some(pad_length))
+    } else {
+        (i, None)
+    };
+
+    if pad_length.is_some() && i1.len() <= pad_length.unwrap() as usize {
+        return Err(Err::Failure(Error::new(input, InnerError::ProtocolError)));
+    }
+
+    let (_, payload) = take(i1.len() - pad_length.unwrap_or(0) as usize)(i1)?;
+
+    Ok((
+        remaining,
+        Frame::Data(Data {
+            stream_id: header.stream_id,
+            payload,
+            end_stream: header.flags & 0x1 != 0,
+        }),
+    ))
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Headers<'a> {
+    pub stream_id: u32,
+    pub stream_dependency: Option<StreamDependency>,
+    pub weight: Option<u8>,
+    pub header_block_fragment: &'a [u8],
+    pub end_stream: bool,
+    pub end_headers: bool,
+    pub priority: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct StreamDependency {
+    pub exclusive: bool,
+    pub stream_id: u32,
+}
+
+pub fn headers_frame<'a, 'b>(
+    input: &'a [u8],
+    header: &'b FrameHeader,
+) -> IResult<&'a [u8], Frame<'a>, Error<'a>> {
+    let (remaining, i) = take(header.payload_len)(input)?;
+
+    let (i1, pad_length) = if header.flags & 0x8 != 0 {
+        let (i, pad_length) = be_u8(i)?;
+        (i, Some(pad_length))
+    } else {
+        (i, None)
+    };
+
+    let (i2, stream_dependency) = if header.flags & 0x20 != 0 {
+        let (i, stream) = map(be_u32, |i| StreamDependency {
+            exclusive: i & 0x8000 != 0,
+            stream_id: i & 0x7FFF,
+        })(i1)?;
+        (i, Some(stream))
+    } else {
+        (i1, None)
+    };
+
+    let (i3, weight) = if header.flags & 0x20 != 0 {
+        let (i, weight) = be_u8(i2)?;
+        (i, Some(weight))
+    } else {
+        (i2, None)
+    };
+
+    if pad_length.is_some() && i3.len() <= pad_length.unwrap() as usize {
+        return Err(Err::Failure(Error::new(input, InnerError::ProtocolError)));
+    }
+
+    let (_, header_block_fragment) = take(i3.len() - pad_length.unwrap_or(0) as usize)(i3)?;
+
+    Ok((
+        remaining,
+        Frame::Headers(Headers {
+            stream_id: header.stream_id,
+            stream_dependency,
+            weight,
+            header_block_fragment,
+            end_stream: header.flags & 0x1 != 0,
+            end_headers: header.flags & 0x4 != 0,
+            priority: header.flags & 0x20 != 0,
+        }),
+    ))
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RstStream {
+    pub stream_id: u32,
+    pub error_code: u32,
+}
+
+pub fn rst_stream_frame<'a, 'b>(
+    input: &'a [u8],
+    header: &'b FrameHeader,
+) -> IResult<&'a [u8], Frame<'a>, Error<'a>> {
+    let (i, error_code) = be_u32(input)?;
+    Ok((
+        i,
+        Frame::RstStream(RstStream {
+            stream_id: header.stream_id,
+            error_code,
+        }),
+    ))
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Settings {
+    pub settings: Vec<Setting>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Setting {
+    pub identifier: u16,
+    pub value: u32,
+}
+
+pub fn settings_frame<'a, 'b>(
+    input: &'a [u8],
+    header: &'b FrameHeader,
+) -> IResult<&'a [u8], Frame<'a>, Error<'a>> {
+    let (i, data) = take(header.payload_len)(input)?;
+
+    let (_, settings) = many0(map(
+        complete(tuple((be_u16, be_u32))),
+        |(identifier, value)| Setting { identifier, value },
+    ))(data)?;
+
+    Ok((i, Frame::Settings(Settings { settings })))
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Ping {
+    pub payload: [u8; 8],
+}
+
+pub fn ping_frame<'a, 'b>(
+    input: &'a [u8],
+    header: &'b FrameHeader,
+) -> IResult<&'a [u8], Frame<'a>, Error<'a>> {
+    let (i, data) = take(8usize)(input)?;
+
+    let mut p = Ping { payload: [0; 8] };
+
+    for i in 0..8 {
+        p.payload[i] = data[i];
+    }
+
+    Ok((i, Frame::Ping(p)))
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct WindowUpdate {
+    pub stream_id: u32,
+    pub increment: u32,
+}
+
+pub fn window_update_frame<'a, 'b>(
+    input: &'a [u8],
+    header: &'b FrameHeader,
+) -> IResult<&'a [u8], Frame<'a>, Error<'a>> {
+    let (i, increment) = be_u32(input)?;
+    let increment = increment & 0x7FFF;
+
+    //FIXME: if stream id is 0, trat it as connection error?
+    if increment == 0 {
+        return Err(Err::Failure(Error::new(input, InnerError::ProtocolError)));
+    }
+
+    Ok((
+        i,
+        Frame::WindowUpdate(WindowUpdate {
+            stream_id: header.stream_id,
+            increment,
+        }),
+    ))
+}

--- a/lib/src/protocol/mux/parser.rs
+++ b/lib/src/protocol/mux/parser.rs
@@ -207,7 +207,7 @@ pub fn frame_header(input: &[u8], max_frame_size: u32) -> IResult<&[u8], FrameHe
         FrameType::WindowUpdate => true,
     };
     if !valid_stream_id {
-        println!("invalid stream_id: {stream_id}");
+        error!("invalid stream_id: {}", stream_id);
         return Err(Err::Failure(ParserError::new_h2(i, H2Error::ProtocolError)));
     }
 
@@ -223,7 +223,7 @@ pub fn frame_header(input: &[u8], max_frame_size: u32) -> IResult<&[u8], FrameHe
 }
 
 fn convert_frame_type(t: u8) -> Option<FrameType> {
-    info!("got frame type: {}", t);
+    debug!("got frame type: {}", t);
     match t {
         0 => Some(FrameType::Data),
         1 => Some(FrameType::Headers),
@@ -353,7 +353,6 @@ pub fn data_frame<'a>(
     header: &FrameHeader,
 ) -> IResult<&'a [u8], Frame, ParserError<'a>> {
     let (remaining, i) = take(header.payload_len)(input)?;
-    println!("{i:?}");
 
     let (i, pad_length) = if header.flags & 0x8 != 0 {
         let (i, pad_length) = be_u8(i)?;

--- a/lib/src/protocol/mux/pkawa.rs
+++ b/lib/src/protocol/mux/pkawa.rs
@@ -45,7 +45,7 @@ pub fn handle_header<C>(
                     } else if compare_no_case(&k, b":scheme") {
                         scheme = val;
                     } else if compare_no_case(&k, b"cookie") {
-                        panic!("cookies should be split in pairs");
+                        todo!("cookies should be split in pairs");
                     } else {
                         if compare_no_case(&k, b"content-length") {
                             let length =

--- a/lib/src/protocol/mux/pkawa.rs
+++ b/lib/src/protocol/mux/pkawa.rs
@@ -5,15 +5,21 @@ use kawa::{
     Store, Version,
 };
 
-use crate::{pool::Checkout, protocol::http::parser::compare_no_case};
-
-use super::GenericHttpStream;
+use crate::{
+    pool::Checkout,
+    protocol::{
+        http::parser::compare_no_case,
+        mux::{h2::Prioriser, parser::PriorityPart, GenericHttpStream, StreamId},
+    },
+};
 
 pub fn handle_header<C>(
+    decoder: &mut hpack::Decoder,
+    prioriser: &mut Prioriser,
+    stream_id: StreamId,
     kawa: &mut GenericHttpStream,
     input: &[u8],
     end_stream: bool,
-    decoder: &mut hpack::Decoder,
     callbacks: &mut C,
 ) where
     C: ParserCallbacks<Checkout>,
@@ -28,44 +34,56 @@ pub fn handle_header<C>(
             let mut authority = Store::Empty;
             let mut path = Store::Empty;
             let mut scheme = Store::Empty;
-            decoder
-                .decode_with_cb(input, |k, v| {
-                    let start = kawa.storage.end as u32;
-                    kawa.storage.write_all(&v).unwrap();
-                    let len_key = k.len() as u32;
-                    let len_val = v.len() as u32;
-                    let val = Store::Slice(Slice {
-                        start,
-                        len: len_val,
-                    });
+            let decode_status = decoder.decode_with_cb(input, |k, v| {
+                let start = kawa.storage.end as u32;
+                kawa.storage.write_all(&v).unwrap();
+                let len_key = k.len() as u32;
+                let len_val = v.len() as u32;
+                let val = Store::Slice(Slice {
+                    start,
+                    len: len_val,
+                });
 
-                    if compare_no_case(&k, b":method") {
-                        method = val;
-                    } else if compare_no_case(&k, b":authority") {
-                        authority = val;
-                    } else if compare_no_case(&k, b":path") {
-                        path = val;
-                    } else if compare_no_case(&k, b":scheme") {
-                        scheme = val;
-                    } else if compare_no_case(&k, b"cookie") {
-                        todo!("cookies should be split in pairs");
-                    } else if compare_no_case(&k, b"priority") {
-                        unimplemented!();
-                    } else {
-                        if compare_no_case(&k, b"content-length") {
-                            let length =
-                                unsafe { from_utf8_unchecked(&v).parse::<usize>().unwrap() };
-                            kawa.body_size = BodySize::Length(length);
-                        }
-                        kawa.storage.write_all(&k).unwrap();
-                        let key = Store::Slice(Slice {
-                            start: start + len_val,
-                            len: len_key,
-                        });
-                        kawa.push_block(Block::Header(Pair { key, val }));
+                if compare_no_case(&k, b":method") {
+                    method = val;
+                } else if compare_no_case(&k, b":scheme") {
+                    scheme = val;
+                } else if compare_no_case(&k, b":path") {
+                    path = val;
+                } else if compare_no_case(&k, b":authority") {
+                    authority = val;
+                } else if compare_no_case(&k, b"cookie---") {
+                    todo!("cookies should be split in pairs");
+                } else if compare_no_case(&k, b"priority") {
+                    todo!("decode priority");
+                    prioriser.push_priority(
+                        stream_id,
+                        PriorityPart::Rfc9218 {
+                            urgency: todo!(),
+                            incremental: todo!(),
+                        },
+                    )
+                } else {
+                    if compare_no_case(&k, b"content-length") {
+                        let length = unsafe { from_utf8_unchecked(&v).parse::<usize>().unwrap() };
+                        kawa.body_size = BodySize::Length(length);
                     }
-                })
-                .unwrap();
+                    kawa.storage.write_all(&k).unwrap();
+                    let key = Store::Slice(Slice {
+                        start: start + len_val,
+                        len: len_key,
+                    });
+                    kawa.push_block(Block::Header(Pair { key, val }));
+                }
+            });
+            if let Err(error) = decode_status {
+                println!("INVALID FRAGMENT: {error:?}");
+                kawa.parsing_phase.error("Invalid header fragment".into());
+            }
+            if method.is_empty() || authority.is_empty() || path.is_empty() {
+                println!("MISSING PSEUDO HEADERS");
+                kawa.parsing_phase.error("Missing pseudo headers".into());
+            }
             // uri is only used by H1 statusline, in most cases it only consists of the path
             // a better algorithm should be used though
             // let buffer = kawa.storage.data();
@@ -89,30 +107,36 @@ pub fn handle_header<C>(
         Kind::Response => {
             let mut code = 0;
             let mut status = Store::Empty;
-            decoder
-                .decode_with_cb(input, |k, v| {
-                    let start = kawa.storage.end as u32;
-                    kawa.storage.write_all(&v).unwrap();
-                    let len_key = k.len() as u32;
-                    let len_val = v.len() as u32;
-                    let val = Store::Slice(Slice {
-                        start,
-                        len: len_val,
-                    });
+            let decode_status = decoder.decode_with_cb(input, |k, v| {
+                let start = kawa.storage.end as u32;
+                kawa.storage.write_all(&v).unwrap();
+                let len_key = k.len() as u32;
+                let len_val = v.len() as u32;
+                let val = Store::Slice(Slice {
+                    start,
+                    len: len_val,
+                });
 
-                    if compare_no_case(&k, b":status") {
-                        status = val;
-                        code = unsafe { from_utf8_unchecked(&v).parse::<u16>().ok().unwrap() }
-                    } else {
-                        kawa.storage.write_all(&k).unwrap();
-                        let key = Store::Slice(Slice {
-                            start: start + len_val,
-                            len: len_key,
-                        });
-                        kawa.push_block(Block::Header(Pair { key, val }));
-                    }
-                })
-                .unwrap();
+                if compare_no_case(&k, b":status") {
+                    status = val;
+                    code = unsafe { from_utf8_unchecked(&v).parse::<u16>().ok().unwrap() }
+                } else {
+                    kawa.storage.write_all(&k).unwrap();
+                    let key = Store::Slice(Slice {
+                        start: start + len_val,
+                        len: len_key,
+                    });
+                    kawa.push_block(Block::Header(Pair { key, val }));
+                }
+            });
+            if let Err(error) = decode_status {
+                println!("INVALID FRAGMENT: {error:?}");
+                kawa.parsing_phase.error("Invalid header fragment".into());
+            }
+            if status.is_empty() {
+                println!("MISSING PSEUDO HEADERS");
+                kawa.parsing_phase.error("Missing pseudo headers".into());
+            }
             StatusLine::Response {
                 version: Version::V20,
                 code,
@@ -124,7 +148,14 @@ pub fn handle_header<C>(
 
     // everything has been parsed
     kawa.storage.head = kawa.storage.end;
+    println!(
+        "index: {}/{}/{}",
+        kawa.storage.start, kawa.storage.head, kawa.storage.end
+    );
 
+    if kawa.is_error() {
+        return;
+    }
     callbacks.on_headers(kawa);
 
     if end_stream {
@@ -181,7 +212,7 @@ pub fn handle_trailer(
         })
         .unwrap();
 
-    assert!(end_stream);
+    // assert!(end_stream);
     kawa.push_block(Block::Flags(Flags {
         end_body: end_stream,
         end_chunk: false,

--- a/lib/src/protocol/mux/pkawa.rs
+++ b/lib/src/protocol/mux/pkawa.rs
@@ -17,20 +17,6 @@ use crate::{
     },
 };
 
-trait AdHocStore {
-    fn len(&self) -> usize;
-}
-impl AdHocStore for Store {
-    fn len(&self) -> usize {
-        match self {
-            Store::Empty => 0,
-            Store::Slice(slice) | Store::Detached(slice) => slice.len(),
-            Store::Static(s) => s.len(),
-            Store::Alloc(a, i) => a.len() - *i as usize,
-        }
-    }
-}
-
 pub fn handle_header<C>(
     decoder: &mut hpack::Decoder,
     prioriser: &mut Prioriser,

--- a/lib/src/protocol/mux/pkawa.rs
+++ b/lib/src/protocol/mux/pkawa.rs
@@ -103,9 +103,6 @@ where
                         }
                     } else if compare_no_case(&k, b"priority") {
                         // todo!("decode priority");
-                        warn!("DECODE PRIORITY: {}", unsafe {
-                            std::str::from_utf8_unchecked(v.as_ref())
-                        });
                         prioriser.push_priority(
                             stream_id,
                             PriorityPart::Rfc9218 {

--- a/lib/src/protocol/mux/pkawa.rs
+++ b/lib/src/protocol/mux/pkawa.rs
@@ -1,0 +1,107 @@
+use std::{io::Write, str::from_utf8_unchecked};
+
+use crate::protocol::http::parser::compare_no_case;
+
+use super::GenericHttpStream;
+
+pub fn handle_header(kawa: &mut GenericHttpStream, input: &[u8], decoder: &mut hpack::Decoder) {
+    println!("{input:?}");
+    kawa.push_block(kawa::Block::StatusLine);
+    kawa.detached.status_line = match kawa.kind {
+        kawa::Kind::Request => {
+            let mut method = kawa::Store::Empty;
+            let mut authority = kawa::Store::Empty;
+            let mut path = kawa::Store::Empty;
+            let mut scheme = kawa::Store::Empty;
+            decoder
+                .decode_with_cb(input, |k, v| {
+                    let start = kawa.storage.end as u32;
+                    kawa.storage.write(&k).unwrap();
+                    kawa.storage.write(&v).unwrap();
+                    let len_key = k.len() as u32;
+                    let len_val = v.len() as u32;
+                    let key = kawa::Store::Slice(kawa::repr::Slice {
+                        start,
+                        len: len_key,
+                    });
+                    let val = kawa::Store::Slice(kawa::repr::Slice {
+                        start: start + len_key,
+                        len: len_val,
+                    });
+
+                    if compare_no_case(&k, b":method") {
+                        method = val;
+                    } else if compare_no_case(&k, b":authority") {
+                        authority = val;
+                    } else if compare_no_case(&k, b":path") {
+                        path = val;
+                    } else if compare_no_case(&k, b":scheme") {
+                        scheme = val;
+                    } else {
+                        kawa.push_block(kawa::Block::Header(kawa::Pair { key, val }));
+                    }
+                })
+                .unwrap();
+            let buffer = kawa.storage.data();
+            let uri = unsafe {
+                format!(
+                    "{}://{}{}",
+                    from_utf8_unchecked(scheme.data(buffer)),
+                    from_utf8_unchecked(authority.data(buffer)),
+                    from_utf8_unchecked(path.data(buffer))
+                )
+            };
+            println!("Reconstructed URI: {uri}");
+            kawa::StatusLine::Request {
+                version: kawa::Version::V20,
+                method,
+                uri: kawa::Store::from_string(uri),
+                authority,
+                path,
+            }
+        }
+        kawa::Kind::Response => {
+            let mut code = 0;
+            let mut status = kawa::Store::Empty;
+            decoder
+                .decode_with_cb(input, |k, v| {
+                    let start = kawa.storage.end as u32;
+                    kawa.storage.write(&k).unwrap();
+                    kawa.storage.write(&v).unwrap();
+                    let len_key = k.len() as u32;
+                    let len_val = v.len() as u32;
+                    let key = kawa::Store::Slice(kawa::repr::Slice {
+                        start,
+                        len: len_key,
+                    });
+                    let val = kawa::Store::Slice(kawa::repr::Slice {
+                        start: start + len_key,
+                        len: len_val,
+                    });
+
+                    if compare_no_case(&k, b":status") {
+                        status = val;
+                        code = unsafe {
+                            std::str::from_utf8_unchecked(&k)
+                                .parse::<u16>()
+                                .ok()
+                                .unwrap()
+                        }
+                    } else {
+                        kawa.push_block(kawa::Block::Header(kawa::Pair { key, val }));
+                    }
+                })
+                .unwrap();
+            kawa::StatusLine::Response {
+                version: kawa::Version::V20,
+                code,
+                status,
+                reason: kawa::Store::Empty,
+            }
+        }
+    };
+
+    // everything has been parsed
+    kawa.storage.head = kawa.storage.end;
+    kawa.parsing_phase = kawa::ParsingPhase::Chunks { first: true };
+}

--- a/lib/src/protocol/mux/pkawa.rs
+++ b/lib/src/protocol/mux/pkawa.rs
@@ -117,7 +117,7 @@ pub fn handle_header<C>(
                 version: Version::V20,
                 code,
                 status,
-                reason: Store::Static(b"Default"),
+                reason: Store::Static(b"FromH2"),
             }
         }
     };

--- a/lib/src/protocol/mux/pkawa.rs
+++ b/lib/src/protocol/mux/pkawa.rs
@@ -56,20 +56,22 @@ pub fn handle_header<C>(
                     }
                 })
                 .unwrap();
-            let buffer = kawa.storage.data();
-            let uri = unsafe {
-                format!(
-                    "{}://{}{}",
-                    from_utf8_unchecked(scheme.data(buffer)),
-                    from_utf8_unchecked(authority.data(buffer)),
-                    from_utf8_unchecked(path.data(buffer))
-                )
-            };
-            println!("Reconstructed URI: {uri}");
+            // uri is only used by H1 statusline, in most cases it only consists of the path
+            // a better algorithm should be used though
+            // let buffer = kawa.storage.data();
+            // let uri = unsafe {
+            //     format!(
+            //         "{}://{}{}",
+            //         from_utf8_unchecked(scheme.data(buffer)),
+            //         from_utf8_unchecked(authority.data(buffer)),
+            //         from_utf8_unchecked(path.data(buffer))
+            //     )
+            // };
+            // println!("Reconstructed URI: {uri}");
             kawa::StatusLine::Request {
                 version: kawa::Version::V20,
                 method,
-                uri: kawa::Store::from_string(uri),
+                uri: path.clone(), //kawa::Store::from_string(uri),
                 authority,
                 path,
             }

--- a/lib/src/protocol/mux/pkawa.rs
+++ b/lib/src/protocol/mux/pkawa.rs
@@ -44,6 +44,8 @@ pub fn handle_header<C>(
                         path = val;
                     } else if compare_no_case(&k, b":scheme") {
                         scheme = val;
+                    } else if compare_no_case(&k, b"cookie") {
+                        panic!("cookies should be split in pairs");
                     } else {
                         if compare_no_case(&k, b"content-length") {
                             let length =
@@ -145,6 +147,11 @@ pub fn handle_header<C>(
         }));
         kawa.body_size = BodySize::Length(0);
     }
+
+    if kawa.parsing_phase == ParsingPhase::Terminated {
+        return;
+    }
+
     kawa.parsing_phase = match kawa.body_size {
         BodySize::Chunked => ParsingPhase::Chunks { first: true },
         BodySize::Length(0) => ParsingPhase::Terminated,

--- a/lib/src/protocol/mux/pkawa.rs
+++ b/lib/src/protocol/mux/pkawa.rs
@@ -46,6 +46,8 @@ pub fn handle_header<C>(
                         scheme = val;
                     } else if compare_no_case(&k, b"cookie") {
                         todo!("cookies should be split in pairs");
+                    } else if compare_no_case(&k, b"priority") {
+                        unimplemented!();
                     } else {
                         if compare_no_case(&k, b"content-length") {
                             let length =

--- a/lib/src/protocol/mux/serializer.rs
+++ b/lib/src/protocol/mux/serializer.rs
@@ -1,0 +1,37 @@
+use cookie_factory::{
+    bytes::{be_u24, be_u32, be_u8},
+    gen,
+    sequence::tuple,
+    GenError,
+};
+
+use super::parser::{FrameHeader, FrameType};
+
+pub fn gen_frame_header<'a, 'b>(
+    buf: &'a mut [u8],
+    frame: &'b FrameHeader,
+) -> Result<(&'a mut [u8], usize), GenError> {
+    let serializer = tuple((
+        be_u24(frame.payload_len),
+        be_u8(serialize_frame_type(&frame.frame_type)),
+        be_u8(frame.flags),
+        be_u32(frame.stream_id),
+    ));
+
+    gen(serializer, buf).map(|(buf, size)| (buf, size as usize))
+}
+
+pub fn serialize_frame_type(f: &FrameType) -> u8 {
+    match *f {
+        FrameType::Data => 0,
+        FrameType::Headers => 1,
+        FrameType::Priority => 2,
+        FrameType::RstStream => 3,
+        FrameType::Settings => 4,
+        FrameType::PushPromise => 5,
+        FrameType::Ping => 6,
+        FrameType::GoAway => 7,
+        FrameType::WindowUpdate => 8,
+        FrameType::Continuation => 9,
+    }
+}

--- a/lib/src/protocol/mux/serializer.rs
+++ b/lib/src/protocol/mux/serializer.rs
@@ -114,3 +114,26 @@ pub fn gen_rst_stream<'a>(
         gen(be_u32(error_code as u32), buf).map(|(buf, size)| (buf, (old_size + size as usize)))
     })
 }
+
+pub fn gen_goaway<'a>(
+    buf: &'a mut [u8],
+    last_stream_id: u32,
+    error_code: H2Error,
+) -> Result<(&'a mut [u8], usize), GenError> {
+    gen_frame_header(
+        buf,
+        &FrameHeader {
+            payload_len: 4,
+            frame_type: FrameType::GoAway,
+            flags: 0,
+            stream_id: 0,
+        },
+    )
+    .and_then(|(buf, old_size)| {
+        gen(
+            tuple((be_u32(last_stream_id), be_u32(error_code as u32))),
+            buf,
+        )
+        .map(|(buf, size)| (buf, (old_size + size as usize)))
+    })
+}

--- a/lib/src/protocol/mux/serializer.rs
+++ b/lib/src/protocol/mux/serializer.rs
@@ -1,5 +1,3 @@
-use core::slice;
-
 use cookie_factory::{
     bytes::{be_u16, be_u24, be_u32, be_u8},
     combinator::slice,

--- a/lib/src/protocol/mux/serializer.rs
+++ b/lib/src/protocol/mux/serializer.rs
@@ -15,9 +15,9 @@ pub const H2_PRI: &str = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 pub const SETTINGS_ACKNOWLEDGEMENT: [u8; 9] = [0, 0, 0, 4, 1, 0, 0, 0, 0];
 pub const PING_ACKNOWLEDGEMENT_HEADER: [u8; 9] = [0, 0, 8, 6, 1, 0, 0, 0, 0];
 
-pub fn gen_frame_header<'a, 'b>(
+pub fn gen_frame_header<'a>(
     buf: &'a mut [u8],
-    frame: &'b FrameHeader,
+    frame: &FrameHeader,
 ) -> Result<(&'a mut [u8], usize), GenError> {
     let serializer = tuple((
         be_u24(frame.payload_len),
@@ -100,11 +100,11 @@ pub fn gen_settings<'a>(
     })
 }
 
-pub fn gen_rst_stream<'a>(
-    buf: &'a mut [u8],
+pub fn gen_rst_stream(
+    buf: &mut [u8],
     stream_id: u32,
     error_code: H2Error,
-) -> Result<(&'a mut [u8], usize), GenError> {
+) -> Result<(&mut [u8], usize), GenError> {
     gen_frame_header(
         buf,
         &FrameHeader {
@@ -119,11 +119,11 @@ pub fn gen_rst_stream<'a>(
     })
 }
 
-pub fn gen_goaway<'a>(
-    buf: &'a mut [u8],
+pub fn gen_goaway(
+    buf: &mut [u8],
     last_stream_id: u32,
     error_code: H2Error,
-) -> Result<(&'a mut [u8], usize), GenError> {
+) -> Result<(&mut [u8], usize), GenError> {
     gen_frame_header(
         buf,
         &FrameHeader {

--- a/lib/src/protocol/mux/serializer.rs
+++ b/lib/src/protocol/mux/serializer.rs
@@ -1,11 +1,21 @@
+use core::slice;
+
 use cookie_factory::{
-    bytes::{be_u24, be_u32, be_u8},
+    bytes::{be_u16, be_u24, be_u32, be_u8},
+    combinator::slice,
     gen,
     sequence::tuple,
     GenError,
 };
 
-use super::parser::{FrameHeader, FrameType};
+use super::{
+    h2::H2Settings,
+    parser::{FrameHeader, FrameType},
+};
+
+pub const H2_PRI: &str = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+pub const SETTINGS_ACKNOWLEDGEMENT: [u8; 9] = [0, 0, 0, 4, 1, 0, 0, 0, 0];
+pub const PING_ACKNOWLEDGEMENT_HEADER: [u8; 9] = [0, 0, 0, 6, 1, 0, 0, 0, 0];
 
 pub fn gen_frame_header<'a, 'b>(
     buf: &'a mut [u8],
@@ -34,4 +44,56 @@ pub fn serialize_frame_type(f: &FrameType) -> u8 {
         FrameType::WindowUpdate => 8,
         FrameType::Continuation => 9,
     }
+}
+
+// pub fn gen_settings_acknoledgement<'a>(buf: &'a mut [u8]) {
+//     for (i, b) in SETTINGS_ACKNOWLEDGEMENT.iter().enumerate() {
+//         buf[i] = *b;
+//     }
+// }
+
+pub fn gen_ping_acknolegment<'a>(
+    buf: &'a mut [u8],
+    payload: &[u8],
+) -> Result<(&'a mut [u8], usize), GenError> {
+    gen(
+        tuple((slice(PING_ACKNOWLEDGEMENT_HEADER), slice(payload))),
+        buf,
+    )
+    .map(|(buf, size)| (buf, size as usize))
+}
+
+pub fn gen_settings<'a>(
+    buf: &'a mut [u8],
+    settings: &H2Settings,
+) -> Result<(&'a mut [u8], usize), GenError> {
+    gen_frame_header(
+        buf,
+        &FrameHeader {
+            payload_len: 6 * 6,
+            frame_type: FrameType::Settings,
+            flags: 0,
+            stream_id: 0,
+        },
+    )
+    .and_then(|(buf, old_size)| {
+        gen(
+            tuple((
+                be_u16(1),
+                be_u32(settings.settings_header_table_size),
+                be_u16(2),
+                be_u32(settings.settings_enable_push as u32),
+                be_u16(3),
+                be_u32(settings.settings_max_concurrent_streams),
+                be_u16(4),
+                be_u32(settings.settings_initial_window_size),
+                be_u16(5),
+                be_u32(settings.settings_max_frame_size),
+                be_u16(6),
+                be_u32(settings.settings_max_header_list_size),
+            )),
+            buf,
+        )
+        .map(|(buf, size)| (buf, (old_size + size as usize)))
+    })
 }

--- a/lib/src/protocol/mux/serializer.rs
+++ b/lib/src/protocol/mux/serializer.rs
@@ -13,7 +13,7 @@ use super::{
 
 pub const H2_PRI: &str = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 pub const SETTINGS_ACKNOWLEDGEMENT: [u8; 9] = [0, 0, 0, 4, 1, 0, 0, 0, 0];
-pub const PING_ACKNOWLEDGEMENT_HEADER: [u8; 9] = [0, 0, 0, 6, 1, 0, 0, 0, 0];
+pub const PING_ACKNOWLEDGEMENT_HEADER: [u8; 9] = [0, 0, 8, 6, 1, 0, 0, 0, 0];
 
 pub fn gen_frame_header<'a, 'b>(
     buf: &'a mut [u8],
@@ -68,7 +68,7 @@ pub fn gen_settings<'a>(
     gen_frame_header(
         buf,
         &FrameHeader {
-            payload_len: 6 * 6,
+            payload_len: 6 * 8,
             frame_type: FrameType::Settings,
             flags: 0,
             stream_id: 0,
@@ -89,6 +89,10 @@ pub fn gen_settings<'a>(
                 be_u32(settings.settings_max_frame_size),
                 be_u16(6),
                 be_u32(settings.settings_max_header_list_size),
+                be_u16(8),
+                be_u32(settings.settings_enable_connect_protocol as u32),
+                be_u16(9),
+                be_u32(settings.settings_no_rfc7540_priorities as u32),
             )),
             buf,
         )
@@ -123,7 +127,7 @@ pub fn gen_goaway<'a>(
     gen_frame_header(
         buf,
         &FrameHeader {
-            payload_len: 4,
+            payload_len: 8,
             frame_type: FrameType::GoAway,
             flags: 0,
             stream_id: 0,

--- a/lib/src/protocol/mux/serializer.rs
+++ b/lib/src/protocol/mux/serializer.rs
@@ -6,7 +6,7 @@ use cookie_factory::{
     GenError,
 };
 
-use super::{
+use crate::protocol::mux::{
     h2::H2Settings,
     parser::{FrameHeader, FrameType, H2Error},
 };

--- a/lib/src/protocol/rustls.rs
+++ b/lib/src/protocol/rustls.rs
@@ -6,7 +6,7 @@ use rusty_ulid::Ulid;
 use sozu_command::{config::MAX_LOOP_ITERATIONS, logging::LogContext};
 
 use crate::{
-    protocol::SessionState, timer::TimeoutContainer, Readiness, Ready, SessionMetrics,
+    protocol::SessionState, timer::TimeoutContainer, L7Proxy, Readiness, Ready, SessionMetrics,
     SessionResult, StateResult,
 };
 
@@ -223,10 +223,10 @@ impl TlsHandshake {
 }
 
 impl SessionState for TlsHandshake {
-    fn ready(
+    fn ready<P: L7Proxy>(
         &mut self,
         _session: Rc<RefCell<dyn crate::ProxySession>>,
-        _proxy: Rc<RefCell<dyn crate::L7Proxy>>,
+        _proxy: Rc<RefCell<P>>,
         _metrics: &mut SessionMetrics,
     ) -> SessionResult {
         let mut counter = 0;

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -132,10 +132,7 @@ impl Router {
         let method_rule = MethodRule::new(front.method.clone());
 
         let route = match &front.cluster_id {
-            Some(cluster_id) => Route::Cluster {
-                id: cluster_id.clone(),
-                h2: front.h2,
-            },
+            Some(cluster_id) => Route::Cluster(cluster_id.clone()),
             None => Route::Deny,
         };
 
@@ -599,7 +596,7 @@ pub enum Route {
     /// send a 401 default answer
     Deny,
     /// the cluster to which the frontend belongs
-    Cluster { id: ClusterId, h2: bool },
+    Cluster(ClusterId),
 }
 
 #[cfg(test)]
@@ -718,42 +715,27 @@ mod tests {
             b"*.sozu.io",
             &PathRule::Prefix("".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::Cluster {
-                id: "base".to_string(),
-                h2: false
-            }
+            &Route::Cluster("base".to_string())
         ));
         println!("{:#?}", router.tree);
         assert_eq!(
             router.lookup("www.sozu.io", "/api", &Method::Get),
-            Ok(Route::Cluster {
-                id: "base".to_string(),
-                h2: false
-            })
+            Ok(Route::Cluster("base".to_string()))
         );
         assert!(router.add_tree_rule(
             b"*.sozu.io",
             &PathRule::Prefix("/api".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::Cluster {
-                id: "api".to_string(),
-                h2: false
-            }
+            &Route::Cluster("api".to_string())
         ));
         println!("{:#?}", router.tree);
         assert_eq!(
             router.lookup("www.sozu.io", "/ap", &Method::Get),
-            Ok(Route::Cluster {
-                id: "base".to_string(),
-                h2: false
-            })
+            Ok(Route::Cluster("base".to_string()))
         );
         assert_eq!(
             router.lookup("www.sozu.io", "/api", &Method::Get),
-            Ok(Route::Cluster {
-                id: "api".to_string(),
-                h2: false
-            })
+            Ok(Route::Cluster("api".to_string()))
         );
     }
 
@@ -772,42 +754,27 @@ mod tests {
             b"*.sozu.io",
             &PathRule::Prefix("".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::Cluster {
-                id: "base".to_string(),
-                h2: false
-            }
+            &Route::Cluster("base".to_string())
         ));
         println!("{:#?}", router.tree);
         assert_eq!(
             router.lookup("www.sozu.io", "/api", &Method::Get),
-            Ok(Route::Cluster {
-                id: "base".to_string(),
-                h2: false
-            })
+            Ok(Route::Cluster("base".to_string()))
         );
         assert!(router.add_tree_rule(
             b"api.sozu.io",
             &PathRule::Prefix("".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::Cluster {
-                id: "api".to_string(),
-                h2: false
-            }
+            &Route::Cluster("api".to_string())
         ));
         println!("{:#?}", router.tree);
         assert_eq!(
             router.lookup("www.sozu.io", "/api", &Method::Get),
-            Ok(Route::Cluster {
-                id: "base".to_string(),
-                h2: false
-            })
+            Ok(Route::Cluster("base".to_string()))
         );
         assert_eq!(
             router.lookup("api.sozu.io", "/api", &Method::Get),
-            Ok(Route::Cluster {
-                id: "api".to_string(),
-                h2: false
-            })
+            Ok(Route::Cluster("api".to_string()))
         );
     }
 
@@ -819,35 +786,23 @@ mod tests {
             b"www./.*/.io",
             &PathRule::Prefix("".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::Cluster {
-                id: "base".to_string(),
-                h2: false
-            }
+            &Route::Cluster("base".to_string())
         ));
         println!("{:#?}", router.tree);
         assert!(router.add_tree_rule(
             b"www.doc./.*/.io",
             &PathRule::Prefix("".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::Cluster {
-                id: "doc".to_string(),
-                h2: false
-            }
+            &Route::Cluster("doc".to_string())
         ));
         println!("{:#?}", router.tree);
         assert_eq!(
             router.lookup("www.sozu.io", "/", &Method::Get),
-            Ok(Route::Cluster {
-                id: "base".to_string(),
-                h2: false
-            })
+            Ok(Route::Cluster("base".to_string()))
         );
         assert_eq!(
             router.lookup("www.doc.sozu.io", "/", &Method::Get),
-            Ok(Route::Cluster {
-                id: "doc".to_string(),
-                h2: false
-            })
+            Ok(Route::Cluster("doc".to_string()))
         );
         assert!(router.remove_tree_rule(
             b"www./.*/.io",
@@ -858,10 +813,7 @@ mod tests {
         assert!(router.lookup("www.sozu.io", "/", &Method::Get).is_err());
         assert_eq!(
             router.lookup("www.doc.sozu.io", "/", &Method::Get),
-            Ok(Route::Cluster {
-                id: "doc".to_string(),
-                h2: false
-            })
+            Ok(Route::Cluster("doc".to_string()))
         );
     }
 
@@ -873,45 +825,30 @@ mod tests {
             &"*".parse::<DomainRule>().unwrap(),
             &PathRule::Prefix("/.well-known/acme-challenge".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::Cluster {
-                id: "acme".to_string(),
-                h2: false
-            }
+            &Route::Cluster("acme".to_string())
         ));
         assert!(router.add_tree_rule(
             "www.example.com".as_bytes(),
             &PathRule::Prefix("/".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::Cluster {
-                id: "example".to_string(),
-                h2: false
-            }
+            &Route::Cluster("example".to_string())
         ));
         assert!(router.add_tree_rule(
             "*.test.example.com".as_bytes(),
             &PathRule::Regex(Regex::new("/hello[A-Z]+/").unwrap()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::Cluster {
-                id: "examplewildcard".to_string(),
-                h2: false
-            }
+            &Route::Cluster("examplewildcard".to_string())
         ));
         assert!(router.add_tree_rule(
             "/test[0-9]/.example.com".as_bytes(),
             &PathRule::Prefix("/".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::Cluster {
-                id: "exampleregex".to_string(),
-                h2: false
-            }
+            &Route::Cluster("exampleregex".to_string())
         ));
 
         assert_eq!(
             router.lookup("www.example.com", "/helloA", &Method::new(&b"GET"[..])),
-            Ok(Route::Cluster {
-                id: "example".to_string(),
-                h2: false
-            })
+            Ok(Route::Cluster("example".to_string()))
         );
         assert_eq!(
             router.lookup(
@@ -919,10 +856,7 @@ mod tests {
                 "/.well-known/acme-challenge",
                 &Method::new(&b"GET"[..])
             ),
-            Ok(Route::Cluster {
-                id: "acme".to_string(),
-                h2: false
-            })
+            Ok(Route::Cluster("acme".to_string()))
         );
         assert!(router
             .lookup("www.test.example.com", "/", &Method::new(&b"GET"[..]))
@@ -933,10 +867,7 @@ mod tests {
                 "/helloAB/",
                 &Method::new(&b"GET"[..])
             ),
-            Ok(Route::Cluster {
-                id: "examplewildcard".to_string(),
-                h2: false
-            })
+            Ok(Route::Cluster("examplewildcard".to_string()))
         );
         assert_eq!(
             router.lookup(
@@ -944,17 +875,11 @@ mod tests {
                 "/helloAB/",
                 &Method::new(&b"GET"[..])
             ),
-            Ok(Route::Cluster {
-                id: "examplewildcard".to_string(),
-                h2: false
-            })
+            Ok(Route::Cluster("examplewildcard".to_string()))
         );
         assert_eq!(
             router.lookup("test1.example.com", "/helloAB/", &Method::new(&b"GET"[..])),
-            Ok(Route::Cluster {
-                id: "exampleregex".to_string(),
-                h2: false
-            })
+            Ok(Route::Cluster("exampleregex".to_string()))
         );
     }
 }

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -935,7 +935,7 @@ mod tests {
             ),
             Ok(Route::Cluster {
                 id: "examplewildcard".to_string(),
-                h2: true
+                h2: false
             })
         );
         assert_eq!(

--- a/lib/src/socket.rs
+++ b/lib/src/socket.rs
@@ -265,8 +265,8 @@ impl SocketHandler for FrontRustls {
             (size, SocketResult::Error)
         } else if is_closed {
             (size, SocketResult::Closed)
-        // } else if !can_read {
-        //     (size, SocketResult::WouldBlock)
+        } else if !can_read {
+            (size, SocketResult::WouldBlock)
         } else {
             (size, SocketResult::Continue)
         }

--- a/lib/src/socket.rs
+++ b/lib/src/socket.rs
@@ -265,8 +265,8 @@ impl SocketHandler for FrontRustls {
             (size, SocketResult::Error)
         } else if is_closed {
             (size, SocketResult::Closed)
-        } else if !can_read {
-            (size, SocketResult::WouldBlock)
+        // } else if !can_read {
+        //     (size, SocketResult::WouldBlock)
         } else {
             (size, SocketResult::Continue)
         }

--- a/lib/src/socket.rs
+++ b/lib/src/socket.rs
@@ -194,6 +194,31 @@ impl SocketHandler for FrontRustls {
                 incr!("rustls.read.infinite_loop.error");
             }
 
+            while !self.session.wants_read() {
+                match self.session.reader().read(&mut buf[size..]) {
+                    Ok(0) => break,
+                    Ok(sz) => {
+                        size += sz;
+                    }
+                    Err(e) => match e.kind() {
+                        ErrorKind::WouldBlock => {
+                            break;
+                        }
+                        ErrorKind::ConnectionReset
+                        | ErrorKind::ConnectionAborted
+                        | ErrorKind::BrokenPipe => {
+                            is_closed = true;
+                            break;
+                        }
+                        _ => {
+                            error!("could not read data from TLS stream: {:?}", e);
+                            is_error = true;
+                            break;
+                        }
+                    },
+                }
+            }
+
             if size == buf.len() {
                 break;
             }
@@ -233,31 +258,6 @@ impl SocketHandler for FrontRustls {
                 error!("could not process read TLS packets: {:?}", e);
                 is_error = true;
                 break;
-            }
-
-            while !self.session.wants_read() {
-                match self.session.reader().read(&mut buf[size..]) {
-                    Ok(0) => break,
-                    Ok(sz) => {
-                        size += sz;
-                    }
-                    Err(e) => match e.kind() {
-                        ErrorKind::WouldBlock => {
-                            break;
-                        }
-                        ErrorKind::ConnectionReset
-                        | ErrorKind::ConnectionAborted
-                        | ErrorKind::BrokenPipe => {
-                            is_closed = true;
-                            break;
-                        }
-                        _ => {
-                            error!("could not read data from TLS stream: {:?}", e);
-                            is_error = true;
-                            break;
-                        }
-                    },
-                }
             }
         }
 

--- a/lib/src/socket.rs
+++ b/lib/src/socket.rs
@@ -198,7 +198,7 @@ impl SocketHandler for FrontRustls {
                 break;
             }
 
-            if !can_read | is_error | is_closed {
+            if !can_read || is_error || is_closed {
                 break;
             }
 

--- a/lib/src/socket.rs
+++ b/lib/src/socket.rs
@@ -173,6 +173,12 @@ pub struct FrontRustls {
     pub session: ServerConnection,
 }
 
+impl std::fmt::Debug for FrontRustls {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("FrontRustls")
+    }
+}
+
 impl SocketHandler for FrontRustls {
     fn socket_read(&mut self, buf: &mut [u8]) -> (usize, SocketResult) {
         let mut size = 0usize;

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -224,7 +224,7 @@ impl TcpSession {
             backend_address: None,
             protocol: "TCP",
             endpoint: EndpointRecord::Tcp,
-            tags: listener.get_tags(&listener.get_addr().to_string()),
+            tags: listener.get_tags(&listener.address().to_string()),
             client_rtt: socket_rtt(self.state.front_socket()),
             server_rtt: None,
             user_agent: None,
@@ -1099,8 +1099,20 @@ pub struct TcpListener {
 }
 
 impl ListenerHandler for TcpListener {
-    fn get_addr(&self) -> &SocketAddr {
+    fn protocol(&self) -> Protocol {
+        Protocol::TCP
+    }
+
+    fn address(&self) -> &SocketAddr {
         &self.address
+    }
+
+    fn public_address(&self) -> SocketAddr {
+        self.config
+            .public_address
+            .as_ref()
+            .map(|addr| addr.clone().into())
+            .unwrap_or(self.address.clone())
     }
 
     fn get_tags(&self, key: &str) -> Option<&CachedTags> {

--- a/os-build/archlinux/PKGBUILD
+++ b/os-build/archlinux/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Jan-Erik Rediger <badboy at archlinux dot us>
 
 pkgname=sozu-git
-pkgver=1.0.6
+pkgver=1.1.0-rc.0
 pkgrel=1
 pkgdesc="HTTP reverse proxy, configurable at runtime, fast and safe, built in Rust"
 arch=('i686' 'x86_64')

--- a/os-build/archlinux/PKGBUILD
+++ b/os-build/archlinux/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Jan-Erik Rediger <badboy at archlinux dot us>
 
 pkgname=sozu-git
-pkgver=1.1.0-rc.0
+pkgver=1.1.0-rc.1
 pkgrel=1
 pkgdesc="HTTP reverse proxy, configurable at runtime, fast and safe, built in Rust"
 arch=('i686' 'x86_64')

--- a/os-build/archlinux/PKGBUILD
+++ b/os-build/archlinux/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Jan-Erik Rediger <badboy at archlinux dot us>
 
 pkgname=sozu-git
-pkgver=1.1.0-rc.1
+pkgver=1.1.0-rc.2
 pkgrel=1
 pkgdesc="HTTP reverse proxy, configurable at runtime, fast and safe, built in Rust"
 arch=('i686' 'x86_64')

--- a/os-build/linux-rpm/sozu.spec
+++ b/os-build/linux-rpm/sozu.spec
@@ -6,7 +6,7 @@
 
 Summary:	A lightweight, fast, always-up reverse proxy server.
 Name:		sozu
-Version:	1.1.0-rc.1
+Version:	1.1.0-rc.2
 Release:	1%{?dist}
 Epoch:		1
 License:	AGPL-3.0

--- a/os-build/linux-rpm/sozu.spec
+++ b/os-build/linux-rpm/sozu.spec
@@ -6,7 +6,7 @@
 
 Summary:	A lightweight, fast, always-up reverse proxy server.
 Name:		sozu
-Version:	1.0.6
+Version:	1.1.0-rc.0
 Release:	1%{?dist}
 Epoch:		1
 License:	AGPL-3.0

--- a/os-build/linux-rpm/sozu.spec
+++ b/os-build/linux-rpm/sozu.spec
@@ -6,7 +6,7 @@
 
 Summary:	A lightweight, fast, always-up reverse proxy server.
 Name:		sozu
-Version:	1.1.0-rc.0
+Version:	1.1.0-rc.1
 Release:	1%{?dist}
 Epoch:		1
 License:	AGPL-3.0


### PR DESCRIPTION
In an effort to bring HTTP2 support into Sozu, we introduce Mux.
Mux is a SessionState that replaces the current kawa_h1 HTTP State.
Mux is able to handle HTTP1 and HTTP2 clients and backends as well as multiple backend connections.
Mux operates on the level of kawa streams, separating the protocol details in self-contained units, and can seamlessly translate between HTTP1 and HTTP2.