### PR TITLE
fix: Resolve path when saving state

### DIFF
--- a/bin/src/ctl/mod.rs
+++ b/bin/src/ctl/mod.rs
@@ -55,6 +55,8 @@ pub enum CtlError {
     WrongResponse(Response),
     #[error("could not setup the logger: {0}")]
     SetupLogging(LogError),
+    #[error("could not resolve path for {0} : {1}")]
+    ResolvePath(String, std::io::Error),
 }
 
 pub struct CommandManager {

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -30,7 +30,13 @@ impl CommandManager {
     pub fn save_state(&mut self, path: String) -> Result<(), CtlError> {
         debug!("Saving the state to file {}", path);
 
-        self.send_request(RequestType::SaveState(path).into())
+        let current_directory =
+            std::env::current_dir().map_err(|err| CtlError::ResolvePath(path.to_owned(), err))?;
+
+        let absolute_path = current_directory.join(&path);
+        self.send_request(
+            RequestType::SaveState(String::from(absolute_path.to_string_lossy())).into(),
+        )
     }
 
     pub fn load_state(&mut self, path: String) -> Result<(), CtlError> {


### PR DESCRIPTION
- Resolve absolute path from the cli
- Default to sozu working directory if a relative path is provided to sozu