### PR TITLE
feat: add per-status-code HTTP metrics and buffer pool gauges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@
 
 See milestone [`v1.1.0`](https://github.com/sozu-proxy/sozu/projects/3?card_filter_query=milestone%3Av1.1.0)
 
+### Added
+
+- **Per-status-code HTTP counters across H1 and H2 ([#1196](https://github.com/sozu-proxy/sozu/pull/1196))**: in addition to the bucket counters `http.status.{1xx,…,5xx,other,none}`, Sōzu now emits `http.status.<code>` for an eighteen-code short-list — `200/201/204`, `301/302/304`, `400/401/403/404/408/413/429`, `500/502/503/504/507`. The list covers Sōzu's default-answer codes and the upstream codes operators routinely chart. Codes outside the list contribute only to their bucket so the metric keyspace stays bounded. The lookup lives in `lib/src/metrics/mod.rs::http_status_code_metric_name` and is shared by H1 (`save_http_status_metric`) and H2 (`mux::stream::generate_access_log`). Closes [#937](https://github.com/sozu-proxy/sozu/issues/937), [#1146](https://github.com/sozu-proxy/sozu/issues/1146).
+- **Buffer pool gauges ([#1196](https://github.com/sozu-proxy/sozu/pull/1196))**: the run loop now samples `buffer.in_use` (renamed from `buffer.number`), `buffer.capacity`, and `buffer.usage_percent` once per iteration alongside `process.uptime_seconds` / `server.live`. `buffer.in_use` is still emitted on checkout/drop in `lib/src/pool.rs` for high-resolution dashboards.
+- **Slab utilisation gauges ([#1196](https://github.com/sozu-proxy/sozu/pull/1196))**: `slab.capacity`, `slab.usage_percent` (against `slab.capacity()`), and `slab.accept_threshold_percent` (against the historical `at_capacity()` gate `10 + 2 * max_connections`). The two percent gauges are kept independent because `slab_entries_per_connection` can make configured slab capacity larger than the accept gate, and operators want to chart both frontiers.
+
+### Changed (potentially dashboard-breaking)
+
+- **Renamed metrics ([#1196](https://github.com/sozu-proxy/sozu/pull/1196))**:
+  - `client.connections_percentage` → `client.connections_percent`
+  - `client.max_connections` → `client.connections_max`
+  - `buffer.number` → `buffer.in_use`
+
+  The new names are emitted from the run loop alongside the rest of the
+  proxy gauges; per-event emission of `client.connections_*` from
+  `SessionManager::incr/decr` is dropped (the high-resolution
+  `client.connections` signal is preserved). Dashboards scraping the old
+  names need to be updated.
+
+- **`http.errors` is now labelled with `(cluster_id, backend_id)` ([#1196](https://github.com/sozu-proxy/sozu/pull/1196))**: emitted with labels in both `kawa_h1::log_request_error` and `mux::stream::generate_access_log`. The labels are filtered centrally by `metrics.detail` (`metrics/mod.rs::filter_labels_for_detail`): `process` / `frontend` collapse to a proxy-wide counter (no behaviour change for default deployments that already used `process`), `cluster` (the documented default) attributes errors per cluster, `backend` keeps the per-backend split. No double-counting: the prior unlabeled emission was replaced, not duplicated. Closes [#597](https://github.com/sozu-proxy/sozu/issues/597).
+
 ### Security
 
 - **Worker panic on short hostnames vs `Wildcard` rules ([#1223](https://github.com/sozu-proxy/sozu/issues/1223))**: `DomainRule::Wildcard::matches` in `lib/src/router/mod.rs` computed `hostname.len() - s.len() + 1` unconditionally, panicking with `attempt to subtract with overflow` in debug builds when the incoming hostname was shorter than the configured wildcard pattern (CWE-191 → CWE-754, remote-reachable DoS). In release builds the wrap is masked by the `&&` short-circuit on `ends_with(suffix)`, so the false-positive in §1 of the issue was rare; debug builds always panicked. The arm now uses `<[u8]>::strip_suffix` and validates the leftmost prefix on the returned slice — there is no length arithmetic to underflow, and short hostnames return `false` without panic. Boundary case `hostname == suffix` (empty leftmost label, e.g. `.foo.example.com` against `*.foo.example.com`) is now rejected as an invalid DNS label per RFC 1035 §3.1. Reachable from H1 (`HttpListener::frontend_from_request`, `lib/src/http.rs:658`), H2 (single-byte `:authority`, `lib/src/https.rs:865`), and operator-driven `Router::has_hostname` introspection. Affected versions: all releases including `sozu-lib` 1.1.1 and earlier (bug introduced in `a9dd46e9`, 2019-06-04). Regression tests `match_domain_rule_wildcard_short_hostname_does_not_panic` and `router_lookup_wildcard_pre_rule_short_hostname_does_not_panic` in `lib/src/router/mod.rs`.

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -927,12 +927,17 @@ from metric names below.
 | `configuration.backends` | gauge | proxy | Number of configured backend servers |
 | `configuration.frontends` | gauge | proxy | Number of configured frontends |
 | `client.connections` | gauge | proxy | Active frontend connections |
-| `client.connections_percentage` | gauge | proxy | Percentage of `max_connections` in use |
-| `client.max_connections` | gauge | proxy | Configured maximum connections |
+| `client.connections_max` | gauge | proxy | Configured `max_connections`. Renamed from `client.max_connections` |
+| `client.connections_percent` | gauge | proxy | Percentage of `max_connections` in use. Renamed from `client.connections_percentage` |
 | `slab.entries` | gauge | proxy | Session slab allocator slots used |
+| `slab.capacity` | gauge | proxy | Configured slab capacity (`10 + slab_entries_per_connection * max_connections`) |
+| `slab.usage_percent` | gauge | proxy | `slab.entries * 100 / slab.capacity`. Pure slab-utilisation gauge |
+| `slab.accept_threshold_percent` | gauge | proxy | `slab.entries * 100 / (10 + 2 * max_connections)`. Charts proximity to the `at_capacity()` accept gate, which can flip true while `slab.usage_percent` still shows headroom (configured slab is larger when `slab_entries_per_connection > 2`) |
 | `process.uptime_seconds` | gauge | proxy | Seconds since the worker started. Captured once in `Server::new`; never reset on hot upgrade (the new worker starts its own counter) |
 | `server.live` | gauge | proxy | `1` while the worker accepts traffic, `0` once a graceful shutdown is requested. Mirrors Envoy `server.live` semantics — L4 health checks (HAProxy / cloud LBs) can poll this gauge to drain a worker before the OS-level termination signal lands |
-| `buffer.number` | gauge | proxy | Buffers currently allocated from the buffer pool |
+| `buffer.in_use` | gauge | proxy | Buffers currently checked out of the buffer pool. Renamed from `buffer.number` |
+| `buffer.capacity` | gauge | proxy | Configured buffer pool capacity |
+| `buffer.usage_percent` | gauge | proxy | `buffer.in_use * 100 / buffer.capacity` |
 | `zombies` | counter | proxy | Zombie sessions detected and removed |
 
 #### Accept queue
@@ -992,7 +997,7 @@ transitions through phases (e.g., Expect → TLS Handshake → HTTPS → WSS).
 | `http.active_requests` | gauge | proxy | Currently in-flight requests |
 | `http.e2e.http11` | counter | proxy | Completed HTTP/1.1 request/response cycles |
 | `http.e2e.h2` | counter | proxy | Completed HTTP/2 request/response cycles |
-| `http.errors` | counter | proxy | General HTTP processing errors |
+| `http.errors` | counter | proxy, cluster, backend | General HTTP processing errors. Labels are filtered centrally per `metrics.detail`: `process` / `frontend` collapse to a proxy-wide counter, `cluster` (default) attributes per cluster, `backend` keeps the per-backend split |
 | `tcp.requests` | counter | proxy | TCP proxy connection requests |
 
 #### Byte counters
@@ -1020,7 +1025,12 @@ p99.9, p99.99, p99.999, p100) and sent as `|ms` values over StatsD.
 
 #### Response status classes
 
-Incremented per backend response (scope: cluster + backend for `1xx`–`5xx`):
+Incremented per backend response (scope: cluster + backend for `1xx`–`5xx`).
+Buckets are emitted for every response with a status; per-code counters
+below are emitted in addition to the bucket for the eighteen short-listed
+codes Sōzu either generates as a default answer or that operators routinely
+chart. Status codes outside that list contribute only to their bucket so
+the metric keyspace stays bounded.
 
 | Metric | Type | Scope | Description |
 |--------|------|-------|-------------|
@@ -1031,6 +1041,10 @@ Incremented per backend response (scope: cluster + backend for `1xx`–`5xx`):
 | `http.status.5xx` | counter | cluster, backend | 5xx server error responses |
 | `http.status.other` | counter | proxy | Non-standard status codes |
 | `http.status.none` | counter | proxy | Responses without a status code |
+| `http.status.200` / `201` / `204` | counter | cluster, backend | Common 2xx success codes (in addition to `http.status.2xx`) |
+| `http.status.301` / `302` / `304` | counter | cluster, backend | Common 3xx redirect/cache codes (in addition to `http.status.3xx`) |
+| `http.status.400` / `401` / `403` / `404` / `408` / `413` / `429` | counter | cluster, backend | Common 4xx client-error codes (in addition to `http.status.4xx`) |
+| `http.status.500` / `502` / `503` / `504` / `507` | counter | cluster, backend | Common 5xx server-error codes (in addition to `http.status.5xx`) |
 
 #### Default answer / error responses
 

--- a/doc/debugging_strategies.md
+++ b/doc/debugging_strategies.md
@@ -92,6 +92,11 @@ The following metrics track requests that are correctly sent to the backend serv
 * `sozu.http.status.3xx`: counts requests with 300 to 399 status
 * `sozu.http.status.4xx`: counts requests with 400 to 499 status
 * `sozu.http.status.5xx`: counts requests with 500 to 599 status
+* `sozu.http.status.<code>`: per-code counters for an eighteen-code short-list
+  (`200/201/204`, `301/302/304`, `400/401/403/404/408/413/429`,
+  `500/502/503/504/507`); see `doc/configure.md` for the full list. Codes
+  outside the list contribute only to their bucket so the metric keyspace
+  stays bounded.
 * `sozu.http.requests`: incremented at each request (sum of above counters)
 
 #### data transmitted
@@ -183,7 +188,7 @@ These metrics are closely linked to resource usage, which is tracked by the foll
 * `sozu.slab.entries`: number of slots used in the slab allocator. Typically, there's one slot per listener socket,
 one for the connection to the main process, one for the metrics socket, then one per frontend connection and
 one per backend connection. So the number of connections should always be close to (but lower than) the slab count.
-* `sozu.buffer.number`: number of buffers used in the buffer pool. Inactive sessions and requests for which we send
+* `sozu.buffer.in_use` (renamed from `sozu.buffer.number`): number of buffers used in the buffer pool. Inactive sessions and requests for which we send
 a default answer (400, 404, 413, 503 HTTP errors) do not use buffers. Active HTTP sessions use one buffer (except
 in pipelining mode), WebSocket sessions use two buffers. So the number of buffers should always be lower than the
 slab count, and lower than the number of connections.

--- a/doc/lifetime_of_a_session.md
+++ b/doc/lifetime_of_a_session.md
@@ -65,8 +65,11 @@ Every mio registration carries a `Token` (a `usize`). The
 maps each token back to the session that owns the registration. This
 slab is also the unit of bookkeeping that enforces `max_connections`
 (`lib/src/server.rs:188, 194`) and gauges
-`client.connections` / `client.connections_percentage` /
-`client.max_connections` (`lib/src/server.rs:223-228`).
+`client.connections`, `client.connections_max`,
+`client.connections_percent`, `slab.{entries,capacity,usage_percent,
+accept_threshold_percent}` and `buffer.{in_use,capacity,usage_percent}`,
+all sampled once per run-loop iteration in
+`Server::run` (`lib/src/server.rs`).
 
 A single session typically occupies *two* slab entries while it is
 forwarding traffic: one for the frontend token (registered when the
@@ -462,8 +465,11 @@ set to read a session's life from a dashboard:
   (`lib/src/protocol/rustls.rs:193, 254, 261, 328-345`).
 - `https.alpn.rejected.{unsupported,http11_disabled}` — ALPN refusal
   causes (`lib/src/https.rs:342, 359, 372`).
-- `client.connections{,_percentage}`, `client.max_connections` —
-  slab-backed lifecycle gauges (`lib/src/server.rs:223-228, 236-241`).
+- `client.connections`, `client.connections_max`,
+  `client.connections_percent` — slab-backed lifecycle gauges
+  (`client.connections` is sampled per increment/decrement in
+  `SessionManager::incr/decr`; `_max` and `_percent` are sampled in the
+  run loop alongside `slab.*` and `buffer.*`).
 - `accept_queue.backpressure`, `accept_queue.saturated_seconds` —
   binary backpressure + time-integrated saturation
   (`lib/src/server.rs:196, 207, 682-699`).

--- a/doc/observability.md
+++ b/doc/observability.md
@@ -54,7 +54,7 @@ Three properties shape every extension:
 | `incr!(key)` / `incr!(key, cluster_id, backend_id)` | `&'static str` | Increment by 1. The 3-arg form labels by cluster+backend. | `incr!("h2.frames.rx.data");` |
 | `count!(key, value)` | `&'static str, i64` | Increment by N (e.g. byte counts). | `count!("bytes_in", n as i64);` |
 | `decr!(key)` | `&'static str` | Decrement by 1. Pair with a prior `incr!`. | `decr!("http.active_requests");` |
-| `gauge!(key, value)` | `&'static str, usize` | **Absolute snapshot.** ⚠️ Last-writer-wins across emit sites — only safe for proxy-level state with a single emitter (e.g. `client.connections`). | `gauge!("client.max_connections", n);` |
+| `gauge!(key, value)` | `&'static str, usize` | **Absolute snapshot.** ⚠️ Last-writer-wins across emit sites — only safe for proxy-level state with a single emitter (e.g. `client.connections`). | `gauge!("client.connections_max", n);` |
 | `gauge_add!(key, delta)` / `gauge_add!(key, delta, cluster, backend)` | `&'static str, i64` | **Lifecycle delta.** Aggregates correctly across emit sites. Pair every `+1` with a `-1` on every close path. | `gauge_add!("backend.pool.size", 1);` |
 | `time!(key, ms)` / `time!(key, cluster_id, ms)` | `&'static str, usize` | Latency in ms. Stored as HDR histogram in the local drain. | `time!("backend_response_time", cluster, ms);` |
 

--- a/lib/src/metrics/local_drain.rs
+++ b/lib/src/metrics/local_drain.rs
@@ -720,23 +720,23 @@ mod tests {
 
     #[test]
     fn receive_and_yield_cluster_metrics() {
+        // Mirrors what `kawa_h1::log_request_error` and
+        // `mux::stream::generate_access_log` emit when `metrics.detail` is
+        // `cluster`: the dotted metric name `http.errors` aggregated under
+        // the cluster (with the backend label dropped centrally).
         let mut local_drain = LocalDrain::new("prefix".to_string());
-        local_drain.receive_metric(
-            "http_errors",
-            Some("test-cluster"),
-            None,
-            MetricValue::Count(1),
-        );
-        local_drain.receive_metric(
-            "http_errors",
-            Some("test-cluster"),
-            None,
-            MetricValue::Count(1),
-        );
+        for _ in 0..2 {
+            local_drain.receive_metric(
+                "http.errors",
+                Some("test-cluster"),
+                None,
+                MetricValue::Count(1),
+            );
+        }
 
         let mut map = BTreeMap::new();
         map.insert(
-            "http_errors".to_string(),
+            "http.errors".to_string(),
             FilteredMetrics {
                 inner: Some(Inner::Count(2)),
             },
@@ -747,10 +747,37 @@ mod tests {
         };
 
         let returned_cluster_metrics = local_drain
-            .metrics_of_one_cluster("test-cluster", ["http_errors".to_string()].as_ref())
+            .metrics_of_one_cluster("test-cluster", ["http.errors".to_string()].as_ref())
             .expect("could not query metrics for this cluster");
 
         assert_eq!(expected_cluster_metrics, returned_cluster_metrics);
+    }
+
+    #[test]
+    fn receive_and_yield_http_error_metrics_per_backend() {
+        // Same shape as the cluster-level test above, but with the backend
+        // label preserved (the `metrics.detail = "backend"` path).
+        let mut local_drain = LocalDrain::new("prefix".to_string());
+
+        for _ in 0..3 {
+            local_drain.receive_metric(
+                "http.errors",
+                Some("test-cluster"),
+                Some("test-backend"),
+                MetricValue::Count(1),
+            );
+        }
+
+        let backend_metrics = local_drain
+            .metrics_of_one_backend("test-backend", ["http.errors".to_string()].as_ref())
+            .expect("could not query metrics for this backend");
+
+        assert_eq!(
+            backend_metrics.metrics.get("http.errors"),
+            Some(&FilteredMetrics {
+                inner: Some(Inner::Count(3)),
+            })
+        );
     }
 
     #[test]

--- a/lib/src/metrics/local_drain.rs
+++ b/lib/src/metrics/local_drain.rs
@@ -935,4 +935,66 @@ mod tests {
             "gauge should be 0 after surviving clear + decrement"
         );
     }
+
+    #[test]
+    fn receive_and_yield_http_status_metrics() {
+        // Sanity check that per-code counters (`http.status.{200,…}`) and the
+        // bucket counter (`http.status.2xx`) are stored independently and
+        // retrievable per backend, mirroring what the H1 + H2 emission paths
+        // produce after `crate::metrics::http_status_code_metric_name` short-
+        // lists a code.
+        let mut local_drain = LocalDrain::new("prefix".to_string());
+
+        for _ in 0..2 {
+            local_drain.receive_metric(
+                "http.status.2xx",
+                Some("test-cluster"),
+                Some("test-backend"),
+                MetricValue::Count(1),
+            );
+            local_drain.receive_metric(
+                "http.status.200",
+                Some("test-cluster"),
+                Some("test-backend"),
+                MetricValue::Count(1),
+            );
+        }
+        local_drain.receive_metric(
+            "http.status.404",
+            Some("test-cluster"),
+            Some("test-backend"),
+            MetricValue::Count(1),
+        );
+
+        let backend_metrics = local_drain
+            .metrics_of_one_backend(
+                "test-backend",
+                [
+                    "http.status.2xx".to_string(),
+                    "http.status.200".to_string(),
+                    "http.status.404".to_string(),
+                ]
+                .as_ref(),
+            )
+            .expect("could not query metrics for this backend");
+
+        assert_eq!(
+            backend_metrics.metrics.get("http.status.2xx"),
+            Some(&FilteredMetrics {
+                inner: Some(Inner::Count(2)),
+            })
+        );
+        assert_eq!(
+            backend_metrics.metrics.get("http.status.200"),
+            Some(&FilteredMetrics {
+                inner: Some(Inner::Count(2)),
+            })
+        );
+        assert_eq!(
+            backend_metrics.metrics.get("http.status.404"),
+            Some(&FilteredMetrics {
+                inner: Some(Inner::Count(1)),
+            })
+        );
+    }
 }

--- a/lib/src/metrics/mod.rs
+++ b/lib/src/metrics/mod.rs
@@ -52,6 +52,42 @@ fn filter_labels_for_detail<'a>(
     }
 }
 
+/// Map a numeric HTTP status code to its dedicated counter name, if any.
+///
+/// Returns `Some("http.status.<code>")` for the eighteen status codes Sōzu
+/// either generates as a default answer or that operators routinely chart
+/// (`200/201/204`, `301/302/304`, `400/401/403/404/408/413/429`, plus the
+/// `5xx` family Sōzu can synthesise — `500/502/503/504/507`). All other
+/// codes return `None` so the bucket counter (`http.status.{1xx,…,other}`)
+/// remains the sole emission and metric cardinality stays bounded.
+///
+/// Hoisted out of the protocol modules so H1 (`kawa_h1::save_http_status_metric`)
+/// and H2 (`mux::stream::generate_access_log`) cannot drift on which codes
+/// get a per-code counter.
+pub(crate) fn http_status_code_metric_name(status: u16) -> Option<&'static str> {
+    match status {
+        200 => Some("http.status.200"),
+        201 => Some("http.status.201"),
+        204 => Some("http.status.204"),
+        301 => Some("http.status.301"),
+        302 => Some("http.status.302"),
+        304 => Some("http.status.304"),
+        400 => Some("http.status.400"),
+        401 => Some("http.status.401"),
+        403 => Some("http.status.403"),
+        404 => Some("http.status.404"),
+        408 => Some("http.status.408"),
+        413 => Some("http.status.413"),
+        429 => Some("http.status.429"),
+        500 => Some("http.status.500"),
+        502 => Some("http.status.502"),
+        503 => Some("http.status.503"),
+        504 => Some("http.status.504"),
+        507 => Some("http.status.507"),
+        _ => None,
+    }
+}
+
 thread_local! {
   pub static METRICS: RefCell<Aggregator> = RefCell::new(Aggregator::new(String::from("sozu")));
 }

--- a/lib/src/pool.rs
+++ b/lib/src/pool.rs
@@ -49,7 +49,7 @@ impl Pool {
             })
             .map(|c| {
                 let old_buffer_count = BUFFER_COUNT.fetch_add(1, Ordering::SeqCst);
-                gauge!("buffer.number", old_buffer_count + 1);
+                gauge!("buffer.in_use", old_buffer_count + 1);
                 Checkout { inner: c }
             })
     }
@@ -113,7 +113,7 @@ impl ops::DerefMut for Checkout {
 impl Drop for Checkout {
     fn drop(&mut self) {
         let old_buffer_count = BUFFER_COUNT.fetch_sub(1, Ordering::SeqCst);
-        gauge!("buffer.number", old_buffer_count - 1);
+        gauge!("buffer.in_use", old_buffer_count - 1);
     }
 }
 

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -2177,7 +2177,17 @@ fn handle_connection_result(
     }
 }
 
-/// Save the HTTP status code of the backend response
+/// Save the HTTP status code of the backend response.
+///
+/// Emits two counters per response with a known status:
+///
+/// 1. The bucket counter `http.status.{1xx,…,5xx,other}` (always),
+/// 2. A per-code counter `http.status.{200,301,…}` when the code is on the
+///    short-list maintained by [`crate::metrics::http_status_code_metric_name`].
+///
+/// Status-less responses still emit `http.status.none` upstream of this
+/// function (see `generate_access_log` for the H2 path); the H1 entry point
+/// only carries `Some(status)` so the `else` branch is unnecessary here.
 fn save_http_status_metric(status: Option<u16>, context: LogContext) {
     if let Some(status) = status {
         match status {
@@ -2200,6 +2210,10 @@ fn save_http_status_metric(status: Option<u16>, context: LogContext) {
                 // http responses with other codes (protocol error)
                 incr!("http.status.other");
             }
+        }
+
+        if let Some(per_code) = crate::metrics::http_status_code_metric_name(status) {
+            incr!(per_code, context.cluster_id, context.backend_id);
         }
     }
 }

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -1046,7 +1046,17 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         self.log_request(metrics, false, None);
     }
     pub fn log_request_error(&self, metrics: &mut SessionMetrics, message: &str) {
-        incr!("http.errors");
+        // Labelled with `(cluster_id, backend_id)` so per-cluster dashboards
+        // can attribute error rates. The labels are dropped centrally by
+        // `filter_labels_for_detail` (`metrics/mod.rs`) when
+        // `metrics.detail` is `process` / `frontend` / `cluster`, so default
+        // setups still see the same proxy-wide counter — no double-counting,
+        // no surprise cardinality.
+        incr!(
+            "http.errors",
+            self.context.cluster_id.as_deref(),
+            self.context.backend_id.as_deref()
+        );
         error!(
             "{} Could not process request properly got: {}",
             log_context!(self),

--- a/lib/src/protocol/mux/stream.rs
+++ b/lib/src/protocol/mux/stream.rs
@@ -220,8 +220,11 @@ impl Stream {
             }
         };
 
-        // Save the HTTP status code of the backend response
-        let key = if let Some(status) = context.status {
+        // Save the HTTP status code of the backend response. Emits the bucket
+        // counter unconditionally, plus the per-code counter from
+        // `crate::metrics::http_status_code_metric_name` when the status is on
+        // the short-list shared with the H1 path (`save_http_status_metric`).
+        let bucket_key = if let Some(status) = context.status {
             match status {
                 100..=199 => "http.status.1xx",
                 200..=299 => "http.status.2xx",
@@ -234,10 +237,20 @@ impl Stream {
             "http.status.none"
         };
         incr!(
-            key,
+            bucket_key,
             context.cluster_id.as_deref(),
             context.backend_id.as_deref()
         );
+
+        if let Some(status) = context.status {
+            if let Some(per_code) = crate::metrics::http_status_code_metric_name(status) {
+                incr!(
+                    per_code,
+                    context.cluster_id.as_deref(),
+                    context.backend_id.as_deref()
+                );
+            }
+        }
 
         let endpoint = sozu_command::logging::EndpointRecord::Http {
             method: context.method.as_deref(),

--- a/lib/src/protocol/mux/stream.rs
+++ b/lib/src/protocol/mux/stream.rs
@@ -205,7 +205,14 @@ impl Stream {
             self.request_counted = false;
         }
         if error {
-            incr!("http.errors");
+            // Labelled with `(cluster_id, backend_id)`; see the matching
+            // emission in `kawa_h1::log_request_error` for the cardinality
+            // contract (`metrics::filter_labels_for_detail`).
+            incr!(
+                "http.errors",
+                context.cluster_id.as_deref(),
+                context.backend_id.as_deref()
+            );
         }
         let protocol = match context.protocol {
             Protocol::HTTP => "http",

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -185,7 +185,22 @@ impl SessionManager {
 
     /// The slab is considered at capacity if it contains more sessions than twice max_connections
     pub fn at_capacity(&self) -> bool {
-        self.slab.len() >= 10 + 2 * self.max_connections
+        self.slab.len() >= self.accept_slab_threshold()
+    }
+
+    /// The slab fill level at which `at_capacity` flips to true and the
+    /// accept queue is flushed. Reported as `slab.accept_threshold` so the
+    /// per-iteration `slab.accept_threshold_percent` gauge in the run loop
+    /// can chart proximity to this gate, distinct from raw slab usage.
+    ///
+    /// The constant `10 + 2 * max_connections` is the historical pre-knob
+    /// budget; configured slab capacity is
+    /// `10 + slab_entries_per_connection * max_connections` (see
+    /// `command/src/config.rs`) and can be larger, so `slab.usage_percent`
+    /// (against `slab.capacity()`) and `slab.accept_threshold_percent`
+    /// (against this gate) are emitted as independent gauges.
+    pub fn accept_slab_threshold(&self) -> usize {
+        10 + 2 * self.max_connections
     }
 
     /// Check the number of connections against max_connections, and the slab capacity.
@@ -220,12 +235,12 @@ impl SessionManager {
     pub fn incr(&mut self) {
         self.nb_connections += 1;
         assert!(self.nb_connections <= self.max_connections);
+        // `client.connections_max` and `client.connections_percent` are
+        // emitted from the run loop alongside `process.uptime_seconds` /
+        // `server.live` so all proxy gauges advance in lock-step. Keeping
+        // `client.connections` per-event preserves the high-resolution
+        // signal scrapers expect.
         gauge!("client.connections", self.nb_connections);
-        gauge!(
-            "client.connections_percentage",
-            self.nb_connections * 100 / self.max_connections
-        );
-        gauge!("client.max_connections", self.max_connections);
     }
 
     /// Decrements the number of sessions, start accepting new connections
@@ -234,11 +249,6 @@ impl SessionManager {
         assert!(self.nb_connections != 0);
         self.nb_connections -= 1;
         gauge!("client.connections", self.nb_connections);
-        gauge!(
-            "client.connections_percentage",
-            self.nb_connections * 100 / self.max_connections
-        );
-        gauge!("client.max_connections", self.max_connections);
 
         // do not be ready to accept right away, wait until we get back to 10% capacity
         if !self.can_accept && self.nb_connections < self.max_connections * 90 / 100 {
@@ -320,6 +330,12 @@ pub struct Server {
     /// time spent saturated rather than just whether saturation occurred.
     last_saturation_tick: Instant,
     max_poll_errors: i32, // TODO: make this configurable? this defaults to 10000 for now
+    /// Shared reference to the buffer pool the protocol stacks check buffers
+    /// in and out of. Held here so the run loop can sample
+    /// `buffer.in_use` / `buffer.capacity` / `buffer.usage_percent` once per
+    /// iteration without requiring each protocol module to expose its own
+    /// snapshot.
+    pool: Rc<RefCell<Pool>>,
     pub poll: Poll,
     poll_timeout: Option<Duration>, // TODO: make this configurable? this defaults to 1000 milliseconds for now
     scm_listeners: Option<Listeners>,
@@ -496,6 +512,7 @@ impl Server {
             started_at: Instant::now(),        // captured once, never reset
             last_saturation_tick: Instant::now(), // 1Hz saturation ticker anchor
             max_poll_errors: 10000,            // TODO: make it configurable?
+            pool,
             poll_timeout: Some(Duration::from_millis(1000)), // TODO: make it configurable?
             poll,
             scm_listeners: None,
@@ -688,8 +705,62 @@ impl Server {
                 });
             }
 
-            gauge!("client.connections", self.sessions.borrow().nb_connections);
-            gauge!("slab.entries", self.sessions.borrow().slab.len());
+            // Frontend session gauges. `client.connections` keeps the
+            // per-event signal from `SessionManager::incr/decr`; the rest
+            // follow the once-per-iteration batching contract this run loop
+            // uses for `process.uptime_seconds` / `server.live`.
+            //
+            // `slab.usage_percent` charts pure slab utilisation against
+            // `slab.capacity()`. `slab.accept_threshold_percent` charts how
+            // close the slab is to the `at_capacity()` accept gate
+            // (`10 + 2 * max_connections`, see
+            // `SessionManager::accept_slab_threshold`). Configured slab
+            // capacity can be larger than that gate (`slab_entries_per_connection`
+            // > 2), so the two gauges are kept independent on purpose.
+            {
+                let sessions = self.sessions.borrow();
+                let nb_connections = sessions.nb_connections;
+                let max_connections = sessions.max_connections;
+                let slab_len = sessions.slab.len();
+                let slab_capacity = sessions.slab.capacity();
+                let accept_threshold = sessions.accept_slab_threshold();
+
+                gauge!("client.connections", nb_connections);
+                gauge!("client.connections_max", max_connections);
+                if max_connections > 0 {
+                    gauge!(
+                        "client.connections_percent",
+                        nb_connections * 100 / max_connections
+                    );
+                }
+
+                gauge!("slab.entries", slab_len);
+                gauge!("slab.capacity", slab_capacity);
+                if slab_capacity > 0 {
+                    gauge!("slab.usage_percent", slab_len * 100 / slab_capacity);
+                }
+                if accept_threshold > 0 {
+                    gauge!(
+                        "slab.accept_threshold_percent",
+                        slab_len * 100 / accept_threshold
+                    );
+                }
+            }
+            // Buffer pool gauges. `buffer.in_use` replaces the older
+            // `buffer.number` (renamed in `lib/src/pool.rs` for naming
+            // consistency with the surrounding `buffer.*` keys).
+            // `buffer.usage_percent` is computed against the configured
+            // `buffer.capacity` so dashboards can chart pool pressure.
+            {
+                let pool = self.pool.borrow();
+                let used = pool.inner.used();
+                let capacity = pool.inner.capacity();
+                gauge!("buffer.in_use", used);
+                gauge!("buffer.capacity", capacity);
+                if capacity > 0 {
+                    gauge!("buffer.usage_percent", used * 100 / capacity);
+                }
+            }
             // 1Hz tick for `accept_queue.saturated_seconds`. Increments once
             // per `ACCEPT_SATURATION_TICK` while `SessionManager::can_accept`
             // is `false`. Distinguishes "queue spent N seconds at max" from


### PR DESCRIPTION
## Summary

- Per-status-code tracking for 18 common HTTP codes as `http.status.{code}` metrics
- Per-cluster/backend `http.errors` counter for error aggregation
- `buffer.used` and `buffer.capacity` gauges emitted each event loop iteration
- 2 new tests in `local_drain.rs` for metric aggregation

## Review fixes applied
- Added missing 507 status code (Sozu generates `Answer507` but tracker omitted it)
- Formatting cleanup

Closes #937, closes #597, closes #1146

## Test plan
- [x] `cargo test --workspace` passes (2 new tests)
- [x] `cargo clippy --workspace` clean
- [x] E2e tests pass (20/20)