### PR TITLE
feat(router): URL rewrite, redirection, and custom headers

### DIFF
--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -256,6 +256,7 @@ impl CommandManager {
                     method,
                     position: RulePosition::Tree.into(),
                     tags: tags.unwrap_or_default(),
+                    ..Default::default()
                 })
                 .into(),
             ),
@@ -301,6 +302,7 @@ impl CommandManager {
                     method,
                     position: RulePosition::Tree.into(),
                     tags: tags.unwrap_or_default(),
+                    ..Default::default()
                 })
                 .into(),
             ),

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -215,6 +215,26 @@ message ListenersList {
     map<string, TcpListenerConfig> tcp_listeners = 3;
 }
 
+// Redirect policy for a frontend
+enum RedirectPolicy {
+    // Forward traffic to the backend (default)
+    FORWARD = 0;
+    // Return a 301 Moved Permanently
+    PERMANENT = 1;
+    // Return a 401 Unauthorized
+    UNAUTHORIZED = 2;
+}
+
+// Scheme to use when building a redirect URL
+enum RedirectScheme {
+    // Use the same scheme as the incoming request
+    USE_SAME = 0;
+    // Force HTTP
+    USE_HTTP = 1;
+    // Force HTTPS
+    USE_HTTPS = 2;
+}
+
 // An HTTP or HTTPS frontend, as order to, or received from, Sōzu
 message RequestHttpFrontend {
     optional string cluster_id = 1;
@@ -225,6 +245,36 @@ message RequestHttpFrontend {
     required RulePosition position = 6 [default = TREE];
     // custom tags to identify the frontend in the access logs
     map<string, string> tags = 7;
+    // redirect policy: forward, permanent redirect, or deny
+    optional RedirectPolicy redirect = 8;
+    // whether basic auth is required
+    optional bool required_auth = 9;
+    // scheme to use when building a redirect URL
+    optional RedirectScheme redirect_scheme = 10;
+    // template for building redirect URLs, supports $HOST[n] and $PATH[n] placeholders
+    optional string redirect_template = 11;
+    // rewrite the host header before forwarding to the backend
+    optional string rewrite_host = 12;
+    // rewrite the path before forwarding to the backend
+    optional string rewrite_path = 13;
+    // rewrite the port in the forwarded URL
+    optional uint32 rewrite_port = 14;
+    // custom headers to add on this frontend
+    repeated Header headers = 15;
+}
+
+// Position of a custom header (on request, response, or both)
+enum HeaderPosition {
+    REQUEST = 1;
+    RESPONSE = 2;
+    BOTH = 3;
+}
+
+// A custom header to add to requests/responses on a frontend
+message Header {
+    required HeaderPosition position = 1;
+    required string key = 2;
+    required string val = 3;
 }
 
 message RequestTcpFrontend {
@@ -355,6 +405,8 @@ message Cluster {
     reserved 6;
     optional LoadMetric load_metric = 7;
     map<string, string> answers = 8;
+    // optional port to use when building HTTPS redirect URLs
+    optional uint32 https_redirect_port = 9;
 }
 
 enum LoadBalancingAlgorithms {

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -62,12 +62,12 @@ use crate::{
     certificate::split_certificate_chain,
     logging::AccessLogFormat,
     proto::command::{
-        ActivateListener, AddBackend, AddCertificate, CertificateAndKey, Cluster,
-        HttpListenerConfig, HttpsListenerConfig, ListenerType, LoadBalancingAlgorithms,
-        LoadBalancingParams, LoadMetric, MetricsConfiguration, PathRule, ProtobufAccessLogFormat,
-        ProxyProtocolConfig, Request, RequestHttpFrontend, RequestTcpFrontend, RulePosition,
-        ServerConfig, ServerMetricsConfig, SocketAddress, TcpListenerConfig, TlsVersion,
-        WorkerRequest, request::RequestType,
+        ActivateListener, AddBackend, AddCertificate, CertificateAndKey, Cluster, Header,
+        HeaderPosition, HttpListenerConfig, HttpsListenerConfig, ListenerType,
+        LoadBalancingAlgorithms, LoadBalancingParams, LoadMetric, MetricsConfiguration, PathRule,
+        ProtobufAccessLogFormat, ProxyProtocolConfig, RedirectPolicy, RedirectScheme, Request,
+        RequestHttpFrontend, RequestTcpFrontend, RulePosition, ServerConfig, ServerMetricsConfig,
+        SocketAddress, TcpListenerConfig, TlsVersion, WorkerRequest, request::RequestType,
     },
 };
 
@@ -635,6 +635,14 @@ pub enum PathRuleType {
     Equals,
 }
 
+/// A custom header to add on a frontend, as configured in the TOML file
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct HeaderConfig {
+    pub position: HeaderPosition,
+    pub key: String,
+    pub val: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FileClusterFrontendConfig {
@@ -653,6 +661,16 @@ pub struct FileClusterFrontendConfig {
     #[serde(default)]
     pub position: RulePosition,
     pub tags: Option<BTreeMap<String, String>>,
+    #[serde(default)]
+    pub required_auth: Option<bool>,
+    pub redirect: Option<RedirectPolicy>,
+    pub redirect_scheme: Option<RedirectScheme>,
+    pub redirect_template: Option<String>,
+    pub rewrite_host: Option<String>,
+    pub rewrite_path: Option<String>,
+    pub rewrite_port: Option<u16>,
+    #[serde(default)]
+    pub headers: Vec<HeaderConfig>,
 }
 
 impl FileClusterFrontendConfig {
@@ -738,6 +756,14 @@ impl FileClusterFrontendConfig {
             path,
             method: self.method.clone(),
             tags: self.tags.clone(),
+            required_auth: self.required_auth.unwrap_or(false),
+            redirect: self.redirect,
+            redirect_scheme: self.redirect_scheme,
+            redirect_template: self.redirect_template.clone(),
+            rewrite_host: self.rewrite_host.clone(),
+            rewrite_path: self.rewrite_path.clone(),
+            rewrite_port: self.rewrite_port,
+            headers: self.headers.clone(),
         })
     }
 }
@@ -765,6 +791,7 @@ pub struct FileClusterConfig {
     pub protocol: FileClusterProtocolConfig,
     pub sticky_session: Option<bool>,
     pub https_redirect: Option<bool>,
+    pub https_redirect_port: Option<u16>,
     #[serde(default)]
     pub send_proxy: Option<bool>,
     #[serde(default)]
@@ -857,6 +884,7 @@ impl FileClusterConfig {
                     backends: self.backends,
                     sticky_session: self.sticky_session.unwrap_or(false),
                     https_redirect: self.https_redirect.unwrap_or(false),
+                    https_redirect_port: self.https_redirect_port,
                     load_balancing: self.load_balancing,
                     load_metric: self.load_metric,
                     answers,
@@ -881,6 +909,16 @@ pub struct HttpFrontendConfig {
     #[serde(default)]
     pub position: RulePosition,
     pub tags: Option<BTreeMap<String, String>>,
+    #[serde(default)]
+    pub required_auth: bool,
+    pub redirect: Option<RedirectPolicy>,
+    pub redirect_scheme: Option<RedirectScheme>,
+    pub redirect_template: Option<String>,
+    pub rewrite_host: Option<String>,
+    pub rewrite_path: Option<String>,
+    pub rewrite_port: Option<u16>,
+    #[serde(default)]
+    pub headers: Vec<HeaderConfig>,
 }
 
 impl HttpFrontendConfig {
@@ -888,6 +926,33 @@ impl HttpFrontendConfig {
         let mut v = Vec::new();
 
         let tags = self.tags.clone().unwrap_or_default();
+        let headers: Vec<Header> = self
+            .headers
+            .iter()
+            .map(|h| Header {
+                position: h.position.into(),
+                key: h.key.clone(),
+                val: h.val.clone(),
+            })
+            .collect();
+
+        let make_frontend = |tags| RequestHttpFrontend {
+            cluster_id: Some(cluster_id.to_string()),
+            address: self.address.into(),
+            hostname: self.hostname.clone(),
+            path: self.path.clone(),
+            method: self.method.clone(),
+            position: self.position.into(),
+            tags,
+            required_auth: Some(self.required_auth),
+            redirect: self.redirect.map(Into::into),
+            redirect_scheme: self.redirect_scheme.map(Into::into),
+            redirect_template: self.redirect_template.clone(),
+            rewrite_host: self.rewrite_host.clone(),
+            rewrite_path: self.rewrite_path.clone(),
+            rewrite_port: self.rewrite_port.map(|x| x as u32),
+            headers: headers.clone(),
+        };
 
         if self.key.is_some() && self.certificate.is_some() {
             v.push(
@@ -898,10 +963,6 @@ impl HttpFrontendConfig {
                         certificate: self.certificate.clone().unwrap(),
                         certificate_chain: self.certificate_chain.clone().unwrap_or_default(),
                         versions: self.tls_versions.iter().map(|v| *v as i32).collect(),
-                        // This field is used to override the certificate subject and san, we should not set it when
-                        // loading the configuration, as we may provide a wildcard certificate for a specific domain.
-                        // As a result, we will reject legit traffic for others domains as the certificate resolver will
-                        // not load twice the same certificate and then do not register the certificate for others domains.
                         names: vec![],
                     },
                     expired_at: None,
@@ -909,32 +970,9 @@ impl HttpFrontendConfig {
                 .into(),
             );
 
-            v.push(
-                RequestType::AddHttpsFrontend(RequestHttpFrontend {
-                    cluster_id: Some(cluster_id.to_string()),
-                    address: self.address.into(),
-                    hostname: self.hostname.clone(),
-                    path: self.path.clone(),
-                    method: self.method.clone(),
-                    position: self.position.into(),
-                    tags,
-                })
-                .into(),
-            );
+            v.push(RequestType::AddHttpsFrontend(make_frontend(tags)).into());
         } else {
-            //create the front both for HTTP and HTTPS if possible
-            v.push(
-                RequestType::AddHttpFrontend(RequestHttpFrontend {
-                    cluster_id: Some(cluster_id.to_string()),
-                    address: self.address.into(),
-                    hostname: self.hostname.clone(),
-                    path: self.path.clone(),
-                    method: self.method.clone(),
-                    position: self.position.into(),
-                    tags,
-                })
-                .into(),
-            );
+            v.push(RequestType::AddHttpFrontend(make_frontend(tags)).into());
         }
 
         v
@@ -949,6 +987,8 @@ pub struct HttpClusterConfig {
     pub backends: Vec<BackendConfig>,
     pub sticky_session: bool,
     pub https_redirect: bool,
+    #[serde(default)]
+    pub https_redirect_port: Option<u16>,
     pub load_balancing: LoadBalancingAlgorithms,
     pub load_metric: Option<LoadMetric>,
     pub answers: BTreeMap<String, String>,
@@ -965,6 +1005,7 @@ impl HttpClusterConfig {
                 load_balancing: self.load_balancing as i32,
                 answers: self.answers.clone(),
                 load_metric: self.load_metric.map(|s| s as i32),
+                https_redirect_port: self.https_redirect_port.map(|p| p as u32),
             })
             .into(),
         ];
@@ -1026,6 +1067,7 @@ impl TcpClusterConfig {
                 load_balancing: self.load_balancing as i32,
                 load_metric: self.load_metric.map(|s| s as i32),
                 answers: BTreeMap::new(),
+                https_redirect_port: None,
             })
             .into(),
         ];

--- a/command/src/request.rs
+++ b/command/src/request.rs
@@ -13,9 +13,9 @@ use rusty_ulid::Ulid;
 use crate::{
     proto::{
         command::{
-            InitialState, IpAddress, LoadBalancingAlgorithms, PathRuleKind, Request,
-            RequestHttpFrontend, RulePosition, SocketAddress, Uint128, WorkerRequest, ip_address,
-            request::RequestType,
+            InitialState, IpAddress, LoadBalancingAlgorithms, PathRuleKind, RedirectPolicy,
+            RedirectScheme, Request, RequestHttpFrontend, RulePosition, SocketAddress, Uint128,
+            WorkerRequest, ip_address, request::RequestType,
         },
         display::format_request_type,
     },
@@ -173,6 +173,20 @@ impl RequestHttpFrontend {
                 }
             })?,
             tags: Some(self.tags),
+            required_auth: self.required_auth.unwrap_or(false),
+            redirect: self
+                .redirect
+                .and_then(|v| RedirectPolicy::try_from(v).ok())
+                .unwrap_or(RedirectPolicy::Forward),
+            redirect_scheme: self
+                .redirect_scheme
+                .and_then(|v| RedirectScheme::try_from(v).ok())
+                .unwrap_or(RedirectScheme::UseSame),
+            redirect_template: self.redirect_template,
+            rewrite_host: self.rewrite_host,
+            rewrite_path: self.rewrite_path,
+            rewrite_port: self.rewrite_port.map(|p| p as u16),
+            headers: self.headers,
         })
     }
 }

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -2,9 +2,9 @@ use std::{cmp::Ordering, collections::BTreeMap, fmt, net::SocketAddr};
 
 use crate::{
     proto::command::{
-        AddBackend, FilteredTimeSerie, LoadBalancingParams, PathRule, PathRuleKind,
-        RequestHttpFrontend, RequestTcpFrontend, Response, ResponseContent, ResponseStatus,
-        RulePosition, RunState, WorkerResponse,
+        AddBackend, FilteredTimeSerie, Header, LoadBalancingParams, PathRule, PathRuleKind,
+        RedirectPolicy, RedirectScheme, RequestHttpFrontend, RequestTcpFrontend, Response,
+        ResponseContent, ResponseStatus, RulePosition, RunState, WorkerResponse,
     },
     state::ClusterId,
 };
@@ -39,6 +39,26 @@ pub struct HttpFrontend {
     #[serde(default)]
     pub position: RulePosition,
     pub tags: Option<BTreeMap<String, String>>,
+    #[serde(default)]
+    pub required_auth: bool,
+    #[serde(default)]
+    pub redirect: RedirectPolicy,
+    #[serde(default)]
+    pub redirect_scheme: RedirectScheme,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redirect_template: Option<String>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rewrite_host: Option<String>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rewrite_path: Option<String>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rewrite_port: Option<u16>,
+    #[serde(default)]
+    pub headers: Vec<Header>,
 }
 
 impl From<HttpFrontend> for RequestHttpFrontend {
@@ -51,6 +71,22 @@ impl From<HttpFrontend> for RequestHttpFrontend {
             method: val.method,
             position: val.position.into(),
             tags: val.tags.unwrap_or_default(),
+            required_auth: if val.required_auth { Some(true) } else { None },
+            redirect: if val.redirect != RedirectPolicy::Forward {
+                Some(val.redirect.into())
+            } else {
+                None
+            },
+            redirect_scheme: if val.redirect_scheme != RedirectScheme::UseSame {
+                Some(val.redirect_scheme.into())
+            } else {
+                None
+            },
+            redirect_template: val.redirect_template,
+            rewrite_host: val.rewrite_host,
+            rewrite_path: val.rewrite_path,
+            rewrite_port: val.rewrite_port.map(|x| x as u32),
+            headers: val.headers,
         }
     }
 }

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -5,7 +5,6 @@ use std::{
     net::{Shutdown, SocketAddr},
     os::unix::io::AsRawFd,
     rc::{Rc, Weak},
-    str::from_utf8_unchecked,
     time::{Duration, Instant},
 };
 
@@ -41,7 +40,7 @@ use crate::{
         },
         proxy_protocol::expect::ExpectProxyProtocol,
     },
-    router::{Route, Router},
+    router::{RouteResult, Router},
     server::{ListenToken, SessionManager},
     socket::server_bind,
     timer::TimeoutContainer,
@@ -437,7 +436,7 @@ impl L7ListenerHandler for HttpListener {
         host: &str,
         uri: &str,
         method: &Method,
-    ) -> Result<Route, FrontendFromRequestError> {
+    ) -> Result<RouteResult, FrontendFromRequestError> {
         let start = Instant::now();
         let (remaining_input, (hostname, _)) = match hostname_and_port(host.as_bytes()) {
             Ok(tuple) => tuple,
@@ -455,16 +454,7 @@ impl L7ListenerHandler for HttpListener {
             ));
         }
 
-        /*if port == Some(&b"80"[..]) {
-        // it is alright to call from_utf8_unchecked,
-        // we already verified that there are only ascii
-        // chars in there
-          unsafe { from_utf8_unchecked(hostname) }
-        } else {
-          host
-        }
-        */
-        let host = unsafe { from_utf8_unchecked(hostname) };
+        let host = std::str::from_utf8(hostname).unwrap_or(host);
 
         let route = self.fronts.lookup(host, uri, method).map_err(|e| {
             incr!("http.failed_backend_matching");
@@ -473,7 +463,7 @@ impl L7ListenerHandler for HttpListener {
 
         let now = Instant::now();
 
-        if let Route::ClusterId(cluster) = &route {
+        if let Some(cluster) = &route.cluster_id {
             time!("frontend_matching_time", cluster, (now - start).as_millis());
         }
 
@@ -1326,6 +1316,14 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some(cluster_id1),
                 tags: None,
+                required_auth: false,
+                redirect: Default::default(),
+                redirect_scheme: Default::default(),
+                redirect_template: None,
+                rewrite_host: None,
+                rewrite_path: None,
+                rewrite_port: None,
+                headers: Vec::new(),
             })
             .expect("Could not add http frontend");
         fronts
@@ -1337,6 +1335,14 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some(cluster_id2),
                 tags: None,
+                required_auth: false,
+                redirect: Default::default(),
+                redirect_scheme: Default::default(),
+                redirect_template: None,
+                rewrite_host: None,
+                rewrite_path: None,
+                rewrite_port: None,
+                headers: Vec::new(),
             })
             .expect("Could not add http frontend");
         fronts
@@ -1348,6 +1354,14 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some(cluster_id3),
                 tags: None,
+                required_auth: false,
+                redirect: Default::default(),
+                redirect_scheme: Default::default(),
+                redirect_template: None,
+                rewrite_host: None,
+                rewrite_path: None,
+                rewrite_port: None,
+                headers: Vec::new(),
             })
             .expect("Could not add http frontend");
         fronts
@@ -1359,6 +1373,14 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some("cluster_1".to_owned()),
                 tags: None,
+                required_auth: false,
+                redirect: Default::default(),
+                redirect_scheme: Default::default(),
+                redirect_template: None,
+                rewrite_host: None,
+                rewrite_path: None,
+                rewrite_port: None,
+                headers: Vec::new(),
             })
             .expect("Could not add http frontend");
 
@@ -1385,20 +1407,20 @@ mod tests {
         let frontend4 = listener.frontend_from_request("lolcatho.st", "/yolo/swag", &Method::Get);
         let frontend5 = listener.frontend_from_request("domain", "/", &Method::Get);
         assert_eq!(
-            frontend1.expect("should find frontend"),
-            Route::ClusterId("cluster_1".to_string())
+            frontend1.expect("should find frontend").cluster_id,
+            Some("cluster_1".to_string())
         );
         assert_eq!(
-            frontend2.expect("should find frontend"),
-            Route::ClusterId("cluster_1".to_string())
+            frontend2.expect("should find frontend").cluster_id,
+            Some("cluster_1".to_string())
         );
         assert_eq!(
-            frontend3.expect("should find frontend"),
-            Route::ClusterId("cluster_2".to_string())
+            frontend3.expect("should find frontend").cluster_id,
+            Some("cluster_2".to_string())
         );
         assert_eq!(
-            frontend4.expect("should find frontend"),
-            Route::ClusterId("cluster_3".to_string())
+            frontend4.expect("should find frontend").cluster_id,
+            Some("cluster_3".to_string())
         );
         assert!(frontend5.is_err());
     }

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -5,7 +5,7 @@ use std::{
     net::{Shutdown, SocketAddr as StdSocketAddr},
     os::unix::io::AsRawFd,
     rc::{Rc, Weak},
-    str::{from_utf8, from_utf8_unchecked},
+    str::from_utf8,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -63,7 +63,7 @@ use crate::{
         proxy_protocol::expect::ExpectProxyProtocol,
         rustls::TlsHandshake,
     },
-    router::{Route, Router},
+    router::{RouteResult, Router},
     server::{ListenToken, SessionManager},
     socket::{FrontRustls, server_bind},
     timer::TimeoutContainer,
@@ -553,7 +553,7 @@ impl L7ListenerHandler for HttpsListener {
         host: &str,
         uri: &str,
         method: &Method,
-    ) -> Result<Route, FrontendFromRequestError> {
+    ) -> Result<RouteResult, FrontendFromRequestError> {
         let start = Instant::now();
         let (remaining_input, (hostname, _)) = match hostname_and_port(host.as_bytes()) {
             Ok(tuple) => tuple,
@@ -572,10 +572,7 @@ impl L7ListenerHandler for HttpsListener {
             ));
         }
 
-        // it is alright to call from_utf8_unchecked,
-        // we already verified that there are only ascii
-        // chars in there
-        let host = unsafe { from_utf8_unchecked(hostname) };
+        let host = std::str::from_utf8(hostname).unwrap_or(host);
 
         let route = self.fronts.lookup(host, uri, method).map_err(|e| {
             incr!("http.failed_backend_matching");
@@ -584,7 +581,7 @@ impl L7ListenerHandler for HttpsListener {
 
         let now = Instant::now();
 
-        if let Route::ClusterId(cluster) = &route {
+        if let Some(cluster) = &route.cluster_id {
             time!("frontend_matching_time", cluster, (now - start).as_millis());
         }
 
@@ -1486,7 +1483,7 @@ mod tests {
     use sozu_command::{config::ListenerBuilder, proto::command::SocketAddress};
 
     use super::*;
-    use crate::router::{MethodRule, PathRule, Route, Router, pattern_trie::TrieNode};
+    use crate::router::{Frontend, MethodRule, PathRule, Router, pattern_trie::TrieNode};
 
     /*
     #[test]
@@ -1519,25 +1516,25 @@ mod tests {
             "lolcatho.st".as_bytes(),
             &PathRule::Prefix(uri1),
             &MethodRule::new(None),
-            &Route::ClusterId(cluster_id1.clone())
+            &Frontend::forward(cluster_id1.clone())
         ));
         assert!(fronts.add_tree_rule(
             "lolcatho.st".as_bytes(),
             &PathRule::Prefix(uri2),
             &MethodRule::new(None),
-            &Route::ClusterId(cluster_id2)
+            &Frontend::forward(cluster_id2)
         ));
         assert!(fronts.add_tree_rule(
             "lolcatho.st".as_bytes(),
             &PathRule::Prefix(uri3),
             &MethodRule::new(None),
-            &Route::ClusterId(cluster_id3)
+            &Frontend::forward(cluster_id3)
         ));
         assert!(fronts.add_tree_rule(
             "other.domain".as_bytes(),
             &PathRule::Prefix("test".to_string()),
             &MethodRule::new(None),
-            &Route::ClusterId(cluster_id1)
+            &Frontend::forward(cluster_id1)
         ));
 
         let address = SocketAddress::new_v4(127, 0, 0, 1, 1032);
@@ -1575,31 +1572,30 @@ mod tests {
         println!("TEST {}", line!());
         let frontend1 = listener.frontend_from_request("lolcatho.st", "/", &Method::Get);
         assert_eq!(
-            frontend1.expect("should find a frontend"),
-            Route::ClusterId("cluster_1".to_string())
+            frontend1.expect("should find a frontend").cluster_id,
+            Some("cluster_1".to_string())
         );
         println!("TEST {}", line!());
         let frontend2 = listener.frontend_from_request("lolcatho.st", "/test", &Method::Get);
         assert_eq!(
-            frontend2.expect("should find a frontend"),
-            Route::ClusterId("cluster_1".to_string())
+            frontend2.expect("should find a frontend").cluster_id,
+            Some("cluster_1".to_string())
         );
         println!("TEST {}", line!());
         let frontend3 = listener.frontend_from_request("lolcatho.st", "/yolo/test", &Method::Get);
         assert_eq!(
-            frontend3.expect("should find a frontend"),
-            Route::ClusterId("cluster_2".to_string())
+            frontend3.expect("should find a frontend").cluster_id,
+            Some("cluster_2".to_string())
         );
         println!("TEST {}", line!());
         let frontend4 = listener.frontend_from_request("lolcatho.st", "/yolo/swag", &Method::Get);
         assert_eq!(
-            frontend4.expect("should find a frontend"),
-            Route::ClusterId("cluster_3".to_string())
+            frontend4.expect("should find a frontend").cluster_id,
+            Some("cluster_3".to_string())
         );
         println!("TEST {}", line!());
         let frontend5 = listener.frontend_from_request("domain", "/", &Method::Get);
         assert!(frontend5.is_err());
-        // assert!(false);
     }
 
     #[test]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -361,7 +361,7 @@ use sozu_command::{
 };
 use tls::CertificateResolverError;
 
-use crate::{backends::BackendMap, router::Route};
+use crate::{backends::BackendMap, router::RouteResult};
 
 /// Anything that can be registered in mio (subscribe to kernel events)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -553,7 +553,7 @@ pub trait L7ListenerHandler {
         host: &str,
         uri: &str,
         method: &Method,
-    ) -> Result<Route, FrontendFromRequestError>;
+    ) -> Result<RouteResult, FrontendFromRequestError>;
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -601,6 +601,8 @@ pub enum RetrieveClusterError {
     NoPath,
     #[error("unauthorized route")]
     UnauthorizedRoute,
+    #[error("redirected")]
+    Redirected,
     #[error("{0}")]
     RetrieveFrontend(FrontendFromRequestError),
 }

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -1,15 +1,18 @@
 use std::{
     net::{IpAddr, SocketAddr},
+    rc::Rc,
     str::{from_utf8, from_utf8_unchecked},
 };
 
 use rusty_ulid::Ulid;
+use sozu_command::logging::CachedTags;
 use sozu_command_lib::logging::LogContext;
 
 use crate::{
     Protocol,
     pool::Checkout,
     protocol::http::{GenericHttpStream, Method, parser::compare_no_case},
+    router::HeaderEdit,
 };
 
 #[cfg(feature = "opentelemetry")]
@@ -65,6 +68,13 @@ fn build_traceparent(trace_id: &[u8; 32], parent_id: &[u8; 16]) -> [u8; 55] {
     buf
 }
 
+#[derive(Debug)]
+pub struct HttpRoute {
+    pub method: Option<Method>,
+    pub authority: Option<String>,
+    pub path: Option<String>,
+}
+
 /// This is the container used to store and use information about the session from within a Kawa parser callback
 #[derive(Debug)]
 pub struct HttpContext {
@@ -75,13 +85,10 @@ pub struct HttpContext {
     pub keep_alive_frontend: bool,
     /// the value of the sticky session cookie in the request
     pub sticky_session_found: Option<String>,
-    // ---------- Status Line
-    /// the value of the method in the request line
-    pub method: Option<Method>,
-    /// the value of the authority of the request (in the request line of "Host" header)
-    pub authority: Option<String>,
-    /// the value of the path in the request line
-    pub path: Option<String>,
+    /// position of the last header of the request (the "Sozu-Id"), only valid until prepare is called
+    pub last_header: Option<usize>,
+    // ---------- Route
+    pub route: HttpRoute,
     /// the value of the status code in the response line
     pub status: Option<u16>,
     /// the value of the reason in the response line
@@ -110,6 +117,10 @@ pub struct HttpContext {
     /// the sticky session that should be used
     /// used to create a "Set-Cookie" header in the response in case it differs from sticky_session_found
     pub sticky_session: Option<String>,
+    /// Headers to add to response
+    pub headers_response: Rc<[HeaderEdit]>,
+    /// tags of the contacted frontend
+    pub tags: Option<Rc<CachedTags>>,
 }
 
 impl kawa::h1::ParserCallbacks<Checkout> for HttpContext {
@@ -144,10 +155,15 @@ impl HttpContext {
             sticky_name,
             sticky_session: None,
             sticky_session_found: None,
+            last_header: None,
+            headers_response: Rc::new([]),
+            tags: None,
 
-            method: None,
-            authority: None,
-            path: None,
+            route: HttpRoute {
+                method: None,
+                authority: None,
+                path: None,
+            },
             status: None,
             reason: None,
             user_agent: None,
@@ -178,20 +194,16 @@ impl HttpContext {
             ..
         } = &request.detached.status_line
         {
-            self.method = method.data_opt(buf).map(Method::new);
-            self.authority = authority
+            self.route.method = method.data_opt(buf).map(Method::new);
+            self.route.authority = authority
                 .data_opt(buf)
                 .and_then(|data| from_utf8(data).ok())
                 .map(ToOwned::to_owned);
-            self.path = path
+            self.route.path = path
                 .data_opt(buf)
                 .and_then(|data| from_utf8(data).ok())
                 .map(ToOwned::to_owned);
         }
-
-        // if self.method == Some(Method::Get) && request.body_size == kawa::BodySize::Empty {
-        //     request.parsing_phase = kawa::ParsingPhase::Terminated;
-        // }
 
         let public_ip = self.public_address.ip();
         let public_port = self.public_address.port();
@@ -243,19 +255,17 @@ impl HttpContext {
                         }
                     } else if compare_no_case(key, b"X-Forwarded-Proto") {
                         has_x_proto = true;
-                        // header.val = kawa::Store::Static(proto.as_bytes());
                         incr!("http.trusting.x_proto");
                         let val = header.val.data(buf);
                         if !compare_no_case(val, proto.as_bytes()) {
                             incr!("http.trusting.x_proto.diff");
                             debug!(
                                 "Trusting X-Forwarded-Proto for {:?} even though {:?} != {}",
-                                self.authority, val, proto
+                                self.route.authority, val, proto
                             );
                         }
                     } else if compare_no_case(key, b"X-Forwarded-Port") {
                         has_x_port = true;
-                        // header.val = kawa::Store::from_string(public_port.to_string());
                         incr!("http.trusting.x_port");
                         let val = header.val.data(buf);
                         let expected = public_port.to_string();
@@ -263,7 +273,7 @@ impl HttpContext {
                             incr!("http.trusting.x_port.diff");
                             debug!(
                                 "Trusting X-Forwarded-Port for {:?} even though {:?} != {}",
-                                self.authority, val, expected
+                                self.route.authority, val, expected
                             );
                         }
                     } else if compare_no_case(key, b"X-Forwarded-For") {
@@ -402,6 +412,8 @@ impl HttpContext {
                 val: kawa::Store::Static(b"close"),
             }));
         }
+
+        self.last_header = Some(request.blocks.len());
         // Create a custom "Sozu-Id" header
         request.push_block(kawa::Block::Header(kawa::Pair {
             key: kawa::Store::Static(b"Sozu-Id"),
@@ -428,7 +440,7 @@ impl HttpContext {
                 .map(ToOwned::to_owned);
         }
 
-        if self.method == Some(Method::Head) {
+        if self.route.method == Some(Method::Head) {
             response.parsing_phase = kawa::ParsingPhase::Terminated;
         }
 
@@ -452,6 +464,8 @@ impl HttpContext {
             }
         }
 
+        response.blocks.reserve(2 + self.headers_response.len());
+
         // If the sticky_session is set and differs from the one found in the request
         // create a "Set-Cookie" header to update the sticky_name value
         if let Some(sticky_session) = &self.sticky_session {
@@ -466,6 +480,8 @@ impl HttpContext {
             }
         }
 
+        apply_header_edits(response, self.headers_response.clone());
+
         // Create a custom "Sozu-Id" header
         response.push_block(kawa::Block::Header(kawa::Pair {
             key: kawa::Store::Static(b"Sozu-Id"),
@@ -477,12 +493,15 @@ impl HttpContext {
         self.keep_alive_backend = true;
         self.keep_alive_frontend = true;
         self.sticky_session_found = None;
-        self.method = None;
-        self.authority = None;
-        self.path = None;
+        self.route.method = None;
+        self.route.authority = None;
+        self.route.path = None;
         self.status = None;
         self.reason = None;
         self.user_agent = None;
+        self.cluster_id = None;
+        self.backend_id = None;
+        self.headers_response = Rc::new([]);
     }
 
     pub fn log_context(&self) -> LogContext<'_> {
@@ -491,5 +510,33 @@ impl HttpContext {
             cluster_id: self.cluster_id.as_deref(),
             backend_id: self.backend_id.as_deref(),
         }
+    }
+}
+
+impl HttpRoute {
+    pub fn extract(&self) -> Result<(&str, &str, &Method), crate::RetrieveClusterError> {
+        let given_method = self
+            .method
+            .as_ref()
+            .ok_or(crate::RetrieveClusterError::NoMethod)?;
+        let given_authority = self
+            .authority
+            .as_deref()
+            .ok_or(crate::RetrieveClusterError::NoHost)?;
+        let given_path = self
+            .path
+            .as_deref()
+            .ok_or(crate::RetrieveClusterError::NoPath)?;
+
+        Ok((given_authority, given_path, given_method))
+    }
+}
+
+pub fn apply_header_edits(kawa: &mut GenericHttpStream, headers: Rc<[HeaderEdit]>) {
+    for header in &*headers {
+        kawa.push_block(kawa::Block::Header(kawa::Pair {
+            key: kawa::Store::from_slice(&header.key),
+            val: kawa::Store::from_slice(&header.val),
+        }));
     }
 }

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -1,7 +1,7 @@
 use std::{
     net::{IpAddr, SocketAddr},
     rc::Rc,
-    str::{from_utf8, from_utf8_unchecked},
+    str::from_utf8,
 };
 
 use rusty_ulid::Ulid;
@@ -338,12 +338,11 @@ impl HttpContext {
             let has_forwarded = forwarded.is_some();
 
             if let Some(header) = x_for {
-                header.val = kawa::Store::from_string(format!("{}, {peer_ip}", unsafe {
-                    from_utf8_unchecked(header.val.data(buf))
-                }));
+                let prev = from_utf8(header.val.data(buf)).unwrap_or_default();
+                header.val = kawa::Store::from_string(format!("{prev}, {peer_ip}"));
             }
             if let Some(header) = &mut forwarded {
-                let value = unsafe { from_utf8_unchecked(header.val.data(buf)) };
+                let value = from_utf8(header.val.data(buf)).unwrap_or_default();
                 let new_value = match public_ip {
                     IpAddr::V4(_) => {
                         format!(

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -20,6 +20,8 @@ use sozu_command::{
     proto::command::{Event, EventKind, ListenerType},
 };
 
+use sozu_command::proto::command::{RedirectPolicy, RedirectScheme};
+
 use crate::{
     AcceptError, BackendConnectAction, BackendConnectionError, L7ListenerHandler, L7Proxy,
     ListenerHandler, Protocol, ProxySession, Readiness, RetrieveClusterError, SessionIsToBeClosed,
@@ -31,13 +33,13 @@ use crate::{
         http::{
             answers::DefaultAnswerStream,
             diagnostics::{diagnostic_400_502, diagnostic_413_507},
-            editor::HttpContext,
-            parser::Method,
+            editor::{HttpContext, apply_header_edits},
+            parser::{Method, hostname_and_port},
         },
         pipe::WebSocketContext,
     },
     retry::RetryPolicy,
-    router::Route,
+    router::RouteResult,
     server::{CONN_RETRIES, push_event},
     socket::{SocketHandler, SocketResult, TransportProtocol, stats::socket_rtt},
     sozu_command::{logging::LogContext, ready::Ready},
@@ -863,9 +865,9 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
 impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L> {
     fn log_endpoint(&self) -> EndpointRecord<'_> {
         EndpointRecord::Http {
-            method: self.context.method.as_deref(),
-            authority: self.context.authority.as_deref(),
-            path: self.context.path.as_deref(),
+            method: self.context.route.method.as_deref(),
+            authority: self.context.route.authority.as_deref(),
+            path: self.context.route.path.as_deref(),
             reason: self.context.reason.as_deref(),
             status: self.context.status,
         }
@@ -903,9 +905,9 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
     /// Format the context of the websocket into a loggable String
     pub fn websocket_context(&self) -> WebSocketContext {
         WebSocketContext::Http {
-            method: self.context.method.clone(),
-            authority: self.context.authority.clone(),
-            path: self.context.path.clone(),
+            method: self.context.route.method.clone(),
+            authority: self.context.route.authority.clone(),
+            path: self.context.route.path.clone(),
             reason: self.context.reason.clone(),
             status: self.context.status,
         }
@@ -913,7 +915,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
 
     pub fn log_request(&self, metrics: &SessionMetrics, error: bool, message: Option<&str>) {
         let listener = self.listener.borrow();
-        let tags = self.context.authority.as_ref().and_then(|host| {
+        let tags = self.context.route.authority.as_ref().and_then(|host| {
             let hostname = match host.split_once(':') {
                 None => host,
                 Some((hostname, _)) => hostname,
@@ -1178,29 +1180,13 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
 
     // -> host, path, method
     pub fn extract_route(&self) -> Result<(&str, &str, &Method), RetrieveClusterError> {
-        let given_method = self
-            .context
-            .method
-            .as_ref()
-            .ok_or(RetrieveClusterError::NoMethod)?;
-        let given_authority = self
-            .context
-            .authority
-            .as_deref()
-            .ok_or(RetrieveClusterError::NoHost)?;
-        let given_path = self
-            .context
-            .path
-            .as_deref()
-            .ok_or(RetrieveClusterError::NoPath)?;
-
-        Ok((given_authority, given_path, given_method))
+        self.context.route.extract()
     }
 
     pub fn get_route(&self) -> String {
-        if let Some(method) = &self.context.method {
-            if let Some(authority) = &self.context.authority {
-                if let Some(path) = &self.context.path {
+        if let Some(method) = &self.context.route.method {
+            if let Some(authority) = &self.context.route.authority {
+                if let Some(path) = &self.context.route.path {
                     return format!("{method} {authority}{path}");
                 }
                 return format!("{method} {authority}");
@@ -1214,8 +1200,8 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         &mut self,
         proxy: Rc<RefCell<dyn L7Proxy>>,
     ) -> Result<String, RetrieveClusterError> {
-        let (host, uri, method) = match self.extract_route() {
-            Ok(tuple) => tuple,
+        let (host, path, method) = match self.extract_route() {
+            Ok((h, p, m)) => (h.to_owned(), p.to_owned(), m.to_owned()),
             Err(cluster_error) => {
                 self.set_answer(DefaultAnswer::Answer400 {
                     message: "Could not extract the route after connection started, this should not happen.".into(),
@@ -1228,43 +1214,133 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             }
         };
 
+        let (_remaining, (_hostname, port)) = hostname_and_port(host.as_bytes()).map_err(|e| {
+            let error = e.to_string();
+            self.set_answer(DefaultAnswer::Answer400 {
+                message: format!("Could not parse host: {error}"),
+                phase: self.request_stream.parsing_phase.marker(),
+                successfully_parsed: "null".into(),
+                partially_parsed: "null".into(),
+                invalid: "null".into(),
+            });
+            RetrieveClusterError::RetrieveFrontend(crate::FrontendFromRequestError::HostParse {
+                host: host.to_owned(),
+                error,
+            })
+        })?;
+
         let route_result = self
             .listener
             .borrow()
-            .frontend_from_request(host, uri, method);
+            .frontend_from_request(&host, &path, &method);
 
-        let route = match route_result {
+        let RouteResult {
+            cluster_id,
+            redirect,
+            redirect_scheme,
+            redirect_template: _,
+            rewritten_host,
+            rewritten_path,
+            rewritten_port,
+            headers_request,
+            headers_response,
+            tags,
+        } = match route_result {
             Ok(route) => route,
             Err(frontend_error) => {
                 self.set_answer(DefaultAnswer::Answer404 {});
                 return Err(RetrieveClusterError::RetrieveFrontend(frontend_error));
             }
         };
+        self.context.cluster_id = cluster_id;
+        self.context.headers_response = headers_response;
+        self.context.tags = tags;
 
-        let cluster_id = match route {
-            Route::ClusterId(cluster_id) => cluster_id,
-            Route::Deny => {
-                self.set_answer(DefaultAnswer::Answer401 {});
-                return Err(RetrieveClusterError::UnauthorizedRoute);
-            }
+        let body = if let Some(position) = self.context.last_header {
+            self.request_stream.blocks.split_off(position)
+        } else {
+            Default::default()
         };
 
-        let frontend_should_redirect_https = matches!(proxy.borrow().kind(), ListenerType::Http)
-            && proxy
-                .borrow()
-                .clusters()
-                .get(&cluster_id)
-                .map(|cluster| cluster.https_redirect)
-                .unwrap_or(false);
-
-        if frontend_should_redirect_https {
-            self.set_answer(DefaultAnswer::Answer301 {
-                location: format!("https://{host}{uri}"),
-            });
-            return Err(RetrieveClusterError::UnauthorizedRoute);
+        let original_host = host.to_owned();
+        match &mut self.request_stream.detached.status_line {
+            kawa::StatusLine::Request { authority, uri, .. } => {
+                let buf = self.request_stream.storage.mut_buffer();
+                if let Some(new) = &rewritten_host {
+                    authority.modify(buf, new.as_bytes());
+                    self.request_stream
+                        .blocks
+                        .push_back(kawa::Block::Header(kawa::Pair {
+                            key: kawa::Store::Static(b"X-Forwarded-Host"),
+                            val: kawa::Store::from_slice(original_host.as_bytes()),
+                        }));
+                }
+                if let Some(new) = &rewritten_path {
+                    uri.modify(buf, new.as_bytes());
+                }
+            }
+            _ => unreachable!(),
         }
 
-        Ok(cluster_id)
+        let host = rewritten_host.as_deref().unwrap_or(&host);
+        let path = rewritten_path.as_deref().unwrap_or(&path);
+        let is_https = matches!(proxy.borrow().kind(), ListenerType::Https);
+        let proto = match (redirect_scheme, is_https) {
+            (RedirectScheme::UseHttp, _) | (RedirectScheme::UseSame, false) => "http",
+            (RedirectScheme::UseHttps, _) | (RedirectScheme::UseSame, true) => "https",
+        };
+
+        let cluster_id = &self.context.cluster_id;
+        let (https_redirect, https_redirect_port) = match cluster_id {
+            Some(cid) => proxy
+                .borrow()
+                .clusters()
+                .get(cid)
+                .map_or((false, None), |cluster| {
+                    (cluster.https_redirect, cluster.https_redirect_port)
+                }),
+            None => (false, None),
+        };
+
+        let port = match (
+            port,
+            rewritten_port,
+            https_redirect_port,
+            !is_https && https_redirect,
+        ) {
+            (_, Some(p), _, _) => format!(":{p}"),
+            (_, _, Some(p), true) => format!(":{p}"),
+            (Some(p), _, _, _) => {
+                format!(":{}", std::str::from_utf8(p).unwrap_or_default())
+            }
+            _ => String::new(),
+        };
+
+        match (cluster_id, redirect) {
+            (_, RedirectPolicy::Unauthorized) => {
+                self.set_answer(DefaultAnswer::Answer401 {});
+                Err(RetrieveClusterError::UnauthorizedRoute)
+            }
+            (_, RedirectPolicy::Permanent) => {
+                let location = format!("{proto}://{host}{port}{path}");
+                self.set_answer(DefaultAnswer::Answer301 { location });
+                Err(RetrieveClusterError::Redirected)
+            }
+            (None, RedirectPolicy::Forward) => {
+                self.set_answer(DefaultAnswer::Answer401 {});
+                Err(RetrieveClusterError::UnauthorizedRoute)
+            }
+            (Some(cluster_id), RedirectPolicy::Forward) => {
+                if !is_https && https_redirect {
+                    let location = format!("https://{host}{port}{path}");
+                    self.set_answer(DefaultAnswer::Answer301 { location });
+                    return Err(RetrieveClusterError::Redirected);
+                }
+                apply_header_edits(&mut self.request_stream, headers_request);
+                self.request_stream.blocks.extend(body);
+                Ok(cluster_id.to_owned())
+            }
+        }
     }
 
     pub fn backend_from_request(

--- a/lib/src/protocol/kawa_h1/parser.rs
+++ b/lib/src/protocol/kawa_h1/parser.rs
@@ -2,7 +2,6 @@ use std::{
     cmp::min,
     fmt::{self, Write},
     ops::Deref,
-    str::from_utf8_unchecked,
 };
 
 use nom::{
@@ -60,7 +59,7 @@ impl Method {
         } else if compare_no_case(s, b"CONNECT") {
             Method::Connect
         } else {
-            Method::Custom(String::from(unsafe { from_utf8_unchecked(s) }))
+            Method::Custom(String::from(std::str::from_utf8(s).unwrap_or_default()))
         }
     }
 }

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -1,10 +1,22 @@
 pub mod pattern_trie;
 
-use std::{str::from_utf8, time::Instant};
+use std::{
+    fmt::{Debug, Write},
+    rc::Rc,
+    str::from_utf8,
+    time::Instant,
+};
 
+use nom::AsChar;
+use pattern_trie::{TrieMatches, TrieSubMatch};
 use regex::bytes::Regex;
+
 use sozu_command::{
-    proto::command::{PathRule as CommandPathRule, PathRuleKind, RulePosition},
+    logging::CachedTags,
+    proto::command::{
+        HeaderPosition, PathRule as CommandPathRule, PathRuleKind, RedirectPolicy, RedirectScheme,
+        RulePosition,
+    },
     response::HttpFrontend,
     state::ClusterId,
 };
@@ -15,8 +27,12 @@ use crate::{protocol::http::parser::Method, router::pattern_trie::TrieNode};
 pub enum RouterError {
     #[error("Could not parse rule from frontend path {0:?}")]
     InvalidPathRule(String),
-    #[error("parsing hostname {hostname} failed")]
-    InvalidDomain { hostname: String },
+    #[error("Could not parse hostname {0:?}")]
+    InvalidDomain(String),
+    #[error("Could not parse host rewrite {0:?}")]
+    InvalidHostRewrite(String),
+    #[error("Could not parse path rewrite {0:?}")]
+    InvalidPathRewrite(String),
     #[error("Could not add route {0}")]
     AddRoute(String),
     #[error("Could not remove route {0}")]
@@ -30,9 +46,9 @@ pub enum RouterError {
 }
 
 pub struct Router {
-    pre: Vec<(DomainRule, PathRule, MethodRule, Route)>,
-    pub tree: TrieNode<Vec<(PathRule, MethodRule, Route)>>,
-    post: Vec<(DomainRule, PathRule, MethodRule, Route)>,
+    pre: Vec<(DomainRule, PathRule, MethodRule, Frontend)>,
+    pub tree: TrieNode<Vec<(PathRule, MethodRule, Frontend)>>,
+    post: Vec<(DomainRule, PathRule, MethodRule, Frontend)>,
 }
 
 impl Default for Router {
@@ -50,35 +66,46 @@ impl Router {
         }
     }
 
-    pub fn lookup(
+    pub fn lookup<'a>(
         &self,
-        hostname: &str,
-        path: &str,
-        method: &Method,
-    ) -> Result<Route, RouterError> {
+        hostname: &'a str,
+        path: &'a str,
+        method: &'a Method,
+    ) -> Result<RouteResult, RouterError> {
         let hostname_b = hostname.as_bytes();
         let path_b = path.as_bytes();
-        for (domain_rule, path_rule, method_rule, cluster_id) in &self.pre {
+        for (domain_rule, path_rule, method_rule, route) in &self.pre {
             if domain_rule.matches(hostname_b)
                 && path_rule.matches(path_b) != PathRuleResult::None
                 && method_rule.matches(method) != MethodRuleResult::None
             {
-                return Ok(cluster_id.clone());
+                return Ok(RouteResult::new_no_trie(
+                    hostname_b,
+                    domain_rule,
+                    path_b,
+                    path_rule,
+                    route,
+                ));
             }
         }
 
-        if let Some((_, path_rules)) = self.tree.lookup(hostname_b, true) {
+        let trie_path = Vec::with_capacity(16);
+        if let Some(((_, rules), trie_path)) = self.tree.lookup(hostname_b, true, trie_path) {
             let mut prefix_length = 0;
-            let mut route = None;
+            let mut frontend = None;
 
-            for (rule, method_rule, cluster_id) in path_rules {
-                match rule.matches(path_b) {
+            for (path_rule, method_rule, route) in rules {
+                match path_rule.matches(path_b) {
                     PathRuleResult::Regex | PathRuleResult::Equals => {
                         match method_rule.matches(method) {
-                            MethodRuleResult::Equals => return Ok(cluster_id.clone()),
+                            MethodRuleResult::Equals => {
+                                return Ok(RouteResult::new_with_trie(
+                                    hostname_b, trie_path, path_b, path_rule, route,
+                                ));
+                            }
                             MethodRuleResult::All => {
                                 prefix_length = path_b.len();
-                                route = Some(cluster_id);
+                                frontend = Some((path_rule, route));
                             }
                             MethodRuleResult::None => {}
                         }
@@ -89,11 +116,11 @@ impl Router {
                                 // FIXME: the rule order will be important here
                                 MethodRuleResult::Equals => {
                                     prefix_length = size;
-                                    route = Some(cluster_id);
+                                    frontend = Some((path_rule, route));
                                 }
                                 MethodRuleResult::All => {
                                     prefix_length = size;
-                                    route = Some(cluster_id);
+                                    frontend = Some((path_rule, route));
                                 }
                                 MethodRuleResult::None => {}
                             }
@@ -103,17 +130,25 @@ impl Router {
                 }
             }
 
-            if let Some(cluster_id) = route {
-                return Ok(cluster_id.clone());
+            if let Some((path_rule, route)) = frontend {
+                return Ok(RouteResult::new_with_trie(
+                    hostname_b, trie_path, path_b, path_rule, route,
+                ));
             }
         }
 
-        for (domain_rule, path_rule, method_rule, cluster_id) in self.post.iter() {
+        for (domain_rule, path_rule, method_rule, route) in self.post.iter() {
             if domain_rule.matches(hostname_b)
                 && path_rule.matches(path_b) != PathRuleResult::None
                 && method_rule.matches(method) != MethodRuleResult::None
             {
-                return Ok(cluster_id.clone());
+                return Ok(RouteResult::new_no_trie(
+                    hostname_b,
+                    domain_rule,
+                    path_b,
+                    path_rule,
+                    route,
+                ));
             }
         }
 
@@ -125,34 +160,22 @@ impl Router {
     }
 
     pub fn add_http_front(&mut self, front: &HttpFrontend) -> Result<(), RouterError> {
+        let domain_rule = front
+            .hostname
+            .parse::<DomainRule>()
+            .map_err(|_| RouterError::InvalidDomain(front.hostname.clone()))?;
+
         let path_rule = PathRule::from_config(front.path.clone())
             .ok_or(RouterError::InvalidPathRule(front.path.to_string()))?;
 
         let method_rule = MethodRule::new(front.method.clone());
 
-        let route = match &front.cluster_id {
-            Some(cluster_id) => Route::ClusterId(cluster_id.clone()),
-            None => Route::Deny,
-        };
+        let route = Frontend::new(&domain_rule, &path_rule, front)?;
 
         let success = match front.position {
-            RulePosition::Pre => {
-                let domain = front.hostname.parse::<DomainRule>().map_err(|_| {
-                    RouterError::InvalidDomain {
-                        hostname: front.hostname.clone(),
-                    }
-                })?;
-
-                self.add_pre_rule(&domain, &path_rule, &method_rule, &route)
-            }
+            RulePosition::Pre => self.add_pre_rule(&domain_rule, &path_rule, &method_rule, &route),
             RulePosition::Post => {
-                let domain = front.hostname.parse::<DomainRule>().map_err(|_| {
-                    RouterError::InvalidDomain {
-                        hostname: front.hostname.clone(),
-                    }
-                })?;
-
-                self.add_post_rule(&domain, &path_rule, &method_rule, &route)
+                self.add_post_rule(&domain_rule, &path_rule, &method_rule, &route)
             }
             RulePosition::Tree => {
                 self.add_tree_rule(front.hostname.as_bytes(), &path_rule, &method_rule, &route)
@@ -172,22 +195,20 @@ impl Router {
 
         let remove_success = match front.position {
             RulePosition::Pre => {
-                let domain = front.hostname.parse::<DomainRule>().map_err(|_| {
-                    RouterError::InvalidDomain {
-                        hostname: front.hostname.clone(),
-                    }
-                })?;
+                let domain_rule = front
+                    .hostname
+                    .parse::<DomainRule>()
+                    .map_err(|_| RouterError::InvalidDomain(front.hostname.clone()))?;
 
-                self.remove_pre_rule(&domain, &path_rule, &method_rule)
+                self.remove_pre_rule(&domain_rule, &path_rule, &method_rule)
             }
             RulePosition::Post => {
-                let domain = front.hostname.parse::<DomainRule>().map_err(|_| {
-                    RouterError::InvalidDomain {
-                        hostname: front.hostname.clone(),
-                    }
-                })?;
+                let domain_rule = front
+                    .hostname
+                    .parse::<DomainRule>()
+                    .map_err(|_| RouterError::InvalidDomain(front.hostname.clone()))?;
 
-                self.remove_post_rule(&domain, &path_rule, &method_rule)
+                self.remove_post_rule(&domain_rule, &path_rule, &method_rule)
             }
             RulePosition::Tree => {
                 self.remove_tree_rule(front.hostname.as_bytes(), &path_rule, &method_rule)
@@ -204,7 +225,7 @@ impl Router {
         hostname: &[u8],
         path: &PathRule,
         method: &MethodRule,
-        cluster: &Route,
+        cluster: &Frontend,
     ) -> bool {
         let hostname = match from_utf8(hostname) {
             Err(_) => return false,
@@ -242,7 +263,6 @@ impl Router {
         hostname: &[u8],
         path: &PathRule,
         method: &MethodRule,
-        // _cluster: &Route,
     ) -> bool {
         let hostname = match from_utf8(hostname) {
             Err(_) => return false,
@@ -279,7 +299,7 @@ impl Router {
         domain: &DomainRule,
         path: &PathRule,
         method: &MethodRule,
-        cluster_id: &Route,
+        cluster_id: &Frontend,
     ) -> bool {
         if !self
             .pre
@@ -303,7 +323,7 @@ impl Router {
         domain: &DomainRule,
         path: &PathRule,
         method: &MethodRule,
-        cluster_id: &Route,
+        cluster_id: &Frontend,
     ) -> bool {
         if !self
             .post
@@ -364,13 +384,13 @@ impl Router {
 #[derive(Clone, Debug)]
 pub enum DomainRule {
     Any,
-    Exact(String),
+    Equals(String),
     Wildcard(String),
     Regex(Regex),
 }
 
 fn convert_regex_domain_rule(hostname: &str) -> Option<String> {
-    let mut result = String::new();
+    let mut result = String::from("\\A");
 
     let s = hostname.as_bytes();
     let mut index = 0;
@@ -385,6 +405,7 @@ fn convert_regex_domain_rule(hostname: &str) -> Option<String> {
                     }
                     index = i + 1;
                     found = true;
+                    break;
                 }
             }
 
@@ -412,6 +433,7 @@ fn convert_regex_domain_rule(hostname: &str) -> Option<String> {
         }
 
         if index == s.len() {
+            result.push_str("\\z");
             return Some(result);
         } else if s[index] == b'.' {
             result.push_str("\\.");
@@ -431,7 +453,7 @@ impl DomainRule {
                 hostname.ends_with(s[1..].as_bytes())
                     && !&hostname[..len_without_suffix].contains(&b'.')
             }
-            DomainRule::Exact(s) => s.as_bytes() == hostname,
+            DomainRule::Equals(s) => s.as_bytes() == hostname,
             DomainRule::Regex(r) => {
                 let start = Instant::now();
                 let is_a_match = r.is_match(hostname);
@@ -448,7 +470,7 @@ impl std::cmp::PartialEq for DomainRule {
         match (self, other) {
             (DomainRule::Any, DomainRule::Any) => true,
             (DomainRule::Wildcard(s1), DomainRule::Wildcard(s2)) => s1 == s2,
-            (DomainRule::Exact(s1), DomainRule::Exact(s2)) => s1 == s2,
+            (DomainRule::Equals(s1), DomainRule::Equals(s2)) => s1 == s2,
             (DomainRule::Regex(r1), DomainRule::Regex(r2)) => r1.as_str() == r2.as_str(),
             _ => false,
         }
@@ -480,7 +502,7 @@ impl std::str::FromStr for DomainRule {
             }
         } else {
             match ::idna::domain_to_ascii(s) {
-                Ok(r) => DomainRule::Exact(r),
+                Ok(r) => DomainRule::Equals(r),
                 Err(_) => return Err(()),
             }
         })
@@ -494,7 +516,7 @@ pub enum PathRule {
     Equals(String),
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PathRuleResult {
     Regex,
     Prefix(usize),
@@ -587,13 +609,439 @@ impl MethodRule {
     }
 }
 
-/// The cluster to which the traffic will be redirected
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum Route {
-    /// send a 401 default answer
-    Deny,
-    /// the cluster to which the frontend belongs
-    ClusterId(ClusterId),
+#[derive(Debug, Clone)]
+enum RewritePart {
+    String(String),
+    Host(usize),
+    Path(usize),
+}
+
+impl RewritePart {
+    pub fn string(s: &str) -> Self {
+        Self::String(String::from(s))
+    }
+    pub fn bytes(b: &[u8]) -> Self {
+        Self::String(from_utf8(b).unwrap_or_default().to_owned())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RewriteParts(Vec<RewritePart>);
+
+impl RewriteParts {
+    pub fn new(
+        pattern: &str,
+        index_max_host: usize,
+        index_max_path: usize,
+        used_index_host: &mut usize,
+        used_index_path: &mut usize,
+    ) -> Option<Self> {
+        let mut result = Vec::new();
+        let mut i = 0;
+        let pattern = pattern.as_bytes();
+        while i < pattern.len() {
+            if pattern[i] == b'$' {
+                let is_host = if pattern[i..].starts_with(b"$HOST[") {
+                    i += 6;
+                    true
+                } else if pattern[i..].starts_with(b"$PATH[") {
+                    i += 6;
+                    false
+                } else {
+                    return None;
+                };
+                let mut index = 0;
+                while i < pattern.len() && pattern[i].is_dec_digit() {
+                    index = index * 10 + (pattern[i] - b'0') as usize;
+                    i += 1;
+                }
+                if i >= pattern.len() || pattern[i] != b']' {
+                    return None;
+                }
+                if is_host {
+                    if index >= index_max_host {
+                        return None;
+                    }
+                    if index >= *used_index_host {
+                        *used_index_host = index + 1;
+                    }
+                    result.push(RewritePart::Host(index));
+                } else {
+                    if index >= index_max_path {
+                        return None;
+                    }
+                    if index >= *used_index_path {
+                        *used_index_path = index + 1;
+                    }
+                    result.push(RewritePart::Path(index));
+                }
+                i += 1;
+            } else {
+                let start = i;
+                while i < pattern.len() && pattern[i] != b'$' {
+                    i += 1;
+                }
+                result.push(RewritePart::bytes(&pattern[start..i]));
+            }
+        }
+        Some(Self(result))
+    }
+
+    pub fn run(&self, host_captures: &[&str], path_captures: &[&str]) -> String {
+        let mut cap = 0;
+        for part in &self.0 {
+            cap += match part {
+                RewritePart::String(s) => s.len(),
+                RewritePart::Host(i) => host_captures.get(*i).map(|s| s.len()).unwrap_or(0),
+                RewritePart::Path(i) => path_captures.get(*i).map(|s| s.len()).unwrap_or(0),
+            };
+        }
+        let mut result = String::with_capacity(cap);
+        for part in &self.0 {
+            let _ = match part {
+                RewritePart::String(s) => result.write_str(s),
+                RewritePart::Host(i) => result.write_str(host_captures.get(*i).unwrap_or(&"")),
+                RewritePart::Path(i) => result.write_str(path_captures.get(*i).unwrap_or(&"")),
+            };
+        }
+        result
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct HeaderEdit {
+    pub key: Rc<[u8]>,
+    pub val: Rc<[u8]>,
+}
+
+impl Debug for HeaderEdit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!(
+            "({:?}, {:?})",
+            String::from_utf8_lossy(&self.key),
+            String::from_utf8_lossy(&self.val)
+        ))
+    }
+}
+
+/// What to do with the traffic
+#[derive(Debug, Clone)]
+pub struct Frontend {
+    cluster_id: Option<ClusterId>,
+    redirect: RedirectPolicy,
+    redirect_scheme: RedirectScheme,
+    redirect_template: Option<String>,
+    capture_cap_host: usize,
+    capture_cap_path: usize,
+    rewrite_host: Option<RewriteParts>,
+    rewrite_path: Option<RewriteParts>,
+    rewrite_port: Option<u16>,
+    headers_request: Rc<[HeaderEdit]>,
+    headers_response: Rc<[HeaderEdit]>,
+    tags: Option<Rc<CachedTags>>,
+}
+
+impl Frontend {
+    pub fn new(
+        domain_rule: &DomainRule,
+        path_rule: &PathRule,
+        front: &HttpFrontend,
+    ) -> Result<Self, RouterError> {
+        let cluster_id = front.cluster_id.clone();
+        let rewrite_port = front.rewrite_port;
+        let rewrite_path = front.rewrite_path.clone();
+        let rewrite_host = front.rewrite_host.clone();
+        let redirect = front.redirect;
+        let redirect_scheme = front.redirect_scheme;
+        let redirect_template = front.redirect_template.clone();
+        let headers = &front.headers;
+        let tags = front
+            .tags
+            .clone()
+            .map(|tags| Rc::new(CachedTags::new(tags)));
+
+        let deny = match (&cluster_id, redirect, &redirect_template) {
+            (_, RedirectPolicy::Unauthorized, _) => true,
+            (None, RedirectPolicy::Forward, None) => {
+                warn!(
+                    "Frontend[domain: {:?}, path: {:?}]: forward on clusterless frontends are unauthorized",
+                    domain_rule, path_rule
+                );
+                true
+            }
+            _ => false,
+        };
+        if deny {
+            return Ok(Self {
+                cluster_id: cluster_id.clone(),
+                redirect: RedirectPolicy::Unauthorized,
+                redirect_scheme,
+                redirect_template: None,
+                capture_cap_host: 0,
+                capture_cap_path: 0,
+                rewrite_host: None,
+                rewrite_path: None,
+                rewrite_port: None,
+                headers_request: Rc::new([]),
+                headers_response: Rc::new([]),
+                tags: None,
+            });
+        }
+        let mut capture_cap_host = match domain_rule {
+            DomainRule::Any => 1,
+            DomainRule::Equals(_) => 1,
+            DomainRule::Wildcard(_) => 2,
+            DomainRule::Regex(regex) => regex.captures_len(),
+        };
+        let mut capture_cap_path = match path_rule {
+            PathRule::Equals(_) => 1,
+            PathRule::Prefix(_) => 2,
+            PathRule::Regex(regex) => regex.captures_len(),
+        };
+        let mut used_capture_host = 0;
+        let mut used_capture_path = 0;
+        let rewrite_host = if let Some(p) = rewrite_host {
+            Some(
+                RewriteParts::new(
+                    &p,
+                    capture_cap_host,
+                    capture_cap_path,
+                    &mut used_capture_host,
+                    &mut used_capture_path,
+                )
+                .ok_or(RouterError::InvalidHostRewrite(p))?,
+            )
+        } else {
+            None
+        };
+        let rewrite_path = if let Some(p) = rewrite_path {
+            Some(
+                RewriteParts::new(
+                    &p,
+                    capture_cap_host,
+                    capture_cap_path,
+                    &mut used_capture_host,
+                    &mut used_capture_path,
+                )
+                .ok_or(RouterError::InvalidPathRewrite(p))?,
+            )
+        } else {
+            None
+        };
+        if used_capture_host == 0 {
+            capture_cap_host = 0;
+        }
+        if used_capture_path == 0 {
+            capture_cap_path = 0;
+        }
+        let mut headers_request = Vec::new();
+        let mut headers_response = Vec::new();
+        for header in headers {
+            let edit = HeaderEdit {
+                key: header.key.clone().into_bytes().into(),
+                val: header.val.clone().into_bytes().into(),
+            };
+            match header.position() {
+                HeaderPosition::Request => headers_request.push(edit),
+                HeaderPosition::Response => headers_response.push(edit),
+                HeaderPosition::Both => {
+                    headers_request.push(edit.clone());
+                    headers_response.push(edit);
+                }
+            }
+        }
+        Ok(Frontend {
+            cluster_id,
+            redirect,
+            redirect_scheme,
+            redirect_template,
+            capture_cap_host,
+            capture_cap_path,
+            rewrite_host,
+            rewrite_path,
+            rewrite_port,
+            headers_request: headers_request.into(),
+            headers_response: headers_response.into(),
+            tags,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn forward(cluster_id: ClusterId) -> Self {
+        Self {
+            cluster_id: Some(cluster_id),
+            redirect: RedirectPolicy::Forward,
+            redirect_scheme: RedirectScheme::UseSame,
+            redirect_template: None,
+            capture_cap_host: 0,
+            capture_cap_path: 0,
+            rewrite_host: None,
+            rewrite_path: None,
+            rewrite_port: None,
+            headers_request: Rc::new([]),
+            headers_response: Rc::new([]),
+            tags: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RouteResult {
+    pub cluster_id: Option<ClusterId>,
+    pub redirect: RedirectPolicy,
+    pub redirect_scheme: RedirectScheme,
+    pub redirect_template: Option<String>,
+    pub rewritten_host: Option<String>,
+    pub rewritten_path: Option<String>,
+    pub rewritten_port: Option<u16>,
+    pub headers_request: Rc<[HeaderEdit]>,
+    pub headers_response: Rc<[HeaderEdit]>,
+    pub tags: Option<Rc<CachedTags>>,
+}
+
+impl RouteResult {
+    fn deny(cluster_id: &Option<ClusterId>) -> Self {
+        Self {
+            cluster_id: cluster_id.clone(),
+            redirect: RedirectPolicy::Unauthorized,
+            redirect_scheme: RedirectScheme::UseSame,
+            redirect_template: None,
+            rewritten_host: None,
+            rewritten_path: None,
+            rewritten_port: None,
+            headers_request: Rc::new([]),
+            headers_response: Rc::new([]),
+            tags: None,
+        }
+    }
+
+    fn new<'a>(
+        captures_host: Vec<&'a str>,
+        path: &'a [u8],
+        path_rule: &PathRule,
+        route: &Frontend,
+    ) -> Self {
+        let Frontend {
+            cluster_id,
+            redirect,
+            redirect_scheme,
+            redirect_template,
+            capture_cap_path,
+            rewrite_host,
+            rewrite_path,
+            rewrite_port,
+            headers_request,
+            headers_response,
+            tags,
+            ..
+        } = route;
+        let mut captures_path = Vec::with_capacity(*capture_cap_path);
+        if *capture_cap_path > 0 {
+            captures_path.push(from_utf8(path).unwrap_or_default());
+            match path_rule {
+                PathRule::Prefix(prefix) => {
+                    captures_path.push(from_utf8(&path[prefix.len()..]).unwrap_or_default())
+                }
+                PathRule::Regex(regex) => {
+                    captures_path.extend(regex.captures(path).unwrap().iter().skip(1).map(|c| {
+                        c.map(|c| from_utf8(c.as_bytes()).unwrap_or_default())
+                            .unwrap_or("")
+                    }))
+                }
+                _ => {}
+            }
+        }
+        Self {
+            cluster_id: cluster_id.clone(),
+            redirect: *redirect,
+            redirect_scheme: *redirect_scheme,
+            redirect_template: redirect_template.clone(),
+            rewritten_host: rewrite_host
+                .as_ref()
+                .map(|rewrite| rewrite.run(&captures_host, &captures_path)),
+            rewritten_path: rewrite_path
+                .as_ref()
+                .map(|rewrite| rewrite.run(&captures_host, &captures_path)),
+            rewritten_port: *rewrite_port,
+            headers_request: headers_request.clone(),
+            headers_response: headers_response.clone(),
+            tags: tags.clone(),
+        }
+    }
+
+    fn new_no_trie<'a>(
+        domain: &'a [u8],
+        domain_rule: &DomainRule,
+        path: &'a [u8],
+        path_rule: &PathRule,
+        route: &Frontend,
+    ) -> Self {
+        let Frontend {
+            cluster_id,
+            redirect,
+            capture_cap_host,
+            ..
+        } = route;
+        if *redirect == RedirectPolicy::Unauthorized {
+            return Self::deny(cluster_id);
+        }
+        let mut captures_host = Vec::with_capacity(*capture_cap_host);
+        if *capture_cap_host > 0 {
+            captures_host.push(from_utf8(domain).unwrap_or_default());
+            match domain_rule {
+                DomainRule::Wildcard(suffix) => captures_host
+                    .push(from_utf8(&domain[..domain.len() - suffix.len()]).unwrap_or_default()),
+                DomainRule::Regex(regex) => captures_host.extend(
+                    regex
+                        .captures(domain)
+                        .unwrap()
+                        .iter()
+                        .skip(1)
+                        .map(|c| from_utf8(c.unwrap().as_bytes()).unwrap_or_default()),
+                ),
+                _ => {}
+            }
+        }
+        Self::new(captures_host, path, path_rule, route)
+    }
+
+    fn new_with_trie<'a>(
+        domain: &'a [u8],
+        domain_submatches: TrieMatches<'_, 'a>,
+        path: &'a [u8],
+        path_rule: &PathRule,
+        route: &Frontend,
+    ) -> Self {
+        let Frontend {
+            cluster_id,
+            redirect,
+            capture_cap_host,
+            ..
+        } = route;
+        if *redirect == RedirectPolicy::Unauthorized {
+            return Self::deny(cluster_id);
+        }
+        let mut captures_host = Vec::with_capacity(*capture_cap_host);
+        if *capture_cap_host > 0 {
+            captures_host.push(from_utf8(domain).unwrap_or_default());
+            for submatch in domain_submatches {
+                match submatch {
+                    TrieSubMatch::Wildcard(part) => {
+                        captures_host.push(from_utf8(part).unwrap_or_default())
+                    }
+                    TrieSubMatch::Regexp(part, regex) => captures_host.extend(
+                        regex
+                            .captures(part)
+                            .unwrap()
+                            .iter()
+                            .skip(1)
+                            .map(|c| from_utf8(c.unwrap().as_bytes()).unwrap_or_default()),
+                    ),
+                }
+            }
+        }
+        Self::new(captures_host, path, path_rule, route)
+    }
 }
 
 #[cfg(test)]
@@ -606,23 +1054,23 @@ mod tests {
             convert_regex_domain_rule("www.example.com")
                 .unwrap()
                 .as_str(),
-            "www\\.example\\.com"
+            "\\Awww\\.example\\.com\\z"
         );
         assert_eq!(
             convert_regex_domain_rule("*.example.com").unwrap().as_str(),
-            "*\\.example\\.com"
+            "\\A*\\.example\\.com\\z"
         );
         assert_eq!(
             convert_regex_domain_rule("test.*.example.com")
                 .unwrap()
                 .as_str(),
-            "test\\.*\\.example\\.com"
+            "\\Atest\\.*\\.example\\.com\\z"
         );
         assert_eq!(
             convert_regex_domain_rule("css./cdn[a-z0-9]+/.example.com")
                 .unwrap()
                 .as_str(),
-            "css\\.cdn[a-z0-9]+\\.example\\.com"
+            "\\Acss\\.cdn[a-z0-9]+\\.example\\.com\\z"
         );
 
         assert_eq!(
@@ -640,7 +1088,7 @@ mod tests {
         assert_eq!("*".parse::<DomainRule>().unwrap(), DomainRule::Any);
         assert_eq!(
             "www.example.com".parse::<DomainRule>().unwrap(),
-            DomainRule::Exact("www.example.com".to_string())
+            DomainRule::Equals("www.example.com".to_string())
         );
         assert_eq!(
             "*.example.com".parse::<DomainRule>().unwrap(),
@@ -649,7 +1097,7 @@ mod tests {
         assert_eq!("test.*.example.com".parse::<DomainRule>(), Err(()));
         assert_eq!(
             "/cdn[0-9]+/.example.com".parse::<DomainRule>().unwrap(),
-            DomainRule::Regex(Regex::new("cdn[0-9]+\\.example\\.com").unwrap())
+            DomainRule::Regex(Regex::new("\\Acdn[0-9]+\\.example\\.com\\z").unwrap())
         );
     }
 
@@ -657,7 +1105,7 @@ mod tests {
     fn match_domain_rule() {
         assert!(DomainRule::Any.matches("www.example.com".as_bytes()));
         assert!(
-            DomainRule::Exact("www.example.com".to_string()).matches("www.example.com".as_bytes())
+            DomainRule::Equals("www.example.com".to_string()).matches("www.example.com".as_bytes())
         );
         assert!(
             DomainRule::Wildcard("*.example.com".to_string()).matches("www.example.com".as_bytes())
@@ -720,27 +1168,33 @@ mod tests {
             b"*.sozu.io",
             &PathRule::Prefix("".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("base".to_string())
+            &Frontend::forward("base".to_string())
         ));
         println!("{:#?}", router.tree);
         assert_eq!(
-            router.lookup("www.sozu.io", "/api", &Method::Get),
-            Ok(Route::ClusterId("base".to_string()))
+            router
+                .lookup("www.sozu.io", "/api", &Method::Get)
+                .map(|r| r.cluster_id),
+            Ok(Some("base".to_string()))
         );
         assert!(router.add_tree_rule(
             b"*.sozu.io",
             &PathRule::Prefix("/api".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("api".to_string())
+            &Frontend::forward("api".to_string())
         ));
         println!("{:#?}", router.tree);
         assert_eq!(
-            router.lookup("www.sozu.io", "/ap", &Method::Get),
-            Ok(Route::ClusterId("base".to_string()))
+            router
+                .lookup("www.sozu.io", "/ap", &Method::Get)
+                .map(|r| r.cluster_id),
+            Ok(Some("base".to_string()))
         );
         assert_eq!(
-            router.lookup("www.sozu.io", "/api", &Method::Get),
-            Ok(Route::ClusterId("api".to_string()))
+            router
+                .lookup("www.sozu.io", "/api", &Method::Get)
+                .map(|r| r.cluster_id),
+            Ok(Some("api".to_string()))
         );
     }
 
@@ -759,27 +1213,33 @@ mod tests {
             b"*.sozu.io",
             &PathRule::Prefix("".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("base".to_string())
+            &Frontend::forward("base".to_string())
         ));
         println!("{:#?}", router.tree);
         assert_eq!(
-            router.lookup("www.sozu.io", "/api", &Method::Get),
-            Ok(Route::ClusterId("base".to_string()))
+            router
+                .lookup("www.sozu.io", "/api", &Method::Get)
+                .map(|r| r.cluster_id),
+            Ok(Some("base".to_string()))
         );
         assert!(router.add_tree_rule(
             b"api.sozu.io",
             &PathRule::Prefix("".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("api".to_string())
+            &Frontend::forward("api".to_string())
         ));
         println!("{:#?}", router.tree);
         assert_eq!(
-            router.lookup("www.sozu.io", "/api", &Method::Get),
-            Ok(Route::ClusterId("base".to_string()))
+            router
+                .lookup("www.sozu.io", "/api", &Method::Get)
+                .map(|r| r.cluster_id),
+            Ok(Some("base".to_string()))
         );
         assert_eq!(
-            router.lookup("api.sozu.io", "/api", &Method::Get),
-            Ok(Route::ClusterId("api".to_string()))
+            router
+                .lookup("api.sozu.io", "/api", &Method::Get)
+                .map(|r| r.cluster_id),
+            Ok(Some("api".to_string()))
         );
     }
 
@@ -791,23 +1251,27 @@ mod tests {
             b"www./.*/.io",
             &PathRule::Prefix("".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("base".to_string())
+            &Frontend::forward("base".to_string())
         ));
         println!("{:#?}", router.tree);
         assert!(router.add_tree_rule(
             b"www.doc./.*/.io",
             &PathRule::Prefix("".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("doc".to_string())
+            &Frontend::forward("doc".to_string())
         ));
         println!("{:#?}", router.tree);
         assert_eq!(
-            router.lookup("www.sozu.io", "/", &Method::Get),
-            Ok(Route::ClusterId("base".to_string()))
+            router
+                .lookup("www.sozu.io", "/", &Method::Get)
+                .map(|r| r.cluster_id),
+            Ok(Some("base".to_string()))
         );
         assert_eq!(
-            router.lookup("www.doc.sozu.io", "/", &Method::Get),
-            Ok(Route::ClusterId("doc".to_string()))
+            router
+                .lookup("www.doc.sozu.io", "/", &Method::Get)
+                .map(|r| r.cluster_id),
+            Ok(Some("doc".to_string()))
         );
         assert!(router.remove_tree_rule(
             b"www./.*/.io",
@@ -817,8 +1281,10 @@ mod tests {
         println!("{:#?}", router.tree);
         assert!(router.lookup("www.sozu.io", "/", &Method::Get).is_err());
         assert_eq!(
-            router.lookup("www.doc.sozu.io", "/", &Method::Get),
-            Ok(Route::ClusterId("doc".to_string()))
+            router
+                .lookup("www.doc.sozu.io", "/", &Method::Get)
+                .map(|r| r.cluster_id),
+            Ok(Some("doc".to_string()))
         );
     }
 
@@ -830,38 +1296,42 @@ mod tests {
             &"*".parse::<DomainRule>().unwrap(),
             &PathRule::Prefix("/.well-known/acme-challenge".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("acme".to_string())
+            &Frontend::forward("acme".to_string())
         ));
         assert!(router.add_tree_rule(
             "www.example.com".as_bytes(),
             &PathRule::Prefix("/".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("example".to_string())
+            &Frontend::forward("example".to_string())
         ));
         assert!(router.add_tree_rule(
             "*.test.example.com".as_bytes(),
             &PathRule::Regex(Regex::new("/hello[A-Z]+/").unwrap()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("examplewildcard".to_string())
+            &Frontend::forward("examplewildcard".to_string())
         ));
         assert!(router.add_tree_rule(
             "/test[0-9]/.example.com".as_bytes(),
             &PathRule::Prefix("/".to_string()),
             &MethodRule::new(Some("GET".to_string())),
-            &Route::ClusterId("exampleregex".to_string())
+            &Frontend::forward("exampleregex".to_string())
         ));
 
         assert_eq!(
-            router.lookup("www.example.com", "/helloA", &Method::new(&b"GET"[..])),
-            Ok(Route::ClusterId("example".to_string()))
+            router
+                .lookup("www.example.com", "/helloA", &Method::new(&b"GET"[..]))
+                .map(|r| r.cluster_id),
+            Ok(Some("example".to_string()))
         );
         assert_eq!(
-            router.lookup(
-                "www.example.com",
-                "/.well-known/acme-challenge",
-                &Method::new(&b"GET"[..])
-            ),
-            Ok(Route::ClusterId("acme".to_string()))
+            router
+                .lookup(
+                    "www.example.com",
+                    "/.well-known/acme-challenge",
+                    &Method::new(&b"GET"[..])
+                )
+                .map(|r| r.cluster_id),
+            Ok(Some("acme".to_string()))
         );
         assert!(
             router
@@ -869,16 +1339,20 @@ mod tests {
                 .is_err()
         );
         assert_eq!(
-            router.lookup(
-                "www.test.example.com",
-                "/helloAB/",
-                &Method::new(&b"GET"[..])
-            ),
-            Ok(Route::ClusterId("examplewildcard".to_string()))
+            router
+                .lookup(
+                    "www.test.example.com",
+                    "/helloAB/",
+                    &Method::new(&b"GET"[..])
+                )
+                .map(|r| r.cluster_id),
+            Ok(Some("examplewildcard".to_string()))
         );
         assert_eq!(
-            router.lookup("test1.example.com", "/helloAB/", &Method::new(&b"GET"[..])),
-            Ok(Route::ClusterId("exampleregex".to_string()))
+            router
+                .lookup("test1.example.com", "/helloAB/", &Method::new(&b"GET"[..]))
+                .map(|r| r.cluster_id),
+            Ok(Some("exampleregex".to_string()))
         );
     }
 }

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -617,9 +617,6 @@ enum RewritePart {
 }
 
 impl RewritePart {
-    pub fn string(s: &str) -> Self {
-        Self::String(String::from(s))
-    }
     pub fn bytes(b: &[u8]) -> Self {
         Self::String(from_utf8(b).unwrap_or_default().to_owned())
     }
@@ -1170,7 +1167,6 @@ mod tests {
             &MethodRule::new(Some("GET".to_string())),
             &Frontend::forward("base".to_string())
         ));
-        println!("{:#?}", router.tree);
         assert_eq!(
             router
                 .lookup("www.sozu.io", "/api", &Method::Get)
@@ -1183,7 +1179,6 @@ mod tests {
             &MethodRule::new(Some("GET".to_string())),
             &Frontend::forward("api".to_string())
         ));
-        println!("{:#?}", router.tree);
         assert_eq!(
             router
                 .lookup("www.sozu.io", "/ap", &Method::Get)
@@ -1215,7 +1210,6 @@ mod tests {
             &MethodRule::new(Some("GET".to_string())),
             &Frontend::forward("base".to_string())
         ));
-        println!("{:#?}", router.tree);
         assert_eq!(
             router
                 .lookup("www.sozu.io", "/api", &Method::Get)
@@ -1228,7 +1222,6 @@ mod tests {
             &MethodRule::new(Some("GET".to_string())),
             &Frontend::forward("api".to_string())
         ));
-        println!("{:#?}", router.tree);
         assert_eq!(
             router
                 .lookup("www.sozu.io", "/api", &Method::Get)
@@ -1253,14 +1246,14 @@ mod tests {
             &MethodRule::new(Some("GET".to_string())),
             &Frontend::forward("base".to_string())
         ));
-        println!("{:#?}", router.tree);
+
         assert!(router.add_tree_rule(
             b"www.doc./.*/.io",
             &PathRule::Prefix("".to_string()),
             &MethodRule::new(Some("GET".to_string())),
             &Frontend::forward("doc".to_string())
         ));
-        println!("{:#?}", router.tree);
+
         assert_eq!(
             router
                 .lookup("www.sozu.io", "/", &Method::Get)
@@ -1278,7 +1271,7 @@ mod tests {
             &PathRule::Prefix("".to_string()),
             &MethodRule::new(Some("GET".to_string()))
         ));
-        println!("{:#?}", router.tree);
+
         assert!(router.lookup("www.sozu.io", "/", &Method::Get).is_err());
         assert_eq!(
             router

--- a/lib/src/router/pattern_trie.rs
+++ b/lib/src/router/pattern_trie.rs
@@ -4,6 +4,12 @@ use regex::bytes::Regex;
 
 pub type Key = Vec<u8>;
 pub type KeyValue<K, V> = (K, V);
+pub type TrieMatches<'a, 'b> = Vec<TrieSubMatch<'b, 'a>>;
+
+pub enum TrieSubMatch<'a, 'b> {
+    Wildcard(&'a [u8]),
+    Regexp(&'a [u8], &'b Regex),
+}
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum InsertResult {
@@ -19,12 +25,10 @@ pub enum RemoveResult {
 }
 
 fn find_last_dot(input: &[u8]) -> Option<usize> {
-    //println!("find_last_dot: input = {}", from_utf8(input).unwrap());
     (0..input.len()).rev().find(|&i| input[i] == b'.')
 }
 
 fn find_last_slash(input: &[u8]) -> Option<usize> {
-    //println!("find_last_dot: input = {}", from_utf8(input).unwrap());
     (0..input.len()).rev().find(|&i| input[i] == b'/')
 }
 
@@ -94,7 +98,6 @@ impl<V: Debug + Clone> TrieNode<V> {
     }
 
     pub fn insert(&mut self, key: Key, value: V) -> InsertResult {
-        //println!("insert: key == {}", std::str::from_utf8(&key).unwrap());
         if key.is_empty() {
             return InsertResult::Failed;
         }
@@ -108,7 +111,6 @@ impl<V: Debug + Clone> TrieNode<V> {
     }
 
     pub fn insert_recursive(&mut self, partial_key: &[u8], key: &Key, value: V) -> InsertResult {
-        //println!("insert_rec: key == {}", std::str::from_utf8(partial_key).unwrap());
         assert_ne!(partial_key, &b""[..]);
 
         if partial_key[partial_key.len() - 1] == b'/' {
@@ -120,13 +122,15 @@ impl<V: Debug + Clone> TrieNode<V> {
                 }
 
                 if let Ok(s) = str::from_utf8(&partial_key[pos + 1..partial_key.len() - 1]) {
+                    let anchored = format!("\\A{s}\\z");
                     for t in self.regexps.iter_mut() {
-                        if t.0.as_str() == s {
+                        if t.0.as_str() == anchored {
                             return t.1.insert_recursive(&partial_key[..pos - 1], key, value);
                         }
                     }
 
-                    if let Ok(r) = Regex::new(s) {
+                    let s = anchored;
+                    if let Ok(r) = Regex::new(&s) {
                         if pos > 0 {
                             let mut node = TrieNode::root();
                             let pos = pos - 1;
@@ -190,8 +194,6 @@ impl<V: Debug + Clone> TrieNode<V> {
     }
 
     pub fn remove_recursive(&mut self, partial_key: &[u8]) -> RemoveResult {
-        //println!("remove: key == {}", std::str::from_utf8(partial_key).unwrap());
-
         if partial_key.is_empty() {
             if self.key_value.is_some() {
                 self.key_value = None;
@@ -219,10 +221,11 @@ impl<V: Debug + Clone> TrieNode<V> {
                 }
 
                 if let Ok(s) = str::from_utf8(&partial_key[pos + 1..partial_key.len() - 1]) {
+                    let anchored = format!("\\A{s}\\z");
                     if pos > 0 {
                         let mut remove_result = RemoveResult::NotFound;
                         for t in self.regexps.iter_mut() {
-                            if t.0.as_str() == s
+                            if t.0.as_str() == anchored
                                 && t.1.remove_recursive(&partial_key[..pos - 1]) == RemoveResult::Ok
                             {
                                 remove_result = RemoveResult::Ok;
@@ -231,7 +234,7 @@ impl<V: Debug + Clone> TrieNode<V> {
                         return remove_result;
                     } else {
                         let len = self.regexps.len();
-                        self.regexps.retain(|(r, _)| r.as_str() != s);
+                        self.regexps.retain(|(r, _)| r.as_str() != anchored);
                         if len > self.regexps.len() {
                             return RemoveResult::Ok;
                         }
@@ -247,7 +250,6 @@ impl<V: Debug + Clone> TrieNode<V> {
             None => (&b""[..], partial_key),
             Some(pos) => (&partial_key[..pos], &partial_key[pos..]),
         };
-        //println!("remove: prefix|suffix: {} | {}", std::str::from_utf8(prefix).unwrap(), std::str::from_utf8(suffix).unwrap());
 
         match self.children.get_mut(suffix) {
             Some(child) => match child.remove_recursive(prefix) {
@@ -263,11 +265,14 @@ impl<V: Debug + Clone> TrieNode<V> {
         }
     }
 
-    pub fn lookup(&self, partial_key: &[u8], accept_wildcard: bool) -> Option<&KeyValue<Key, V>> {
-        //println!("lookup: key == {}", std::str::from_utf8(partial_key).unwrap());
-
+    pub fn lookup<'a, 'b>(
+        &'a self,
+        partial_key: &'b [u8],
+        accept_wildcard: bool,
+        mut path: TrieMatches<'a, 'b>,
+    ) -> Option<(&'a KeyValue<Key, V>, TrieMatches<'a, 'b>)> {
         if partial_key.is_empty() {
-            return self.key_value.as_ref();
+            return self.key_value.as_ref().map(|kv| (kv, path));
         }
 
         let pos = find_last_dot(partial_key);
@@ -275,30 +280,23 @@ impl<V: Debug + Clone> TrieNode<V> {
             None => (&b""[..], partial_key),
             Some(pos) => (&partial_key[..pos], &partial_key[pos..]),
         };
-        //println!("lookup: prefix|suffix: {} | {}", std::str::from_utf8(prefix).unwrap(), std::str::from_utf8(suffix).unwrap());
 
         match self.children.get(suffix) {
-            Some(child) => child.lookup(prefix, accept_wildcard),
+            Some(child) => child.lookup(prefix, accept_wildcard, path),
             None => {
-                //println!("no child found, testing wildcard and regexps");
-
                 if prefix.is_empty() && self.wildcard.is_some() && accept_wildcard {
-                    //println!("no dot, wildcard applies");
-                    self.wildcard.as_ref()
+                    path.insert(0, TrieSubMatch::Wildcard(suffix));
+                    self.wildcard.as_ref().map(|kv| (kv, path))
                 } else {
-                    //println!("there's still a subdomain, wildcard does not apply");
-
-                    for (regexp, child) in self.regexps.iter() {
-                        let suffix = if suffix[0] == b'.' {
-                            &suffix[1..]
-                        } else {
-                            suffix
-                        };
-                        //println!("testing regexp: {} on suffix {}", r.as_str(), str::from_utf8(s).unwrap());
-
+                    let suffix = if suffix[0] == b'.' {
+                        &suffix[1..]
+                    } else {
+                        suffix
+                    };
+                    for (regexp, child) in &self.regexps {
                         if regexp.is_match(suffix) {
-                            //println!("matched");
-                            return child.lookup(prefix, accept_wildcard);
+                            path.insert(0, TrieSubMatch::Regexp(suffix, regexp));
+                            return child.lookup(prefix, accept_wildcard, path);
                         }
                     }
 
@@ -313,8 +311,6 @@ impl<V: Debug + Clone> TrieNode<V> {
         partial_key: &[u8],
         accept_wildcard: bool,
     ) -> Option<&mut KeyValue<Key, V>> {
-        //println!("lookup: key == {}", std::str::from_utf8(partial_key).unwrap());
-
         if partial_key.is_empty() {
             return self.key_value.as_mut();
         }
@@ -332,8 +328,9 @@ impl<V: Debug + Clone> TrieNode<V> {
                 }
 
                 if let Ok(s) = str::from_utf8(&partial_key[pos + 1..partial_key.len() - 1]) {
+                    let anchored = format!("\\A{s}\\z");
                     for t in self.regexps.iter_mut() {
-                        if t.0.as_str() == s {
+                        if t.0.as_str() == anchored {
                             return t.1.lookup_mut(&partial_key[..pos - 1], accept_wildcard);
                         }
                     }
@@ -348,29 +345,20 @@ impl<V: Debug + Clone> TrieNode<V> {
             None => (&b""[..], partial_key),
             Some(pos) => (&partial_key[..pos], &partial_key[pos..]),
         };
-        //println!("lookup: prefix|suffix: {} | {}", std::str::from_utf8(prefix).unwrap(), std::str::from_utf8(suffix).unwrap());
 
         match self.children.get_mut(suffix) {
             Some(child) => child.lookup_mut(prefix, accept_wildcard),
             None => {
-                //println!("no child found, testing wildcard and regexps");
-
                 if prefix.is_empty() && self.wildcard.is_some() && accept_wildcard {
-                    //println!("no dot, wildcard applies");
                     self.wildcard.as_mut()
                 } else {
-                    //println!("there's still a subdomain, wildcard does not apply");
-
-                    for &mut (ref regexp, ref mut child) in self.regexps.iter_mut() {
-                        let suffix = if suffix[0] == b'.' {
-                            &suffix[1..]
-                        } else {
-                            suffix
-                        };
-                        //println!("testing regexp: {} on suffix {}", r.as_str(), str::from_utf8(s).unwrap());
-
+                    let suffix = if suffix[0] == b'.' {
+                        &suffix[1..]
+                    } else {
+                        suffix
+                    };
+                    for (regexp, child) in &mut self.regexps {
                         if regexp.is_match(suffix) {
-                            //println!("matched");
                             return child.lookup_mut(prefix, accept_wildcard);
                         }
                     }
@@ -407,7 +395,6 @@ impl<V: Debug + Clone> TrieNode<V> {
         }
 
         for (regexp, child) in self.regexps.iter() {
-            //print!("{}{}:", prefix, regexp.as_str());
             child.print_recursive(regexp.as_str().as_bytes(), indent + 1);
         }
     }
@@ -421,7 +408,8 @@ impl<V: Debug + Clone> TrieNode<V> {
     }
 
     pub fn domain_lookup(&self, key: &[u8], accept_wildcard: bool) -> Option<&KeyValue<Key, V>> {
-        self.lookup(key, accept_wildcard)
+        let path = Vec::new();
+        self.lookup(key, accept_wildcard, path).map(|(kv, _)| kv)
     }
 
     pub fn domain_lookup_mut(
@@ -493,7 +481,6 @@ mod tests {
             root.domain_lookup(&b"abce"[..], true),
             Some(&(b"abce"[..].to_vec(), 2))
         );
-        //assert!(false);
     }
 
     #[test]
@@ -780,17 +767,13 @@ mod tests {
                 continue;
             }
 
-            //println!("inserting key: '{}', value: '{}'", k, v);
-            //assert_eq!(root.domain_insert(Vec::from(k.as_bytes()), *v), InsertResult::Ok);
             assert_eq!(
                 root.insert(Vec::from(k.as_bytes()), *v),
                 InsertResult::Ok,
                 "could not insert ({k}, {v})"
             );
-            //root.print();
         }
 
-        //root.print();
         for (k, v) in h.iter() {
             if k.is_empty() {
                 continue;
@@ -808,8 +791,7 @@ mod tests {
                 continue;
             }
 
-            //match root.domain_lookup(k.as_bytes()) {
-            match root.lookup(k.as_bytes(), false) {
+            match root.domain_lookup(k.as_bytes(), false) {
                 None => {
                     println!("did not find key '{k}'");
                     return false;


### PR DESCRIPTION
## Summary

- Add `RedirectPolicy`, `RedirectScheme`, `HeaderPosition` enums and `Header` message to protobuf schema; extend `RequestHttpFrontend` with fields 8-15 (redirect, rewrite, headers)
- Replace the `Route` enum with a richer `Frontend` struct and `RouteResult` type that carry rewrite templates, redirect configuration, and per-frontend custom headers
- Add `RewriteParts` template system supporting `$HOST[n]`/`$PATH[n]` capture-based URL rewriting, with `TrieMatches`/`TrieSubMatch` for regex capture propagation through the pattern trie
- Rewrite `cluster_id_from_request` to handle redirect policies (301/401), apply URL rewrites to authority/URI, inject `X-Forwarded-Host`, and apply custom header edits via `apply_header_edits`
- Replace all `unsafe { from_utf8_unchecked() }` with safe `from_utf8().unwrap_or()` alternatives
- Replace `get_unchecked` with bounds-checked `.get().unwrap_or()` access
- Anchor segment-level regexes in the pattern trie with `\A`/`\z` for precise matching

## PR Chain

This is PR C in the rewrite series:
- PR A: Backend refactor (Origin struct) — `feat/backend-origin-refactor`
- PR B: Flexible HTTP answer templates — `feat/rewrite-answer-templates`  
- **PR C (this)**: URL rewrite + redirection + custom headers — `feat/url-rewrite`
- PR D: Basic authentication (future)

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo clippy --workspace` — no new warnings
- [x] `cargo +nightly fmt` — clean
- [x] `cargo test --workspace` — all 125 tests pass (9 ignored)
- [x] Pattern trie regex insert/remove/lookup tests pass with `\A`/`\z` anchoring
- [x] Router regex insert/remove tests pass
- [x] State diff roundtrip test passes (default field omission)
- [ ] Integration test with actual HTTP requests using redirect/rewrite configuration