### PR TITLE
test(e2e): poll-until-goaway for h2_rapid_reset, kill a timing flake

### DIFF
--- a/e2e/src/tests/h2_tests.rs
+++ b/e2e/src/tests/h2_tests.rs
@@ -1487,9 +1487,28 @@ fn try_h2_rapid_reset_triggers_goaway() -> State {
     }
     let _ = tls.flush();
 
-    // Read response — expect GOAWAY with ENHANCE_YOUR_CALM
-    thread::sleep(Duration::from_millis(500));
-    let response_data = read_all_available(&mut tls, Duration::from_secs(2));
+    // Poll for GOAWAY with ENHANCE_YOUR_CALM, exiting as soon as we see it.
+    // The previous shape (fixed 500ms sleep + 2s read) tripped under CPU
+    // contention — 400 frames (200 HEADERS + 200 RST_STREAM) can take
+    // longer than 500ms to process through the kernel TLS stack + Sōzu's
+    // H2 frame parser when the host is otherwise busy. The flood detector
+    // fires well before the 200th stream, so short-circuiting on the first
+    // GOAWAY keeps the happy path fast while the 8 s ceiling absorbs
+    // extreme scheduling delays.
+    let poll_deadline = std::time::Instant::now() + Duration::from_secs(8);
+    let mut response_data: Vec<u8> = Vec::new();
+    let mut got_enhance_your_calm = false;
+    while std::time::Instant::now() < poll_deadline {
+        let chunk = read_all_available(&mut tls, Duration::from_millis(100));
+        if !chunk.is_empty() {
+            response_data.extend_from_slice(&chunk);
+            let frames = parse_h2_frames(&response_data);
+            if contains_goaway_with_error(&frames, H2_ERROR_ENHANCE_YOUR_CALM) {
+                got_enhance_your_calm = true;
+                break;
+            }
+        }
+    }
     let frames = parse_h2_frames(&response_data);
 
     println!("H2 Rapid Reset - received {} frames", frames.len());
@@ -1502,7 +1521,6 @@ fn try_h2_rapid_reset_triggers_goaway() -> State {
         }
     }
 
-    let got_enhance_your_calm = contains_goaway_with_error(&frames, H2_ERROR_ENHANCE_YOUR_CALM);
     println!("H2 Rapid Reset - got ENHANCE_YOUR_CALM: {got_enhance_your_calm}");
 
     drop(tls);


### PR DESCRIPTION
## Summary

`test_h2_rapid_reset_triggers_goaway` was flaky under heavy host CPU contention (reproducible with 5+ parallel Claude/cargo sessions running on the same host). The test's fixed 500 ms pre-read sleep + 2 s `read_all_available` budget would miss the GOAWAY(ENHANCE_YOUR_CALM) frame when the kernel TLS stack + H2 frame parser needed more wall clock to drain 400 queued rapid-reset frames.

CI has been consistently green — the matrix runners have enough idle CPU that 500 ms is always enough. This is a developer-experience fix for anyone running the e2e suite on a busy box.

## Change

Replace the fixed pre-read sleep + single read with a poll-until-GOAWAY loop:

- Exit as soon as a GOAWAY(ENHANCE_YOUR_CALM) frame is parsed (fast path ≈100 ms on idle hosts).
- 8 s total ceiling so extreme scheduling delays terminate the attempt rather than hanging until the harness-level timeout.
- Read in 100 ms chunks via the existing `read_all_available` helper; re-parse after each chunk.

No change to production code or detector behaviour.

## Test plan

- [x] `cargo test -p sozu-e2e --lib tests::h2_tests::test_h2_rapid_reset_triggers_goaway` — pass (12.5 s isolated)
- [x] `cargo test -p sozu-e2e --lib tests::h2_tests:: -- --test-threads=8` — 66 pass, 0 fail, 1 ignored, 156 s (the full h2_tests suite under simulated load; this is what used to reproduce the flake)
- [ ] CI matrix — expected green (it already was on the parent MRs)

## Context

Spotted during the post-review pass on #1225 (telemetry MR). Small independent MR against `feat/h2-mux` so it merges on its own cadence regardless of #1225.