### PR TITLE
Refine granularity of 400 and 502 error diagnostics

### DIFF
--- a/lib/src/protocol/kawa_h1/answers.rs
+++ b/lib/src/protocol/kawa_h1/answers.rs
@@ -341,7 +341,7 @@ pub struct HttpAnswers {
 //   border-radius: 5px;
 // }
 // </style>";
-// const FOOTER: &str = "<footer>This is an automatic answer by Sozu.</footer>";
+// const FOOTER: &str = "<footer>This is an automatic answer by Sōzu.</footer>";
 fn default_301() -> String {
     String::from(
         "\
@@ -363,19 +363,43 @@ Connection: close\r
 %Content-Length: %CONTENT_LENGTH\r
 Sozu-Id: %REQUEST_ID\r
 \r
+<html><head><meta charset='utf-8'><head><body>
 <style>pre{background:#EEE;padding:10px;border:1px solid #AAA;border-radius: 5px;}</style>
 <h1>400 Bad Request</h1>
 <pre>
 {
+    \"status_code\": 400,
     \"route\": \"%ROUTE\",
     \"request_id\": \"%REQUEST_ID\",
+    \"parsing_phase\": \"%PHASE\",
+    \"successfully_parsed\": %SUCCESSFULLY_PARSED,
+    \"partially_parsed\": %PARTIALLY_PARSED,
+    \"invalid\": %INVALID
 }
 </pre>
-<p>Request could not be parsed. Parser stopped at phase: %PHASE.</p>
-<p>Diagnostic: %MESSAGE</p>
-<p>Further details:</p>
-<pre>%DETAILS</pre>
-<footer>This is an automatic answer by Sozu.</footer>",
+<p>Request could not be parsed. %MESSAGE</p>
+<div id=details hidden=true>
+<p>While parsing %PHASE, this was reported as invalid:</p>
+<pre>
+<span id=p1 style='background:rgba(0,255,0,0.2)'></span><span id=p2 style='background:rgba(255,255,0,0.2)'></span><span id=p3 style='background:rgba(255,0,0,0.2)'></span>
+</pre>
+</div>
+<script>
+function display(id, chunks) {
+    let [start, end] = chunks.split(' … ');
+    let dec = new TextDecoder('utf8');
+    let decode = chunk => dec.decode(new Uint8Array(chunk.split(' ').filter(e => e).map(e => parseInt(e, 16))));
+    document.getElementById(id).innerText = JSON.stringify(end ? `${decode(start)} […] ${decode(end)}` : `${decode(start)}`).slice(1,-1);
+}
+let p1 = %SUCCESSFULLY_PARSED;
+let p2 = %PARTIALLY_PARSED;
+let p3 = %INVALID;
+if (p1 !== null) {
+    document.getElementById('details').hidden=false;
+    display('p1', p1);display('p2', p2);display('p3', p3);
+}
+</script>
+<footer>This is an automatic answer by Sōzu.</footer></body></html>",
     )
 }
 
@@ -387,15 +411,17 @@ Cache-Control: no-cache\r
 Connection: close\r
 Sozu-Id: %REQUEST_ID\r
 \r
+<html><head><meta charset='utf-8'><head><body>
 <style>pre{background:#EEE;padding:10px;border:1px solid #AAA;border-radius: 5px;}</style>
 <h1>401 Unauthorized</h1>
 <pre>
 {
+    \"status_code\": 401,
     \"route\": \"%ROUTE\",
-    \"request_id\": \"%REQUEST_ID\",
+    \"request_id\": \"%REQUEST_ID\"
 }
 </pre>
-<footer>This is an automatic answer by Sozu.</footer>",
+<footer>This is an automatic answer by Sōzu.</footer></body></html>",
     )
 }
 
@@ -407,15 +433,17 @@ Cache-Control: no-cache\r
 Connection: close\r
 Sozu-Id: %REQUEST_ID\r
 \r
+<html><head><meta charset='utf-8'><head><body>
 <style>pre{background:#EEE;padding:10px;border:1px solid #AAA;border-radius: 5px;}</style>
 <h1>404 Not Found</h1>
 <pre>
 {
+    \"status_code\": 404,
     \"route\": \"%ROUTE\",
-    \"request_id\": \"%REQUEST_ID\",
+    \"request_id\": \"%REQUEST_ID\"
 }
 </pre>
-<footer>This is an automatic answer by Sozu.</footer>",
+<footer>This is an automatic answer by Sōzu.</footer></body></html>",
     )
 }
 
@@ -427,16 +455,18 @@ Cache-Control: no-cache\r
 Connection: close\r
 Sozu-Id: %REQUEST_ID\r
 \r
+<html><head><meta charset='utf-8'><head><body>
 <style>pre{background:#EEE;padding:10px;border:1px solid #AAA;border-radius: 5px;}</style>
 <h1>408 Request Timeout</h1>
 <pre>
 {
+    \"status_code\": 408,
     \"route\": \"%ROUTE\",
-    \"request_id\": \"%REQUEST_ID\",
+    \"request_id\": \"%REQUEST_ID\"
 }
 </pre>
 <p>Request timed out after %DURATION.</p>
-<footer>This is an automatic answer by Sozu.</footer>",
+<footer>This is an automatic answer by Sōzu.</footer></body></html>",
     )
 }
 
@@ -449,17 +479,18 @@ Connection: close\r
 %Content-Length: %CONTENT_LENGTH\r
 Sozu-Id: %REQUEST_ID\r
 \r
+<html><head><meta charset='utf-8'><head><body>
 <style>pre{background:#EEE;padding:10px;border:1px solid #AAA;border-radius: 5px;}</style>
 <h1>413 Payload Too Large</h1>
 <pre>
 {
+    \"status_code\": 413,
     \"route\": \"%ROUTE\",
-    \"request_id\": \"%REQUEST_ID\",
+    \"request_id\": \"%REQUEST_ID\"
 }
 </pre>
-<p>Request needed more than %CAPACITY bytes to fit. Parser stopped at phase: %PHASE.</p>
-<p>Diagnostic: %MESSAGE</p>
-<footer>This is an automatic answer by Sozu.</footer>",
+<p>Request needed more than %CAPACITY bytes to fit. Parser stopped at phase: %PHASE. %MESSAGE</p>
+<footer>This is an automatic answer by Sōzu.</footer></body></html>",
     )
 }
 
@@ -472,21 +503,45 @@ Connection: close\r
 %Content-Length: %CONTENT_LENGTH\r
 Sozu-Id: %REQUEST_ID\r
 \r
+<html><head><meta charset='utf-8'><head><body>
 <style>pre{background:#EEE;padding:10px;border:1px solid #AAA;border-radius: 5px;}</style>
 <h1>502 Bad Gateway</h1>
 <pre>
 {
+    \"status_code\": 502,
     \"route\": \"%ROUTE\",
     \"request_id\": \"%REQUEST_ID\",
     \"cluster_id\": \"%CLUSTER_ID\",
     \"backend_id\": \"%BACKEND_ID\",
+    \"parsing_phase\": \"%PHASE\",
+    \"successfully_parsed\": \"%SUCCESSFULLY_PARSED\",
+    \"partially_parsed\": \"%PARTIALLY_PARSED\",
+    \"invalid\": \"%INVALID\"
 }
 </pre>
-<p>Response could not be parsed. Parser stopped at phase: %PHASE.</p>
-<p>Diagnostic: %MESSAGE</p>
-<p>Further details:</p>
-<pre>%DETAILS</pre>
-<footer>This is an automatic answer by Sozu.</footer>",
+<p>Response could not be parsed. %MESSAGE</p>
+<div id=details hidden=true>
+<p>While parsing %PHASE, this was reported as invalid:</p>
+<pre>
+<span id=p1 style='background:rgba(0,255,0,0.2)'></span><span id=p2 style='background:rgba(255,255,0,0.2)'></span><span id=p3 style='background:rgba(255,0,0,0.2)'></span>
+</pre>
+</div>
+<script>
+function display(id, chunks) {
+    let [start, end] = chunks.split(' … ');
+    let dec = new TextDecoder('utf8');
+    let decode = chunk => dec.decode(new Uint8Array(chunk.split(' ').filter(e => e).map(e => parseInt(e, 16))));
+    document.getElementById(id).innerText = JSON.stringify(end ? `${decode(start)} […] ${decode(end)}` : `${decode(start)}`).slice(1,-1);
+}
+let p1 = %SUCCESSFULLY_PARSED;
+let p2 = %PARTIALLY_PARSED;
+let p3 = %INVALID;
+if (p1 !== null) {
+    document.getElementById('details').hidden=false;
+    display('p1', p1);display('p2', p2);display('p3', p3);
+}
+</script>
+<footer>This is an automatic answer by Sōzu.</footer></body></html>",
     )
 }
 
@@ -499,18 +554,20 @@ Connection: close\r
 %Content-Length: %CONTENT_LENGTH\r
 Sozu-Id: %REQUEST_ID\r
 \r
+<html><head><meta charset='utf-8'><head><body>
 <style>pre{background:#EEE;padding:10px;border:1px solid #AAA;border-radius: 5px;}</style>
 <h1>503 Service Unavailable</h1>
 <pre>
 {
+    \"status_code\": 503,
     \"route\": \"%ROUTE\",
     \"request_id\": \"%REQUEST_ID\",
     \"cluster_id\": \"%CLUSTER_ID\",
-    \"backend_id\": \"%BACKEND_ID\",
+    \"backend_id\": \"%BACKEND_ID\"
 }
 </pre>
-<p>Diagnostic: %MESSAGE</p>
-<footer>This is an automatic answer by Sozu.</footer>",
+<p>%MESSAGE</p>
+<footer>This is an automatic answer by Sōzu.</footer></body></html>",
     )
 }
 
@@ -522,18 +579,20 @@ Cache-Control: no-cache\r
 Connection: close\r
 Sozu-Id: %REQUEST_ID\r
 \r
+<html><head><meta charset='utf-8'><head><body>
 <style>pre{background:#EEE;padding:10px;border:1px solid #AAA;border-radius: 5px;}</style>
 <h1>504 Gateway Timeout</h1>
 <pre>
 {
+    \"status_code\": 504,
     \"route\": \"%ROUTE\",
     \"request_id\": \"%REQUEST_ID\",
     \"cluster_id\": \"%CLUSTER_ID\",
-    \"backend_id\": \"%BACKEND_ID\",
+    \"backend_id\": \"%BACKEND_ID\"
 }
 </pre>
 <p>Response timed out after %DURATION.</p>
-<footer>This is an automatic answer by Sozu.</footer>",
+<footer>This is an automatic answer by Sōzu.</footer></body></html>",
     )
 }
 
@@ -546,19 +605,20 @@ Connection: close\r
 %Content-Length: %CONTENT_LENGTH\r
 Sozu-Id: %REQUEST_ID\r
 \r
+<html><head><meta charset='utf-8'><head><body>
 <style>pre{background:#EEE;padding:10px;border:1px solid #AAA;border-radius: 5px;}</style>
 <h1>507 Insufficient Storage</h1>
 <pre>
 {
+    \"status_code\": 507,
     \"route\": \"%ROUTE\",
     \"request_id\": \"%REQUEST_ID\",
     \"cluster_id\": \"%CLUSTER_ID\",
-    \"backend_id\": \"%BACKEND_ID\",
+    \"backend_id\": \"%BACKEND_ID\"
 }
 </pre>
-<p>Response needed more than %CAPACITY bytes to fit. Parser stopped at phase: %PHASE.</p>
-<p>Diagnostic: %MESSAGE/p>
-<footer>This is an automatic answer by Sozu.</footer>",
+<p>Response needed more than %CAPACITY bytes to fit. Parser stopped at phase: %PHASE. %MESSAGE/p>
+<footer>This is an automatic answer by Sōzu.</footer></body></html>",
     )
 }
 
@@ -641,11 +701,23 @@ impl HttpAnswers {
             valid_in_header: false,
             typ: ReplacementType::VariableOnce(0),
         };
-        let details = TemplateVariable {
-            name: "DETAILS",
+        let successfully_parsed = TemplateVariable {
+            name: "SUCCESSFULLY_PARSED",
             valid_in_body: true,
             valid_in_header: false,
-            typ: ReplacementType::VariableOnce(0),
+            typ: ReplacementType::Variable(0),
+        };
+        let partially_parsed = TemplateVariable {
+            name: "PARTIALLY_PARSED",
+            valid_in_body: true,
+            valid_in_header: false,
+            typ: ReplacementType::Variable(0),
+        };
+        let invalid = TemplateVariable {
+            name: "INVALID",
+            valid_in_body: true,
+            valid_in_header: false,
+            typ: ReplacementType::Variable(0),
         };
 
         match status {
@@ -657,7 +729,7 @@ impl HttpAnswers {
             400 => Template::new(
                 400,
                 answer,
-                &[length, route, request_id, message, phase, details],
+                &[length, route, request_id, message, phase, successfully_parsed, partially_parsed, invalid],
             ),
             401 => Template::new(
                 401,
@@ -682,7 +754,7 @@ impl HttpAnswers {
             502 => Template::new(
                 502,
                 answer,
-                &[length, route, request_id, cluster_id, backend_id, message, phase, details],
+                &[length, route, request_id, cluster_id, backend_id, message, phase, successfully_parsed, partially_parsed, invalid],
             ),
             503 => Template::new(
                 503,
@@ -806,10 +878,19 @@ impl HttpAnswers {
             DefaultAnswer::Answer400 {
                 message,
                 phase,
-                details,
+                successfully_parsed,
+                partially_parsed,
+                invalid,
             } => {
-                variables = vec![route.into(), request_id.into(), phase_to_vec(phase)];
-                variables_once = vec![message.into(), details.into()];
+                variables = vec![
+                    route.into(),
+                    request_id.into(),
+                    phase_to_vec(phase),
+                    successfully_parsed.into(),
+                    partially_parsed.into(),
+                    invalid.into(),
+                ];
+                variables_once = vec![message.into()];
                 &self.listener_answers.answer_400
             }
             DefaultAnswer::Answer401 {} => {
@@ -844,7 +925,9 @@ impl HttpAnswers {
             DefaultAnswer::Answer502 {
                 message,
                 phase,
-                details,
+                successfully_parsed,
+                partially_parsed,
+                invalid,
             } => {
                 variables = vec![
                     route.into(),
@@ -852,8 +935,11 @@ impl HttpAnswers {
                     cluster_id.unwrap_or_default().into(),
                     backend_id.unwrap_or_default().into(),
                     phase_to_vec(phase),
+                    successfully_parsed.into(),
+                    partially_parsed.into(),
+                    invalid.into(),
                 ];
-                variables_once = vec![message.into(), details.into()];
+                variables_once = vec![message.into()];
                 &self.listener_answers.answer_502
             }
             DefaultAnswer::Answer503 { message } => {

--- a/lib/src/protocol/kawa_h1/diagnostics.rs
+++ b/lib/src/protocol/kawa_h1/diagnostics.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use kawa::{Block, Pair, ParsingErrorKind, ParsingPhase, ParsingPhaseMarker};
+use kawa::{ParsingErrorKind, ParsingPhase, ParsingPhaseMarker};
 
 use super::GenericHttpStream;
 
@@ -10,29 +10,32 @@ const CHARSET: &str = "all characters are LATIN-1 (no UTF-8 allowed)";
 const CHARSET: &str = "all characters are UASCII (no UTF-8 allowed)";
 
 fn hex_dump(buffer: &[u8], window: usize, start: usize, end: usize) -> String {
-    let mut result = String::with_capacity(window * 4 * 2 + 10);
+    let mut result = String::with_capacity(window * 3 + 10);
+    result.push('\"');
     if end - start <= window {
         let slice = &buffer[start..end];
-        for c in slice {
-            let _ = write!(result, " {c:02x}");
+        for (i, c) in slice.iter().enumerate() {
+            let _ = write!(result, "{c:02x}");
+            if i < slice.len() - 1 {
+                result.push(' ');
+            }
         }
-        result.push_str(&" ".repeat((window + start - end) * 3 + 4));
-        result.push_str(&String::from_utf8_lossy(slice).escape_debug().to_string());
     } else {
-        let slice1 = &buffer[start..start + window - 1];
-        let slice2 = &buffer[end - window + 1..end];
+        let half = window / 2;
+        let slice1 = &buffer[start..start + half - 1];
+        let slice2 = &buffer[end - half + 1..end];
         for c in slice1 {
-            let _ = write!(result, " {c:02x}");
+            let _ = write!(result, "{c:02x} ");
         }
-        result.push_str(" ..    ");
-        result.push_str(&String::from_utf8_lossy(slice1).escape_debug().to_string());
-        result.push_str("..\n ..");
-        for c in slice2 {
-            let _ = write!(result, " {c:02x}");
+        result.push_str("… ");
+        for (i, c) in slice2.iter().enumerate() {
+            let _ = write!(result, "{c:02x}");
+            if i < slice2.len() - 1 {
+                result.push(' ');
+            }
         }
-        result.push_str("    ..");
-        result.push_str(&String::from_utf8_lossy(slice2).escape_debug().to_string());
     }
+    result.push('\"');
     result
 }
 
@@ -40,13 +43,13 @@ pub fn diagnostic_400_502(
     marker: ParsingPhaseMarker,
     kind: ParsingErrorKind,
     kawa: &GenericHttpStream,
-) -> (String, String) {
+) -> (String, String, String, String) {
     match kind {
         ParsingErrorKind::Consuming { index } => {
             let message = match marker {
                 ParsingPhaseMarker::StatusLine => {
                     format!(
-                        "The request line is invalid. Make sure it is well formated and {CHARSET}."
+                        "The status line is invalid. Make sure it is well formated and {CHARSET}."
                     )
                 }
                 ParsingPhaseMarker::Headers | ParsingPhaseMarker::Trailers => {
@@ -55,52 +58,29 @@ pub fn diagnostic_400_502(
                     } else {
                         "trailer"
                     };
-                    if let Some(Block::Header(Pair { key, .. })) = kawa.blocks.back() {
-                        format!(
-                            "A {marker} is invalid, make sure {CHARSET}. Last valid {marker} is: {:?}.",
-                            String::from_utf8_lossy(key.data(kawa.storage.buffer())),
-                        )
-                    } else {
-                        format!("The first {marker} is invalid, make sure {CHARSET}.")
-                    }
+                    format!("A {marker} is invalid, make sure {CHARSET}.")
                 }
                 ParsingPhaseMarker::Cookies => {
-                    if kawa.detached.jar.len() > 1 {
-                        let Pair { key, .. } = &kawa.detached.jar[kawa.detached.jar.len() - 2];
-                        format!(
-                            "A cookie is invalid, make sure {CHARSET}. Last valid cookie is: {:?}.",
-                            String::from_utf8_lossy(key.data(kawa.storage.buffer())),
-                        )
-                    } else {
-                        format!("The first cookie is invalid, make sure {CHARSET}.")
-                    }
+                    format!("A cookie is invalid, make sure {CHARSET}.")
                 }
                 ParsingPhaseMarker::Body
                 | ParsingPhaseMarker::Chunks
                 | ParsingPhaseMarker::Terminated
                 | ParsingPhaseMarker::Error => {
-                    format!("Parsing phase {marker:?} should not produce 400 error.")
+                    "The parser stopped in an unexpected phase.".into()
                 }
             };
             let buffer = kawa.storage.buffer();
-            let details = format!(
-                "\
-Parsed successfully:
-{}
-Partially parsed (valid):
-{}
-Invalid:
-{}",
-                hex_dump(buffer, 32, kawa.storage.start, kawa.storage.head),
-                hex_dump(buffer, 32, kawa.storage.head, index as usize),
-                hex_dump(buffer, 32, index as usize, kawa.storage.end),
-            );
-            (message, details)
+            let successfully_parsed = hex_dump(buffer, 32, kawa.storage.start, kawa.storage.head);
+            let partially_parsed = hex_dump(buffer, 32, kawa.storage.head, index as usize);
+            let invalid = hex_dump(buffer, 32, index as usize, kawa.storage.end);
+            (message, successfully_parsed, partially_parsed, invalid)
         }
         ParsingErrorKind::Processing { message } => (
-            "The request was successfully parsed but presents inconsistent or invalid values."
-                .into(),
-            message.to_owned(),
+            format!("The request is correctly structured but presents inconsistent or invalid values: {message}."),
+            "null".into(),
+            "null".into(),
+            "null".into(),
         ),
     }
 }
@@ -108,12 +88,11 @@ Invalid:
 pub fn diagnostic_413_507(parsing_phase: ParsingPhase) -> String {
     match parsing_phase {
         kawa::ParsingPhase::StatusLine => {
-            "Request line is too long. Note that an URL should not exceed 2083 characters."
-                .to_string()
+            "Status line is too long. Note that an URL should not exceed 2083 characters.".into()
         }
         kawa::ParsingPhase::Headers | kawa::ParsingPhase::Cookies { .. } => {
-            "Headers are too long. All headers should fit in a single buffer.".to_string()
+            "Headers are too long. All headers should fit in a single buffer.".into()
         }
-        phase => format!("Unexpected parsing phase: {phase:?}"),
+        _ => "The parser stopped in an unexpected phase.".into(),
     }
 }


### PR DESCRIPTION
Follow up to #1143 and #1150.
This splits the `DETAILS` variable of errors 400 and 502 into 3 hexadecimal buffers `SUCCESSFULLY_PARSED`, `PARTIALLY_PARSED`, and `INVALID`. This avoids any XSS attacks from this variable. The last valid header/trailer/cookie has also been removed from `MESSAGE`.
The new 400 and 502 use JavaScript to display the hexadecimal buffers as utf-8 (using the safe `innerText`) and hopefully help the client fix the problem:
![image](https://github.com/user-attachments/assets/8e9d55de-c45e-40da-8645-8999a7d1fd1c)