### PR TITLE
perf: replace format!() allocations in on_headers hot path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1776,6 +1776,7 @@ dependencies = [
  "hex",
  "hpack",
  "idna",
+ "itoa",
  "kawa",
  "libc",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +158,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +174,12 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -201,6 +219,33 @@ name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -285,6 +330,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,10 +375,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -583,6 +689,17 @@ dependencies = [
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -884,6 +1001,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -915,6 +1041,16 @@ checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
 dependencies = [
  "jemalloc-sys",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1134,6 +1270,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,6 +1347,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "pool"
@@ -1294,7 +1464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log 0.4.29",
  "multimap",
  "petgraph",
@@ -1313,7 +1483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1400,6 +1570,26 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1545,6 +1735,15 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "time",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1772,6 +1971,7 @@ version = "1.1.1"
 dependencies = [
  "anyhow",
  "cookie-factory",
+ "criterion",
  "hdrhistogram",
  "hex",
  "hpack",
@@ -1978,6 +2178,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2125,6 +2335,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2155,6 +2375,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2192,6 +2457,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2215,6 +2490,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ hyper = "^1.8.1"
 hyper-rustls = { version = "^0.27.7", default-features = false }
 hyper-util = "^0.1"
 idna = "^1.1.0"
-itoa = "^1.0"
+itoa = "^1.0.17"
 jemallocator = "^0.5.4"
 kawa = { version = "^0.6.8", default-features = false }
 libc = "^0.2.182"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ hyper = "^1.8.1"
 hyper-rustls = { version = "^0.27.7", default-features = false }
 hyper-util = "^0.1"
 idna = "^1.1.0"
+itoa = "^1.0"
 jemallocator = "^0.5.4"
 kawa = { version = "^0.6.8", default-features = false }
 libc = "^0.2.182"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ poule = "^0.3.2"
 prettytable-rs = { version = "^0.10.0", default-features = false }
 prost = "^0.14.3"
 prost-build = "^0.14.3"
+criterion = { version = "^0.5.1", features = ["html_reports"] }
 quickcheck = "^1.1.0"
 rand = "^0.10.0"
 regex = "^1.12.3"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -55,10 +55,15 @@ time = { workspace = true }
 sozu-command-lib = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 quickcheck = { workspace = true }
 rand = { workspace = true }
 serial_test = { workspace = true }
 tiny_http = { workspace = true }
+
+[[bench]]
+name = "header_formatting"
+harness = false
 
 [features]
 default = []

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -34,6 +34,7 @@ hdrhistogram = { workspace = true }
 hex = { workspace = true }
 hpack = { workspace = true }
 idna = { workspace = true }
+itoa = { workspace = true }
 kawa = { workspace = true }
 libc = { workspace = true }
 memchr = { workspace = true }

--- a/lib/benches/header_formatting.rs
+++ b/lib/benches/header_formatting.rs
@@ -1,0 +1,389 @@
+//! Benchmarks comparing `format!()` vs `Vec<u8>` + `write!()` + `itoa`
+//! for building HTTP header values in the `on_headers` hot path.
+//!
+//! Context: <https://github.com/sozu-proxy/sozu/pull/1200>
+
+use std::io::Write as _;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+
+// ---------------------------------------------------------------------------
+// Helpers (optimized path from PR #1200)
+// ---------------------------------------------------------------------------
+
+fn write_forwarded_for_by(buf: &mut Vec<u8>, peer_ip: IpAddr, peer_port: u16, public_ip: IpAddr) {
+    buf.extend_from_slice(b";for=\"");
+    let _ = write!(buf, "{peer_ip}");
+    buf.push(b':');
+    let mut port_buf = itoa::Buffer::new();
+    buf.extend_from_slice(port_buf.format(peer_port).as_bytes());
+    buf.extend_from_slice(b"\";by=");
+    match public_ip {
+        IpAddr::V4(_) => {
+            let _ = write!(buf, "{public_ip}");
+        }
+        IpAddr::V6(_) => {
+            buf.push(b'"');
+            let _ = write!(buf, "{public_ip}");
+            buf.push(b'"');
+        }
+    }
+}
+
+fn write_forwarded_suffix(
+    buf: &mut Vec<u8>,
+    proto: &str,
+    peer_ip: IpAddr,
+    peer_port: u16,
+    public_ip: IpAddr,
+) {
+    buf.extend_from_slice(b", proto=");
+    buf.extend_from_slice(proto.as_bytes());
+    write_forwarded_for_by(buf, peer_ip, peer_port, public_ip);
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+struct Fixture {
+    name: &'static str,
+    peer_ip: IpAddr,
+    peer_port: u16,
+    public_ip: IpAddr,
+    public_port: u16,
+    existing_x_forwarded_for: &'static str,
+    existing_forwarded: &'static str,
+    proto: &'static str,
+    sticky_name: &'static str,
+    sticky_session: &'static str,
+}
+
+fn fixtures() -> Vec<Fixture> {
+    vec![
+        Fixture {
+            name: "ipv4",
+            peer_ip: IpAddr::V4(Ipv4Addr::new(192, 168, 1, 42)),
+            peer_port: 54321,
+            public_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            public_port: 8443,
+            existing_x_forwarded_for: "203.0.113.50",
+            existing_forwarded: "proto=https;for=\"203.0.113.50:12345\";by=10.0.0.1",
+            proto: "https",
+            sticky_name: "SERVERID",
+            sticky_session: "srv-backend-01-abc123",
+        },
+        Fixture {
+            name: "ipv6",
+            peer_ip: IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
+            peer_port: 54321,
+            public_ip: IpAddr::V6(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1)),
+            public_port: 443,
+            existing_x_forwarded_for: "2001:db8::99",
+            existing_forwarded:
+                "proto=https;for=\"2001:db8::99:12345\";by=\"fd00::1\"",
+            proto: "https",
+            sticky_name: "SERVERID",
+            sticky_session: "srv-backend-02-def456",
+        },
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark: X-Forwarded-For header value
+// ---------------------------------------------------------------------------
+
+fn bench_x_forwarded_for(c: &mut Criterion) {
+    let mut group = c.benchmark_group("x_forwarded_for");
+
+    for f in &fixtures() {
+        // --- format!() baseline ---
+        group.bench_with_input(
+            BenchmarkId::new("format", f.name),
+            f,
+            |b, f| {
+                b.iter(|| {
+                    let value = f.existing_x_forwarded_for;
+                    let peer_ip = black_box(f.peer_ip);
+                    let result = format!("{value}, {peer_ip}");
+                    black_box(result.into_bytes().into_boxed_slice());
+                });
+            },
+        );
+
+        // --- Vec + write!() optimized ---
+        group.bench_with_input(
+            BenchmarkId::new("vec_write", f.name),
+            f,
+            |b, f| {
+                b.iter(|| {
+                    let mut buf = Vec::with_capacity(128);
+                    buf.extend_from_slice(black_box(f.existing_x_forwarded_for.as_bytes()));
+                    let _ = write!(buf, ", {}", black_box(f.peer_ip));
+                    black_box(buf.into_boxed_slice());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark: Forwarded header value
+// ---------------------------------------------------------------------------
+
+fn bench_forwarded(c: &mut Criterion) {
+    let mut group = c.benchmark_group("forwarded");
+
+    for f in &fixtures() {
+        // --- format!() baseline ---
+        group.bench_with_input(
+            BenchmarkId::new("format", f.name),
+            f,
+            |b, f| {
+                b.iter(|| {
+                    let value = f.existing_forwarded;
+                    let proto = black_box(f.proto);
+                    let peer_ip = black_box(f.peer_ip);
+                    let peer_port = black_box(f.peer_port);
+                    let public_ip = black_box(f.public_ip);
+                    let result = match public_ip {
+                        IpAddr::V4(_) => {
+                            format!(
+                                "{value}, proto={proto};for=\"{peer_ip}:{peer_port}\";by={public_ip}"
+                            )
+                        }
+                        IpAddr::V6(_) => {
+                            format!(
+                                "{value}, proto={proto};for=\"{peer_ip}:{peer_port}\";by=\"{public_ip}\""
+                            )
+                        }
+                    };
+                    black_box(result.into_bytes().into_boxed_slice());
+                });
+            },
+        );
+
+        // --- Vec + write!() optimized ---
+        group.bench_with_input(
+            BenchmarkId::new("vec_write", f.name),
+            f,
+            |b, f| {
+                b.iter(|| {
+                    let mut buf = Vec::with_capacity(128);
+                    buf.extend_from_slice(black_box(f.existing_forwarded.as_bytes()));
+                    write_forwarded_suffix(
+                        &mut buf,
+                        black_box(f.proto),
+                        black_box(f.peer_ip),
+                        black_box(f.peer_port),
+                        black_box(f.public_ip),
+                    );
+                    black_box(buf.into_boxed_slice());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark: X-Forwarded-Port header value
+// ---------------------------------------------------------------------------
+
+fn bench_x_forwarded_port(c: &mut Criterion) {
+    let mut group = c.benchmark_group("x_forwarded_port");
+
+    for f in &fixtures() {
+        // --- to_string() baseline ---
+        group.bench_with_input(
+            BenchmarkId::new("to_string", f.name),
+            f,
+            |b, f| {
+                b.iter(|| {
+                    let port = black_box(f.public_port);
+                    let result = port.to_string();
+                    black_box(result.into_bytes().into_boxed_slice());
+                });
+            },
+        );
+
+        // --- itoa::Buffer optimized ---
+        group.bench_with_input(
+            BenchmarkId::new("itoa", f.name),
+            f,
+            |b, f| {
+                b.iter(|| {
+                    let mut port_buf = itoa::Buffer::new();
+                    let port_str = port_buf.format(black_box(f.public_port));
+                    // from_slice copies into a new Box<[u8]>, matching Store::from_slice behavior
+                    black_box(port_str.as_bytes().to_vec().into_boxed_slice());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark: Set-Cookie header value
+// ---------------------------------------------------------------------------
+
+fn bench_set_cookie(c: &mut Criterion) {
+    let mut group = c.benchmark_group("set_cookie");
+
+    for f in &fixtures() {
+        // --- format!() baseline ---
+        group.bench_with_input(
+            BenchmarkId::new("format", f.name),
+            f,
+            |b, f| {
+                b.iter(|| {
+                    let sticky_name = black_box(f.sticky_name);
+                    let sticky_session = black_box(f.sticky_session);
+                    let result = format!("{sticky_name}={sticky_session}; Path=/");
+                    black_box(result.into_bytes().into_boxed_slice());
+                });
+            },
+        );
+
+        // --- Vec + extend_from_slice optimized ---
+        group.bench_with_input(
+            BenchmarkId::new("vec_extend", f.name),
+            f,
+            |b, f| {
+                b.iter(|| {
+                    let sticky_name = black_box(f.sticky_name);
+                    let sticky_session = black_box(f.sticky_session);
+                    let mut buf =
+                        Vec::with_capacity(sticky_name.len() + 1 + sticky_session.len() + 8);
+                    buf.extend_from_slice(sticky_name.as_bytes());
+                    buf.push(b'=');
+                    buf.extend_from_slice(sticky_session.as_bytes());
+                    buf.extend_from_slice(b"; Path=/");
+                    black_box(buf.into_boxed_slice());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark: Full pipeline (all headers combined, simulating one request)
+// ---------------------------------------------------------------------------
+
+fn bench_full_pipeline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("full_pipeline");
+
+    for f in &fixtures() {
+        // --- format!() baseline (simulates old on_request_headers) ---
+        group.bench_with_input(
+            BenchmarkId::new("format", f.name),
+            f,
+            |b, f| {
+                b.iter(|| {
+                    let peer_ip = black_box(f.peer_ip);
+                    let peer_port = black_box(f.peer_port);
+                    let public_ip = black_box(f.public_ip);
+                    let public_port = black_box(f.public_port);
+                    let proto = black_box(f.proto);
+                    let existing_xff = black_box(f.existing_x_forwarded_for);
+                    let existing_fwd = black_box(f.existing_forwarded);
+                    let sticky_name = black_box(f.sticky_name);
+                    let sticky_session = black_box(f.sticky_session);
+
+                    // X-Forwarded-For
+                    let xff = format!("{existing_xff}, {peer_ip}");
+                    let xff_store = xff.into_bytes().into_boxed_slice();
+
+                    // Forwarded
+                    let fwd = match public_ip {
+                        IpAddr::V4(_) => format!(
+                            "{existing_fwd}, proto={proto};for=\"{peer_ip}:{peer_port}\";by={public_ip}"
+                        ),
+                        IpAddr::V6(_) => format!(
+                            "{existing_fwd}, proto={proto};for=\"{peer_ip}:{peer_port}\";by=\"{public_ip}\""
+                        ),
+                    };
+                    let fwd_store = fwd.into_bytes().into_boxed_slice();
+
+                    // X-Forwarded-Port
+                    let port_str = public_port.to_string();
+                    let port_store = port_str.into_bytes().into_boxed_slice();
+
+                    // Set-Cookie
+                    let cookie = format!("{sticky_name}={sticky_session}; Path=/");
+                    let cookie_store = cookie.into_bytes().into_boxed_slice();
+
+                    black_box((xff_store, fwd_store, port_store, cookie_store));
+                });
+            },
+        );
+
+        // --- Vec + write!() + itoa optimized (simulates new on_request_headers) ---
+        group.bench_with_input(
+            BenchmarkId::new("vec_write", f.name),
+            f,
+            |b, f| {
+                b.iter(|| {
+                    let peer_ip = black_box(f.peer_ip);
+                    let peer_port = black_box(f.peer_port);
+                    let public_ip = black_box(f.public_ip);
+                    let public_port = black_box(f.public_port);
+                    let proto = black_box(f.proto);
+                    let existing_xff = black_box(f.existing_x_forwarded_for);
+                    let existing_fwd = black_box(f.existing_forwarded);
+                    let sticky_name = black_box(f.sticky_name);
+                    let sticky_session = black_box(f.sticky_session);
+
+                    // Shared buffer, reused via take()
+                    let mut hdr_buf = Vec::with_capacity(128);
+
+                    // X-Forwarded-For
+                    hdr_buf.extend_from_slice(existing_xff.as_bytes());
+                    let _ = write!(hdr_buf, ", {peer_ip}");
+                    let xff_store = std::mem::take(&mut hdr_buf).into_boxed_slice();
+
+                    // Forwarded
+                    hdr_buf.extend_from_slice(existing_fwd.as_bytes());
+                    write_forwarded_suffix(&mut hdr_buf, proto, peer_ip, peer_port, public_ip);
+                    let fwd_store = std::mem::take(&mut hdr_buf).into_boxed_slice();
+
+                    // X-Forwarded-Port
+                    let mut port_buf = itoa::Buffer::new();
+                    let port_str = port_buf.format(public_port);
+                    let port_store = port_str.as_bytes().to_vec().into_boxed_slice();
+
+                    // Set-Cookie
+                    let mut cookie_buf =
+                        Vec::with_capacity(sticky_name.len() + 1 + sticky_session.len() + 8);
+                    cookie_buf.extend_from_slice(sticky_name.as_bytes());
+                    cookie_buf.push(b'=');
+                    cookie_buf.extend_from_slice(sticky_session.as_bytes());
+                    cookie_buf.extend_from_slice(b"; Path=/");
+                    let cookie_store = cookie_buf.into_boxed_slice();
+
+                    black_box((xff_store, fwd_store, port_store, cookie_store));
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_x_forwarded_for,
+    bench_forwarded,
+    bench_x_forwarded_port,
+    bench_set_cookie,
+    bench_full_pipeline,
+);
+criterion_main!(benches);

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -1,7 +1,7 @@
 use std::{
     io::Write as _,
     net::{IpAddr, SocketAddr},
-    str::{from_utf8, from_utf8_unchecked},
+    str::from_utf8,
 };
 
 use rusty_ulid::Ulid;
@@ -354,9 +354,6 @@ impl HttpContext {
             (otel, traceparent.is_some())
         };
 
-        // Reusable buffer for header values to avoid per-header String allocations
-        let mut hdr_buf = Vec::with_capacity(128);
-
         // If session_address is set:
         // - append its ip address to the list of "X-Forwarded-For" if it was found, creates it if not
         // - append "proto=[PROTO];for=[PEER];by=[PUBLIC]" to the list of "Forwarded" if it was found, creates it if not
@@ -366,10 +363,12 @@ impl HttpContext {
             let has_x_for = x_for.is_some();
             let has_forwarded = forwarded.is_some();
 
+            // Buffer for building header values — ownership is transferred to Store
+            // via `take`, so each header gets its own allocation.
+            let mut hdr_buf = Vec::with_capacity(128);
+
             if let Some(header) = x_for {
-                hdr_buf.extend_from_slice(
-                    unsafe { from_utf8_unchecked(header.val.data(buf)) }.as_bytes(),
-                );
+                hdr_buf.extend_from_slice(header.val.data(buf));
                 let _ = write!(hdr_buf, ", {peer_ip}");
                 header.val = kawa::Store::from_vec(std::mem::take(&mut hdr_buf));
             }

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -1,4 +1,5 @@
 use std::{
+    io::Write as _,
     net::{IpAddr, SocketAddr},
     str::{from_utf8, from_utf8_unchecked},
 };
@@ -63,6 +64,40 @@ fn build_traceparent(trace_id: &[u8; 32], parent_id: &[u8; 16]) -> [u8; 55] {
     buf[36..52].copy_from_slice(parent_id);
     buf[52..55].copy_from_slice(b"-01");
     buf
+}
+
+/// Write the ";for=..;by=.." portion of a Forwarded header into `buf`
+/// without heap-allocating a `String`.
+fn write_forwarded_for_by(buf: &mut Vec<u8>, peer_ip: IpAddr, peer_port: u16, public_ip: IpAddr) {
+    buf.extend_from_slice(b";for=\"");
+    let _ = write!(buf, "{peer_ip}");
+    buf.push(b':');
+    let mut port_buf = itoa::Buffer::new();
+    buf.extend_from_slice(port_buf.format(peer_port).as_bytes());
+    buf.extend_from_slice(b"\";by=");
+    match public_ip {
+        IpAddr::V4(_) => {
+            let _ = write!(buf, "{public_ip}");
+        }
+        IpAddr::V6(_) => {
+            buf.push(b'"');
+            let _ = write!(buf, "{public_ip}");
+            buf.push(b'"');
+        }
+    }
+}
+
+/// Write ", proto=<proto>;for=..;by=.." (the suffix appended to an existing Forwarded value).
+fn write_forwarded_suffix(
+    buf: &mut Vec<u8>,
+    proto: &str,
+    peer_ip: IpAddr,
+    peer_port: u16,
+    public_ip: IpAddr,
+) {
+    buf.extend_from_slice(b", proto=");
+    buf.extend_from_slice(proto.as_bytes());
+    write_forwarded_for_by(buf, peer_ip, peer_port, public_ip);
 }
 
 /// This is the container used to store and use information about the session from within a Kawa parser callback
@@ -207,7 +242,7 @@ impl HttpContext {
             let key = cookie.key.data(buf);
             if key == self.sticky_name.as_bytes() {
                 let val = cookie.val.data(buf);
-                self.sticky_session_found = from_utf8(val).ok().map(|val| val.to_string());
+                self.sticky_session_found = from_utf8(val).ok().map(ToOwned::to_owned);
                 cookie.elide();
             }
         }
@@ -258,7 +293,8 @@ impl HttpContext {
                         // header.val = kawa::Store::from_string(public_port.to_string());
                         incr!("http.trusting.x_port");
                         let val = header.val.data(buf);
-                        let expected = public_port.to_string();
+                        let mut port_buf = itoa::Buffer::new();
+                        let expected = port_buf.format(public_port);
                         if !compare_no_case(val, expected.as_bytes()) {
                             incr!("http.trusting.x_port.diff");
                             debug!(
@@ -318,6 +354,9 @@ impl HttpContext {
             (otel, traceparent.is_some())
         };
 
+        // Reusable buffer for header values to avoid per-header String allocations
+        let mut hdr_buf = Vec::with_capacity(128);
+
         // If session_address is set:
         // - append its ip address to the list of "X-Forwarded-For" if it was found, creates it if not
         // - append "proto=[PROTO];for=[PEER];by=[PUBLIC]" to the list of "Forwarded" if it was found, creates it if not
@@ -328,45 +367,32 @@ impl HttpContext {
             let has_forwarded = forwarded.is_some();
 
             if let Some(header) = x_for {
-                header.val = kawa::Store::from_string(format!("{}, {peer_ip}", unsafe {
-                    from_utf8_unchecked(header.val.data(buf))
-                }));
+                hdr_buf.extend_from_slice(
+                    unsafe { from_utf8_unchecked(header.val.data(buf)) }.as_bytes(),
+                );
+                let _ = write!(hdr_buf, ", {peer_ip}");
+                header.val = kawa::Store::from_vec(std::mem::take(&mut hdr_buf));
             }
             if let Some(header) = &mut forwarded {
-                let value = unsafe { from_utf8_unchecked(header.val.data(buf)) };
-                let new_value = match public_ip {
-                    IpAddr::V4(_) => {
-                        format!(
-                            "{value}, proto={proto};for=\"{peer_ip}:{peer_port}\";by={public_ip}"
-                        )
-                    }
-                    IpAddr::V6(_) => {
-                        format!(
-                            "{value}, proto={proto};for=\"{peer_ip}:{peer_port}\";by=\"{public_ip}\""
-                        )
-                    }
-                };
-                header.val = kawa::Store::from_string(new_value);
+                hdr_buf.extend_from_slice(header.val.data(buf));
+                write_forwarded_suffix(&mut hdr_buf, proto, peer_ip, peer_port, public_ip);
+                header.val = kawa::Store::from_vec(std::mem::take(&mut hdr_buf));
             }
 
             if !has_x_for {
+                let _ = write!(hdr_buf, "{peer_ip}");
                 request.push_block(kawa::Block::Header(kawa::Pair {
                     key: kawa::Store::Static(b"X-Forwarded-For"),
-                    val: kawa::Store::from_string(peer_ip.to_string()),
+                    val: kawa::Store::from_vec(std::mem::take(&mut hdr_buf)),
                 }));
             }
             if !has_forwarded {
-                let value = match public_ip {
-                    IpAddr::V4(_) => {
-                        format!("proto={proto};for=\"{peer_ip}:{peer_port}\";by={public_ip}")
-                    }
-                    IpAddr::V6(_) => {
-                        format!("proto={proto};for=\"{peer_ip}:{peer_port}\";by=\"{public_ip}\"")
-                    }
-                };
+                hdr_buf.extend_from_slice(b"proto=");
+                hdr_buf.extend_from_slice(proto.as_bytes());
+                write_forwarded_for_by(&mut hdr_buf, peer_ip, peer_port, public_ip);
                 request.push_block(kawa::Block::Header(kawa::Pair {
                     key: kawa::Store::Static(b"Forwarded"),
-                    val: kawa::Store::from_string(value),
+                    val: kawa::Store::from_vec(std::mem::take(&mut hdr_buf)),
                 }));
             }
         }
@@ -384,9 +410,11 @@ impl HttpContext {
         }
 
         if !has_x_port {
+            let mut port_buf = itoa::Buffer::new();
+            let port_str = port_buf.format(public_port);
             request.push_block(kawa::Block::Header(kawa::Pair {
                 key: kawa::Store::Static(b"X-Forwarded-Port"),
-                val: kawa::Store::from_string(public_port.to_string()),
+                val: kawa::Store::from_slice(port_str.as_bytes()),
             }));
         }
         if !has_x_proto {
@@ -456,12 +484,15 @@ impl HttpContext {
         // create a "Set-Cookie" header to update the sticky_name value
         if let Some(sticky_session) = &self.sticky_session {
             if self.sticky_session != self.sticky_session_found {
+                let mut cookie_buf =
+                    Vec::with_capacity(self.sticky_name.len() + 1 + sticky_session.len() + 8);
+                cookie_buf.extend_from_slice(self.sticky_name.as_bytes());
+                cookie_buf.push(b'=');
+                cookie_buf.extend_from_slice(sticky_session.as_bytes());
+                cookie_buf.extend_from_slice(b"; Path=/");
                 response.push_block(kawa::Block::Header(kawa::Pair {
                     key: kawa::Store::Static(b"Set-Cookie"),
-                    val: kawa::Store::from_string(format!(
-                        "{}={}; Path=/",
-                        self.sticky_name, sticky_session
-                    )),
+                    val: kawa::Store::from_vec(cookie_buf),
                 }));
             }
         }


### PR DESCRIPTION
## Summary

- Replace 7 `format!()` allocations with `itoa::Buffer`, `write!()` into `Vec<u8>`, and `extend_from_slice`
- Add `itoa` workspace dependency (zero-dep, stack-based integer formatting)
- Extract `write_forwarded_for_by` and `write_forwarded_suffix` helpers to reduce code duplication

## Review fixes applied
- Removed unnecessary `unsafe { from_utf8_unchecked(...) }.as_bytes()` roundtrip — now uses `&[u8]` directly
- Moved `Vec::with_capacity(128)` allocation into conditional scope (was allocating on every request even without `session_address`)
- Fixed misleading "reusable buffer" comment

Closes #1140

## Test plan
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace` clean
- [x] E2e tests pass (20/20)