### PR TITLE
fix ListFrontends command

### DIFF
--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -180,7 +180,10 @@ pub enum SubCmd {
         #[clap(subcommand)]
         cmd: ConfigCmd,
     },
-    #[clap(name = "events", about = "receive sozu events about the status of backends")]
+    #[clap(
+        name = "events",
+        about = "receive sozu events about the status of backends"
+    )]
     Events,
 }
 

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -121,6 +121,9 @@ impl Server {
                 })
                 .into(),
             ),
+            RequestType::ListFrontends(filters) => {
+                Some(ContentType::FrontendList(self.state.list_frontends(filters)).into())
+            }
             _ => None,
         }
     }


### PR DESCRIPTION
This command was omitted when refactoring the main process event loop, and would yield:

```
sozu -c sozu.toml frontend list

Logs will be sent to stdout
Access logs will be sent to Some("stdout")
2024-08-01T07:48:10.897998Z 1722498490897998395 9733 DEBUG CTL	sozu::ctl	applying timeout 15s
2024-08-01T07:48:10.898016Z 1722498490898016569 9733 DEBUG CTL	sozu::ctl	Executing command Frontend { cmd: List { http: false, https: false, tcp: false, domain: None } }
2024-08-01T07:48:10.898024Z 1722498490898024284 9733 DEBUG CTL	sozu::ctl::request_builder	Listing frontends

Request failed: main process could not list frontends
```

This PR adds the missing lines when dispatching a command on the main process.

Now the result is as awaited:

```
sozu -c sozu.toml frontend list                                                                                                                                                                                                                                                               09:50
Logs will be sent to stdout
Access logs will be sent to Some("stdout")
2024-08-01T07:50:53.037670Z 1722498653037670688 17130 DEBUG CTL	sozu::ctl	applying timeout 15s
2024-08-01T07:50:53.037685Z 1722498653037685386 17130 DEBUG CTL	sozu::ctl	Executing command Frontend { cmd: List { http: false, https: false, tcp: false, domain: None } }
2024-08-01T07:50:53.037693Z 1722498653037693872 17130 DEBUG CTL	sozu::ctl::request_builder	Listing frontends
Success: Successfully listed frontends
┌─────────────────┬──────────────┬───────────┬──────────────────────────────────────────────┬────────┬──────────┬───────────────────┐
│ HTTP frontends  │              │           │                                              │        │          │                   │
├─────────────────┼──────────────┼───────────┼──────────────────────────────────────────────┼────────┼──────────┼───────────────────┤
│ cluster_id      │ address      │ hostname  │ path                                         │ method │ position │ tags              │
├─────────────────┼──────────────┼───────────┼──────────────────────────────────────────────┼────────┼──────────┼───────────────────┤
│ MyCluster       │ 0.0.0.0:1080 │ localhost │ PathRule { kind: Prefix, value: "" }         │ None   │ 0        │ owner-id=emmanuel │
├─────────────────┼──────────────┼───────────┼──────────────────────────────────────────────┼────────┼──────────┼───────────────────┤
│ MyCluster       │ 0.0.0.0:1080 │ localhost │ PathRule { kind: Prefix, value: "/api" }     │ None   │ 0        │ owner-id=emmanuel │
├─────────────────┼──────────────┼───────────┼──────────────────────────────────────────────┼────────┼──────────┼───────────────────┤
│ MyCluster       │ 0.0.0.0:1080 │ localhost │ PathRule { kind: Prefix, value: "/latency" } │ None   │ 0        │ owner-id=emmanuel │
└─────────────────┴──────────────┴───────────┴──────────────────────────────────────────────┴────────┴──────────┴───────────────────┘
```