### PR TITLE
feat(kawa_h1): flexible HTTP answer template system

### DIFF
--- a/bin/config.toml
+++ b/bin/config.toml
@@ -164,24 +164,11 @@ address = "0.0.0.0:8080"
 # this option is incompatible with expect_proxy
 # public_address = "1.2.3.4:80"
 
-# For details about custom HTTP answers, see `doc/configure.md`,
-# and for defaults, check out `/lib/src/protocol/kawa_h1/answers.rs`
-# a 401 response is sent when a frontend has a Deny rule
-# answer_401 = "/absolute/path/to/custom_401.http"
-# a 404 response is sent when sozu does not know about the requested domain or path
-# answer_404 = "/absolute/path/to/custom_404.http"
-# a 408 response is sent when a frontend has a Deny rule (unusual)
-# answer_408 = "/absolute/path/to/custom_408.http"
-# a 413 response is sent when a request was too large
-# answer_413 = "/absolute/path/to/custom_413.http"
-# a 502 response means the response sent by a backend could not be parsed by Sōzu
-# answer_502 = "/absolute/path/to/custom_502.http"
-# a 503 response is sent if there are no backend servers available
-# answer_503 = "/absolute/path/to/custom_503.http"
-# a 504 response means the backend timed out
-# answer_504 = "/absolute/path/to/custom_504.http"
-# a 507 response occurs when the response sent by a backend is too big
-# answer_507 = "/absolute/path/to/custom_507.http"
+# Custom HTTP answer templates as a map of status code to file path.
+# For details, see `doc/configure.md` and `/lib/src/protocol/kawa_h1/answers.rs`
+# [listeners.answers]
+# "404" = "/absolute/path/to/custom_404.http"
+# "503" = "/absolute/path/to/custom_503.http"
 
 # defines the sticky session cookie's name, if `sticky_session` is activated for
 # a cluster. Defaults to "SOZUBALANCEID"
@@ -202,24 +189,11 @@ address = "0.0.0.0:8443"
 # this option is incompatible with expect_proxy
 # public_address = "1.2.3.4:80"
 
-# For details about custom HTTP answers, see `doc/configure.md`,
-# and for defaults, check out `/lib/src/protocol/kawa_h1/answers.rs`
-# a 401 response is sent when a frontend has a Deny rule
-# answer_401 = "/absolute/path/to/custom_401.http"
-# a 404 response is sent when sozu does not know about the requested domain or path
-# answer_404 = "/absolute/path/to/custom_404.http"
-# a 408 response is sent when a frontend has a Deny rule (unusual)
-# answer_408 = "/absolute/path/to/custom_408.http"
-# a 413 response is sent when a request was too large
-# answer_413 = "/absolute/path/to/custom_413.http"
-# a 502 response means the response sent by a backend could not be parsed by Sōzu
-# answer_502 = "/absolute/path/to/custom_502.http"
-# a 503 response is sent if there are no backend servers available
-# answer_503 = "/absolute/path/to/custom_503.http"
-# a 504 response means the backend timed out
-# answer_504 = "/absolute/path/to/custom_504.http"
-# a 507 response occurs when the response sent by a backend is too big
-# answer_507 = "/absolute/path/to/custom_507.http"
+# Custom HTTP answer templates as a map of status code to file path.
+# For details, see `doc/configure.md` and `/lib/src/protocol/kawa_h1/answers.rs`
+# [listeners.answers]
+# "404" = "/absolute/path/to/custom_404.http"
+# "503" = "/absolute/path/to/custom_503.http"
 
 # defines the sticky session cookie's name, if `sticky_session` is activated for
 # a cluster. Defaults to "SOZUBALANCEID"

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -527,15 +527,11 @@ pub enum HttpListenerCmd {
         )]
         public_address: Option<SocketAddr>,
         #[clap(
-            long = "answer-404",
-            help = "path to file of the 404 answer sent to the client when a frontend is not found"
+            long = "answer",
+            value_name = "NAME=PATH",
+            help = "custom answer template as NAME=PATH (e.g. 404=/path/to/404.http)"
         )]
-        answer_404: Option<String>,
-        #[clap(
-            long = "answer-503",
-            help = "path to file of the 503 answer sent to the client when a cluster has no backends available"
-        )]
-        answer_503: Option<String>,
+        answers: Vec<String>,
         #[clap(
             long = "expect-proxy",
             help = "Configures the client socket to receive a PROXY protocol header"
@@ -605,15 +601,11 @@ pub enum HttpsListenerCmd {
         )]
         public_address: Option<SocketAddr>,
         #[clap(
-            long = "answer-404",
-            help = "path to file of the 404 answer sent to the client when a frontend is not found"
+            long = "answer",
+            value_name = "NAME=PATH",
+            help = "custom answer template as NAME=PATH (e.g. 404=/path/to/404.http)"
         )]
-        answer_404: Option<String>,
-        #[clap(
-            long = "answer-503",
-            help = "path to file of the 503 answer sent to the client when a cluster has no backends available"
-        )]
-        answer_503: Option<String>,
+        answers: Vec<String>,
         #[clap(long = "tls-versions", help = "list of TLS versions to use")]
         tls_versions: Vec<TlsVersion>,
         #[clap(

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -1,5 +1,14 @@
 use std::collections::BTreeMap;
 
+fn parse_answer_args(args: &[String]) -> BTreeMap<String, String> {
+    args.iter()
+        .filter_map(|arg| {
+            let (name, path) = arg.split_once('=')?;
+            Some((name.to_owned(), path.to_owned()))
+        })
+        .collect()
+}
+
 use sozu_command_lib::{
     certificate::{
         decode_fingerprint, get_fingerprint_from_certificate_path, load_full_certificate,
@@ -322,8 +331,7 @@ impl CommandManager {
             HttpsListenerCmd::Add {
                 address,
                 public_address,
-                answer_404,
-                answer_503,
+                answers,
                 tls_versions,
                 cipher_list,
                 expect_proxy,
@@ -333,10 +341,10 @@ impl CommandManager {
                 request_timeout,
                 connect_timeout,
             } => {
+                let answers_map = parse_answer_args(&answers);
                 let https_listener = ListenerBuilder::new_https(address.into())
                     .with_public_address(public_address)
-                    .with_answer_404_path(answer_404)
-                    .with_answer_503_path(answer_503)
+                    .with_answers(answers_map)
                     .with_tls_versions(tls_versions)
                     .with_cipher_list(cipher_list)
                     .with_expect_proxy(expect_proxy)
@@ -367,8 +375,7 @@ impl CommandManager {
             HttpListenerCmd::Add {
                 address,
                 public_address,
-                answer_404,
-                answer_503,
+                answers,
                 expect_proxy,
                 sticky_name,
                 front_timeout,
@@ -376,10 +383,10 @@ impl CommandManager {
                 request_timeout,
                 connect_timeout,
             } => {
+                let answers_map = parse_answer_args(&answers);
                 let http_listener = ListenerBuilder::new_http(address.into())
                     .with_public_address(public_address)
-                    .with_answer_404_path(answer_404)
-                    .with_answer_503_path(answer_503)
+                    .with_answers(answers_map)
                     .with_expect_proxy(expect_proxy)
                     .with_sticky_name(sticky_name)
                     .with_front_timeout(front_timeout)

--- a/command/assets/config.toml
+++ b/command/assets/config.toml
@@ -17,7 +17,7 @@ protocol = "http"
 [[listeners]]
 address = "0.0.0.0:443"
 protocol = "https"
-answer_404 = "./assets/custom_404.html"
+answers = { "404" = "./assets/custom_404.html" }
 tls_versions = ["TLS_V12"]
 
 [[listeners]]
@@ -28,7 +28,7 @@ expect_proxy = true
 [clusters]
 [clusters.MyCluster]
 protocol = "http"
-answer_503 = "./assets/custom_503.html"
+answers = { "503" = "./assets/custom_503.html" }
 #sticky_session = false
 #https_redirect = false
 frontends = [

--- a/command/build.rs
+++ b/command/build.rs
@@ -30,6 +30,9 @@ pub fn main() {
         .message_attribute("Response", "#[derive(Hash, Eq)]")
         .message_attribute("InitialState", "#[derive(Hash, Eq)]")
         .message_attribute("ProtobufAccessLog", "#[derive(Hash, Eq)]")
+        .message_attribute("HttpListenerConfig", "#[derive(Hash, Eq)]")
+        .message_attribute("HttpsListenerConfig", "#[derive(Hash, Eq)]")
+        .message_attribute("Cluster", "#[derive(Hash, Eq)]")
         .enum_attribute(".", "#[serde(rename_all = \"SCREAMING_SNAKE_CASE\")]")
         .enum_attribute(
             "ResponseContent.content_type",

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -129,7 +129,8 @@ message HttpListenerConfig {
     required uint32 request_timeout = 10 [default = 10];
     // wether the listener is actively listening on its socket
     required bool active = 11 [default = false];
-    optional CustomHttpAnswers http_answers = 12;
+    reserved 12;
+    map<string, string> answers = 13;
 }
 
 // details of an HTTPS listener
@@ -161,7 +162,8 @@ message HttpsListenerConfig {
     // The tickets allow the client to resume a session. This protects the client
     // agains session tracking. Defaults to 4.
     required uint64 send_tls13_tickets = 20;
-    optional CustomHttpAnswers http_answers = 21;
+    reserved 21;
+    map<string, string> answers = 22;
 }
 
 // details of an TCP listener
@@ -179,30 +181,6 @@ message TcpListenerConfig {
     required bool active = 7 [default = false];
 }
 
-// custom HTTP answers, useful for 404, 503 pages
-message CustomHttpAnswers {
-    // MovedPermanently
-    optional string answer_301 = 1;
-    // BadRequest
-    optional string answer_400 = 2;
-    // Unauthorized
-    optional string answer_401 = 3;
-    // NotFound
-    optional string answer_404 = 4;
-    // RequestTimeout
-    optional string answer_408 = 5;
-    // PayloadTooLarge
-    optional string answer_413 = 6;
-    // BadGateway
-    optional string answer_502 = 7;
-    // ServiceUnavailable
-    optional string answer_503 = 8;
-    // GatewayTimeout
-    optional string answer_504 = 9;
-    // InsufficientStorage
-    optional string answer_507 = 10;
-
-}
 
 message ActivateListener {
     required SocketAddress address = 1;
@@ -374,8 +352,9 @@ message Cluster {
     required bool https_redirect = 3;
     optional ProxyProtocolConfig proxy_protocol = 4;
     required LoadBalancingAlgorithms load_balancing = 5 [default = ROUND_ROBIN];
-    optional string answer_503 = 6;
+    reserved 6;
     optional LoadMetric load_metric = 7;
+    map<string, string> answers = 8;
 }
 
 enum LoadBalancingAlgorithms {

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -63,11 +63,11 @@ use crate::{
     logging::AccessLogFormat,
     proto::command::{
         ActivateListener, AddBackend, AddCertificate, CertificateAndKey, Cluster,
-        CustomHttpAnswers, HttpListenerConfig, HttpsListenerConfig, ListenerType,
-        LoadBalancingAlgorithms, LoadBalancingParams, LoadMetric, MetricsConfiguration, PathRule,
-        ProtobufAccessLogFormat, ProxyProtocolConfig, Request, RequestHttpFrontend,
-        RequestTcpFrontend, RulePosition, ServerConfig, ServerMetricsConfig, SocketAddress,
-        TcpListenerConfig, TlsVersion, WorkerRequest, request::RequestType,
+        HttpListenerConfig, HttpsListenerConfig, ListenerType, LoadBalancingAlgorithms,
+        LoadBalancingParams, LoadMetric, MetricsConfiguration, PathRule, ProtobufAccessLogFormat,
+        ProxyProtocolConfig, Request, RequestHttpFrontend, RequestTcpFrontend, RulePosition,
+        ServerConfig, ServerMetricsConfig, SocketAddress, TcpListenerConfig, TlsVersion,
+        WorkerRequest, request::RequestType,
     },
 };
 
@@ -242,16 +242,7 @@ pub struct ListenerBuilder {
     pub address: SocketAddr,
     pub protocol: Option<ListenerProtocol>,
     pub public_address: Option<SocketAddr>,
-    pub answer_301: Option<String>,
-    pub answer_400: Option<String>,
-    pub answer_401: Option<String>,
-    pub answer_404: Option<String>,
-    pub answer_408: Option<String>,
-    pub answer_413: Option<String>,
-    pub answer_502: Option<String>,
-    pub answer_503: Option<String>,
-    pub answer_504: Option<String>,
-    pub answer_507: Option<String>,
+    pub answers: Option<BTreeMap<String, String>>,
     pub tls_versions: Option<Vec<TlsVersion>>,
     pub cipher_list: Option<Vec<String>>,
     pub cipher_suites: Option<Vec<String>>,
@@ -304,16 +295,7 @@ impl ListenerBuilder {
     fn new(address: SocketAddress, protocol: ListenerProtocol) -> ListenerBuilder {
         ListenerBuilder {
             address: address.into(),
-            answer_301: None,
-            answer_401: None,
-            answer_400: None,
-            answer_404: None,
-            answer_408: None,
-            answer_413: None,
-            answer_502: None,
-            answer_503: None,
-            answer_504: None,
-            answer_507: None,
+            answers: None,
             back_timeout: None,
             certificate_chain: None,
             certificate: None,
@@ -340,23 +322,19 @@ impl ListenerBuilder {
         self
     }
 
-    pub fn with_answer_404_path<S>(&mut self, answer_404_path: Option<S>) -> &mut Self
-    where
-        S: ToString,
-    {
-        if let Some(path) = answer_404_path {
-            self.answer_404 = Some(path.to_string());
+    pub fn with_answer<S: ToString>(&mut self, name: S, path: Option<String>) -> &mut Self {
+        if let Some(path) = path {
+            self.answers
+                .get_or_insert_with(BTreeMap::new)
+                .insert(name.to_string(), path);
         }
         self
     }
 
-    pub fn with_answer_503_path<S>(&mut self, answer_503_path: Option<S>) -> &mut Self
-    where
-        S: ToString,
-    {
-        if let Some(path) = answer_503_path {
-            self.answer_503 = Some(path.to_string());
-        }
+    pub fn with_answers(&mut self, answers: BTreeMap<String, String>) -> &mut Self {
+        self.answers
+            .get_or_insert_with(BTreeMap::new)
+            .extend(answers);
         self
     }
 
@@ -431,21 +409,9 @@ impl ListenerBuilder {
         self
     }
 
-    /// Get the custom HTTP answers from the file system using the provided paths
-    fn get_http_answers(&self) -> Result<Option<CustomHttpAnswers>, ConfigError> {
-        let http_answers = CustomHttpAnswers {
-            answer_301: read_http_answer_file(&self.answer_301)?,
-            answer_400: read_http_answer_file(&self.answer_400)?,
-            answer_401: read_http_answer_file(&self.answer_401)?,
-            answer_404: read_http_answer_file(&self.answer_404)?,
-            answer_408: read_http_answer_file(&self.answer_408)?,
-            answer_413: read_http_answer_file(&self.answer_413)?,
-            answer_502: read_http_answer_file(&self.answer_502)?,
-            answer_503: read_http_answer_file(&self.answer_503)?,
-            answer_504: read_http_answer_file(&self.answer_504)?,
-            answer_507: read_http_answer_file(&self.answer_507)?,
-        };
-        Ok(Some(http_answers))
+    /// Load the custom HTTP answers from the file system using the provided paths
+    fn load_answers(&self) -> Result<BTreeMap<String, String>, ConfigError> {
+        load_answers(self.answers.as_ref())
     }
 
     /// Assign the timeouts of the config to this listener, only if timeouts did not exist
@@ -469,7 +435,7 @@ impl ListenerBuilder {
             self.assign_config_timeouts(config);
         }
 
-        let http_answers = self.get_http_answers()?;
+        let answers = self.load_answers()?;
 
         let configuration = HttpListenerConfig {
             address: self.address.into(),
@@ -480,7 +446,7 @@ impl ListenerBuilder {
             back_timeout: self.back_timeout.unwrap_or(DEFAULT_BACK_TIMEOUT),
             connect_timeout: self.connect_timeout.unwrap_or(DEFAULT_CONNECT_TIMEOUT),
             request_timeout: self.request_timeout.unwrap_or(DEFAULT_REQUEST_TIMEOUT),
-            http_answers,
+            answers,
             ..Default::default()
         };
 
@@ -552,7 +518,7 @@ impl ListenerBuilder {
             .map(split_certificate_chain)
             .unwrap_or_default();
 
-        let http_answers = self.get_http_answers()?;
+        let answers = self.load_answers()?;
 
         if let Some(config) = config {
             self.assign_config_timeouts(config);
@@ -579,7 +545,7 @@ impl ListenerBuilder {
             send_tls13_tickets: self
                 .send_tls13_tickets
                 .unwrap_or(DEFAULT_SEND_TLS_13_TICKETS),
-            http_answers,
+            answers,
         };
 
         Ok(https_listener_config)
@@ -611,6 +577,24 @@ impl ListenerBuilder {
 }
 
 /// read a custom HTTP answer from a file
+/// Load answer templates from file paths into their contents.
+/// Each entry in the map is a template name -> file path.
+/// Returns a map of template name -> file contents.
+pub fn load_answers(
+    answers: Option<&BTreeMap<String, String>>,
+) -> Result<BTreeMap<String, String>, ConfigError> {
+    let Some(answers) = answers else {
+        return Ok(BTreeMap::new());
+    };
+    let mut loaded = BTreeMap::new();
+    for (name, path) in answers {
+        if let Some(content) = read_http_answer_file(&Some(path.clone()))? {
+            loaded.insert(name.clone(), content);
+        }
+    }
+    Ok(loaded)
+}
+
 fn read_http_answer_file(path: &Option<String>) -> Result<Option<String>, ConfigError> {
     match path {
         Some(path) => {
@@ -785,7 +769,7 @@ pub struct FileClusterConfig {
     pub send_proxy: Option<bool>,
     #[serde(default)]
     pub load_balancing: LoadBalancingAlgorithms,
-    pub answer_503: Option<String>,
+    pub answers: Option<BTreeMap<String, String>>,
     #[serde(default)]
     pub load_metric: Option<LoadMetric>,
 }
@@ -865,14 +849,7 @@ impl FileClusterConfig {
                     frontends.push(http_frontend);
                 }
 
-                let answer_503 = self.answer_503.as_ref().and_then(|path| {
-                    Config::load_file(path)
-                        .map_err(|e| {
-                            error!("cannot load 503 error page at path '{}': {:?}", path, e);
-                            e
-                        })
-                        .ok()
-                });
+                let answers = load_answers(self.answers.as_ref())?;
 
                 Ok(ClusterConfig::Http(HttpClusterConfig {
                     cluster_id: cluster_id.to_string(),
@@ -882,7 +859,7 @@ impl FileClusterConfig {
                     https_redirect: self.https_redirect.unwrap_or(false),
                     load_balancing: self.load_balancing,
                     load_metric: self.load_metric,
-                    answer_503,
+                    answers,
                 }))
             }
         }
@@ -974,7 +951,7 @@ pub struct HttpClusterConfig {
     pub https_redirect: bool,
     pub load_balancing: LoadBalancingAlgorithms,
     pub load_metric: Option<LoadMetric>,
-    pub answer_503: Option<String>,
+    pub answers: BTreeMap<String, String>,
 }
 
 impl HttpClusterConfig {
@@ -986,7 +963,7 @@ impl HttpClusterConfig {
                 https_redirect: self.https_redirect,
                 proxy_protocol: None,
                 load_balancing: self.load_balancing as i32,
-                answer_503: self.answer_503.clone(),
+                answers: self.answers.clone(),
                 load_metric: self.load_metric.map(|s| s as i32),
             })
             .into(),
@@ -1048,7 +1025,7 @@ impl TcpClusterConfig {
                 proxy_protocol: self.proxy_protocol.map(|s| s as i32),
                 load_balancing: self.load_balancing as i32,
                 load_metric: self.load_metric.map(|s| s as i32),
-                answer_503: None,
+                answers: BTreeMap::new(),
             })
             .into(),
         ];
@@ -1875,7 +1852,7 @@ mod tests {
             SocketAddress::new_v4(127, 0, 0, 1, 8080),
             ListenerProtocol::Http,
         )
-        .with_answer_404_path(Some("404.html"))
+        .with_answer("404", Some("404.html".to_owned()))
         .to_owned();
         println!("http: {:?}", to_string(&http));
 
@@ -1883,7 +1860,7 @@ mod tests {
             SocketAddress::new_v4(127, 0, 0, 1, 8443),
             ListenerProtocol::Https,
         )
-        .with_answer_404_path(Some("404.html"))
+        .with_answer("404", Some("404.html".to_owned()))
         .to_owned();
         println!("https: {:?}", to_string(&https));
 

--- a/command/src/proto/display.rs
+++ b/command/src/proto/display.rs
@@ -15,13 +15,12 @@ use crate::{
         DisplayError,
         command::{
             AggregatedMetrics, AvailableMetrics, CertificateAndKey, CertificateSummary,
-            CertificatesWithFingerprints, ClusterMetrics, CustomHttpAnswers, Event, EventKind,
-            FilteredMetrics, HttpEndpoint, HttpListenerConfig, HttpsListenerConfig,
-            ListOfCertificatesByAddress, ListedFrontends, ListenersList, ProtobufEndpoint,
-            QueryCertificatesFilters, RequestCounts, Response, ResponseContent, ResponseStatus,
-            RunState, SocketAddress, TlsVersion, WorkerInfos, WorkerMetrics, WorkerResponses,
-            filtered_metrics, protobuf_endpoint, request::RequestType,
-            response_content::ContentType,
+            CertificatesWithFingerprints, ClusterMetrics, Event, EventKind, FilteredMetrics,
+            HttpEndpoint, HttpListenerConfig, HttpsListenerConfig, ListOfCertificatesByAddress,
+            ListedFrontends, ListenersList, ProtobufEndpoint, QueryCertificatesFilters,
+            RequestCounts, Response, ResponseContent, ResponseStatus, RunState, SocketAddress,
+            TlsVersion, WorkerInfos, WorkerMetrics, WorkerResponses, filtered_metrics,
+            protobuf_endpoint, request::RequestType, response_content::ContentType,
         },
     },
 };
@@ -1024,8 +1023,8 @@ impl Display for HttpListenerConfig {
         table.set_format(*prettytable::format::consts::FORMAT_BOX_CHARS);
         table.add_row(row!["socket address", format!("{:?}", self.address)]);
         table.add_row(row!["public address", format!("{:?}", self.public_address),]);
-        for http_answer_row in CustomHttpAnswers::to_rows(&self.http_answers) {
-            table.add_row(http_answer_row);
+        for (name, answer) in &self.answers {
+            table.add_row(row![format!("answer {name}"), answer]);
         }
         table.add_row(row!["expect proxy", self.expect_proxy]);
         table.add_row(row!["sticky name", self.sticky_name]);
@@ -1049,8 +1048,8 @@ impl Display for HttpsListenerConfig {
 
         table.add_row(row!["socket address", format!("{:?}", self.address)]);
         table.add_row(row!["public address", format!("{:?}", self.public_address)]);
-        for http_answer_row in CustomHttpAnswers::to_rows(&self.http_answers) {
-            table.add_row(http_answer_row);
+        for (name, answer) in &self.answers {
+            table.add_row(row![format!("answer {name}"), answer]);
         }
         table.add_row(row!["versions", tls_versions]);
         table.add_row(row!["cipher list", list_string_vec(&self.cipher_list),]);
@@ -1069,42 +1068,6 @@ impl Display for HttpsListenerConfig {
         table.add_row(row!["request timeout", self.request_timeout]);
         table.add_row(row!["activated", self.active]);
         write!(f, "{}", table)
-    }
-}
-
-impl CustomHttpAnswers {
-    fn to_rows(option: &Option<Self>) -> Vec<Row> {
-        let mut rows = Vec::new();
-        if let Some(answers) = option {
-            if let Some(a) = &answers.answer_301 {
-                rows.push(row!("301", a));
-            }
-            if let Some(a) = &answers.answer_400 {
-                rows.push(row!("400", a));
-            }
-            if let Some(a) = &answers.answer_404 {
-                rows.push(row!("404", a));
-            }
-            if let Some(a) = &answers.answer_408 {
-                rows.push(row!("408", a));
-            }
-            if let Some(a) = &answers.answer_413 {
-                rows.push(row!("413", a));
-            }
-            if let Some(a) = &answers.answer_502 {
-                rows.push(row!("502", a));
-            }
-            if let Some(a) = &answers.answer_503 {
-                rows.push(row!("503", a));
-            }
-            if let Some(a) = &answers.answer_504 {
-                rows.push(row!("504", a));
-            }
-            if let Some(a) = &answers.answer_507 {
-                rows.push(row!("507", a));
-            }
-        }
-        rows
     }
 }
 

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -1478,9 +1478,7 @@ mod tests {
     use rand::{RngExt, rng, seq::SliceRandom};
 
     use super::*;
-    use crate::proto::command::{
-        CustomHttpAnswers, LoadBalancingParams, RequestHttpFrontend, RulePosition,
-    };
+    use crate::proto::command::{LoadBalancingParams, RequestHttpFrontend, RulePosition};
 
     #[test]
     fn serialize() {
@@ -1982,10 +1980,8 @@ mod tests {
     #[test]
     fn listener_diff() {
         let mut state: ConfigState = Default::default();
-        let custom_http_answers = Some(CustomHttpAnswers {
-            answer_404: Some("test".to_string()),
-            ..Default::default()
-        });
+        let custom_answers: BTreeMap<String, String> =
+            [("404".to_owned(), "test".to_owned())].into();
         state
             .dispatch(
                 &RequestType::AddTcpListener(TcpListenerConfig {
@@ -2049,7 +2045,7 @@ mod tests {
             .dispatch(
                 &RequestType::AddHttpListener(HttpListenerConfig {
                     address: SocketAddress::new_v4(0, 0, 0, 0, 8080),
-                    http_answers: custom_http_answers.clone(),
+                    answers: custom_answers.clone(),
                     ..Default::default()
                 })
                 .into(),
@@ -2069,7 +2065,7 @@ mod tests {
             .dispatch(
                 &RequestType::AddHttpsListener(HttpsListenerConfig {
                     address: SocketAddress::new_v4(0, 0, 0, 0, 8443),
-                    http_answers: custom_http_answers.clone(),
+                    answers: custom_answers.clone(),
                     ..Default::default()
                 })
                 .into(),
@@ -2111,7 +2107,7 @@ mod tests {
             .into(),
             RequestType::AddHttpListener(HttpListenerConfig {
                 address: SocketAddress::new_v4(0, 0, 0, 0, 8080),
-                http_answers: custom_http_answers.clone(),
+                answers: custom_answers.clone(),
                 ..Default::default()
             })
             .into(),
@@ -2128,7 +2124,7 @@ mod tests {
             .into(),
             RequestType::AddHttpsListener(HttpsListenerConfig {
                 address: SocketAddress::new_v4(0, 0, 0, 0, 8443),
-                http_answers: custom_http_answers.clone(),
+                answers: custom_answers.clone(),
                 ..Default::default()
             })
             .into(),

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -127,14 +127,12 @@ in `lib/src/protocol/kawa_h1/answers.rs`, and then change them to your liking. F
 `\r` newlines of the default strings for clarity.
 Sōzu will parse your file and replace whatever newline symbol(s) you use.
 
-Then, for each listener, provide the absolute paths of each custom answer.
+Then, for each listener, provide the answer templates as a map of status code to file path.
 
 ```toml
-# a 404 response is sent when sozu does not know about the requested domain or path
-answer_404 = "/path/to/my-404-answer.http"
-# a 503 response is sent if there are no backend servers available
-answer_503 = "/path/to/my-503-answer.http"
-# answer_507 = ...
+[listeners.answers]
+"404" = "/path/to/my-404-answer.http"
+"503" = "/path/to/my-503-answer.http"
 ```
 
 If a frontend has a `sticky_session`, the sticky name is defined at the listener level.

--- a/e2e/src/http_utils/mod.rs
+++ b/e2e/src/http_utils/mod.rs
@@ -24,6 +24,7 @@ pub fn http_request<S1: Into<String>, S2: Into<String>, S3: Into<String>, S4: In
     )
 }
 
+/// Template content for custom answers (no Content-Length, auto-injected by the template system)
 pub fn immutable_answer(status: u16) -> String {
     match status {
         400 => String::from(
@@ -37,6 +38,25 @@ pub fn immutable_answer(status: u16) -> String {
         ),
         503 => String::from(
             "HTTP/1.1 503 Service Unavailable\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n",
+        ),
+        _ => unimplemented!(),
+    }
+}
+
+/// Expected response for custom answers (includes auto-injected Content-Length)
+pub fn immutable_answer_expected(status: u16) -> String {
+    match status {
+        400 => String::from(
+            "HTTP/1.1 400 Bad Request\r\nCache-Control: no-cache\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
+        ),
+        404 => String::from(
+            "HTTP/1.1 404 Not Found\r\nCache-Control: no-cache\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
+        ),
+        502 => String::from(
+            "HTTP/1.1 502 Bad Gateway\r\nCache-Control: no-cache\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
+        ),
+        503 => String::from(
+            "HTTP/1.1 503 Service Unavailable\r\nCache-Control: no-cache\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
         ),
         _ => unimplemented!(),
     }

--- a/e2e/src/tests/tests.rs
+++ b/e2e/src/tests/tests.rs
@@ -9,15 +9,15 @@ use sozu_command_lib::{
     info,
     logging::setup_default_logging,
     proto::command::{
-        ActivateListener, AddCertificate, CertificateAndKey, Cluster, CustomHttpAnswers,
-        ListenerType, RemoveBackend, RequestHttpFrontend, SocketAddress, request::RequestType,
+        ActivateListener, AddCertificate, CertificateAndKey, Cluster, ListenerType, RemoveBackend,
+        RequestHttpFrontend, SocketAddress, request::RequestType,
     },
     scm_socket::Listeners,
     state::ConfigState,
 };
 
 use crate::{
-    http_utils::{http_ok_response, http_request, immutable_answer},
+    http_utils::{http_ok_response, http_request, immutable_answer, immutable_answer_expected},
     mock::{
         aggregator::SimpleAggregator,
         async_backend::BackendHandle as AsyncBackend,
@@ -633,14 +633,13 @@ fn try_http_behaviors() -> State {
     let mut http_config = ListenerBuilder::new_http(front_address.into())
         .to_http(None)
         .unwrap();
-    let http_answers = CustomHttpAnswers {
-        answer_400: Some(immutable_answer(400)),
-        answer_404: Some(immutable_answer(404)),
-        answer_502: Some(immutable_answer(502)),
-        answer_503: Some(immutable_answer(503)),
-        ..Default::default()
-    };
-    http_config.http_answers = Some(http_answers);
+    http_config.answers = [
+        ("400".to_owned(), immutable_answer(400)),
+        ("404".to_owned(), immutable_answer(404)),
+        ("502".to_owned(), immutable_answer(502)),
+        ("503".to_owned(), immutable_answer(503)),
+    ]
+    .into();
 
     worker.send_proxy_request_type(RequestType::AddHttpListener(http_config));
     worker.send_proxy_request_type(RequestType::ActivateListener(ActivateListener {
@@ -662,7 +661,7 @@ fn try_http_behaviors() -> State {
 
     let response = client.receive();
     println!("response: {response:?}");
-    assert_eq!(response, Some(immutable_answer(404)));
+    assert_eq!(response, Some(immutable_answer_expected(404)));
     assert_eq!(client.receive(), None);
 
     worker.send_proxy_request_type(RequestType::AddHttpFrontend(RequestHttpFrontend {
@@ -677,7 +676,7 @@ fn try_http_behaviors() -> State {
 
     let response = client.receive();
     println!("response: {response:?}");
-    assert_eq!(response, Some(immutable_answer(503)));
+    assert_eq!(response, Some(immutable_answer_expected(503)));
     assert_eq!(client.receive(), None);
 
     let back_address = create_local_address();
@@ -697,7 +696,7 @@ fn try_http_behaviors() -> State {
 
     let response = client.receive();
     println!("response: {response:?}");
-    assert_eq!(response, Some(immutable_answer(400)));
+    assert_eq!(response, Some(immutable_answer_expected(400)));
     assert_eq!(client.receive(), None);
 
     let mut backend = SyncBackend::new("backend", back_address, "TEST\r\n\r\n");
@@ -714,7 +713,7 @@ fn try_http_behaviors() -> State {
     let response = client.receive();
     println!("request: {request:?}");
     println!("response: {response:?}");
-    assert_eq!(response, Some(immutable_answer(502)));
+    assert_eq!(response, Some(immutable_answer_expected(502)));
     assert_eq!(client.receive(), None);
 
     info!("expecting 200");
@@ -777,7 +776,7 @@ fn try_http_behaviors() -> State {
     let response = client.receive();
     println!("request: {request:?}");
     println!("response: {response:?}");
-    assert_eq!(response, Some(immutable_answer(503)));
+    assert_eq!(response, Some(immutable_answer_expected(503)));
     assert_eq!(client.receive(), None);
 
     worker.send_proxy_request_type(RequestType::RemoveBackend(RemoveBackend {
@@ -942,11 +941,11 @@ fn try_https_redirect() -> State {
         .unwrap();
     let answer_301_prefix = "HTTP/1.1 301 Moved Permanently\r\nLocation: ";
 
-    let http_answers = CustomHttpAnswers {
-        answer_301: Some(format!("{answer_301_prefix}%REDIRECT_LOCATION\r\n\r\n")),
-        ..Default::default()
-    };
-    http_config.http_answers = Some(http_answers);
+    http_config.answers = [(
+        "301".to_owned(),
+        format!("{answer_301_prefix}%REDIRECT_LOCATION\r\n\r\n"),
+    )]
+    .into();
 
     worker.send_proxy_request_type(RequestType::AddHttpListener(http_config));
     worker.send_proxy_request_type(RequestType::ActivateListener(ActivateListener {
@@ -977,7 +976,9 @@ fn try_https_redirect() -> State {
     client.connect();
     client.send();
     let answer = client.receive();
-    let expected_answer = format!("{answer_301_prefix}https://example.com/redirected?true\r\n\r\n");
+    let expected_answer = format!(
+        "{answer_301_prefix}https://example.com/redirected?true\r\nContent-Length: 0\r\n\r\n"
+    );
     assert_eq!(answer, Some(expected_answer));
 
     State::Success

--- a/lib/examples/http.rs
+++ b/lib/examples/http.rs
@@ -46,7 +46,7 @@ fn main() -> anyhow::Result<()> {
         sticky_session: false,
         https_redirect: false,
         load_balancing: LoadBalancingAlgorithms::RoundRobin as i32,
-        answer_503: Some("A custom forbidden message".to_string()),
+        answers: [("503".to_owned(), "A custom forbidden message".to_owned())].into(),
         ..Default::default()
     };
 

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::RefCell,
-    collections::{hash_map::Entry, BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, hash_map::Entry},
     io::ErrorKind,
     net::{Shutdown, SocketAddr},
     os::unix::io::AsRawFd,
@@ -10,16 +10,16 @@ use std::{
 };
 
 use mio::{
+    Interest, Registry, Token,
     net::{TcpListener as MioTcpListener, TcpStream},
     unix::SourceFd,
-    Interest, Registry, Token,
 };
 use rusty_ulid::Ulid;
 use sozu_command::{
     logging::CachedTags,
     proto::command::{
-        request::RequestType, Cluster, HttpListenerConfig, ListenerType, RemoveListener,
-        RequestHttpFrontend, WorkerRequest, WorkerResponse,
+        Cluster, HttpListenerConfig, ListenerType, RemoveListener, RequestHttpFrontend,
+        WorkerRequest, WorkerResponse, request::RequestType,
     },
     ready::Ready,
     response::HttpFrontend,
@@ -27,24 +27,24 @@ use sozu_command::{
 };
 
 use crate::{
+    AcceptError, FrontendFromRequestError, L7ListenerHandler, L7Proxy, ListenerError,
+    ListenerHandler, Protocol, ProxyConfiguration, ProxyError, ProxySession, SessionIsToBeClosed,
+    SessionMetrics, SessionResult, StateMachineBuilder, StateResult,
     backends::BackendMap,
     pool::Pool,
     protocol::{
+        Http, Pipe, SessionState,
         http::{
-            answers::HttpAnswers,
-            parser::{hostname_and_port, Method},
             ResponseStream,
+            answers::HttpAnswers,
+            parser::{Method, hostname_and_port},
         },
         proxy_protocol::expect::ExpectProxyProtocol,
-        Http, Pipe, SessionState,
     },
     router::{Route, Router},
     server::{ListenToken, SessionManager},
     socket::server_bind,
     timer::TimeoutContainer,
-    AcceptError, FrontendFromRequestError, L7ListenerHandler, L7Proxy, ListenerError,
-    ListenerHandler, Protocol, ProxyConfiguration, ProxyError, ProxySession, SessionIsToBeClosed,
-    SessionMetrics, SessionResult, StateMachineBuilder, StateResult,
 };
 
 #[derive(PartialEq, Eq)]
@@ -593,16 +593,16 @@ impl HttpProxy {
         Ok((owned.token, taken_listener))
     }
 
-    pub fn add_cluster(&mut self, mut cluster: Cluster) -> Result<(), ProxyError> {
-        if let Some(answer_503) = cluster.answer_503.take() {
+    pub fn add_cluster(&mut self, cluster: Cluster) -> Result<(), ProxyError> {
+        if !cluster.answers.is_empty() {
             for listener in self.listeners.values() {
                 listener
                     .borrow()
                     .answers
                     .borrow_mut()
-                    .add_custom_answer(&cluster.cluster_id, answer_503.clone())
-                    .map_err(|(status, error)| {
-                        ProxyError::AddCluster(ListenerError::TemplateParse(status, error))
+                    .add_cluster_answers(&cluster.cluster_id, &cluster.answers)
+                    .map_err(|(name, error)| {
+                        ProxyError::AddCluster(ListenerError::TemplateParse(name, error))
                     })?;
             }
         }
@@ -618,7 +618,7 @@ impl HttpProxy {
                 .borrow()
                 .answers
                 .borrow_mut()
-                .remove_custom_answer(cluster_id);
+                .remove_cluster_answers(cluster_id);
         }
         Ok(())
     }
@@ -726,8 +726,8 @@ impl HttpListener {
             active: false,
             address: config.address.into(),
             answers: Rc::new(RefCell::new(
-                HttpAnswers::new(&config.http_answers)
-                    .map_err(|(status, error)| ListenerError::TemplateParse(status, error))?,
+                HttpAnswers::new(&config.answers)
+                    .map_err(|(name, error)| ListenerError::TemplateParse(name, error))?,
             )),
             config,
             fronts: Router::new(),
@@ -1060,7 +1060,7 @@ mod tests {
         time::Duration,
     };
 
-    use sozu_command::proto::command::{CustomHttpAnswers, SocketAddress};
+    use sozu_command::proto::command::SocketAddress;
 
     use super::{testing::start_http_worker, *};
     use crate::sozu_command::{
@@ -1372,9 +1372,7 @@ mod tests {
             listener: None,
             address: address.into(),
             fronts,
-            answers: Rc::new(RefCell::new(
-                HttpAnswers::new(&Some(CustomHttpAnswers::default())).unwrap(),
-            )),
+            answers: Rc::new(RefCell::new(HttpAnswers::new(&BTreeMap::new()).unwrap())),
             config: default_config,
             token: Token(0),
             active: true,

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::RefCell,
-    collections::{hash_map::Entry, BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, hash_map::Entry},
     io::ErrorKind,
     net::{Shutdown, SocketAddr as StdSocketAddr},
     os::unix::io::AsRawFd,
@@ -11,36 +11,36 @@ use std::{
 };
 
 use mio::{
+    Interest, Registry, Token,
     net::{TcpListener as MioTcpListener, TcpStream as MioTcpStream},
     unix::SourceFd,
-    Interest, Registry, Token,
 };
 use rustls::{
+    CipherSuite, ProtocolVersion, ServerConfig as RustlsServerConfig, ServerConnection,
+    SupportedCipherSuite,
     crypto::{
+        CryptoProvider,
         ring::{
             self,
             cipher_suite::{
-                TLS13_AES_128_GCM_SHA256, TLS13_AES_256_GCM_SHA384, TLS13_CHACHA20_POLY1305_SHA256,
                 TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
                 TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
                 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-                TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+                TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256, TLS13_AES_128_GCM_SHA256,
+                TLS13_AES_256_GCM_SHA384, TLS13_CHACHA20_POLY1305_SHA256,
             },
         },
-        CryptoProvider,
     },
-    CipherSuite, ProtocolVersion, ServerConfig as RustlsServerConfig, ServerConnection,
-    SupportedCipherSuite,
 };
 use rusty_ulid::Ulid;
 use sozu_command::{
     certificate::Fingerprint,
     config::DEFAULT_CIPHER_SUITES,
     proto::command::{
-        request::RequestType, response_content::ContentType, AddCertificate, CertificateSummary,
-        CertificatesByAddress, Cluster, HttpsListenerConfig, ListOfCertificatesByAddress,
-        ListenerType, RemoveCertificate, RemoveListener, ReplaceCertificate, RequestHttpFrontend,
-        ResponseContent, TlsVersion, WorkerRequest, WorkerResponse,
+        AddCertificate, CertificateSummary, CertificatesByAddress, Cluster, HttpsListenerConfig,
+        ListOfCertificatesByAddress, ListenerType, RemoveCertificate, RemoveListener,
+        ReplaceCertificate, RequestHttpFrontend, ResponseContent, TlsVersion, WorkerRequest,
+        WorkerResponse, request::RequestType, response_content::ContentType,
     },
     ready::Ready,
     response::HttpFrontend,
@@ -48,27 +48,27 @@ use sozu_command::{
 };
 
 use crate::{
-    backends::BackendMap,
-    pool::Pool,
-    protocol::{
-        http::{
-            answers::HttpAnswers,
-            parser::{hostname_and_port, Method},
-            ResponseStream,
-        },
-        proxy_protocol::expect::ExpectProxyProtocol,
-        rustls::TlsHandshake,
-        Http, Pipe, SessionState,
-    },
-    router::{Route, Router},
-    server::{ListenToken, SessionManager},
-    socket::{server_bind, FrontRustls},
-    timer::TimeoutContainer,
-    tls::MutexCertificateResolver,
-    util::UnwrapLog,
     AcceptError, CachedTags, FrontendFromRequestError, L7ListenerHandler, L7Proxy, ListenerError,
     ListenerHandler, Protocol, ProxyConfiguration, ProxyError, ProxySession, SessionIsToBeClosed,
     SessionMetrics, SessionResult, StateMachineBuilder, StateResult,
+    backends::BackendMap,
+    pool::Pool,
+    protocol::{
+        Http, Pipe, SessionState,
+        http::{
+            ResponseStream,
+            answers::HttpAnswers,
+            parser::{Method, hostname_and_port},
+        },
+        proxy_protocol::expect::ExpectProxyProtocol,
+        rustls::TlsHandshake,
+    },
+    router::{Route, Router},
+    server::{ListenToken, SessionManager},
+    socket::{FrontRustls, server_bind},
+    timer::TimeoutContainer,
+    tls::MutexCertificateResolver,
+    util::UnwrapLog,
 };
 
 // const SERVER_PROTOS: &[&str] = &["http/1.1", "h2"];
@@ -609,8 +609,8 @@ impl HttpsListener {
             active: false,
             fronts: Router::new(),
             answers: Rc::new(RefCell::new(
-                HttpAnswers::new(&config.http_answers)
-                    .map_err(|(status, error)| ListenerError::TemplateParse(status, error))?,
+                HttpAnswers::new(&config.answers)
+                    .map_err(|(name, error)| ListenerError::TemplateParse(name, error))?,
             )),
             config,
             token,
@@ -977,19 +977,16 @@ impl HttpsProxy {
         Ok((owned.token, taken_listener))
     }
 
-    pub fn add_cluster(
-        &mut self,
-        mut cluster: Cluster,
-    ) -> Result<Option<ResponseContent>, ProxyError> {
-        if let Some(answer_503) = cluster.answer_503.take() {
+    pub fn add_cluster(&mut self, cluster: Cluster) -> Result<Option<ResponseContent>, ProxyError> {
+        if !cluster.answers.is_empty() {
             for listener in self.listeners.values() {
                 listener
                     .borrow()
                     .answers
                     .borrow_mut()
-                    .add_custom_answer(&cluster.cluster_id, answer_503.clone())
-                    .map_err(|(status, error)| {
-                        ProxyError::AddCluster(ListenerError::TemplateParse(status, error))
+                    .add_cluster_answers(&cluster.cluster_id, &cluster.answers)
+                    .map_err(|(name, error)| {
+                        ProxyError::AddCluster(ListenerError::TemplateParse(name, error))
                     })?;
             }
         }
@@ -1007,7 +1004,7 @@ impl HttpsProxy {
                 .borrow()
                 .answers
                 .borrow_mut()
-                .remove_custom_answer(cluster_id);
+                .remove_cluster_answers(cluster_id);
         }
 
         Ok(None)
@@ -1486,13 +1483,10 @@ pub mod testing {
 mod tests {
     use std::sync::Arc;
 
-    use sozu_command::{
-        config::ListenerBuilder,
-        proto::command::{CustomHttpAnswers, SocketAddress},
-    };
+    use sozu_command::{config::ListenerBuilder, proto::command::SocketAddress};
 
     use super::*;
-    use crate::router::{pattern_trie::TrieNode, MethodRule, PathRule, Route, Router};
+    use crate::router::{MethodRule, PathRule, Route, Router, pattern_trie::TrieNode};
 
     /*
     #[test]
@@ -1571,9 +1565,7 @@ mod tests {
             fronts,
             rustls_details,
             resolver,
-            answers: Rc::new(RefCell::new(
-                HttpAnswers::new(&Some(CustomHttpAnswers::default())).unwrap(),
-            )),
+            answers: Rc::new(RefCell::new(HttpAnswers::new(&BTreeMap::new()).unwrap())),
             config: default_config,
             token: Token(0),
             active: true,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -106,7 +106,7 @@
 //!     sticky_session: false,
 //!     https_redirect: false,
 //!     load_balancing: LoadBalancingAlgorithms::RoundRobin as i32,
-//!     answer_503: Some("A custom forbidden message".to_string()),
+//!     answers: [("503".to_owned(), "A custom answer".to_owned())].into(),
 //!     ..Default::default()
 //! };
 //! ```
@@ -249,7 +249,7 @@
 //!         sticky_session: false,
 //!         https_redirect: false,
 //!         load_balancing: LoadBalancingAlgorithms::RoundRobin as i32,
-//!         answer_503: Some("A custom forbidden message".to_string()),
+//!         answers: [("503".to_owned(), "A custom answer".to_owned())].into(),
 //!         ..Default::default()
 //!     };
 //!
@@ -624,7 +624,7 @@ pub enum ListenerError {
     #[error("failed to parse pem, {0}")]
     PemParse(String),
     #[error("failed to parse template {0}: {1}")]
-    TemplateParse(u16, TemplateError),
+    TemplateParse(String, TemplateError),
     #[error("failed to build rustls context, {0}")]
     BuildRustls(String),
     #[error("could not activate listener with address {address:?}: {error}")]

--- a/lib/src/protocol/kawa_h1/answers.rs
+++ b/lib/src/protocol/kawa_h1/answers.rs
@@ -1,15 +1,15 @@
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{BTreeMap, HashMap, VecDeque},
     fmt,
     rc::Rc,
 };
 
 use kawa::{
-    h1::NoCallbacks, AsBuffer, Block, BodySize, Buffer, Chunk, Kawa, Kind, Pair, ParsingPhase,
-    ParsingPhaseMarker, StatusLine, Store,
+    AsBuffer, Block, BodySize, Buffer, Chunk, Flags, Kawa, Kind, Pair, ParsingPhase,
+    ParsingPhaseMarker, StatusLine, Store, h1::NoCallbacks,
 };
-use sozu_command::proto::command::CustomHttpAnswers;
 
+use super::parser::compare_no_case;
 use crate::{protocol::http::DefaultAnswer, sozu_command::state::ClusterId};
 
 #[derive(Clone)]
@@ -35,6 +35,8 @@ pub enum TemplateError {
     InvalidTemplate(ParsingPhase),
     #[error("unexpected status code: {0}")]
     InvalidStatusCode(u16),
+    #[error("unexpected size info: {0:?}")]
+    InvalidSizeInfo(BodySize),
     #[error("streaming is not supported in templates")]
     UnsupportedStreaming,
     #[error("template variable {0} is not allowed in headers")]
@@ -50,6 +52,7 @@ pub struct TemplateVariable {
     name: &'static str,
     valid_in_body: bool,
     valid_in_header: bool,
+    or_elide_header: bool,
     typ: ReplacementType,
 }
 
@@ -63,11 +66,13 @@ pub enum ReplacementType {
 #[derive(Clone, Copy, Debug)]
 pub struct Replacement {
     block_index: usize,
+    or_elide_header: bool,
     typ: ReplacementType,
 }
 
-// TODO: rename for clarity, for instance HttpAnswerTemplate
 pub struct Template {
+    status: u16,
+    keep_alive: bool,
     kawa: DefaultAnswerStream,
     body_replacements: Vec<Replacement>,
     header_replacements: Vec<Replacement>,
@@ -88,8 +93,8 @@ impl fmt::Debug for Template {
 impl Template {
     /// sanitize the template: transform newlines \r (CR) to \r\n (CRLF)
     fn new(
-        status: u16,
-        answer: String,
+        status: Option<u16>,
+        answer: &str,
         variables: &[TemplateVariable],
     ) -> Result<Self, TemplateError> {
         let mut i = 0;
@@ -126,28 +131,54 @@ impl Template {
         if !kawa.is_main_phase() {
             return Err(TemplateError::InvalidTemplate(kawa.parsing_phase));
         }
-        if let StatusLine::Response { code, .. } = kawa.detached.status_line {
-            if code != status {
-                return Err(TemplateError::InvalidStatusCode(code));
+        if kawa.body_size != BodySize::Empty {
+            return Err(TemplateError::InvalidSizeInfo(kawa.body_size));
+        }
+        let status = if let StatusLine::Response { code, .. } = &kawa.detached.status_line {
+            if let Some(expected_code) = status {
+                if expected_code != *code {
+                    return Err(TemplateError::InvalidStatusCode(*code));
+                }
             }
+            *code
         } else {
             return Err(TemplateError::InvalidType);
-        }
+        };
         let buf = kawa.storage.buffer();
         let mut blocks = VecDeque::new();
         let mut header_replacements = Vec::new();
         let mut body_replacements = Vec::new();
         let mut body_size = 0;
+        let mut keep_alive = true;
         let mut used_once = Vec::new();
         for mut block in kawa.blocks.into_iter() {
             match &mut block {
                 Block::ChunkHeader(_) => return Err(TemplateError::UnsupportedStreaming),
+                Block::Flags(Flags {
+                    end_header: true, ..
+                }) => {
+                    header_replacements.push(Replacement {
+                        block_index: blocks.len(),
+                        or_elide_header: false,
+                        typ: ReplacementType::ContentLength,
+                    });
+                    blocks.push_back(Block::Header(Pair {
+                        key: Store::Static(b"Content-Length"),
+                        val: Store::Static(b"PLACEHOLDER"),
+                    }));
+                    blocks.push_back(block);
+                }
                 Block::StatusLine | Block::Cookies | Block::Flags(_) => {
                     blocks.push_back(block);
                 }
                 Block::Header(Pair { key, val }) => {
                     let val_data = val.data(buf);
                     let key_data = key.data(buf);
+                    if compare_no_case(key_data, b"connection")
+                        && compare_no_case(val_data, b"close")
+                    {
+                        keep_alive = false;
+                    }
                     if let Some(b'%') = val_data.first() {
                         for variable in &variables {
                             if &val_data[1..] == variable.name.as_bytes() {
@@ -165,14 +196,11 @@ impl Template {
                                         }
                                         used_once.push(var_index);
                                     }
-                                    ReplacementType::ContentLength => {
-                                        if let Some(b'%') = key_data.first() {
-                                            *key = Store::new_slice(buf, &key_data[1..]);
-                                        }
-                                    }
+                                    ReplacementType::ContentLength => {}
                                 }
                                 header_replacements.push(Replacement {
                                     block_index: blocks.len(),
+                                    or_elide_header: variable.or_elide_header,
                                     typ: variable.typ,
                                 });
                                 break;
@@ -215,6 +243,7 @@ impl Template {
                                     }
                                     body_replacements.push(Replacement {
                                         block_index: blocks.len(),
+                                        or_elide_header: false,
                                         typ: variable.typ,
                                     });
                                     blocks.push_back(Block::Chunk(Chunk {
@@ -236,6 +265,8 @@ impl Template {
         }
         kawa.blocks = blocks;
         Ok(Self {
+            status,
+            keep_alive,
             kawa,
             body_replacements,
             header_replacements,
@@ -279,6 +310,10 @@ impl Template {
                         pair.val = Store::from_string(body_size.to_string())
                     }
                 }
+                if pair.val.len() == 0 && replacement.or_elide_header {
+                    pair.elide();
+                    continue;
+                }
             }
         }
         Kawa {
@@ -295,62 +330,42 @@ impl Template {
     }
 }
 
-/// a set of templates for HTTP answers, meant for one listener to use
-pub struct ListenerAnswers {
-    /// MovedPermanently
-    pub answer_301: Template,
-    /// BadRequest
-    pub answer_400: Template,
-    /// Unauthorized
-    pub answer_401: Template,
-    /// NotFound
-    pub answer_404: Template,
-    /// RequestTimeout
-    pub answer_408: Template,
-    /// PayloadTooLarge
-    pub answer_413: Template,
-    /// BadGateway
-    pub answer_502: Template,
-    /// ServiceUnavailable
-    pub answer_503: Template,
-    /// GatewayTimeout
-    pub answer_504: Template,
-    /// InsufficientStorage
-    pub answer_507: Template,
-}
-
-/// templates for HTTP answers, set for one cluster
-#[allow(non_snake_case)]
-pub struct ClusterAnswers {
-    /// ServiceUnavailable
-    pub answer_503: Template,
-}
-
 pub struct HttpAnswers {
-    pub listener_answers: ListenerAnswers, // configurated answers
-    pub cluster_custom_answers: HashMap<ClusterId, ClusterAnswers>,
+    pub cluster_answers: HashMap<ClusterId, BTreeMap<String, Template>>,
+    pub listener_answers: BTreeMap<String, Template>,
+    pub fallback: Template,
 }
 
-// const HEADERS: &str = "Connection: close\r
-// Content-Length: 0\r
-// Sozu-Id: %REQUEST_ID\r
-// \r";
-// const STYLE: &str = "<style>
-// pre {
-//   background: #EEE;
-//   padding: 10px;
-//   border: 1px solid #AAA;
-//   border-radius: 5px;
-// }
-// </style>";
-// const FOOTER: &str = "<footer>This is an automatic answer by Sōzu.</footer>";
+fn fallback() -> String {
+    String::from(
+        "\
+HTTP/1.1 404 Not Found\r
+Cache-Control: no-cache\r
+Connection: close\r
+Sozu-Id: %REQUEST_ID\r
+\r
+<html><head><meta charset='utf-8'><head><body>
+<style>pre{background:#EEE;padding:10px;border:1px solid #AAA;border-radius: 5px;}</style>
+<h1>404 Not Found</h1>
+<pre>
+{
+    \"status_code\": 404,
+    \"route\": \"%ROUTE\",
+    \"request_id\": \"%REQUEST_ID\"
+    \"cluster_id\": \"%CLUSTER_ID\",
+}
+</pre>
+<h1>A frontend requested template \"%TEMPLATE_NAME\" that couldn't be found</h1>
+<footer>This is an automatic answer by Sozu.</footer></body></html>",
+    )
+}
+
 fn default_301() -> String {
     String::from(
         "\
 HTTP/1.1 301 Moved Permanently\r
 Location: %REDIRECT_LOCATION\r
 Connection: close\r
-Content-Length: 0\r
 Sozu-Id: %REQUEST_ID\r
 \r\n",
     )
@@ -362,7 +377,6 @@ fn default_400() -> String {
 HTTP/1.1 400 Bad Request\r
 Cache-Control: no-cache\r
 Connection: close\r
-%Content-Length: %CONTENT_LENGTH\r
 Sozu-Id: %REQUEST_ID\r
 \r
 <html><head><meta charset='utf-8'><head><body>
@@ -388,10 +402,10 @@ Sozu-Id: %REQUEST_ID\r
 </div>
 <script>
 function display(id, chunks) {
-    let [start, end] = chunks.split(' … ');
+    let [start, end] = chunks.split(' ... ');
     let dec = new TextDecoder('utf8');
     let decode = chunk => dec.decode(new Uint8Array(chunk.split(' ').filter(e => e).map(e => parseInt(e, 16))));
-    document.getElementById(id).innerText = JSON.stringify(end ? `${decode(start)} […] ${decode(end)}` : `${decode(start)}`).slice(1,-1);
+    document.getElementById(id).innerText = JSON.stringify(end ? `${decode(start)} [...] ${decode(end)}` : `${decode(start)}`).slice(1,-1);
 }
 let p1 = %SUCCESSFULLY_PARSED;
 let p2 = %PARTIALLY_PARSED;
@@ -401,7 +415,7 @@ if (p1 !== null) {
     display('p1', p1);display('p2', p2);display('p3', p3);
 }
 </script>
-<footer>This is an automatic answer by Sōzu.</footer></body></html>",
+<footer>This is an automatic answer by Sozu.</footer></body></html>",
     )
 }
 
@@ -423,7 +437,7 @@ Sozu-Id: %REQUEST_ID\r
     \"request_id\": \"%REQUEST_ID\"
 }
 </pre>
-<footer>This is an automatic answer by Sōzu.</footer></body></html>",
+<footer>This is an automatic answer by Sozu.</footer></body></html>",
     )
 }
 
@@ -432,7 +446,6 @@ fn default_404() -> String {
         "\
 HTTP/1.1 404 Not Found\r
 Cache-Control: no-cache\r
-Connection: close\r
 Sozu-Id: %REQUEST_ID\r
 \r
 <html><head><meta charset='utf-8'><head><body>
@@ -445,7 +458,7 @@ Sozu-Id: %REQUEST_ID\r
     \"request_id\": \"%REQUEST_ID\"
 }
 </pre>
-<footer>This is an automatic answer by Sōzu.</footer></body></html>",
+<footer>This is an automatic answer by Sozu.</footer></body></html>",
     )
 }
 
@@ -468,7 +481,7 @@ Sozu-Id: %REQUEST_ID\r
 }
 </pre>
 <p>Request timed out after %DURATION.</p>
-<footer>This is an automatic answer by Sōzu.</footer></body></html>",
+<footer>This is an automatic answer by Sozu.</footer></body></html>",
     )
 }
 
@@ -478,7 +491,6 @@ fn default_413() -> String {
 HTTP/1.1 413 Payload Too Large\r
 Cache-Control: no-cache\r
 Connection: close\r
-%Content-Length: %CONTENT_LENGTH\r
 Sozu-Id: %REQUEST_ID\r
 \r
 <html><head><meta charset='utf-8'><head><body>
@@ -492,7 +504,7 @@ Sozu-Id: %REQUEST_ID\r
 }
 </pre>
 <p>Request needed more than %CAPACITY bytes to fit. Parser stopped at phase: %PHASE. %MESSAGE</p>
-<footer>This is an automatic answer by Sōzu.</footer></body></html>",
+<footer>This is an automatic answer by Sozu.</footer></body></html>",
     )
 }
 
@@ -502,7 +514,6 @@ fn default_502() -> String {
 HTTP/1.1 502 Bad Gateway\r
 Cache-Control: no-cache\r
 Connection: close\r
-%Content-Length: %CONTENT_LENGTH\r
 Sozu-Id: %REQUEST_ID\r
 \r
 <html><head><meta charset='utf-8'><head><body>
@@ -516,9 +527,9 @@ Sozu-Id: %REQUEST_ID\r
     \"cluster_id\": \"%CLUSTER_ID\",
     \"backend_id\": \"%BACKEND_ID\",
     \"parsing_phase\": \"%PHASE\",
-    \"successfully_parsed\": \"%SUCCESSFULLY_PARSED\",
-    \"partially_parsed\": \"%PARTIALLY_PARSED\",
-    \"invalid\": \"%INVALID\"
+    \"successfully_parsed\": %SUCCESSFULLY_PARSED,
+    \"partially_parsed\": %PARTIALLY_PARSED,
+    \"invalid\": %INVALID
 }
 </pre>
 <p>Response could not be parsed. %MESSAGE</p>
@@ -530,10 +541,10 @@ Sozu-Id: %REQUEST_ID\r
 </div>
 <script>
 function display(id, chunks) {
-    let [start, end] = chunks.split(' … ');
+    let [start, end] = chunks.split(' ... ');
     let dec = new TextDecoder('utf8');
     let decode = chunk => dec.decode(new Uint8Array(chunk.split(' ').filter(e => e).map(e => parseInt(e, 16))));
-    document.getElementById(id).innerText = JSON.stringify(end ? `${decode(start)} […] ${decode(end)}` : `${decode(start)}`).slice(1,-1);
+    document.getElementById(id).innerText = JSON.stringify(end ? `${decode(start)} [...] ${decode(end)}` : `${decode(start)}`).slice(1,-1);
 }
 let p1 = %SUCCESSFULLY_PARSED;
 let p2 = %PARTIALLY_PARSED;
@@ -543,7 +554,7 @@ if (p1 !== null) {
     display('p1', p1);display('p2', p2);display('p3', p3);
 }
 </script>
-<footer>This is an automatic answer by Sōzu.</footer></body></html>",
+<footer>This is an automatic answer by Sozu.</footer></body></html>",
     )
 }
 
@@ -553,7 +564,6 @@ fn default_503() -> String {
 HTTP/1.1 503 Service Unavailable\r
 Cache-Control: no-cache\r
 Connection: close\r
-%Content-Length: %CONTENT_LENGTH\r
 Sozu-Id: %REQUEST_ID\r
 \r
 <html><head><meta charset='utf-8'><head><body>
@@ -569,7 +579,7 @@ Sozu-Id: %REQUEST_ID\r
 }
 </pre>
 <p>%MESSAGE</p>
-<footer>This is an automatic answer by Sōzu.</footer></body></html>",
+<footer>This is an automatic answer by Sozu.</footer></body></html>",
     )
 }
 
@@ -594,7 +604,7 @@ Sozu-Id: %REQUEST_ID\r
 }
 </pre>
 <p>Response timed out after %DURATION.</p>
-<footer>This is an automatic answer by Sōzu.</footer></body></html>",
+<footer>This is an automatic answer by Sozu.</footer></body></html>",
     )
 }
 
@@ -604,7 +614,6 @@ fn default_507() -> String {
 HTTP/1.1 507 Insufficient Storage\r
 Cache-Control: no-cache\r
 Connection: close\r
-%Content-Length: %CONTENT_LENGTH\r
 Sozu-Id: %REQUEST_ID\r
 \r
 <html><head><meta charset='utf-8'><head><body>
@@ -619,8 +628,8 @@ Sozu-Id: %REQUEST_ID\r
     \"backend_id\": \"%BACKEND_ID\"
 }
 </pre>
-<p>Response needed more than %CAPACITY bytes to fit. Parser stopped at phase: %PHASE. %MESSAGE/p>
-<footer>This is an automatic answer by Sōzu.</footer></body></html>",
+<p>Response needed more than %CAPACITY bytes to fit. Parser stopped at phase: %PHASE. %MESSAGE</p>
+<footer>This is an automatic answer by Sozu.</footer></body></html>",
     )
 }
 
@@ -640,225 +649,211 @@ fn phase_to_vec(phase: ParsingPhaseMarker) -> Vec<u8> {
 
 impl HttpAnswers {
     #[rustfmt::skip]
-    pub fn template(status: u16, answer: String) -> Result<Template, (u16, TemplateError)> {
-        let length = TemplateVariable {
-            name: "CONTENT_LENGTH",
-            valid_in_body: false,
-            valid_in_header: true,
-            typ: ReplacementType::ContentLength,
-        };
-
+    pub fn template(name: &str, answer: &str) -> Result<Template, (String, TemplateError)> {
         let route = TemplateVariable {
             name: "ROUTE",
             valid_in_body: true,
             valid_in_header: true,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
         let request_id = TemplateVariable {
             name: "REQUEST_ID",
             valid_in_body: true,
             valid_in_header: true,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
         let cluster_id = TemplateVariable {
             name: "CLUSTER_ID",
             valid_in_body: true,
             valid_in_header: true,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
         let backend_id = TemplateVariable {
             name: "BACKEND_ID",
             valid_in_body: true,
             valid_in_header: true,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
         let duration = TemplateVariable {
             name: "DURATION",
             valid_in_body: true,
             valid_in_header: true,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
         let capacity = TemplateVariable {
             name: "CAPACITY",
             valid_in_body: true,
             valid_in_header: true,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
         let phase = TemplateVariable {
             name: "PHASE",
             valid_in_body: true,
             valid_in_header: true,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
 
         let location = TemplateVariable {
             name: "REDIRECT_LOCATION",
-            valid_in_body: false,
+            valid_in_body: true,
             valid_in_header: true,
+            or_elide_header: false,
             typ: ReplacementType::VariableOnce(0),
         };
         let message = TemplateVariable {
             name: "MESSAGE",
             valid_in_body: true,
             valid_in_header: false,
+            or_elide_header: false,
             typ: ReplacementType::VariableOnce(0),
         };
         let successfully_parsed = TemplateVariable {
             name: "SUCCESSFULLY_PARSED",
             valid_in_body: true,
             valid_in_header: false,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
         let partially_parsed = TemplateVariable {
             name: "PARTIALLY_PARSED",
             valid_in_body: true,
             valid_in_header: false,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
         let invalid = TemplateVariable {
             name: "INVALID",
             valid_in_body: true,
             valid_in_header: false,
+            or_elide_header: false,
+            typ: ReplacementType::Variable(0),
+        };
+        let template_name = TemplateVariable {
+            name: "TEMPLATE_NAME",
+            valid_in_body: true,
+            valid_in_header: true,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
 
-        match status {
-            301 => Template::new(
-                301,
+        match name {
+            "301" => Template::new(
+                Some(301),
                 answer,
-                &[length, route, request_id, location]
+                &[route, request_id, location]
             ),
-            400 => Template::new(
-                400,
+            "400" => Template::new(
+                Some(400),
                 answer,
-                &[length, route, request_id, message, phase, successfully_parsed, partially_parsed, invalid],
+                &[route, request_id, message, phase, successfully_parsed, partially_parsed, invalid],
             ),
-            401 => Template::new(
-                401,
+            "401" => Template::new(
+                Some(401),
                 answer,
-                &[length, route, request_id]
+                &[route, request_id]
             ),
-            404 => Template::new(
-                404,
+            "404" => Template::new(
+                Some(404),
                 answer,
-                &[length, route, request_id]
+                &[route, request_id]
             ),
-            408 => Template::new(
-                408,
+            "408" => Template::new(
+                Some(408),
                 answer,
-                &[length, route, request_id, duration]
+                &[route, request_id, duration]
             ),
-            413 => Template::new(
-                413,
+            "413" => Template::new(
+                Some(413),
                 answer,
-                &[length, route, request_id, capacity, message, phase],
+                &[route, request_id, capacity, message, phase],
             ),
-            502 => Template::new(
-                502,
+            "502" => Template::new(
+                Some(502),
                 answer,
-                &[length, route, request_id, cluster_id, backend_id, message, phase, successfully_parsed, partially_parsed, invalid],
+                &[route, request_id, cluster_id, backend_id, message, phase, successfully_parsed, partially_parsed, invalid],
             ),
-            503 => Template::new(
-                503,
+            "503" => Template::new(
+                Some(503),
                 answer,
-                &[length, route, request_id, cluster_id, backend_id, message],
+                &[route, request_id, cluster_id, backend_id, message],
             ),
-            504 => Template::new(
-                504,
+            "504" => Template::new(
+                Some(504),
                 answer,
-                &[length, route, request_id, cluster_id, backend_id, duration],
+                &[route, request_id, cluster_id, backend_id, duration],
             ),
-            507 => Template::new(
-                507,
+            "507" => Template::new(
+                Some(507),
                 answer,
-                &[length, route, request_id, cluster_id, backend_id, capacity, message, phase],
+                &[route, request_id, cluster_id, backend_id, capacity, message, phase],
             ),
-            _ => Err(TemplateError::InvalidStatusCode(status)),
+            _ => Template::new(
+                None,
+                answer,
+                &[route, request_id, cluster_id, location, template_name]
+            )
         }
-        .map_err(|e| (status, e))
+        .map_err(|e| (name.to_owned(), e))
     }
 
-    pub fn new(conf: &Option<CustomHttpAnswers>) -> Result<Self, (u16, TemplateError)> {
+    pub fn templates(
+        answers: &BTreeMap<String, String>,
+    ) -> Result<BTreeMap<String, Template>, (String, TemplateError)> {
+        answers
+            .iter()
+            .map(|(name, answer)| {
+                Self::template(name, answer).map(|template| (name.clone(), template))
+            })
+            .collect::<Result<_, _>>()
+    }
+
+    pub fn new(answers: &BTreeMap<String, String>) -> Result<Self, (String, TemplateError)> {
+        let mut listener_answers = Self::templates(answers)?;
+        let expected_defaults: &[(&str, fn() -> String)] = &[
+            ("301", default_301),
+            ("400", default_400),
+            ("401", default_401),
+            ("404", default_404),
+            ("408", default_408),
+            ("413", default_413),
+            ("502", default_502),
+            ("503", default_503),
+            ("504", default_504),
+            ("507", default_507),
+        ];
+        for (name, default) in expected_defaults {
+            listener_answers
+                .entry(name.to_string())
+                .or_insert_with(|| Self::template(name, &default()).unwrap());
+        }
         Ok(HttpAnswers {
-            listener_answers: ListenerAnswers {
-                answer_301: Self::template(
-                    301,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_301.clone())
-                        .unwrap_or(default_301()),
-                )?,
-                answer_400: Self::template(
-                    400,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_400.clone())
-                        .unwrap_or(default_400()),
-                )?,
-                answer_401: Self::template(
-                    401,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_401.clone())
-                        .unwrap_or(default_401()),
-                )?,
-                answer_404: Self::template(
-                    404,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_404.clone())
-                        .unwrap_or(default_404()),
-                )?,
-                answer_408: Self::template(
-                    408,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_408.clone())
-                        .unwrap_or(default_408()),
-                )?,
-                answer_413: Self::template(
-                    413,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_413.clone())
-                        .unwrap_or(default_413()),
-                )?,
-                answer_502: Self::template(
-                    502,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_502.clone())
-                        .unwrap_or(default_502()),
-                )?,
-                answer_503: Self::template(
-                    503,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_503.clone())
-                        .unwrap_or(default_503()),
-                )?,
-                answer_504: Self::template(
-                    504,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_504.clone())
-                        .unwrap_or(default_504()),
-                )?,
-                answer_507: Self::template(
-                    507,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_507.clone())
-                        .unwrap_or(default_507()),
-                )?,
-            },
-            cluster_custom_answers: HashMap::new(),
+            fallback: Self::template("", &fallback()).unwrap(),
+            listener_answers,
+            cluster_answers: HashMap::new(),
         })
     }
 
-    pub fn add_custom_answer(
+    pub fn add_cluster_answers(
         &mut self,
         cluster_id: &str,
-        answer_503: String,
-    ) -> Result<(), (u16, TemplateError)> {
-        let answer_503 = Self::template(503, answer_503)?;
-        self.cluster_custom_answers
-            .insert(cluster_id.to_string(), ClusterAnswers { answer_503 });
+        answers: &BTreeMap<String, String>,
+    ) -> Result<(), (String, TemplateError)> {
+        self.cluster_answers
+            .entry(cluster_id.to_owned())
+            .or_default()
+            .append(&mut Self::templates(answers)?);
         Ok(())
     }
 
-    pub fn remove_custom_answer(&mut self, cluster_id: &str) {
-        self.cluster_custom_answers.remove(cluster_id);
+    pub fn remove_cluster_answers(&mut self, cluster_id: &str) {
+        self.cluster_answers.remove(cluster_id);
     }
 
     pub fn get(
@@ -869,14 +864,13 @@ impl HttpAnswers {
         backend_id: Option<&str>,
         route: String,
     ) -> (u16, bool, DefaultAnswerStream) {
-        let status = u16::from(&answer);
         let variables: Vec<Vec<u8>>;
         let mut variables_once: Vec<Vec<u8>>;
-        let template = match answer {
+        let name = match answer {
             DefaultAnswer::Answer301 { location } => {
                 variables = vec![route.into(), request_id.into()];
                 variables_once = vec![location.into()];
-                &self.listener_answers.answer_301
+                "301"
             }
             DefaultAnswer::Answer400 {
                 message,
@@ -894,22 +888,22 @@ impl HttpAnswers {
                     invalid.into(),
                 ];
                 variables_once = vec![message.into()];
-                &self.listener_answers.answer_400
+                "400"
             }
             DefaultAnswer::Answer401 {} => {
                 variables = vec![route.into(), request_id.into()];
                 variables_once = vec![];
-                &self.listener_answers.answer_401
+                "401"
             }
             DefaultAnswer::Answer404 {} => {
                 variables = vec![route.into(), request_id.into()];
                 variables_once = vec![];
-                &self.listener_answers.answer_404
+                "404"
             }
             DefaultAnswer::Answer408 { duration } => {
                 variables = vec![route.into(), request_id.into(), duration.to_string().into()];
                 variables_once = vec![];
-                &self.listener_answers.answer_408
+                "408"
             }
             DefaultAnswer::Answer413 {
                 message,
@@ -923,7 +917,7 @@ impl HttpAnswers {
                     phase_to_vec(phase),
                 ];
                 variables_once = vec![message.into()];
-                &self.listener_answers.answer_413
+                "413"
             }
             DefaultAnswer::Answer502 {
                 message,
@@ -943,7 +937,7 @@ impl HttpAnswers {
                     invalid.into(),
                 ];
                 variables_once = vec![message.into()];
-                &self.listener_answers.answer_502
+                "502"
             }
             DefaultAnswer::Answer503 { message } => {
                 variables = vec![
@@ -953,10 +947,7 @@ impl HttpAnswers {
                     backend_id.unwrap_or_default().into(),
                 ];
                 variables_once = vec![message.into()];
-                cluster_id
-                    .and_then(|id: &str| self.cluster_custom_answers.get(id))
-                    .map(|c| &c.answer_503)
-                    .unwrap_or_else(|| &self.listener_answers.answer_503)
+                "503"
             }
             DefaultAnswer::Answer504 { duration } => {
                 variables = vec![
@@ -967,7 +958,7 @@ impl HttpAnswers {
                     duration.to_string().into(),
                 ];
                 variables_once = vec![];
-                &self.listener_answers.answer_504
+                "504"
             }
             DefaultAnswer::Answer507 {
                 phase,
@@ -983,14 +974,17 @@ impl HttpAnswers {
                     phase_to_vec(phase),
                 ];
                 variables_once = vec![message.into()];
-                &self.listener_answers.answer_507
+                "507"
             }
         };
-        // keep_alive is always false for now; PR B will add template-level keep_alive detection
-        let keep_alive = false;
+        let template = cluster_id
+            .and_then(|id| self.cluster_answers.get(id))
+            .and_then(|answers| answers.get(name))
+            .or_else(|| self.listener_answers.get(name))
+            .unwrap_or(&self.fallback);
         (
-            status,
-            keep_alive,
+            template.status,
+            template.keep_alive,
             template.fill(&variables, &mut variables_once),
         )
     }

--- a/lib/src/protocol/kawa_h1/answers.rs
+++ b/lib/src/protocol/kawa_h1/answers.rs
@@ -351,8 +351,8 @@ Sozu-Id: %REQUEST_ID\r
 {
     \"status_code\": 404,
     \"route\": \"%ROUTE\",
-    \"request_id\": \"%REQUEST_ID\"
-    \"cluster_id\": \"%CLUSTER_ID\",
+    \"request_id\": \"%REQUEST_ID\",
+    \"cluster_id\": \"%CLUSTER_ID\"
 }
 </pre>
 <h1>A frontend requested template \"%TEMPLATE_NAME\" that couldn't be found</h1>

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -12,7 +12,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use mio::{net::TcpStream, Interest, Token};
+use mio::{Interest, Token, net::TcpStream};
 use rusty_ulid::Ulid;
 use sozu_command::{
     config::MAX_LOOP_ITERATIONS,
@@ -21,9 +21,13 @@ use sozu_command::{
 };
 
 use crate::{
+    AcceptError, BackendConnectAction, BackendConnectionError, L7ListenerHandler, L7Proxy,
+    ListenerHandler, Protocol, ProxySession, Readiness, RetrieveClusterError, SessionIsToBeClosed,
+    SessionMetrics, SessionResult, StateResult,
     backends::{Backend, BackendError},
     pool::{Checkout, Pool},
     protocol::{
+        SessionState,
         http::{
             answers::DefaultAnswerStream,
             diagnostics::{diagnostic_400_502, diagnostic_413_507},
@@ -31,17 +35,13 @@ use crate::{
             parser::Method,
         },
         pipe::WebSocketContext,
-        SessionState,
     },
     retry::RetryPolicy,
     router::Route,
-    server::{push_event, CONN_RETRIES},
-    socket::{stats::socket_rtt, SocketHandler, SocketResult, TransportProtocol},
+    server::{CONN_RETRIES, push_event},
+    socket::{SocketHandler, SocketResult, TransportProtocol, stats::socket_rtt},
     sozu_command::{logging::LogContext, ready::Ready},
     timer::TimeoutContainer,
-    AcceptError, BackendConnectAction, BackendConnectionError, L7ListenerHandler, L7Proxy,
-    ListenerHandler, Protocol, ProxySession, Readiness, RetrieveClusterError, SessionIsToBeClosed,
-    SessionMetrics, SessionResult, StateResult,
 };
 
 /// This macro is defined uniquely in this module to help the tracking of kawa h1
@@ -1789,7 +1789,8 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         if counter >= MAX_LOOP_ITERATIONS {
             error!(
                 "{}\tHandling session went through {} iterations, there's a probable infinite loop bug, closing the connection",
-                log_context!(self), MAX_LOOP_ITERATIONS
+                log_context!(self),
+                MAX_LOOP_ITERATIONS
             );
 
             incr!("http.infinite_loop.error");

--- a/os-build/config.toml
+++ b/os-build/config.toml
@@ -150,24 +150,11 @@ address = "0.0.0.0:80"
 # this option is incompatible with expect_proxy
 # public_address = "1.2.3.4:80"
 
-# For details about custom HTTP answers, see `doc/configure.md`,
-# and for defaults, check out `/lib/src/protocol/kawa_h1/answers.rs`
-# a 401 response is sent when a frontend has a Deny rule
-# answer_401 = "/absolute/path/to/custom_401.http"
-# a 404 response is sent when sozu does not know about the requested domain or path
-# answer_404 = "/absolute/path/to/custom_404.http"
-# a 408 response is sent when a frontend has a Deny rule (unusual)
-# answer_408 = "/absolute/path/to/custom_408.http"
-# a 413 response is sent when a request was too large
-# answer_413 = "/absolute/path/to/custom_413.http"
-# a 502 response means the response sent by a backend could not be parsed by Sōzu
-# answer_502 = "/absolute/path/to/custom_502.http"
-# a 503 response is sent if there are no backend servers available
-# answer_503 = "/absolute/path/to/custom_503.http"
-# a 504 response means the backend timed out
-# answer_504 = "/absolute/path/to/custom_504.http"
-# a 507 response occurs when the response sent by a backend is too big
-# answer_507 = "/absolute/path/to/custom_507.http"
+# Custom HTTP answer templates as a map of status code to file path.
+# For details, see `doc/configure.md` and `/lib/src/protocol/kawa_h1/answers.rs`
+# [listeners.answers]
+# "404" = "/absolute/path/to/custom_404.http"
+# "503" = "/absolute/path/to/custom_503.http"
 
 # defines the sticky session cookie's name, if `sticky_session` is activated for
 # a cluster. Defaults to "SOZUBALANCEID"
@@ -188,24 +175,11 @@ address = "0.0.0.0:443"
 # this option is incompatible with expect_proxy
 # public_address = "1.2.3.4:80"
 
-# For details about custom HTTP answers, see `doc/configure.md`,
-# and for defaults, check out `/lib/src/protocol/kawa_h1/answers.rs`
-# a 401 response is sent when a frontend has a Deny rule
-# answer_401 = "/absolute/path/to/custom_401.http"
-# a 404 response is sent when sozu does not know about the requested domain or path
-# answer_404 = "/absolute/path/to/custom_404.http"
-# a 408 response is sent when a frontend has a Deny rule (unusual)
-# answer_408 = "/absolute/path/to/custom_408.http"
-# a 413 response is sent when a request was too large
-# answer_413 = "/absolute/path/to/custom_413.http"
-# a 502 response means the response sent by a backend could not be parsed by Sōzu
-# answer_502 = "/absolute/path/to/custom_502.http"
-# a 503 response is sent if there are no backend servers available
-# answer_503 = "/absolute/path/to/custom_503.http"
-# a 504 response means the backend timed out
-# answer_504 = "/absolute/path/to/custom_504.http"
-# a 507 response occurs when the response sent by a backend is too big
-# answer_507 = "/absolute/path/to/custom_507.http"
+# Custom HTTP answer templates as a map of status code to file path.
+# For details, see `doc/configure.md` and `/lib/src/protocol/kawa_h1/answers.rs`
+# [listeners.answers]
+# "404" = "/absolute/path/to/custom_404.http"
+# "503" = "/absolute/path/to/custom_503.http"
 
 # defines the sticky session cookie's name, if `sticky_session` is activated for
 # a cluster. Defaults to "SOZUBALANCEID"


### PR DESCRIPTION
## Summary
- Replace `CustomHttpAnswers` with `map<string, string>` answer templates on listeners and clusters
- Template variable substitution (status code, request path, cluster ID)
- Proto wire compatibility preserved (reserved fields for removed numbers)

## Depends on
- PR #1206 (backend refactor with Origin struct)

## Test plan
- [ ] Existing e2e tests pass
- [ ] Custom answer templates render correctly
- [ ] Default answers unchanged in behavior