### PR TITLE
feat(auth): add basic HTTP authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1771,6 +1771,7 @@ name = "sozu-lib"
 version = "1.1.1"
 dependencies = [
  "anyhow",
+ "base64",
  "cookie-factory",
  "hdrhistogram",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1794,6 +1794,7 @@ dependencies = [
  "slab",
  "socket2",
  "sozu-command-lib",
+ "subtle",
  "thiserror 2.0.18",
  "time",
  "tiny_http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2" # consistent with rust edition 2024, see https://doc.rust-lang.or
 
 [workspace.dependencies]
 anyhow = "^1.0.102"
+base64 = "^0.21.7"
 clap = "^4.5.60"
 cookie-factory = "^0.3.3"
 futures = "^0.3.32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ serde = "^1.0.228"
 serde_json = "^1.0.149"
 serial_test = "^3.4.0"
 sha2 = "^0.10.9"
+subtle = "^2.6.1"
 slab = "^0.4.12"
 socket2 = "^0.6.3"
 sozu-command-lib = { version = "^1.1.1", path = "command" }

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -407,6 +407,10 @@ message Cluster {
     map<string, string> answers = 8;
     // optional port to use when building HTTPS redirect URLs
     optional uint32 https_redirect_port = 9;
+    // SHA256 hashes of authorized "user:password" credentials for basic auth
+    repeated string authorized_hashes = 10;
+    // realm name for the WWW-Authenticate header in 401 responses
+    optional string www_authenticate = 11;
 }
 
 enum LoadBalancingAlgorithms {

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -799,6 +799,11 @@ pub struct FileClusterConfig {
     pub answers: Option<BTreeMap<String, String>>,
     #[serde(default)]
     pub load_metric: Option<LoadMetric>,
+    /// SHA256 hashes of authorized "user:password" credentials for basic auth
+    #[serde(default)]
+    pub authorized_hashes: Vec<String>,
+    /// realm name for the WWW-Authenticate header in 401 responses
+    pub www_authenticate: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -888,6 +893,8 @@ impl FileClusterConfig {
                     load_balancing: self.load_balancing,
                     load_metric: self.load_metric,
                     answers,
+                    authorized_hashes: self.authorized_hashes,
+                    www_authenticate: self.www_authenticate,
                 }))
             }
         }
@@ -992,6 +999,9 @@ pub struct HttpClusterConfig {
     pub load_balancing: LoadBalancingAlgorithms,
     pub load_metric: Option<LoadMetric>,
     pub answers: BTreeMap<String, String>,
+    #[serde(default)]
+    pub authorized_hashes: Vec<String>,
+    pub www_authenticate: Option<String>,
 }
 
 impl HttpClusterConfig {
@@ -1006,6 +1016,8 @@ impl HttpClusterConfig {
                 answers: self.answers.clone(),
                 load_metric: self.load_metric.map(|s| s as i32),
                 https_redirect_port: self.https_redirect_port.map(|p| p as u32),
+                authorized_hashes: self.authorized_hashes.clone(),
+                www_authenticate: self.www_authenticate.clone(),
             })
             .into(),
         ];
@@ -1068,6 +1080,8 @@ impl TcpClusterConfig {
                 load_metric: self.load_metric.map(|s| s as i32),
                 answers: BTreeMap::new(),
                 https_redirect_port: None,
+                authorized_hashes: Vec::new(),
+                www_authenticate: None,
             })
             .into(),
         ];

--- a/e2e/src/tests/tests.rs
+++ b/e2e/src/tests/tests.rs
@@ -984,6 +984,105 @@ fn try_https_redirect() -> State {
     State::Success
 }
 
+fn try_basic_auth() -> State {
+    let front_address: SocketAddr = create_local_address();
+    let back_address: SocketAddr = create_local_address();
+
+    let (config, listeners, state) = Worker::empty_config();
+    let mut worker = Worker::start_new_worker("AUTH-WORKER", config, &listeners, state);
+
+    let answer_401 = "HTTP/1.1 401 Unauthorized\r\n\
+                       WWW-Authenticate: %WWW_AUTHENTICATE\r\n\
+                       Connection: close\r\n\r\n";
+
+    let mut http_config = ListenerBuilder::new_http(front_address.into())
+        .to_http(None)
+        .unwrap();
+    http_config.answers = [("401".to_owned(), answer_401.to_owned())].into();
+
+    worker.send_proxy_request_type(RequestType::AddHttpListener(http_config));
+    worker.send_proxy_request_type(RequestType::ActivateListener(ActivateListener {
+        address: front_address.into(),
+        proxy: ListenerType::Http.into(),
+        from_scm: false,
+    }));
+
+    // SHA256 of "secret" = 2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b
+    // authorized_hash = "admin:" + hex(sha256("secret"))
+    let authorized_hash =
+        "admin:2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b".to_owned();
+
+    worker.send_proxy_request(
+        RequestType::AddCluster(Cluster {
+            authorized_hashes: vec![authorized_hash],
+            www_authenticate: Some("Basic realm=\"sozu\"".to_owned()),
+            ..Worker::default_cluster("cluster_0")
+        })
+        .into(),
+    );
+
+    worker.send_proxy_request_type(RequestType::AddHttpFrontend(RequestHttpFrontend {
+        hostname: String::from("example.com"),
+        required_auth: Some(true),
+        ..Worker::default_http_frontend("cluster_0", front_address)
+    }));
+
+    worker.send_proxy_request_type(RequestType::AddBackend(Worker::default_backend(
+        "cluster_0",
+        "cluster_0-0",
+        back_address,
+        None,
+    )));
+    worker.read_to_last();
+
+    let mut backend = SyncBackend::new("backend", back_address, http_ok_response("hello"));
+    backend.connect();
+
+    // Test 1: No auth header -> 401
+    let no_auth_request = "GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n";
+    let mut client = Client::new("no-auth-client", front_address, no_auth_request);
+    client.connect();
+    client.send();
+    let response = client.receive().unwrap_or_default();
+    println!("no-auth response: {response:?}");
+    assert!(
+        response.starts_with("HTTP/1.1 401"),
+        "Expected 401, got: {response}"
+    );
+    assert!(
+        response.contains("WWW-Authenticate: Basic realm=\"sozu\""),
+        "Expected WWW-Authenticate header, got: {response}"
+    );
+
+    // Test 2: Wrong credentials -> 401
+    // base64("admin:wrong") = "YWRtaW46d3Jvbmc="
+    let wrong_auth_request = "GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\nAuthorization: Basic YWRtaW46d3Jvbmc=\r\n\r\n";
+    let mut client = Client::new("wrong-auth-client", front_address, wrong_auth_request);
+    client.connect();
+    client.send();
+    let response = client.receive().unwrap_or_default();
+    println!("wrong-auth response: {response:?}");
+    assert!(
+        response.starts_with("HTTP/1.1 401"),
+        "Expected 401, got: {response}"
+    );
+
+    // Test 3: Correct credentials -> 200 (forwarded to backend)
+    // base64("admin:secret") = "YWRtaW46c2VjcmV0"
+    let correct_auth_request = "GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\nAuthorization: Basic YWRtaW46c2VjcmV0\r\n\r\n";
+    let mut client = Client::new("correct-auth-client", front_address, correct_auth_request);
+    client.connect();
+    client.send();
+    backend.accept(0);
+    backend.receive(0);
+    backend.send(0);
+    let response = client.receive().unwrap_or_default();
+    println!("correct-auth response: {response:?}");
+    assert!(response.contains("200 OK"), "Expected 200, got: {response}");
+
+    State::Success
+}
+
 fn try_msg_close() -> State {
     let front_address = create_local_address();
 
@@ -1811,6 +1910,14 @@ fn test_wildcard() {
 fn test_status_header_split() {
     assert_eq!(
         repeat_until_error_or(2, "Status line and Headers split", try_status_header_split),
+        State::Success
+    );
+}
+
+#[test]
+fn test_basic_auth() {
+    assert_eq!(
+        repeat_until_error_or(2, "Basic authentication", try_basic_auth),
         State::Success
     );
 }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -47,6 +47,7 @@ rustls = { workspace = true }
 rustls-pemfile = { workspace = true }
 rusty_ulid = { workspace = true }
 sha2 = { workspace = true }
+subtle = { workspace = true }
 slab = { workspace = true }
 socket2 = { workspace = true, features = ["all"] }
 thiserror = { workspace = true }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -29,6 +29,7 @@ include = [
 
 [dependencies]
 anyhow = { workspace = true }
+base64 = { workspace = true }
 cookie-factory = { workspace = true }
 hdrhistogram = { workspace = true }
 hex = { workspace = true }

--- a/lib/src/protocol/kawa_h1/answers.rs
+++ b/lib/src/protocol/kawa_h1/answers.rs
@@ -423,6 +423,7 @@ fn default_401() -> String {
     String::from(
         "\
 HTTP/1.1 401 Unauthorized\r
+WWW-Authenticate: %WWW_AUTHENTICATE\r
 Cache-Control: no-cache\r
 Connection: close\r
 Sozu-Id: %REQUEST_ID\r
@@ -707,6 +708,13 @@ impl HttpAnswers {
             or_elide_header: false,
             typ: ReplacementType::VariableOnce(0),
         };
+        let www_authenticate = TemplateVariable {
+            name: "WWW_AUTHENTICATE",
+            valid_in_body: false,
+            valid_in_header: true,
+            or_elide_header: true,
+            typ: ReplacementType::VariableOnce(0),
+        };
         let message = TemplateVariable {
             name: "MESSAGE",
             valid_in_body: true,
@@ -757,7 +765,7 @@ impl HttpAnswers {
             "401" => Template::new(
                 Some(401),
                 answer,
-                &[route, request_id]
+                &[route, request_id, www_authenticate]
             ),
             "404" => Template::new(
                 Some(404),
@@ -890,9 +898,9 @@ impl HttpAnswers {
                 variables_once = vec![message.into()];
                 "400"
             }
-            DefaultAnswer::Answer401 {} => {
+            DefaultAnswer::Answer401 { www_authenticate } => {
                 variables = vec![route.into(), request_id.into()];
-                variables_once = vec![];
+                variables_once = vec![www_authenticate.map(Into::into).unwrap_or_default()];
                 "401"
             }
             DefaultAnswer::Answer404 {} => {

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -4,7 +4,9 @@ use std::{
     str::{from_utf8, from_utf8_unchecked},
 };
 
+use base64::Engine;
 use rusty_ulid::Ulid;
+use sha2::{Digest, Sha256};
 use sozu_command::logging::CachedTags;
 use sozu_command_lib::logging::LogContext;
 
@@ -85,6 +87,8 @@ pub struct HttpContext {
     pub keep_alive_frontend: bool,
     /// the value of the sticky session cookie in the request
     pub sticky_session_found: Option<String>,
+    /// hashed value of the last authorization header ("user:" + hex(sha256(password)))
+    pub authorization_found: Option<String>,
     /// position of the last header of the request (the "Sozu-Id"), only valid until prepare is called
     pub last_header: Option<usize>,
     // ---------- Route
@@ -155,6 +159,7 @@ impl HttpContext {
             sticky_name,
             sticky_session: None,
             sticky_session_found: None,
+            authorization_found: None,
             last_header: None,
             headers_response: Rc::new([]),
             tags: None,
@@ -237,6 +242,7 @@ impl HttpContext {
         let mut has_x_port = false;
         let mut has_x_proto = false;
         let mut has_connection = false;
+        let mut auth = None;
         #[cfg(feature = "opentelemetry")]
         let mut traceparent: Option<&mut kawa::Pair> = None;
         #[cfg(feature = "opentelemetry")]
@@ -286,6 +292,8 @@ impl HttpContext {
                             .data_opt(buf)
                             .and_then(|data| from_utf8(data).ok())
                             .map(ToOwned::to_owned);
+                    } else if compare_no_case(key, b"Authorization") {
+                        auth = Some(header);
                     } else {
                         #[cfg(feature = "opentelemetry")]
                         if compare_no_case(key, b"traceparent") {
@@ -304,6 +312,26 @@ impl HttpContext {
                 _ => {}
             }
         }
+
+        // Extract and hash the Authorization header for basic auth verification.
+        // Format: "Authorization: Basic <base64(user:password)>"
+        // Produces: "user:" + hex(sha256(password))
+        self.authorization_found =
+            auth.and_then(|header| header.val.data_opt(buf))
+                .and_then(|auth_val| {
+                    let trimmed = auth_val.trim_ascii_start();
+                    if trimmed.len() <= b"Basic ".len() {
+                        return None;
+                    }
+                    let (kind, token) = trimmed.split_at(b"Basic ".len());
+                    compare_no_case(kind, b"Basic ").then_some(())?;
+                    let token = base64::prelude::BASE64_STANDARD.decode(token).ok()?;
+                    let colon_pos = token.iter().position(|c| *c == b':')?;
+                    let (name, pwd) = token.split_at(colon_pos + 1);
+                    let mut result = String::from_utf8(name.to_vec()).ok()?;
+                    result.push_str(&hex::encode(Sha256::digest(pwd)));
+                    Some(result)
+                });
 
         #[cfg(feature = "opentelemetry")]
         let (otel, has_traceparent) = {
@@ -493,6 +521,7 @@ impl HttpContext {
         self.keep_alive_backend = true;
         self.keep_alive_frontend = true;
         self.sticky_session_found = None;
+        self.authorization_found = None;
         self.route.method = None;
         self.route.authority = None;
         self.route.path = None;

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -87,7 +87,9 @@ pub enum DefaultAnswer {
         partially_parsed: String,
         invalid: String,
     },
-    Answer401 {},
+    Answer401 {
+        www_authenticate: Option<String>,
+    },
     Answer404 {},
     Answer408 {
         duration: String,
@@ -1236,6 +1238,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
 
         let RouteResult {
             cluster_id,
+            required_auth,
             redirect,
             redirect_scheme,
             redirect_template: _,
@@ -1291,16 +1294,40 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         };
 
         let cluster_id = &self.context.cluster_id;
-        let (https_redirect, https_redirect_port) = match cluster_id {
-            Some(cid) => proxy
-                .borrow()
-                .clusters()
-                .get(cid)
-                .map_or((false, None), |cluster| {
-                    (cluster.https_redirect, cluster.https_redirect_port)
-                }),
-            None => (false, None),
-        };
+        let (authorized, www_authenticate, https_redirect, https_redirect_port) =
+            match (&cluster_id, redirect, required_auth) {
+                // unauthorized frontends
+                (_, RedirectPolicy::Unauthorized, _) => (false, None, false, None),
+                // forward frontends with no target (no cluster nor template)
+                (None, RedirectPolicy::Forward, _) => (false, None, false, None),
+                // clusterless frontend with auth (unsupported)
+                (None, _, true) => (false, None, false, None),
+                // clusterless frontends
+                (None, _, false) => (true, None, false, None),
+                // "attached" frontends
+                (Some(cluster_id), _, _) => {
+                    proxy.borrow().clusters().get(cluster_id).map_or(
+                        (true, None, false, None),
+                        |cluster| {
+                            let authorized =
+                                match (required_auth, &self.context.authorization_found) {
+                                    // auth not required
+                                    (false, _) => true,
+                                    // no auth found
+                                    (true, None) => false,
+                                    // validation
+                                    (true, Some(hash)) => cluster.authorized_hashes.contains(hash),
+                                };
+                            (
+                                authorized,
+                                cluster.www_authenticate.clone(),
+                                cluster.https_redirect,
+                                cluster.https_redirect_port,
+                            )
+                        },
+                    )
+                }
+            };
 
         let port = match (
             port,
@@ -1316,21 +1343,13 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             _ => String::new(),
         };
 
-        match (cluster_id, redirect) {
-            (_, RedirectPolicy::Unauthorized) => {
-                self.set_answer(DefaultAnswer::Answer401 {});
-                Err(RetrieveClusterError::UnauthorizedRoute)
-            }
-            (_, RedirectPolicy::Permanent) => {
+        match (cluster_id, redirect, authorized) {
+            (_, RedirectPolicy::Permanent, true) => {
                 let location = format!("{proto}://{host}{port}{path}");
                 self.set_answer(DefaultAnswer::Answer301 { location });
                 Err(RetrieveClusterError::Redirected)
             }
-            (None, RedirectPolicy::Forward) => {
-                self.set_answer(DefaultAnswer::Answer401 {});
-                Err(RetrieveClusterError::UnauthorizedRoute)
-            }
-            (Some(cluster_id), RedirectPolicy::Forward) => {
+            (Some(cluster_id), RedirectPolicy::Forward, true) => {
                 if !is_https && https_redirect {
                     let location = format!("https://{host}{port}{path}");
                     self.set_answer(DefaultAnswer::Answer301 { location });
@@ -1339,6 +1358,10 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
                 apply_header_edits(&mut self.request_stream, headers_request);
                 self.request_stream.blocks.extend(body);
                 Ok(cluster_id.to_owned())
+            }
+            _ => {
+                self.set_answer(DefaultAnswer::Answer401 { www_authenticate });
+                Err(RetrieveClusterError::UnauthorizedRoute)
             }
         }
     }

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -14,6 +14,7 @@ use std::{
 
 use mio::{Interest, Token, net::TcpStream};
 use rusty_ulid::Ulid;
+use subtle::ConstantTimeEq;
 use sozu_command::{
     config::MAX_LOOP_ITERATIONS,
     logging::EndpointRecord,
@@ -1315,8 +1316,11 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
                                     (false, _) => true,
                                     // no auth found
                                     (true, None) => false,
-                                    // validation
-                                    (true, Some(hash)) => cluster.authorized_hashes.contains(hash),
+                                    // validation (constant-time comparison to prevent timing attacks)
+                                    (true, Some(hash)) => cluster
+                                        .authorized_hashes
+                                        .iter()
+                                        .any(|h| h.as_bytes().ct_eq(hash.as_bytes()).into()),
                                 };
                             (
                                 authorized,

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -728,6 +728,7 @@ impl Debug for HeaderEdit {
 #[derive(Debug, Clone)]
 pub struct Frontend {
     cluster_id: Option<ClusterId>,
+    required_auth: bool,
     redirect: RedirectPolicy,
     redirect_scheme: RedirectScheme,
     redirect_template: Option<String>,
@@ -774,6 +775,7 @@ impl Frontend {
         if deny {
             return Ok(Self {
                 cluster_id: cluster_id.clone(),
+                required_auth: false,
                 redirect: RedirectPolicy::Unauthorized,
                 redirect_scheme,
                 redirect_template: None,
@@ -852,6 +854,7 @@ impl Frontend {
         }
         Ok(Frontend {
             cluster_id,
+            required_auth: front.required_auth,
             redirect,
             redirect_scheme,
             redirect_template,
@@ -870,6 +873,7 @@ impl Frontend {
     pub fn forward(cluster_id: ClusterId) -> Self {
         Self {
             cluster_id: Some(cluster_id),
+            required_auth: false,
             redirect: RedirectPolicy::Forward,
             redirect_scheme: RedirectScheme::UseSame,
             redirect_template: None,
@@ -888,6 +892,7 @@ impl Frontend {
 #[derive(Debug, Clone)]
 pub struct RouteResult {
     pub cluster_id: Option<ClusterId>,
+    pub required_auth: bool,
     pub redirect: RedirectPolicy,
     pub redirect_scheme: RedirectScheme,
     pub redirect_template: Option<String>,
@@ -903,6 +908,7 @@ impl RouteResult {
     fn deny(cluster_id: &Option<ClusterId>) -> Self {
         Self {
             cluster_id: cluster_id.clone(),
+            required_auth: false,
             redirect: RedirectPolicy::Unauthorized,
             redirect_scheme: RedirectScheme::UseSame,
             redirect_template: None,
@@ -923,6 +929,7 @@ impl RouteResult {
     ) -> Self {
         let Frontend {
             cluster_id,
+            required_auth,
             redirect,
             redirect_scheme,
             redirect_template,
@@ -953,6 +960,7 @@ impl RouteResult {
         }
         Self {
             cluster_id: cluster_id.clone(),
+            required_auth: *required_auth,
             redirect: *redirect,
             redirect_scheme: *redirect_scheme,
             redirect_template: redirect_template.clone(),


### PR DESCRIPTION
## Summary
- Basic HTTP authentication with SHA256 password hashes
- WWW-Authenticate challenge response (401) with configurable realm
- Per-cluster `authorized_hashes` and `www_authenticate` configuration
- Authorization header extraction and validation in editor.rs
- `required_auth` wired through `Frontend` -> `RouteResult` -> auth check flow

## Changes
- **command.proto**: `authorized_hashes` (field 10) and `www_authenticate` (field 11) on `Cluster`
- **config.rs**: `authorized_hashes` and `www_authenticate` on `FileClusterConfig` and `HttpClusterConfig`
- **editor.rs**: Extract `Authorization: Basic` header, decode base64, SHA256 hash password, store as `authorization_found`
- **answers.rs**: `WWW_AUTHENTICATE` template variable for 401 responses (header-only, elide if empty)
- **mod.rs**: Auth check in `cluster_id_from_request` - compare hash against `authorized_hashes`
- **router/mod.rs**: `required_auth` field on `Frontend` and `RouteResult`
- **e2e**: Auth test covering no-auth 401, wrong-credentials 401, correct-credentials 200

## Depends on
- PR #1208 (URL rewrite + redirect + custom headers)
- PR #1207 (answer templates)
- PR #1206 (backend refactor)

## Test plan
- [x] Existing e2e tests pass (126 pass, 9 ignored)
- [x] Auth e2e test: 401 without credentials
- [x] Auth e2e test: 401 with wrong credentials
- [x] Auth e2e test: 200 with correct credentials
- [x] `cargo build --workspace` -- 0 errors
- [x] `cargo clippy --workspace` -- no new warnings
- [x] `cargo +nightly fmt` -- clean