### PR TITLE
Fix worker soft lock

### DIFF
--- a/lib/src/protocol/pipe.rs
+++ b/lib/src/protocol/pipe.rs
@@ -513,6 +513,8 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
                 if self.frontend_buffer.available_data() == 0 {
                     self.frontend_readiness.interest.insert(Ready::READABLE);
                     self.backend_readiness.interest.remove(Ready::WRITABLE);
+                    count!("back_bytes_out", sz as i64);
+                    metrics.backend_bout += sz;
                     return SessionResult::Continue;
                 }
 
@@ -531,6 +533,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             }
         }
 
+        count!("back_bytes_out", sz as i64);
         metrics.backend_bout += sz;
 
         if !self.check_connections() {

--- a/lib/src/socket.rs
+++ b/lib/src/socket.rs
@@ -287,9 +287,7 @@ impl SocketHandler for FrontRustls {
             }
 
             match self.session.writer().write(&buf[buffered_size..]) {
-                Ok(0) => {
-                    break;
-                }
+                Ok(0) => {} // zero byte written means that the Rustls buffers are full, we will try to write on the socket and try again
                 Ok(sz) => {
                     buffered_size += sz;
                 }
@@ -363,7 +361,7 @@ impl SocketHandler for FrontRustls {
         let mut is_closed = false;
 
         match self.session.writer().write_vectored(bufs) {
-            Ok(0) => {}
+            Ok(0) => {} // zero byte written means that the Rustls buffers are full, we will try to write on the socket and try again
             Ok(sz) => {
                 buffered_size += sz;
             }


### PR DESCRIPTION
Fix for #1132 
In case Rustls buffers were full (default max capacity is 64kb), which can happen if the client connection is slow compared to the rate of response from the backend, an early break prevented the session from flushing these buffers on the socket, thus remaining full. An external loop kept retrying indefinitely until we killed the worker or the client closed the socket.