### PR TITLE
rust 1.82 compatability, mark extern block as unsafe

### DIFF
--- a/bin/src/util.rs
+++ b/bin/src/util.rs
@@ -168,7 +168,7 @@ pub unsafe fn get_executable_path() -> Result<String, UtilError> {
 }
 
 #[cfg(target_os = "macos")]
-extern "C" {
+unsafe extern "C" {
     pub fn _NSGetExecutablePath(buf: *mut libc::c_char, size: *mut u32) -> i32;
 }
 


### PR DESCRIPTION
Unable to build without this change, see: https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-extern.html