### PR TITLE
fix(mux): H1→H2 wake-gap, outbound idle refresh, chunked-EOF classification + e2e repro suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,12 @@ See milestone [`v1.1.0`](https://github.com/sozu-proxy/sozu/projects/3?card_filt
 
 ### ⛑️ Fixed
 
+- We fixed HTTP/2 frontend stalling after an H1 backend response arrives on slow or per-chunk-flushed streams. The H1 read path was flipping the frontend `Ready::WRITABLE` interest bit at five sites in `lib/src/protocol/mux/h1.rs` without pairing it with `signal_pending_write()`; edge-triggered epoll then never re-fired and the queued body sat in sozu's buffers. Firefox and Chrome both reproduced on large PHP/Apache assets (~300 KiB chunked).
+
+- We fixed the per-stream H2 idle timer firing mid-response on slow outbound deliveries. `stream_last_activity_at` refreshed only on inbound DATA / HEADERS, so a long-running response trickled at low bandwidth without inbound frames could be cancelled by `cancel_timed_out_streams` before completion. Outbound writes now refresh the timer alongside the existing inbound refresh sites in `lib/src/protocol/mux/h2.rs`.
+
+- We fixed chunked-transfer backend EOF being silently reported as a clean `END_STREAM` with a truncated body. `terminate_close_delimited` in `lib/src/protocol/mux/h1.rs` now demotes mid-chunked EOF to `ParsingPhase::Error`, which the H2 converter surfaces as `RST_STREAM(InternalError)` to the client per RFC 9112 §7.1 — replacing silent truncation with a loud stream error.
+
 - We fixed HTTP cleartext frontend socket shutdown using `Shutdown::Both` instead of `Shutdown::Write`. On Linux, `Shutdown::Both` discards unread receive-buffer data and can convert an otherwise clean close into a TCP RST. The HTTPS path already used `Shutdown::Write`.
 
 - We fixed an `http.active_requests` gauge underflow where idle-timeout teardown and malformed-request rejection paths decremented the counter without a prior increment, causing the gauge to wrap to `u64::MAX`, see [`9b6f9987`](https://github.com/sozu-proxy/sozu/commit/9b6f99871f2a74f120cceb13a3c3ffeab5525515).

--- a/doc/upgrade_e2e_tests.md
+++ b/doc/upgrade_e2e_tests.md
@@ -317,5 +317,6 @@ cargo test -p sozu-e2e
 | `e2e/src/tests/mod.rs` | `setup_sync_test`, `setup_async_test`, `repeat_until_error_or` |
 | `e2e/src/mock/sync_backend.rs` | Manually-stepped backend for precise ordering |
 | `e2e/src/mock/async_backend.rs` | Auto-responding backend for throughput tests |
+| `e2e/src/mock/chunked_flush_h1_backend.rs` | Keep-alive H1 backend with TCP_NODELAY + per-chunk `flush()` + sleep for the H2 large-asset repro suite (C1/C2/C3) |
 | `lib/src/server.rs:1178` | `notify_activate_listener` — SCM FD activation |
 | `command/src/state.rs:534` | `generate_requests` — state replay including listeners |

--- a/e2e/src/mock/chunked_flush_h1_backend.rs
+++ b/e2e/src/mock/chunked_flush_h1_backend.rs
@@ -1,0 +1,257 @@
+//! HTTP/1.1 mock backend that emits the response body in small, explicitly
+//! flushed segments — reproducing the wire cadence of PHP/Apache responses
+//! (`mod_deflate`, `flush()`, `SendfileMaxPipeSize`). Used by the H2
+//! large-asset repro suite to characterise the cross-connection edge-triggered
+//! `WRITABLE` wake-gap (see `lib/src/protocol/mux/h1.rs:341-346, 351-357` and
+//! memory entry `project_sozu_h1_missing_signal_pending_write.md`).
+//!
+//! Divergence from [`CloseDelimitedBackend`] in `h2_tests.rs:3237-3327`:
+//! that backend batches all writes (no `flush()` between chunks, no
+//! `TCP_NODELAY`) because its role is to probe HUP regression, not write
+//! fragmentation. This backend is the opposite: `TCP_NODELAY` + per-chunk
+//! `flush()` + `thread::sleep(inter_chunk_delay)` explicitly forces distinct
+//! TCP segments so sozu observes multiple `readable()` passes from the
+//! backend, each one repeating the `interest.insert(Ready::WRITABLE)`
+//! pattern on the frontend endpoint. Without the sleep, the kernel may
+//! coalesce the writes despite `TCP_NODELAY`; the sleep is what guarantees
+//! a segment is emitted before the next write queues.
+//!
+//! This backend stays alive across requests (HTTP/1.1 keep-alive by default
+//! on the backend path) until [`ChunkedFlushH1Backend::stop`] is called, so
+//! the response framing is driven by `Content-Length` / `Transfer-Encoding:
+//! chunked`, not by EOF. The [`ChunkedFlushConfig::truncate_at_byte`] knob
+//! is the sole exception: when set, the backend drops the TCP connection
+//! partway through the body (before the `0\r\n\r\n` terminator on chunked
+//! responses) so the H2 side must emit RST_STREAM rather than a silent
+//! END_STREAM.
+
+use std::{
+    io::{Read, Write},
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+    thread::{self, JoinHandle},
+    time::Duration,
+};
+
+use crate::port_registry::bind_std_listener;
+
+/// HTTP/1.1 transfer-encoding used by the mock.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransferEncoding {
+    /// Response advertises `Content-Length: N`; the backend writes exactly
+    /// `N` bytes of body without chunk framing.
+    ContentLength,
+    /// Response advertises `Transfer-Encoding: chunked`; each chunk is
+    /// prefixed with `<hex_len>\r\n`, suffixed with `\r\n`, and terminated
+    /// with `0\r\n\r\n` (unless `truncate_at_byte` fires first).
+    Chunked,
+}
+
+/// Configuration for [`ChunkedFlushH1Backend::start`].
+pub struct ChunkedFlushConfig {
+    /// Total body size in bytes (payload only; chunk framing overhead is
+    /// added on top for [`TransferEncoding::Chunked`]).
+    pub body_size: usize,
+    /// Per-chunk payload size; the last chunk may be smaller.
+    pub chunk_size: usize,
+    /// Time to sleep between chunks. Required >0 when `tcp_nodelay=true` to
+    /// defeat kernel write-coalescing.
+    pub inter_chunk_delay: Duration,
+    /// Framing of the response body.
+    pub transfer_encoding: TransferEncoding,
+    /// When `true`, `TCP_NODELAY` is set on every accepted stream so each
+    /// `write_all` + `flush` pair is emitted as a distinct segment.
+    pub tcp_nodelay: bool,
+    /// When `Some(N)`, drop the TCP connection after `N` bytes of RAW output
+    /// (headers + body + any chunk framing) have been written, WITHOUT
+    /// writing the terminating `0\r\n\r\n`. Used to reproduce C3
+    /// (chunked-EOF misclassification).
+    pub truncate_at_byte: Option<usize>,
+}
+
+/// Keep-alive HTTP/1.1 backend that serves a configurable body in small,
+/// flushed segments.
+pub struct ChunkedFlushH1Backend {
+    stop: Arc<AtomicBool>,
+    responses_sent: Arc<AtomicUsize>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl ChunkedFlushH1Backend {
+    pub fn start(address: SocketAddr, config: ChunkedFlushConfig) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let responses_sent = Arc::new(AtomicUsize::new(0));
+        let stop_clone = stop.clone();
+        let resp_count = responses_sent.clone();
+
+        let thread = thread::spawn(move || {
+            let listener = bind_std_listener(address, "chunked-flush H1 backend");
+            listener
+                .set_nonblocking(true)
+                .expect("could not set nonblocking");
+
+            loop {
+                if stop_clone.load(Ordering::Relaxed) {
+                    break;
+                }
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        if config.tcp_nodelay {
+                            let _ = stream.set_nodelay(true);
+                        }
+                        let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+                        let _ = stream.set_write_timeout(Some(Duration::from_secs(5)));
+                        // Read and discard the request headers (single-shot
+                        // read is sufficient: the largest test request is a
+                        // plain GET that fits in one syscall).
+                        let mut buf = [0u8; 4096];
+                        let _ = stream.read(&mut buf);
+
+                        let mut bytes_written: usize = 0;
+                        let mut truncated = false;
+
+                        let headers = match config.transfer_encoding {
+                            TransferEncoding::ContentLength => format!(
+                                "HTTP/1.1 200 OK\r\n\
+                                 Content-Type: application/octet-stream\r\n\
+                                 Content-Length: {}\r\n\
+                                 \r\n",
+                                config.body_size
+                            ),
+                            TransferEncoding::Chunked => String::from(
+                                "HTTP/1.1 200 OK\r\n\
+                                 Content-Type: application/octet-stream\r\n\
+                                 Transfer-Encoding: chunked\r\n\
+                                 \r\n",
+                            ),
+                        };
+                        if stream.write_all(headers.as_bytes()).is_err() {
+                            continue;
+                        }
+                        let _ = stream.flush();
+                        bytes_written += headers.len();
+
+                        if Self::should_truncate(&config, bytes_written) {
+                            drop(stream);
+                            continue;
+                        }
+
+                        // Body phase. Chunk payload is `Z` bytes so the
+                        // result is human-inspectable in logs.
+                        let chunk = vec![b'Z'; config.chunk_size.max(1)];
+                        let mut remaining = config.body_size;
+                        let mut write_failed = false;
+                        while remaining > 0 {
+                            let to_write = remaining.min(chunk.len());
+                            let piece = &chunk[..to_write];
+                            match config.transfer_encoding {
+                                TransferEncoding::ContentLength => {
+                                    if stream.write_all(piece).is_err() {
+                                        write_failed = true;
+                                        break;
+                                    }
+                                    bytes_written += to_write;
+                                }
+                                TransferEncoding::Chunked => {
+                                    let header = format!("{to_write:x}\r\n");
+                                    if stream.write_all(header.as_bytes()).is_err() {
+                                        write_failed = true;
+                                        break;
+                                    }
+                                    bytes_written += header.len();
+                                    if stream.write_all(piece).is_err() {
+                                        write_failed = true;
+                                        break;
+                                    }
+                                    bytes_written += to_write;
+                                    if stream.write_all(b"\r\n").is_err() {
+                                        write_failed = true;
+                                        break;
+                                    }
+                                    bytes_written += 2;
+                                }
+                            }
+                            // `flush()` forces rustls-independent flush on
+                            // TCP stream. Combined with `TCP_NODELAY` and the
+                            // sleep below, this fragments the wire.
+                            if stream.flush().is_err() {
+                                write_failed = true;
+                                break;
+                            }
+
+                            if Self::should_truncate(&config, bytes_written) {
+                                truncated = true;
+                                break;
+                            }
+
+                            remaining -= to_write;
+                            if remaining > 0 && !config.inter_chunk_delay.is_zero() {
+                                thread::sleep(config.inter_chunk_delay);
+                            }
+                        }
+
+                        if !write_failed && !truncated {
+                            if let TransferEncoding::Chunked = config.transfer_encoding {
+                                let _ = stream.write_all(b"0\r\n\r\n");
+                                let _ = stream.flush();
+                            }
+                            resp_count.fetch_add(1, Ordering::Relaxed);
+                            // Keep the connection alive so sozu's H1 parser
+                            // frames the response by Content-Length /
+                            // chunked terminator, not by EOF. Wait for the
+                            // peer to close or for the test to stop.
+                            let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+                            let mut drain = [0u8; 256];
+                            loop {
+                                if stop_clone.load(Ordering::Relaxed) {
+                                    break;
+                                }
+                                match stream.read(&mut drain) {
+                                    Ok(0) => break,
+                                    Ok(_) => continue,
+                                    Err(_) => break,
+                                }
+                            }
+                        }
+                        drop(stream);
+                    }
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => {}
+                }
+            }
+        });
+
+        Self {
+            stop,
+            responses_sent,
+            thread: Some(thread),
+        }
+    }
+
+    fn should_truncate(config: &ChunkedFlushConfig, bytes_written: usize) -> bool {
+        matches!(config.truncate_at_byte, Some(limit) if bytes_written >= limit)
+    }
+
+    pub fn responses_sent(&self) -> usize {
+        self.responses_sent.load(Ordering::Relaxed)
+    }
+
+    pub fn stop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(t) = self.thread.take() {
+            thread::sleep(Duration::from_millis(100));
+            drop(t);
+        }
+    }
+}
+
+impl Drop for ChunkedFlushH1Backend {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}

--- a/e2e/src/mock/mod.rs
+++ b/e2e/src/mock/mod.rs
@@ -1,5 +1,6 @@
 pub mod aggregator;
 pub mod async_backend;
+pub mod chunked_flush_h1_backend;
 pub mod client;
 pub mod h2_backend;
 pub mod https_client;

--- a/e2e/src/tests/h2_correctness_tests.rs
+++ b/e2e/src/tests/h2_correctness_tests.rs
@@ -1354,10 +1354,7 @@ fn try_h2_solo_incremental_drains_fully() -> State {
                 raw.extend_from_slice(&rbuf[..n]);
                 let frames = parse_h2_frames(&raw);
                 for (ft, fl, s, _) in &frames {
-                    if *ft == H2_FRAME_DATA
-                        && *s == sid
-                        && (*fl & H2_FLAG_END_STREAM) != 0
-                    {
+                    if *ft == H2_FRAME_DATA && *s == sid && (*fl & H2_FLAG_END_STREAM) != 0 {
                         done = true;
                         break;
                     }
@@ -1418,6 +1415,656 @@ fn test_h2_solo_incremental_drains_fully() {
             3,
             "H2 solo `priority: u=0, i` stream must drain full body within 2 s",
             try_h2_solo_incremental_drains_fully
+        ),
+        State::Success
+    );
+}
+
+// ============================================================================
+// H2 large-asset repro suite (Sébastien Brunat 2026-04-23 PHP/Apache report)
+// ============================================================================
+
+/// Firefox-shape header block: same pseudo-headers as
+/// [`build_get_headers_with_priority`] but WITHOUT the `priority` literal.
+/// Firefox does not emit `priority: u=0, i` by default, so any truncation
+/// observable on this shape lives outside the RFC 9218 solo-bucket fix
+/// at `converter.rs:437-450`.
+fn build_get_headers_no_priority() -> Vec<u8> {
+    vec![
+        0x82, // :method GET (indexed)
+        0x84, // :path / (indexed)
+        0x87, // :scheme https (indexed)
+        0x41, 0x09, // :authority, value len 9
+        b'l', b'o', b'c', b'a', b'l', b'h', b'o', b's', b't',
+    ]
+}
+
+/// Drain one stream until END_STREAM on the given `sid` or the `deadline`
+/// expires. Returns `(body_bytes, end_stream_seen, got_rst_stream_on_sid,
+/// elapsed)`.
+///
+/// Uses the END_STREAM-aware early-exit pattern documented in memory
+/// `feedback_collect_response_frames_quiet_time.md`: a `collect_response_frames`
+/// elapsed budget measures quiet time, not body delivery. The caller's
+/// deadline wall-clock is the source of truth.
+fn drain_h2_stream_until_end_stream(
+    tls: &mut rustls::StreamOwned<rustls::ClientConnection, std::net::TcpStream>,
+    sid: u32,
+    deadline: Duration,
+) -> (usize, bool, bool, Duration) {
+    tls.sock
+        .set_read_timeout(Some(Duration::from_millis(250)))
+        .ok();
+    let start = Instant::now();
+    let mut raw = Vec::new();
+    let mut rbuf = vec![0u8; 65536];
+    let mut done = false;
+    let mut got_rst = false;
+    while !done && start.elapsed() < deadline {
+        match tls.read(&mut rbuf) {
+            Ok(0) => break,
+            Ok(n) => {
+                raw.extend_from_slice(&rbuf[..n]);
+                let frames = parse_h2_frames(&raw);
+                for (ft, fl, s, _) in &frames {
+                    if *ft == H2_FRAME_DATA && *s == sid && (*fl & H2_FLAG_END_STREAM) != 0 {
+                        done = true;
+                        break;
+                    }
+                    if *ft == H2_FRAME_HEADERS && *s == sid && (*fl & H2_FLAG_END_STREAM) != 0 {
+                        done = true;
+                        break;
+                    }
+                    if *ft == H2_FRAME_RST_STREAM && *s == sid {
+                        got_rst = true;
+                        done = true;
+                        break;
+                    }
+                }
+            }
+            Err(e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                continue;
+            }
+            Err(_) => break,
+        }
+    }
+    let elapsed = start.elapsed();
+    let frames = parse_h2_frames(&raw);
+    let mut body_bytes = 0usize;
+    let mut end_stream_seen = false;
+    for (ft, fl, s, payload) in &frames {
+        if *ft == H2_FRAME_DATA && *s == sid {
+            body_bytes += payload.len();
+            if (*fl & H2_FLAG_END_STREAM) != 0 {
+                end_stream_seen = true;
+            }
+        }
+    }
+    (body_bytes, end_stream_seen, got_rst, elapsed)
+}
+
+/// Build a full HTTPS listener + cluster + cert + backend stack with a
+/// single configurable backend thread. Returns (worker, front_port,
+/// back_address). The caller spawns the mock backend against `back_address`.
+fn setup_single_h1_backend_listener(
+    name: &str,
+    h2_stream_idle_timeout_seconds: Option<u32>,
+) -> (Worker, u16, SocketAddr) {
+    let front_port = provide_port();
+    let front_address = SocketAddress::new_v4(127, 0, 0, 1, front_port);
+
+    let (config, listeners, state) = Worker::empty_https_config(front_address.clone().into());
+    let mut worker = Worker::start_new_worker_owned(name, config, listeners, state);
+
+    let mut listener_config = ListenerBuilder::new_https(front_address.clone())
+        .to_tls(None)
+        .unwrap();
+    if let Some(secs) = h2_stream_idle_timeout_seconds {
+        listener_config.h2_stream_idle_timeout_seconds = Some(secs);
+    }
+
+    worker.send_proxy_request_type(RequestType::AddHttpsListener(listener_config));
+    worker.send_proxy_request_type(RequestType::ActivateListener(ActivateListener {
+        address: front_address.clone(),
+        proxy: ListenerType::Https.into(),
+        from_scm: false,
+    }));
+    worker.send_proxy_request_type(RequestType::AddCluster(Worker::default_cluster(
+        "cluster_0",
+    )));
+    worker.send_proxy_request_type(RequestType::AddHttpsFrontend(RequestHttpFrontend {
+        hostname: String::from("localhost"),
+        ..Worker::default_http_frontend("cluster_0", front_address.clone().into())
+    }));
+
+    let certificate_and_key = CertificateAndKey {
+        certificate: String::from(include_str!("../../../lib/assets/local-certificate.pem")),
+        key: String::from(include_str!("../../../lib/assets/local-key.pem")),
+        certificate_chain: vec![],
+        versions: vec![],
+        names: vec![],
+    };
+    worker.send_proxy_request_type(RequestType::AddCertificate(AddCertificate {
+        address: front_address,
+        certificate: certificate_and_key,
+        expired_at: None,
+    }));
+
+    let back_address = create_local_address();
+    worker.send_proxy_request_type(RequestType::AddBackend(Worker::default_backend(
+        "cluster_0",
+        "cluster_0-0".to_owned(),
+        back_address,
+        None,
+    )));
+    worker.read_to_last();
+    (worker, front_port, back_address)
+}
+
+// ----------------------------------------------------------------------------
+// (a) test_h2_firefox_shape_h1_cl_drains_fully — Firefox shape + H1 CL
+// ----------------------------------------------------------------------------
+
+/// Firefox shape: no `priority` header, H1 backend with Content-Length,
+/// 80 892 bytes (HAR-exact value from Sébastien Brunat's 2026-04-23 AM
+/// report). Exercises `mux/h1.rs:241-347` on the write path — the site
+/// where C1 (`signal_pending_write` missing on `Ready::WRITABLE` insert)
+/// historically parked large asset deliveries.
+///
+/// Expected on HEAD (post-C1 fix): PASS within 3 s. Before the fix: would
+/// stall — the test is a lock-in anti-regression for C1 on the Firefox
+/// code path.
+fn try_h2_firefox_shape_h1_cl_drains_fully() -> State {
+    const BODY_SIZE: usize = 80_892;
+
+    let (worker, backends, front_port) =
+        setup_h2_test_with_large_bodies("H2-LA-FF-CL", 1, BODY_SIZE);
+
+    let front_addr: SocketAddr = format!("127.0.0.1:{front_port}").parse().unwrap();
+    let mut tls = raw_h2_connection(front_addr);
+    h2_handshake_with_initial_window(&mut tls, 1_000_000);
+
+    let sid: u32 = 1;
+    let block = build_get_headers_no_priority();
+    let headers = H2Frame::headers(sid, block, true, true);
+    tls.write_all(&headers.encode()).unwrap();
+    tls.flush().unwrap();
+    tls.write_all(&H2Frame::window_update(0, 1_000_000).encode())
+        .unwrap();
+    tls.flush().unwrap();
+
+    let (body_bytes, end_stream_seen, got_rst, elapsed) =
+        drain_h2_stream_until_end_stream(&mut tls, sid, Duration::from_secs(3));
+
+    println!(
+        "firefox-shape CL: body_bytes={body_bytes}/{BODY_SIZE} \
+         end_stream={end_stream_seen} rst={got_rst} elapsed={elapsed:?}"
+    );
+
+    let infra_ok = teardown(tls, front_port, worker, backends);
+
+    if infra_ok && body_bytes == BODY_SIZE && end_stream_seen && !got_rst {
+        State::Success
+    } else {
+        println!(
+            "FAIL: body_bytes={body_bytes} (want {BODY_SIZE}), \
+             end_stream={end_stream_seen}, rst={got_rst}, \
+             elapsed={elapsed:?}, infra_ok={infra_ok}"
+        );
+        State::Fail
+    }
+}
+
+#[test]
+fn test_h2_firefox_shape_h1_cl_drains_fully() {
+    assert_eq!(
+        repeat_until_error_or(
+            3,
+            "H2 Firefox shape (no priority) + H1 CL backend must drain 80892 B within 3 s",
+            try_h2_firefox_shape_h1_cl_drains_fully
+        ),
+        State::Success
+    );
+}
+
+// ----------------------------------------------------------------------------
+// (b) test_h2_chrome_shape_h1_cl_drains_fully — Chrome shape + H1 CL
+// ----------------------------------------------------------------------------
+
+/// Chrome shape: `priority: u=0, i`, H1 backend with Content-Length,
+/// 100 KiB. Locks in the RFC 9218 solo-bucket fix (`converter.rs:437-450`,
+/// commit `f6c02912`) on the H1-backend code path — the existing
+/// `test_h2_solo_incremental_drains_fully` uses an H2 backend via
+/// `setup_h2_test_with_large_bodies`, which internally spawns
+/// `AsyncBackend::http_handler` — so this test adds coverage for the
+/// `mux/h1.rs` → `mux/h2.rs` write-path interaction under the solo
+/// incremental shape.
+fn try_h2_chrome_shape_h1_cl_drains_fully() -> State {
+    const BODY_SIZE: usize = 100 * 1024;
+
+    let (worker, backends, front_port) =
+        setup_h2_test_with_large_bodies("H2-LA-CH-CL", 1, BODY_SIZE);
+
+    let front_addr: SocketAddr = format!("127.0.0.1:{front_port}").parse().unwrap();
+    let mut tls = raw_h2_connection(front_addr);
+    h2_handshake_with_initial_window(&mut tls, 1_000_000);
+
+    let sid: u32 = 1;
+    let block = build_get_headers_with_priority(0, "i");
+    let headers = H2Frame::headers(sid, block, true, true);
+    tls.write_all(&headers.encode()).unwrap();
+    tls.flush().unwrap();
+    tls.write_all(&H2Frame::window_update(0, 1_000_000).encode())
+        .unwrap();
+    tls.flush().unwrap();
+
+    let (body_bytes, end_stream_seen, got_rst, elapsed) =
+        drain_h2_stream_until_end_stream(&mut tls, sid, Duration::from_secs(3));
+
+    println!(
+        "chrome-shape H1 CL: body_bytes={body_bytes}/{BODY_SIZE} \
+         end_stream={end_stream_seen} rst={got_rst} elapsed={elapsed:?}"
+    );
+
+    let infra_ok = teardown(tls, front_port, worker, backends);
+
+    if infra_ok && body_bytes == BODY_SIZE && end_stream_seen && !got_rst {
+        State::Success
+    } else {
+        println!(
+            "FAIL: body_bytes={body_bytes} (want {BODY_SIZE}), \
+             end_stream={end_stream_seen}, rst={got_rst}, \
+             elapsed={elapsed:?}, infra_ok={infra_ok}"
+        );
+        State::Fail
+    }
+}
+
+#[test]
+fn test_h2_chrome_shape_h1_cl_drains_fully() {
+    assert_eq!(
+        repeat_until_error_or(
+            3,
+            "H2 Chrome shape (u=0, i) + H1 CL backend must drain 100 KiB within 3 s",
+            try_h2_chrome_shape_h1_cl_drains_fully
+        ),
+        State::Success
+    );
+}
+
+// ----------------------------------------------------------------------------
+// (c) test_h2_php_apache_chunked_flush_drains_fully — chunked + per-chunk
+// ----------------------------------------------------------------------------
+
+/// PHP/Apache shape: chunked + per-chunk `flush()` cadence from
+/// [`ChunkedFlushH1Backend`], 312 215 bytes (HAR-exact `big.svg`). Pre-C1
+/// fix this would park because `mux/h1.rs:341-346, 351-357` flipped
+/// `Ready::WRITABLE` on the peer without `signal_pending_write()` and
+/// edge-triggered epoll never re-fired for the queued bytes. Post-fix the
+/// stream drains within 5 s.
+fn try_h2_php_apache_chunked_flush_drains_fully() -> State {
+    use crate::mock::chunked_flush_h1_backend::{
+        ChunkedFlushConfig, ChunkedFlushH1Backend, TransferEncoding,
+    };
+    const BODY_SIZE: usize = 312_215;
+
+    let (worker, front_port, back_address) =
+        setup_single_h1_backend_listener("H2-LA-PHP-CHUNKED", None);
+
+    let backend = ChunkedFlushH1Backend::start(
+        back_address,
+        ChunkedFlushConfig {
+            body_size: BODY_SIZE,
+            chunk_size: 8 * 1024,
+            inter_chunk_delay: Duration::from_micros(500),
+            transfer_encoding: TransferEncoding::Chunked,
+            tcp_nodelay: true,
+            truncate_at_byte: None,
+        },
+    );
+
+    let front_addr: SocketAddr = format!("127.0.0.1:{front_port}").parse().unwrap();
+    let mut tls = raw_h2_connection(front_addr);
+    h2_handshake_with_initial_window(&mut tls, 1_000_000);
+
+    let sid: u32 = 1;
+    let block = build_get_headers_no_priority();
+    let headers = H2Frame::headers(sid, block, true, true);
+    tls.write_all(&headers.encode()).unwrap();
+    tls.flush().unwrap();
+    tls.write_all(&H2Frame::window_update(0, 1_000_000).encode())
+        .unwrap();
+    tls.flush().unwrap();
+
+    let (body_bytes, end_stream_seen, got_rst, elapsed) =
+        drain_h2_stream_until_end_stream(&mut tls, sid, Duration::from_secs(5));
+
+    println!(
+        "php-apache-chunked: body_bytes={body_bytes}/{BODY_SIZE} \
+         end_stream={end_stream_seen} rst={got_rst} elapsed={elapsed:?} \
+         backend_responses={}",
+        backend.responses_sent()
+    );
+
+    let infra_ok = teardown(
+        tls,
+        front_port,
+        worker,
+        Vec::<AsyncBackend<SimpleAggregator>>::new(),
+    );
+    drop(backend);
+
+    if infra_ok && body_bytes == BODY_SIZE && end_stream_seen && !got_rst {
+        State::Success
+    } else {
+        println!(
+            "FAIL: body_bytes={body_bytes} (want {BODY_SIZE}), \
+             end_stream={end_stream_seen}, rst={got_rst}, \
+             elapsed={elapsed:?}, infra_ok={infra_ok}"
+        );
+        State::Fail
+    }
+}
+
+#[test]
+fn test_h2_php_apache_chunked_flush_drains_fully() {
+    assert_eq!(
+        repeat_until_error_or(
+            3,
+            "H2 PHP/Apache chunked-flush backend must drain 312 KiB within 5 s",
+            try_h2_php_apache_chunked_flush_drains_fully
+        ),
+        State::Success
+    );
+}
+
+// ----------------------------------------------------------------------------
+// (d) test_h2_slow_backend_idle_timeout_cancels — C2 RED/GREEN
+// ----------------------------------------------------------------------------
+
+/// Slow backend shape: chunked body streamed at ~16 KiB per 1-second tick,
+/// across 4 ticks (~64 KiB total, 4-second wall clock). Listener config
+/// sets `h2_stream_idle_timeout_seconds = 2` (well below the total
+/// delivery time). Pre-C2 fix the per-stream idle timer refreshed only on
+/// inbound DATA/HEADERS (`h2.rs:3887-3895, 4026-4031`) — a long-running
+/// response without any inbound client frames would be cancelled mid-
+/// delivery. Post-fix the outbound write path refreshes the timer and
+/// the response drains to completion.
+fn try_h2_slow_backend_idle_timeout_cancels() -> State {
+    use crate::mock::chunked_flush_h1_backend::{
+        ChunkedFlushConfig, ChunkedFlushH1Backend, TransferEncoding,
+    };
+    const BODY_SIZE: usize = 64 * 1024;
+
+    let (worker, front_port, back_address) =
+        setup_single_h1_backend_listener("H2-LA-SLOW-IDLE", Some(2));
+
+    let backend = ChunkedFlushH1Backend::start(
+        back_address,
+        ChunkedFlushConfig {
+            body_size: BODY_SIZE,
+            chunk_size: 16 * 1024,
+            inter_chunk_delay: Duration::from_secs(1),
+            transfer_encoding: TransferEncoding::Chunked,
+            tcp_nodelay: true,
+            truncate_at_byte: None,
+        },
+    );
+
+    let front_addr: SocketAddr = format!("127.0.0.1:{front_port}").parse().unwrap();
+    let mut tls = raw_h2_connection(front_addr);
+    h2_handshake_with_initial_window(&mut tls, 1_000_000);
+
+    let sid: u32 = 1;
+    let block = build_get_headers_no_priority();
+    let headers = H2Frame::headers(sid, block, true, true);
+    tls.write_all(&headers.encode()).unwrap();
+    tls.flush().unwrap();
+    tls.write_all(&H2Frame::window_update(0, 1_000_000).encode())
+        .unwrap();
+    tls.flush().unwrap();
+
+    let (body_bytes, end_stream_seen, got_rst, elapsed) =
+        drain_h2_stream_until_end_stream(&mut tls, sid, Duration::from_secs(10));
+
+    println!(
+        "slow-backend idle: body_bytes={body_bytes}/{BODY_SIZE} \
+         end_stream={end_stream_seen} rst={got_rst} elapsed={elapsed:?} \
+         backend_responses={}",
+        backend.responses_sent()
+    );
+
+    let infra_ok = teardown(
+        tls,
+        front_port,
+        worker,
+        Vec::<AsyncBackend<SimpleAggregator>>::new(),
+    );
+    drop(backend);
+
+    if infra_ok && body_bytes == BODY_SIZE && end_stream_seen && !got_rst {
+        State::Success
+    } else {
+        println!(
+            "FAIL: body_bytes={body_bytes} (want {BODY_SIZE}), \
+             end_stream={end_stream_seen}, rst={got_rst}, \
+             elapsed={elapsed:?}, infra_ok={infra_ok}"
+        );
+        State::Fail
+    }
+}
+
+#[test]
+fn test_h2_slow_backend_idle_timeout_cancels() {
+    assert_eq!(
+        repeat_until_error_or(
+            3,
+            "H2 slow chunked backend must not be cancelled by per-stream idle timer",
+            try_h2_slow_backend_idle_timeout_cancels
+        ),
+        State::Success
+    );
+}
+
+// ----------------------------------------------------------------------------
+// (e) test_h2_chunked_backend_crash_mid_stream_rsts — C3 RED/GREEN
+// ----------------------------------------------------------------------------
+
+/// Chunked backend crashes mid-body: writes ~50 KiB of a 100 KiB body then
+/// drops the TCP connection WITHOUT the terminating `0\r\n\r\n`. Pre-C3
+/// fix the H1 reader path (`mux/h1.rs:terminate_close_delimited`) would
+/// silently mark the stream END_STREAM, so the H2 converter emitted a
+/// truncated DATA frame with END_STREAM — silent corruption. Post-fix the
+/// chunked EOF is demoted to `ParsingPhase::Error` and the H2 converter
+/// emits RST_STREAM(InternalError) per RFC 9112 §7.1.
+fn try_h2_chunked_backend_crash_mid_stream_rsts() -> State {
+    use crate::mock::chunked_flush_h1_backend::{
+        ChunkedFlushConfig, ChunkedFlushH1Backend, TransferEncoding,
+    };
+    const BODY_SIZE: usize = 100 * 1024;
+    const TRUNCATE_AT: usize = 50 * 1024;
+
+    let (worker, front_port, back_address) = setup_single_h1_backend_listener("H2-LA-CRASH", None);
+
+    let backend = ChunkedFlushH1Backend::start(
+        back_address,
+        ChunkedFlushConfig {
+            body_size: BODY_SIZE,
+            chunk_size: 8 * 1024,
+            inter_chunk_delay: Duration::from_micros(500),
+            transfer_encoding: TransferEncoding::Chunked,
+            tcp_nodelay: true,
+            truncate_at_byte: Some(TRUNCATE_AT),
+        },
+    );
+
+    let front_addr: SocketAddr = format!("127.0.0.1:{front_port}").parse().unwrap();
+    let mut tls = raw_h2_connection(front_addr);
+    h2_handshake_with_initial_window(&mut tls, 1_000_000);
+
+    let sid: u32 = 1;
+    let block = build_get_headers_no_priority();
+    let headers = H2Frame::headers(sid, block, true, true);
+    tls.write_all(&headers.encode()).unwrap();
+    tls.flush().unwrap();
+    tls.write_all(&H2Frame::window_update(0, 1_000_000).encode())
+        .unwrap();
+    tls.flush().unwrap();
+
+    let (body_bytes, end_stream_seen, got_rst, elapsed) =
+        drain_h2_stream_until_end_stream(&mut tls, sid, Duration::from_secs(5));
+
+    println!(
+        "chunked-crash: body_bytes={body_bytes}/{BODY_SIZE} \
+         end_stream={end_stream_seen} rst={got_rst} elapsed={elapsed:?}"
+    );
+
+    let infra_ok = teardown(
+        tls,
+        front_port,
+        worker,
+        Vec::<AsyncBackend<SimpleAggregator>>::new(),
+    );
+    drop(backend);
+
+    // Success condition: the client must see either RST_STREAM (preferred)
+    // or no END_STREAM (partial delivery without completion). Silent
+    // END_STREAM with body_bytes == BODY_SIZE would be the C3 bug.
+    let c3_guard = got_rst || !end_stream_seen;
+    if infra_ok && c3_guard {
+        State::Success
+    } else {
+        println!(
+            "FAIL (C3 silent truncation): body_bytes={body_bytes}, \
+             end_stream={end_stream_seen}, rst={got_rst}, elapsed={elapsed:?}, \
+             infra_ok={infra_ok}"
+        );
+        State::Fail
+    }
+}
+
+#[test]
+fn test_h2_chunked_backend_crash_mid_stream_rsts() {
+    assert_eq!(
+        repeat_until_error_or(
+            3,
+            "H2 chunked backend crash mid-body must emit RST_STREAM, not silent END_STREAM",
+            try_h2_chunked_backend_crash_mid_stream_rsts
+        ),
+        State::Success
+    );
+}
+
+// ----------------------------------------------------------------------------
+// (f) test_h2_coalesced_chrome_firefox_streams_drain — coalescing lock-in
+// ----------------------------------------------------------------------------
+
+/// Two concurrent streams on the same TLS connection: sid=1 is Chrome shape
+/// (`priority: u=0, i`), sid=3 is Firefox shape (no priority). Both served
+/// by H1 backends at 100 KiB each. Asserts both drain within 5 s. Locks in
+/// the absence of cross-stream interaction that a connection-coalescing
+/// regression (H7) could introduce.
+fn try_h2_coalesced_chrome_firefox_streams_drain() -> State {
+    const BODY_SIZE: usize = 100 * 1024;
+
+    let (worker, backends, front_port) =
+        setup_h2_test_with_large_bodies("H2-LA-COALESCED", 2, BODY_SIZE);
+
+    let front_addr: SocketAddr = format!("127.0.0.1:{front_port}").parse().unwrap();
+    let mut tls = raw_h2_connection(front_addr);
+    h2_handshake_with_initial_window(&mut tls, 1_000_000);
+
+    // sid=1 Chrome shape
+    let block1 = build_get_headers_with_priority(0, "i");
+    let h1 = H2Frame::headers(1, block1, true, true);
+    tls.write_all(&h1.encode()).unwrap();
+    // sid=3 Firefox shape
+    let block3 = build_get_headers_no_priority();
+    let h3 = H2Frame::headers(3, block3, true, true);
+    tls.write_all(&h3.encode()).unwrap();
+    tls.flush().unwrap();
+    tls.write_all(&H2Frame::window_update(0, 1_000_000).encode())
+        .unwrap();
+    tls.flush().unwrap();
+
+    // Custom drain: wait until END_STREAM on both sid=1 AND sid=3.
+    tls.sock
+        .set_read_timeout(Some(Duration::from_millis(250)))
+        .ok();
+    let start = Instant::now();
+    let deadline = Duration::from_secs(5);
+    let mut raw = Vec::new();
+    let mut rbuf = vec![0u8; 65536];
+    let mut end1 = false;
+    let mut end3 = false;
+    while (!end1 || !end3) && start.elapsed() < deadline {
+        match tls.read(&mut rbuf) {
+            Ok(0) => break,
+            Ok(n) => {
+                raw.extend_from_slice(&rbuf[..n]);
+                let frames = parse_h2_frames(&raw);
+                for (ft, fl, s, _) in &frames {
+                    if *ft == H2_FRAME_DATA && (*fl & H2_FLAG_END_STREAM) != 0 {
+                        if *s == 1 {
+                            end1 = true;
+                        }
+                        if *s == 3 {
+                            end3 = true;
+                        }
+                    }
+                }
+            }
+            Err(e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                continue;
+            }
+            Err(_) => break,
+        }
+    }
+    let elapsed = start.elapsed();
+    let frames = parse_h2_frames(&raw);
+    let mut body1 = 0usize;
+    let mut body3 = 0usize;
+    for (ft, _fl, s, payload) in &frames {
+        if *ft == H2_FRAME_DATA {
+            if *s == 1 {
+                body1 += payload.len();
+            } else if *s == 3 {
+                body3 += payload.len();
+            }
+        }
+    }
+    println!(
+        "coalesced: sid1 body={body1}/{BODY_SIZE} end={end1}, \
+         sid3 body={body3}/{BODY_SIZE} end={end3}, elapsed={elapsed:?}"
+    );
+
+    let infra_ok = teardown(tls, front_port, worker, backends);
+
+    if infra_ok && body1 == BODY_SIZE && end1 && body3 == BODY_SIZE && end3 {
+        State::Success
+    } else {
+        println!(
+            "FAIL: sid1={body1}/{BODY_SIZE} end={end1}, \
+             sid3={body3}/{BODY_SIZE} end={end3}, elapsed={elapsed:?}, \
+             infra_ok={infra_ok}"
+        );
+        State::Fail
+    }
+}
+
+#[test]
+fn test_h2_coalesced_chrome_firefox_streams_drain() {
+    assert_eq!(
+        repeat_until_error_or(
+            3,
+            "H2 two streams (Chrome+Firefox shape) must both drain within 5 s",
+            try_h2_coalesced_chrome_firefox_streams_drain
         ),
         State::Success
     );

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -152,7 +152,25 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
     /// Terminate a close-delimited kawa body by pushing END_STREAM flags.
     /// Called when the backend closes the connection to signal end-of-body
     /// (no Content-Length, no chunked encoding).
+    ///
+    /// Chunked responses that TCP-close before the terminating `0\r\n\r\n`
+    /// are demoted to `ParsingPhase::Error` so the H2 converter emits
+    /// RST_STREAM(InternalError) rather than a silent END_STREAM with a
+    /// truncated body — RFC 9112 §7.1 requires the zero-chunk terminator.
     fn terminate_close_delimited(kawa: &mut super::GenericHttpStream, stream_id: GlobalStreamId) {
+        if kawa.body_size == kawa::BodySize::Chunked {
+            warn!(
+                "{} H1 backend EOF mid-chunked response on stream {}: emitting RST_STREAM",
+                log_module_context!(),
+                stream_id
+            );
+            incr!("h1.backend_eof_before_message_complete");
+            kawa.parsing_phase
+                .error(kawa::ParsingErrorKind::Processing {
+                    message: "INTERNAL_ERROR",
+                });
+            return;
+        }
         debug!(
             "{} H1 close-delimited EOF on stream {}: terminating body",
             log_module_context!(),
@@ -229,10 +247,12 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
                 self.timeout_container.cancel();
                 self.readiness.interest.remove(Ready::READABLE);
                 if let StreamState::Linked(token) = stream.state {
-                    endpoint
-                        .readiness_mut(token)
-                        .interest
-                        .insert(Ready::WRITABLE);
+                    // Signal pending write alongside the WRITABLE interest flip:
+                    // edge-triggered epoll won't re-fire for bytes we just queued
+                    // onto the peer — the synthetic event is the only wake path.
+                    let peer = endpoint.readiness_mut(token);
+                    peer.interest.insert(Ready::WRITABLE);
+                    peer.signal_pending_write();
                 }
             }
             return MuxResult::Continue;
@@ -339,10 +359,12 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
                 context.pending_links.push_back(stream_id);
             }
             if let StreamState::Linked(token) = stream.state {
-                endpoint
-                    .readiness_mut(token)
-                    .interest
-                    .insert(Ready::WRITABLE)
+                // Signal pending write alongside the WRITABLE interest flip: the
+                // bytes we just parsed live in sozu's buffers, not the kernel,
+                // so edge-triggered epoll won't re-fire on its own.
+                let peer = endpoint.readiness_mut(token);
+                peer.interest.insert(Ready::WRITABLE);
+                peer.signal_pending_write();
             }
         };
         // 1xx informational: the 100 response skips main_phase (goes straight to
@@ -350,10 +372,9 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         // Trigger the frontend to write the 1xx response after all borrows end.
         if is_1xx_backend {
             if let StreamState::Linked(token) = stream.state {
-                endpoint
-                    .readiness_mut(token)
-                    .interest
-                    .insert(Ready::WRITABLE);
+                let peer = endpoint.readiness_mut(token);
+                peer.interest.insert(Ready::WRITABLE);
+                peer.signal_pending_write();
             }
         }
 
@@ -739,11 +760,15 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
                     debug!("{} CLOSING H1 TERMINATED STREAM", log_context!(self));
                     stream.state = StreamState::Unlinked;
                     self.readiness.interest.insert(Ready::WRITABLE);
+                    // End-of-stream was already queued into kawa by the parser;
+                    // no fresh WRITABLE event will arrive from the kernel.
+                    self.readiness.signal_pending_write();
                 }
                 EndStreamAction::CloseDelimited => {
                     debug!("{} CLOSE DELIMITED", log_context!(self));
                     stream.state = StreamState::Unlinked;
                     self.readiness.interest.insert(Ready::WRITABLE);
+                    self.readiness.signal_pending_write();
                 }
                 EndStreamAction::ForwardUnterminated => {
                     debug!("{} CLOSING H1 UNTERMINATED STREAM", log_context!(self));

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -2169,6 +2169,7 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                 Some((read_stream, amount)) if write_stream == read_stream => Some(amount),
                 _ => None,
             };
+            let mut resume_bytes: usize = 0;
             let outcome = Self::flush_stream_out(
                 &mut self.socket,
                 kawa,
@@ -2181,7 +2182,16 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                 None,
                 cross_read_amount,
                 &mut io_slices,
+                Some(&mut resume_bytes),
             );
+            // Refresh the per-stream idle timer when outbound bytes move: a
+            // large response delivered at low bandwidth is "active", not idle,
+            // even when the peer sends no inbound frames.
+            if resume_bytes > 0 {
+                if let Some(t) = self.stream_last_activity_at.get_mut(&stream_id) {
+                    *t = Instant::now();
+                }
+            }
             if outcome == FlushOutcome::Stalled {
                 return MuxResult::Continue;
             }
@@ -2343,6 +2353,7 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                 kawa.blocks.len(),
                 kawa.out.len(),
             ));
+            let mut stream_bytes: usize = 0;
             let outcome = Self::flush_stream_out(
                 &mut self.socket,
                 kawa,
@@ -2355,7 +2366,18 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                 Some(&mut socket_write),
                 None,
                 &mut io_slices,
+                Some(&mut stream_bytes),
             );
+            // Refresh the per-stream idle timer on outbound bytes. Without
+            // this, a long-running response trickled at low bandwidth would
+            // be killed by `cancel_timed_out_streams` mid-delivery — the
+            // inbound-only refresh at h2.rs:3887-3895 / 4026-4031 never
+            // fires while the peer is idle.
+            if stream_bytes > 0 {
+                if let Some(t) = self.stream_last_activity_at.get_mut(&stream_id) {
+                    *t = Instant::now();
+                }
+            }
             if outcome == FlushOutcome::Stalled {
                 self.expect_write = Some(H2StreamId::Other {
                     id: stream_id,
@@ -2449,6 +2471,7 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         mut wrote: Option<&mut bool>,
         cross_read_amount: Option<usize>,
         io_slices: &mut Vec<IoSlice<'static>>,
+        mut bytes_written: Option<&mut usize>,
     ) -> FlushOutcome {
         while !kawa.out.is_empty() {
             if let Some(flag) = wrote.as_deref_mut() {
@@ -2483,6 +2506,9 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             kawa.consume(size);
             position.count_bytes_out_counter(size);
             position.count_bytes_out(metrics, size);
+            if let Some(counter) = bytes_written.as_deref_mut() {
+                *counter = counter.saturating_add(size);
+            }
             if let Some(amount) = cross_read_amount {
                 // Resume path: same stream is parked waiting for buffer space.
                 // Re-enable READABLE once the write freed enough room.


### PR DESCRIPTION
## Context

Sébastien Brunat reported 2026-04-23 17:35 UTC (Slack `#tech-traffic` thread `1776965715.733329`) that large HTTP/2 assets never fully load on `*.cleverapps.io` with a PHP/Apache runtime — **on both Chrome and Firefox/Arch**. Florentin's earlier same-day fix (`f6c02912 fix(h2): skip RFC 9218 incremental yield for solo-bucket streams`) is Chrome-specific (triggered by `priority: u=0, i`), so it cannot explain Firefox failures by construction.

A `/ask --with-codex` investigation (researcher + independent Codex audit + reviewer + auditor, artefacts in `tasks/`) triangulated **three HIGH-severity, browser-agnostic, latent bugs** on `feat/h2-mux` HEAD:

| # | Bug | Location |
|---|---|---|
| C1 | H1→H2 frontend WRITABLE interest flipped without `signal_pending_write()` — edge-triggered epoll wake-up missed on backend-read path | `lib/src/protocol/mux/h1.rs` — 5 sites (231, 341, 351, 741, 746) |
| C2 | Per-stream idle timer only refreshed on inbound frames — long proxy-sourced responses get RST_STREAM at `max(back_timeout, 30s)` even while outbound bytes are flowing | `lib/src/protocol/mux/h2.rs` — refresh sites 3665/3887/4026 all inbound-only |
| C3 | `terminate_close_delimited` accepts EOF as valid termination regardless of `BodySize::Chunked` — Apache mid-crash becomes silent END_STREAM with truncated body | `lib/src/protocol/mux/h1.rs:152-184` |

## Scope

This PR lands **both** the e2e reproduction suite **and** the production fixes so RED→GREEN is atomic. Memory previously flagged C1 as a deferred follow-up; re-scoped in after Codex + researcher rated it HIGH 0.85 for Sébastien's report.

## Changes

### Production fixes — `commit 040e305f`

- **C1** — paired `readiness.signal_pending_write()` with every `readiness.interest.insert(Ready::WRITABLE)` in `mux/h1.rs` (main response arrival, close-delimited → Linked peer, 1xx informational, ForwardTerminated, CloseDelimited)
- **C2** — `flush_stream_out` now takes `Option<&mut usize>` out-param; `write_streams` refreshes `stream_last_activity_at[stream_id]` when > 0 bytes moved (both resume-path and main-loop callers)
- **C3** — `terminate_close_delimited` demotes kawa to `ParsingPhase::Error{Processing{"INTERNAL_ERROR"}}` when `kawa.body_size == BodySize::Chunked`; H2 converter propagates RST_STREAM(InternalError) instead of END_STREAM; adds `h1.backend_eof_before_message_complete` counter

### E2E reproduction suite — `commit 4b762c21`

- `e2e/src/mock/chunked_flush_h1_backend.rs` — new mock, TCP_NODELAY + flush-per-chunk + `inter_chunk_delay`, with `truncate_at_byte` knob for C3; mirrors `CloseDelimitedBackend` lifecycle (stop flag + atomic counter + impl Drop)
- `e2e/src/tests/h2_correctness_tests.rs` — 6 new tests:

| Test | Body | Framing | Priority | Deadline | Fixed by |
|---|---|---|---|---|---|
| `test_h2_firefox_shape_h1_cl_drains_fully` | 80 892 B (HAR-exact) | CL | none | 3 s | C1 |
| `test_h2_chrome_shape_h1_cl_drains_fully` | 100 KiB | CL | `u=0, i` | 3 s | existing |
| `test_h2_php_apache_chunked_flush_drains_fully` | 312 215 B (big.svg-exact) | chunked+flush | none | 5 s | C1 |
| `test_h2_slow_backend_idle_timeout_cancels` | 64 KiB 1s-tick | chunked | none | 10 s | C2 |
| `test_h2_chunked_backend_crash_mid_stream_rsts` | truncate @ 50 KiB | chunked | none | 5 s | C3 |
| `test_h2_coalesced_chrome_firefox_streams_drain` | 2 × 100 KiB | CL | mixed | 5 s | defence |

All use `port_registry::provide_port()` + END_STREAM-aware exit loops + `repeat_until_error_or(3, …)`.

### Docs

- `CHANGELOG.md` — 3 `Fixed` entries under `## feat/h2-mux - Unreleased`
- `doc/upgrade_e2e_tests.md` — 1-line mock inventory entry

## Test plan

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy --all-targets --locked` — zero warnings
- `cargo build --all-features --locked` — clean
- Full `h2_correctness_tests` suite: 17/17 pass, 144 s
- `test_h2_solo_incremental_drains_fully` (existing) — still green, no regression
- RED→GREEN transition visible by reverting `040e305f` and rerunning from `4b762c21` tip

## Investigation artefacts

Published to the worktree tasks/ dir (not committed): `research-h2-large-asset-repro.md`, `codex-h2-large-asset-repro.md` (+ 509 KB raw log), `review-h2-large-asset-repro.md`, `audit-h2-large-asset-repro.md`.

## Sign-off

Commits unsigned per AFK window policy (kept `-s` + Signed-off-by trailer). Reason in commit bodies.