### PR TITLE
Fix TLS close initiated by Sozu

### DIFF
--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -305,6 +305,8 @@ impl ProxySession for HttpSession {
         }
 
         self.state.cancel_timeouts();
+        // defer backend closing to the state
+        self.state.close(self.proxy.clone(), &mut self.metrics);
 
         let front_socket = self.state.front_socket();
         if let Err(e) = front_socket.shutdown(Shutdown::Both) {
@@ -328,8 +330,6 @@ impl ProxySession for HttpSession {
         }
         proxy.remove_session(self.frontend_token);
 
-        // defer backend closing to the state
-        self.state.close(self.proxy.clone(), &mut self.metrics);
         self.has_been_closed = true;
     }
 

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -435,6 +435,9 @@ impl ProxySession for HttpsSession {
         }
 
         self.state.cancel_timeouts();
+        // defer backend closing to the state
+        // in case of https it should also send a close notify on the client before the socket is closed below
+        self.state.close(self.proxy.clone(), &mut self.metrics);
 
         let front_socket = self.state.front_socket();
         if let Err(e) = front_socket.shutdown(Shutdown::Both) {
@@ -458,8 +461,6 @@ impl ProxySession for HttpsSession {
         }
         proxy.remove_session(self.frontend_token);
 
-        // defer backend closing to the state
-        self.state.close(self.proxy.clone(), &mut self.metrics);
         self.has_been_closed = true;
     }
 

--- a/lib/src/socket.rs
+++ b/lib/src/socket.rs
@@ -52,6 +52,7 @@ pub trait SocketHandler {
     fn socket_wants_write(&self) -> bool {
         false
     }
+    fn socket_close(&mut self) {}
     fn socket_ref(&self) -> &TcpStream;
     fn socket_mut(&mut self) -> &mut TcpStream;
     fn protocol(&self) -> TransportProtocol;
@@ -428,6 +429,10 @@ impl SocketHandler for FrontRustls {
         } else {
             (buffered_size, SocketResult::Continue)
         }
+    }
+
+    fn socket_close(&mut self) {
+        self.session.send_close_notify();
     }
 
     fn socket_wants_write(&self) -> bool {


### PR DESCRIPTION
Sozu did not send a close notify packet upon closing a TLS connection.
The current solution is limited by the "vertical" design of Sozu but should work in most cases and with most clients.
This use case is an argument for a more "layer-based" approach.