### PR TITLE
ci: rewritten the image building action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "fix"
+      include: "scope"
+    labels: []
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "fix"
+      include: "scope"
+    labels: []
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "fix"
+      include: "scope"
+    labels: []

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
             echo tag=$var >> ${GITHUB_OUTPUT}
           else
             echo arch=linux/amd64 >> ${GITHUB_OUTPUT}
-            echo tag=$var >> ${GITHUB_OUTPUT}
+            echo tag=dev >> ${GITHUB_OUTPUT}
           fi
       - uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,9 +126,9 @@ jobs:
           tags: |
             ghcr.io/sozu-proxy/sozu:${{ steps.config.outputs.tag }}
       - name: Scan image using Grype
-        id: grype
         uses: anchore/scan-action@v5
         with:
           image: ghcr.io/sozu-proxy/sozu:${{ steps.config.outputs.tag }}
           output-format: table
+          severity-cutoff: high
 ...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,6 @@ jobs:
   ghcr:
     name: Docker build and push to GitHub Container Registry
     runs-on: ubuntu-latest
-    if: ${{ !(startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main')) }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/login-action@v3
@@ -106,17 +105,30 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           platforms: linux/amd64,linux/arm64
+      - id: config
+        run: |
+          var="${{ github.ref_name }}"
+          if [[ "$var" == "main" || "$var" == v* ]]; then
+            # TODO: this won't build on arm64, need to fix kawa lib first
+            # echo arch=linux/amd64,linux/arm64 >> ${GITHUB_OUTPUT}
+            echo arch=linux/amd64 >> ${GITHUB_OUTPUT}
+            echo tag=$var >> ${GITHUB_OUTPUT}
+          else
+            echo arch=linux/amd64 >> ${GITHUB_OUTPUT}
+            echo tag=$var >> ${GITHUB_OUTPUT}
+          fi
       - uses: docker/build-push-action@v6
         with:
           builder: ${{ steps.buildx.outputs.name }}
-          platforms: linux/amd64,linux/arm64
-          push: true
+          platforms: ${{ steps.config.outputs.arch }}
+          push: ${{ startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main') }}
+          load: ${{ !(startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main')) }}
           tags: |
-            ghcr.io/${{ github.event.repository.owner.name }}/sozu:${{ github.ref_name }}
+            ghcr.io/sozu-proxy/sozu:${{ steps.config.outputs.tag }}
       - name: Scan image using Grype
         id: grype
         uses: anchore/scan-action@v5
         with:
-          image: ghcr.io/${{ github.event.repository.owner.name }}/sozu:${{ github.ref_name }}
+          image: ghcr.io/sozu-proxy/sozu:${{ steps.config.outputs.tag }}
           output-format: table
 ...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 ---
 name: CI
+
 on: [ push, pull_request ]
+
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   test:
     name: Test
@@ -36,6 +42,7 @@ jobs:
         with:
           command: test
           args: --verbose ${{ matrix.features }}
+
   doc:
     name: Build documentation
     runs-on: ubuntu-latest
@@ -55,6 +62,7 @@ jobs:
         with:
           command: doc
           args: --verbose
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
@@ -81,21 +89,34 @@ jobs:
         with:
           command: tarpaulin
           args: --coveralls $TOKEN
-  dockerhub:
-    name: Docker build and push to Docker Hub
+
+  ghcr:
+    name: Docker build and push to GitHub Container Registry
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: ${{ !(startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main')) }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: docker/setup-qemu-action@v1
-      - uses: docker/setup-buildx-action@v1
-      - uses: docker/login-action@v1
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: docker/build-push-action@v2
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-qemu-action@v3
+      - id: buildx
+        uses: docker/setup-buildx-action@v3
         with:
-          context: .
-          push: 'true'
-          tags: clevercloud/sozu:${{ github.sha }}
+          platforms: linux/amd64,linux/arm64
+      - uses: docker/build-push-action@v6
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.event.repository.owner.name }}/sozu:${{ github.ref_name }}
+      - name: Scan image using Grype
+        id: grype
+        uses: anchore/scan-action@v5
+        with:
+          image: ghcr.io/${{ github.event.repository.owner.name }}/sozu:${{ github.ref_name }}
+          output-format: table
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,17 @@
 FROM docker.io/library/rust:1.80-alpine AS builder
 
 # Update Alpine packages and install build dependencies
-RUN apk update && apk add --no-cache --virtual .build-dependencies \
-    musl-dev \
-    protobuf \
-    protobuf-dev
+RUN apk update && \
+    apk add --no-cache --virtual .build-dependencies \
+        musl-dev \
+        libgcc \
+        cmake \
+        build-base \
+        file \
+        protobuf \
+        protobuf-dev && \
+    apk add --no-cache \
+        llvm-libunwind
 
 # Copy the source code into the image
 COPY . /usr/src/sozu

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,47 @@
-ARG ALPINE_VERSION=edge
+# Stage 1: Build the application
+FROM docker.io/library/rust:1.80-alpine AS builder
 
-FROM alpine:$ALPINE_VERSION AS builder
-
+# Update Alpine packages and install build dependencies
 RUN apk update && apk add --no-cache --virtual .build-dependencies \
-  cargo \
-  cmake \
-  build-base \
-  file \
-  libgcc \
-  musl-dev \
-  protobuf \
-  protobuf-dev \
-  rust
+    musl-dev \
+    protobuf \
+    protobuf-dev
 
-RUN apk add --no-cache llvm-libunwind \
-  pkgconfig
-
+# Copy the source code into the image
 COPY . /usr/src/sozu
 WORKDIR /usr/src/sozu
 
+# Build the application in release mode with a frozen lockfile
 RUN cargo vendor --locked
 RUN cargo build --release --frozen
 
-FROM alpine:$ALPINE_VERSION AS bin
+# Stage 2: Create the runtime environment
+FROM docker.io/library/alpine:3.20 AS bin
 
+# Expose ports for the application
 EXPOSE 80
 EXPOSE 443
 
+# Define volumes for configuration and runtime state
 VOLUME /etc/sozu
 VOLUME /run/sozu
 
+# Create a directory for persistent state
 RUN mkdir -p /var/lib/sozu
 
+# Install runtime dependencies
 RUN apk update && apk add --no-cache \
   llvm-libunwind \
   libgcc \
   ca-certificates
 
+# Copy the built binary from the builder stage
 COPY --from=builder /usr/src/sozu/target/release/sozu /usr/local/bin/sozu
+
+# Copy the default configuration file
 COPY os-build/config.toml /etc/sozu/config.toml
 
+# Set the default entry point to the binary and provide default command
+# to start the application with a specific config
 ENTRYPOINT ["/usr/local/bin/sozu"]
 CMD ["start", "-c", "/etc/sozu/config.toml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG ALPINE_VERSION=edge
 
-FROM alpine:$ALPINE_VERSION as builder
+FROM alpine:$ALPINE_VERSION AS builder
 
 RUN apk update && apk add --no-cache --virtual .build-dependencies \
   cargo \
@@ -21,7 +21,7 @@ WORKDIR /usr/src/sozu
 RUN cargo vendor --locked
 RUN cargo build --release --frozen
 
-FROM alpine:$ALPINE_VERSION as bin
+FROM alpine:$ALPINE_VERSION AS bin
 
 EXPOSE 80
 EXPOSE 443
@@ -38,8 +38,6 @@ RUN apk update && apk add --no-cache \
 
 COPY --from=builder /usr/src/sozu/target/release/sozu /usr/local/bin/sozu
 COPY os-build/config.toml /etc/sozu/config.toml
-COPY lib/assets/404.html /etc/sozu/html/404.html
-COPY lib/assets/503.html /etc/sozu/html/503.html
 
 ENTRYPOINT ["/usr/local/bin/sozu"]
 CMD ["start", "-c", "/etc/sozu/config.toml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM alpine:$ALPINE_VERSION AS builder
 
 RUN apk update && apk add --no-cache --virtual .build-dependencies \
   cargo \
+  cmake \
   build-base \
   file \
   libgcc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,9 @@ RUN mkdir -p /var/lib/sozu
 
 # Install runtime dependencies
 RUN apk update && apk add --no-cache \
-  llvm-libunwind \
-  libgcc \
-  ca-certificates
+    llvm-libunwind \
+    libgcc \
+    ca-certificates
 
 # Copy the built binary from the builder stage
 COPY --from=builder /usr/src/sozu/target/release/sozu /usr/local/bin/sozu

--- a/doc/how_to_use.md
+++ b/doc/how_to_use.md
@@ -32,14 +32,11 @@ Check out the command line [documentation](./configure_cli.md) for more informat
 
 ## Run it with Docker
 
-The repository provides a multi-stage [Dockerfile][df] image based on `alpine:edge`.
+The repository provides a multi-stage [Dockerfile][df] image based on `alpine:3.20`.
 
 You can build the image by doing:
 
     docker build -t sozu .
-
-There's also the [clevercloud/sozu](https://hub.docker.com/r/clevercloud/sozu/) image
-following the master branch (outdated).
 
 Run it with the command:
 
@@ -54,10 +51,6 @@ docker run \
   -p 8443:443 \
   sozu
 ```
-
-To build an image with a specific version of Alpine:
-
-    docker build --build-arg ALPINE_VERSION=3.14 -t sozu:main-alpine-3.14 .
 
 ### Using a custom `config.toml` configuration file
 


### PR DESCRIPTION
I tried to add some fixes to the CI, so the docker image is built and published (now to [GHCR](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)) correctly. This can be easily changed in the future, if GHCR does not meet the expectations.

The action should work as is, as it's mostly copy-pasted from my other project.