### PR TITLE
Elide allocation and formating of opt-out logs

### DIFF
--- a/command/src/logging/logs.rs
+++ b/command/src/logging/logs.rs
@@ -572,13 +572,16 @@ pub fn parse_logging_spec(spec: &str) -> (Vec<LogDirective>, Vec<LogSpecParseErr
                         // treat that as a global fallback
                         match part0.parse() {
                             Ok(num) => (num, None),
-                            Err(_) => (LogLevelFilter::max(), Some(part0)),
+                            Err(_) => {
+                                errors.push(LogSpecParseError::InvalidLogLevel(s.to_string()));
+                                (LogLevelFilter::max(), None)
+                            }
                         }
                     }
                     (Some(part0), Some(""), None) => (LogLevelFilter::max(), Some(part0)),
                     (Some(part0), Some(part1), None) => match part1.parse() {
                         Ok(num) => (num, Some(part0)),
-                        _ => {
+                        Err(_) => {
                             errors.push(LogSpecParseError::InvalidLogLevel(s.to_string()));
                             continue;
                         }
@@ -945,7 +948,7 @@ macro_rules! debug {
         #[cfg(any(debug_assertions, feature = "logs-debug", feature = "logs-trace"))]
         $crate::_log!($crate::logging::LogLevel::Debug, concat!("{}\t", $format), module_path!() $(, $args)*);
         #[cfg(not(any(debug_assertions, feature = "logs-trace")))]
-        {$( let _ = $args; )*}
+        if false {$( let _ = $args; )*}
     }};
 }
 
@@ -956,7 +959,7 @@ macro_rules! trace {
         #[cfg(any(debug_assertions, feature = "logs-trace"))]
         $crate::_log!($crate::logging::LogLevel::Trace, concat!("{}\t", $format), module_path!() $(, $args)*);
         #[cfg(not(any(debug_assertions, feature = "logs-trace")))]
-        {$( let _ = $args; )*}
+        if false {$( let _ = $args; )*}
     }};
 }
 


### PR DESCRIPTION
Compiling Sozu with features `logs-trace` and `logs-debug` increased performance by up to 30%. The default behavior of Sozu to remove debugs and traces made it *slower*.

Recently most logs have been restructured and contain a `format!` as argument. It turns out that `format!` isn't omitted by the compiler even if its result is dropped. So this code triggers an allocation and formatting:
```rs
let _arg0 = format!(...);
```
To force the deletion, disabling a log now generates:
```rs
if false { let _arg0 = format!(...); }
```
which should always be optimized out by the compiler.

> note: after analysis of the call graphs it is clear that the compiler is powerful enough to elide the allocation of a `write_fmt(format!(...))`, causing no performance hit despite the numerous format macros in the new logs. However, we probably should rewrite them to explicitly avoid the allocation and not rely too much on the compiler implementation.