### PR TITLE
fix(h2): RFC 9218 hardening — invariant 16 enforcement + bucket scoping + PRIORITY_UPDATE + close-race

### DIFF
--- a/e2e/src/tests/h2_correctness_tests.rs
+++ b/e2e/src/tests/h2_correctness_tests.rs
@@ -1477,6 +1477,80 @@ fn test_h2_priority_update_on_stream_zero_is_protocol_error() {
     );
 }
 
+/// Tier 3c — LIFECYCLE §9 invariant 19: the converter must NOT yield
+/// between the last DATA frame and the closing `Block::Flags`
+/// (end_stream = true). Three same-urgency incremental streams drive
+/// the round-robin yield; each response body is small enough that the
+/// scheduler reaches the closing Flags right after its first DATA frame.
+/// With Tier 3c's close-race guard, END_STREAM lands in the same pass
+/// rather than waiting for another writable tick (or — pre-invariant-16
+/// — stranding permanently).
+fn try_h2_incremental_round_robin_closes_every_stream() -> State {
+    let (worker, backends, front_port) =
+        setup_h2_test_with_large_bodies("H2-COR-RR-CLOSE", 3, 4 * 1024);
+
+    let front_addr: SocketAddr = format!("127.0.0.1:{front_port}").parse().unwrap();
+    let mut tls = raw_h2_connection(front_addr);
+    h2_handshake_with_initial_window(&mut tls, 0);
+
+    let ids = [1u32, 3, 5];
+    for sid in ids {
+        let block = build_get_headers_with_priority(3, "i");
+        let headers = H2Frame::headers(sid, block, true, true);
+        tls.write_all(&headers.encode()).unwrap();
+    }
+    tls.flush().unwrap();
+
+    thread::sleep(Duration::from_millis(400));
+
+    let mut bulk = Vec::new();
+    for sid in ids {
+        bulk.extend_from_slice(&H2Frame::window_update(sid, 1_000_000).encode());
+    }
+    bulk.extend_from_slice(&H2Frame::window_update(0, 1_000_000).encode());
+    tls.write_all(&bulk).unwrap();
+    tls.flush().unwrap();
+
+    let frames = collect_response_frames(&mut tls, 300, 6, 400);
+    log_frames("RR close-race", &frames);
+
+    // Every stream must observe at least one frame with END_STREAM set
+    // (either the terminal DATA or an empty DATA marker produced by the
+    // converter's close path).
+    let closed: std::collections::HashSet<u32> = frames
+        .iter()
+        .filter_map(|(ft, fl, sid, _)| {
+            if (*ft == H2_FRAME_DATA || *ft == H2_FRAME_HEADERS) && (fl & H2_FLAG_END_STREAM) != 0 {
+                Some(*sid)
+            } else {
+                None
+            }
+        })
+        .collect();
+    let all_closed = ids.iter().all(|sid| closed.contains(sid));
+
+    println!("closed_streams={closed:?} all_closed={all_closed}");
+
+    let infra_ok = teardown(tls, front_port, worker, backends);
+    if infra_ok && all_closed {
+        State::Success
+    } else {
+        State::Fail
+    }
+}
+
+#[test]
+fn test_h2_incremental_round_robin_closes_every_stream() {
+    assert_eq!(
+        repeat_until_error_or(
+            3,
+            "H2 RFC 9218 §4 Tier 3c: round-robin drain emits END_STREAM per stream",
+            try_h2_incremental_round_robin_closes_every_stream
+        ),
+        State::Success
+    );
+}
+
 /// RFC 9218 §4 + sozu incremental-scheduling regression (PR #1209 follow-up):
 /// a SOLO stream whose client sent `priority: u=0, i` (Chrome's navigation
 /// default since Chrome 107) must drain its full response body promptly.

--- a/e2e/src/tests/h2_correctness_tests.rs
+++ b/e2e/src/tests/h2_correctness_tests.rs
@@ -1368,6 +1368,115 @@ fn test_h2_rfc9218_incremental_multi_bucket_drains_sequentially() {
     );
 }
 
+/// Tier 3b — RFC 9218 §7.1: a PRIORITY_UPDATE frame for an open stream
+/// with a well-formed priority field value is accepted and does not
+/// terminate the connection. The response must still drain fully with
+/// END_STREAM.
+fn try_h2_priority_update_on_open_stream_is_accepted() -> State {
+    let (worker, backends, front_port) =
+        setup_h2_test_with_large_bodies("H2-COR-PU-ACCEPT", 1, 1024);
+
+    let front_addr: SocketAddr = format!("127.0.0.1:{front_port}").parse().unwrap();
+    let mut tls = raw_h2_connection(front_addr);
+    h2_handshake_with_initial_window(&mut tls, 65_535);
+
+    // Open stream 1 with a default priority header.
+    let block = build_get_headers_with_priority(3, "i=?0");
+    let headers = H2Frame::headers(1, block, true, true);
+    tls.write_all(&headers.encode()).unwrap();
+    // Re-prioritize stream 1 mid-flight with `u=0, i`.
+    let pu = H2Frame::priority_update(1, "u=0, i");
+    tls.write_all(&pu.encode()).unwrap();
+    tls.flush().unwrap();
+
+    let frames = collect_response_frames(&mut tls, 200, 5, 400);
+    log_frames("PRIORITY_UPDATE accept", &frames);
+
+    // No GOAWAY — the response must deliver normally.
+    let has_goaway = frames.iter().any(|(ft, _, _, _)| *ft == H2_FRAME_GOAWAY);
+    let has_end_stream_on_1 = frames.iter().any(|(ft, fl, sid, _)| {
+        (*ft == H2_FRAME_DATA || *ft == H2_FRAME_HEADERS)
+            && *sid == 1
+            && (fl & H2_FLAG_END_STREAM) != 0
+    });
+
+    println!(
+        "has_goaway={has_goaway} has_end_stream_on_1={has_end_stream_on_1} frames={}",
+        frames.len()
+    );
+
+    let infra_ok = teardown(tls, front_port, worker, backends);
+    if infra_ok && !has_goaway && has_end_stream_on_1 {
+        State::Success
+    } else {
+        State::Fail
+    }
+}
+
+#[test]
+fn test_h2_priority_update_on_open_stream_is_accepted() {
+    assert_eq!(
+        repeat_until_error_or(
+            3,
+            "H2 RFC 9218 §7.1: PRIORITY_UPDATE accepted + response drains",
+            try_h2_priority_update_on_open_stream_is_accepted
+        ),
+        State::Success
+    );
+}
+
+/// Tier 3b — RFC 9218 §7.1: a PRIORITY_UPDATE frame with
+/// `prioritized_stream_id == 0` is a connection-level PROTOCOL_ERROR.
+/// Sozu must emit GOAWAY(PROTOCOL_ERROR) and close the session rather
+/// than silently ignoring the frame.
+fn try_h2_priority_update_on_stream_zero_is_protocol_error() -> State {
+    let (worker, backends, front_port) =
+        setup_h2_test_with_large_bodies("H2-COR-PU-STREAM0", 1, 1024);
+
+    let front_addr: SocketAddr = format!("127.0.0.1:{front_port}").parse().unwrap();
+    let mut tls = raw_h2_connection(front_addr);
+    h2_handshake_with_initial_window(&mut tls, 65_535);
+
+    // Send a PRIORITY_UPDATE targeting stream 0 (the connection itself).
+    let pu = H2Frame::priority_update(0, "u=0, i");
+    tls.write_all(&pu.encode()).unwrap();
+    tls.flush().unwrap();
+
+    let frames = collect_response_frames(&mut tls, 200, 4, 300);
+    log_frames("PRIORITY_UPDATE stream0", &frames);
+
+    let has_protocol_error_goaway = frames.iter().any(|(ft, _, _, payload)| {
+        *ft == H2_FRAME_GOAWAY
+            && payload.len() >= 8
+            // bytes 4..8 carry the error code (RFC 9113 §6.8)
+            && u32::from_be_bytes([payload[4], payload[5], payload[6], payload[7]]) == 0x1
+    });
+
+    println!(
+        "has_protocol_error_goaway={has_protocol_error_goaway} frames={}",
+        frames.len()
+    );
+
+    let infra_ok = teardown(tls, front_port, worker, backends);
+    if infra_ok && has_protocol_error_goaway {
+        State::Success
+    } else {
+        State::Fail
+    }
+}
+
+#[test]
+fn test_h2_priority_update_on_stream_zero_is_protocol_error() {
+    assert_eq!(
+        repeat_until_error_or(
+            3,
+            "H2 RFC 9218 §7.1: PRIORITY_UPDATE on stream 0 → GOAWAY(PROTOCOL_ERROR)",
+            try_h2_priority_update_on_stream_zero_is_protocol_error
+        ),
+        State::Success
+    );
+}
+
 /// RFC 9218 §4 + sozu incremental-scheduling regression (PR #1209 follow-up):
 /// a SOLO stream whose client sent `priority: u=0, i` (Chrome's navigation
 /// default since Chrome 107) must drain its full response body promptly.

--- a/e2e/src/tests/h2_correctness_tests.rs
+++ b/e2e/src/tests/h2_correctness_tests.rs
@@ -1278,6 +1278,96 @@ fn test_h2_rfc9218_non_incremental_sequential() {
     );
 }
 
+/// Tier 3a — LIFECYCLE §9 invariant 17: RFC 9218 incremental peer count
+/// must be scoped to the same urgency bucket, not the whole connection.
+/// Two incremental streams in DIFFERENT urgency buckets (`u=0, i` and
+/// `u=7, i`) are each solo in their own bucket. With the baseline
+/// connection-global count, both streams would see
+/// `incremental_peer_count >= 2` and yield after every DATA frame,
+/// spuriously triggering the same strand the `finalize_write`
+/// WRITABLE-withdrawal guard was added for. With bucket scoping each
+/// stream sees peer count == 1 and drains sequentially — DATA frames
+/// for stream 1 form a contiguous run, stream 3 likewise.
+fn try_h2_rfc9218_incremental_multi_bucket_drains_sequentially() -> State {
+    let (worker, backends, front_port) =
+        setup_h2_test_with_large_bodies("H2-COR-RFC9218-MB", 2, 32 * 1024);
+
+    let front_addr: SocketAddr = format!("127.0.0.1:{front_port}").parse().unwrap();
+    let mut tls = raw_h2_connection(front_addr);
+    // INITIAL_WINDOW_SIZE=0 so both responses park in kawa before any DATA
+    // is released — ensures the scheduler sees both streams as eligible in
+    // a single `writable()` pass.
+    h2_handshake_with_initial_window(&mut tls, 0);
+
+    // Stream 1: highest urgency incremental. Stream 3: lowest urgency
+    // incremental. Different urgency buckets on purpose.
+    let request_ids: [(u32, u8); 2] = [(1, 0), (3, 7)];
+    for (sid, urgency) in request_ids {
+        let block = build_get_headers_with_priority(urgency, "i");
+        let headers = H2Frame::headers(sid, block, true, true);
+        tls.write_all(&headers.encode()).unwrap();
+    }
+    tls.flush().unwrap();
+
+    thread::sleep(Duration::from_millis(400));
+
+    // Bulk WINDOW_UPDATE — see round-robin test for rationale.
+    let mut bulk = Vec::new();
+    for (sid, _) in request_ids {
+        bulk.extend_from_slice(&H2Frame::window_update(sid, 1_000_000).encode());
+    }
+    bulk.extend_from_slice(&H2Frame::window_update(0, 1_000_000).encode());
+    tls.write_all(&bulk).unwrap();
+    tls.flush().unwrap();
+
+    let frames = collect_response_frames(&mut tls, 300, 6, 400);
+    log_frames("RFC 9218 multi-bucket incremental", &frames);
+
+    let order = data_frame_stream_order(&frames);
+    println!("DATA stream-ID order: {order:?}");
+
+    // Each stream is solo in its urgency bucket. `incremental_peer_count`
+    // is 1 per bucket → converter drains sequentially inside each bucket.
+    // Priority sort picks the lower urgency first, so stream 1 drains
+    // before stream 3. Total transitions = 1 (stream 1 block → stream 3
+    // block); baseline (without bucket scoping) would interleave and
+    // produce many more transitions.
+    let transitions = order.windows(2).filter(|w| w[0] != w[1]).count();
+    let streams_seen: std::collections::HashSet<u32> = order.iter().copied().collect();
+    let both_fired = request_ids
+        .iter()
+        .all(|(sid, _)| streams_seen.contains(sid));
+    let sequential_per_bucket =
+        !order.is_empty() && transitions == streams_seen.len().saturating_sub(1);
+
+    println!(
+        "both_fired={both_fired} transitions={transitions} \
+         sequential_per_bucket={sequential_per_bucket} \
+         streams_seen={} total_frames={}",
+        streams_seen.len(),
+        order.len()
+    );
+
+    let infra_ok = teardown(tls, front_port, worker, backends);
+    if infra_ok && both_fired && sequential_per_bucket {
+        State::Success
+    } else {
+        State::Fail
+    }
+}
+
+#[test]
+fn test_h2_rfc9218_incremental_multi_bucket_drains_sequentially() {
+    assert_eq!(
+        repeat_until_error_or(
+            3,
+            "H2 RFC 9218 §4 Tier 3a: incremental_peer_count is bucket-scoped",
+            try_h2_rfc9218_incremental_multi_bucket_drains_sequentially
+        ),
+        State::Success
+    );
+}
+
 /// RFC 9218 §4 + sozu incremental-scheduling regression (PR #1209 follow-up):
 /// a SOLO stream whose client sent `priority: u=0, i` (Chrome's navigation
 /// default since Chrome 107) must drain its full response body promptly.

--- a/e2e/src/tests/h2_utils.rs
+++ b/e2e/src/tests/h2_utils.rs
@@ -177,6 +177,19 @@ impl H2Frame {
         Self::new(H2_FRAME_WINDOW_UPDATE, 0, stream_id, payload)
     }
 
+    /// Build a PRIORITY_UPDATE frame (RFC 9218 §7.1, type `0x10`).
+    ///
+    /// Always sent on stream 0 (connection control stream). Payload:
+    /// 4-byte prioritized stream ID (31-bit, reserved MSB = 0) followed
+    /// by the verbatim priority field value (structured-field token, e.g.
+    /// `"u=0, i"`).
+    pub(crate) fn priority_update(prioritized_stream_id: u32, priority_field: &str) -> Self {
+        let mut payload = Vec::with_capacity(4 + priority_field.len());
+        payload.extend_from_slice(&(prioritized_stream_id & 0x7FFF_FFFF).to_be_bytes());
+        payload.extend_from_slice(priority_field.as_bytes());
+        Self::new(0x10, 0, 0, payload)
+    }
+
     /// Build a DATA frame on stream 0 (invalid per spec).
     pub(crate) fn data_on_stream_zero(payload: Vec<u8>) -> Self {
         Self::new(H2_FRAME_DATA, 0, 0, payload)

--- a/lib/src/protocol/mux/LIFECYCLE.md
+++ b/lib/src/protocol/mux/LIFECYCLE.md
@@ -667,6 +667,18 @@ that touches `h2.rs`, `mod.rs`, or `stream.rs`.
     The same helper backs `ConnectionH2::has_pending_write_full`,
     consulted by `delay_close_for_frontend_flush` so shutdown-drain
     does not close before the stream bytes land on the socket.
+17. **RFC 9218 incremental peer count is bucket-scoped, ready-only.**
+    `converter.incremental_peer_count` (consumed by the converter's
+    DATA-arm yield decision) counts incremental streams in the
+    *same urgency bucket* that are *also ready to emit this pass*
+    (`is_main_phase()` / terminated-but-not-completed / error-but-RST-
+    not-yet-sent). Computed in `write_streams` as
+    `ready_incremental_by_urgency` and looked up per-stream by its
+    own urgency. A connection-global count would wrongly yield a
+    solo incremental stream when an unrelated incremental stream
+    sits in a different urgency bucket — regressing the invariant-15
+    solo-bucket fast path. Guarded by e2e test
+    `test_h2_rfc9218_incremental_multi_bucket_drains_sequentially`.
 
 ---
 

--- a/lib/src/protocol/mux/LIFECYCLE.md
+++ b/lib/src/protocol/mux/LIFECYCLE.md
@@ -696,6 +696,23 @@ that touches `h2.rs`, `mod.rs`, or `stream.rs`.
     Guarded by e2e tests
     `test_h2_priority_update_on_open_stream_is_accepted` and
     `test_h2_priority_update_on_stream_zero_is_protocol_error`.
+19. **Converter close-race: no yield between last DATA and closing
+    Flags.** The H2 converter's DATA arm (`converter.rs`
+    `H2BlockConverter::call`) peeks `kawa.blocks.front()` and
+    suppresses the RFC 9218 incremental-mode yield when the next
+    queued block is a closing `Block::Flags` with `end_stream=true`.
+    Yielding between the last DATA and its companion END_STREAM
+    marker would strand the closing frame in `kawa.blocks` — the
+    invariant-16 guard in `finalize_write` already prevents the
+    wake-up being lost, but forcing a round-trip through the event
+    loop for the terminal 9-byte empty-DATA frame is wasted work.
+    The suppression is scoped narrowly: intermediate Flags blocks
+    (e.g. chunked `end_chunk` without `end_stream`) still yield,
+    and a trailing `Block::Chunk` also yields. Unit-tested in
+    `converter::tests::test_converter_suppresses_yield_before_closing_end_stream_flags`
+    / `test_converter_yields_before_trailing_flags_without_end_stream`
+    / `test_converter_yields_before_chunk_block`; end-to-end guard
+    `test_h2_incremental_round_robin_closes_every_stream`.
 
 ---
 

--- a/lib/src/protocol/mux/LIFECYCLE.md
+++ b/lib/src/protocol/mux/LIFECYCLE.md
@@ -642,19 +642,31 @@ that touches `h2.rs`, `mod.rs`, or `stream.rs`.
     after a DATA frame when `incremental_mode == true` *and*
     `incremental_peer_count > 1`. A solo incremental stream with no
     peer to interleave with must drain sequentially — otherwise
-    `finalize_write` (`h2.rs:2634-2641`) withdraws `Ready::WRITABLE`
-    on a clean pass (no `expect_write` set by the converter) and
-    edge-triggered epoll never re-fires. The scheduler populates both
-    fields once per write pass from `apply_incremental_rotation`'s
-    returned count.
-16. **Never withdraw `Ready::WRITABLE` with pending back-buffer.**
-    `finalize_write` (`h2.rs:2634-2641`) removes `Ready::WRITABLE` only
-    when the pass drained cleanly (`!socket_wants_write &&
-    expect_write.is_none()`) *and* no stream has queued response bytes
-    (`back.out`/`back.blocks`). A voluntary scheduler yield can leave
-    bytes buffered without `expect_write` being set; stripping
-    WRITABLE in that state strands the stream. Defence-in-depth for
-    invariant 15 and any future yield condition.
+    `finalize_write` (`h2.rs` `fn finalize_write`) would withdraw
+    `Ready::WRITABLE` on a clean pass (no `expect_write` set by the
+    converter) and edge-triggered epoll would never re-fire.
+    The scheduler populates both fields once per write pass from
+    `apply_incremental_rotation`'s returned count.
+16. **Never withdraw `Ready::WRITABLE` with pending back-buffer after a
+    pass that made forward progress.** `finalize_write`
+    (`h2.rs` `fn finalize_write`) removes `Ready::WRITABLE` only when
+    the pass drained cleanly (`!socket_wants_write &&
+    expect_write.is_none()`) *and either* `bytes_written_this_pass == 0`
+    *or* no open stream has queued response bytes
+    (`back.out`/`back.blocks`). The progress check is load-bearing: a
+    zero-progress pass (e.g. all streams flow-control-starved) must
+    relinquish `Ready::WRITABLE` so the session dispatcher does not
+    busy-spin — the next wake-up arrives from `WINDOW_UPDATE`,
+    backend readable, or a new request. Enforced at runtime via the
+    file-private helper `any_stream_has_pending_back` (`h2.rs`).
+    A voluntary scheduler yield (RFC 9218 incremental rotation and
+    any future yield site) can leave bytes buffered without
+    `expect_write` being set; stripping `WRITABLE` in that state
+    strands the stream because edge-triggered epoll never re-fires
+    for sozu-owned buffers. Defence-in-depth for invariant 15.
+    The same helper backs `ConnectionH2::has_pending_write_full`,
+    consulted by `delay_close_for_frontend_flush` so shutdown-drain
+    does not close before the stream bytes land on the socket.
 
 ---
 

--- a/lib/src/protocol/mux/LIFECYCLE.md
+++ b/lib/src/protocol/mux/LIFECYCLE.md
@@ -679,6 +679,23 @@ that touches `h2.rs`, `mod.rs`, or `stream.rs`.
     sits in a different urgency bucket — regressing the invariant-15
     solo-bucket fast path. Guarded by e2e test
     `test_h2_rfc9218_incremental_multi_bucket_drains_sequentially`.
+18. **RFC 9218 §7.1 PRIORITY_UPDATE is parsed and honoured.**
+    Frame type `0x10` is recognised at the parser (`parser.rs`
+    `FrameType::PriorityUpdate` + `priority_update_frame`) rather
+    than swallowed as `FrameType::Unknown`. `frame_header` enforces
+    `stream_id == 0` at receipt (RFC 9218 §7.1), and the handler
+    (`h2.rs` `handle_priority_update_frame`) rejects a
+    prioritized-stream-id of `0` with
+    GOAWAY(PROTOCOL_ERROR). Valid frames are decoded via
+    `pkawa::parse_rfc9218_priority` and pushed through the same
+    memory-guarded path as standalone PRIORITY frames
+    (`Prioriser::push_priority_guarded`), so a flood of
+    PRIORITY_UPDATEs for far-future stream IDs cannot pin more than
+    `MAX_PRIORITIES` entries. Updates for streams that are no longer
+    open and outside the idle look-ahead are silently dropped.
+    Guarded by e2e tests
+    `test_h2_priority_update_on_open_stream_is_accepted` and
+    `test_h2_priority_update_on_stream_zero_is_protocol_error`.
 
 ---
 

--- a/lib/src/protocol/mux/connection.rs
+++ b/lib/src/protocol/mux/connection.rs
@@ -338,6 +338,20 @@ impl<Front: SocketHandler> Connection<Front> {
         forward!(self, has_pending_write())
     }
 
+    /// Connection-level [`Self::has_pending_write`] extended with a per-stream
+    /// back-buffer probe (LIFECYCLE §9 invariant 16). Only H2 multiplexes
+    /// multiple streams — H1 falls back to [`Self::has_pending_write`] since
+    /// its single-response pipeline already accounts for pending bytes.
+    pub(super) fn has_pending_write_including_streams<L>(&self, context: &super::Context<L>) -> bool
+    where
+        L: ListenerHandler + L7ListenerHandler,
+    {
+        match self {
+            Connection::H1(c) => c.has_pending_write(),
+            Connection::H2(c) => c.has_pending_write_full(context),
+        }
+    }
+
     pub(super) fn initiate_close_notify(&mut self) -> bool {
         forward!(self, initiate_close_notify())
     }

--- a/lib/src/protocol/mux/converter.rs
+++ b/lib/src/protocol/mux/converter.rs
@@ -439,15 +439,35 @@ impl<T: AsBuffer> BlockConverter<T> for H2BlockConverter<'_> {
                 // can interleave. Non-incremental streams drain sequentially
                 // (current behaviour) by honouring `can_continue`.
                 //
-                // Solo incremental guard: the yield only matters when there
-                // is at least one other incremental peer in the same
-                // urgency bucket. With <= 1 incremental peer, yielding
-                // strands the stream because `finalize_write` then strips
+                // Solo-bucket guard: the yield only matters when there is
+                // at least one other incremental peer in the same urgency
+                // bucket. With <= 1 incremental peer, yielding strands the
+                // stream because `finalize_write` then strips
                 // `Ready::WRITABLE` (no `expect_write` is set on a clean
                 // yield), and edge-triggered epoll will not re-fire. See
                 // `test_h2_solo_incremental_drains_fully` and the h2.rs
                 // scheduler wiring that populates `incremental_peer_count`.
-                return can_continue && !(self.incremental_mode && self.incremental_peer_count > 1);
+                //
+                // Tier 3c close-race guard (LIFECYCLE §9 invariant 19): if
+                // the next block is the closing `Block::Flags` with
+                // `end_stream=true`, suppress the yield unconditionally.
+                // Yielding between the last DATA and the closing Flags
+                // strands the END_STREAM marker in `kawa.blocks` — the
+                // invariant-16 finalize_write guard catches the wake-up
+                // loss, but yielding one frame later is still cheaper than
+                // paying the round-trip through the event loop for a
+                // single END_STREAM frame (often an empty DATA frame with
+                // the END_STREAM flag set, 9 bytes of overhead).
+                let next_closes_stream = matches!(
+                    kawa.blocks.front(),
+                    Some(Block::Flags(Flags {
+                        end_stream: true,
+                        ..
+                    }))
+                );
+                let yield_after_data =
+                    self.incremental_mode && self.incremental_peer_count > 1 && !next_closes_stream;
+                return can_continue && !yield_after_data;
             }
             Block::Flags(Flags {
                 end_header,
@@ -1298,5 +1318,93 @@ mod tests {
                  of incremental_peer_count (= {peers})"
             );
         }
+    }
+
+    // ── LIFECYCLE §9 invariant 19: DATA/trailer close-race suppression ────
+
+    #[test]
+    fn test_converter_suppresses_yield_before_closing_end_stream_flags() {
+        // Two incremental peers normally trigger a yield after DATA. But
+        // if the next queued block is a closing `Block::Flags` (end_stream
+        // = true), yielding would strand END_STREAM. Tier 3c:
+        // converter must drain the closing Flags in the same pass.
+        let mut encoder = loona_hpack::Encoder::new();
+        let mut conv = test_converter(&mut encoder);
+        conv.incremental_mode = true;
+        conv.incremental_peer_count = 3;
+        conv.window = 4096;
+        let mut buf = vec![0u8; 8192];
+        let mut kawa = make_kawa(&mut buf, Kind::Response);
+
+        // Pre-queue the closing Flags so the converter sees it when
+        // peeking `kawa.blocks.front()` inside the DATA arm.
+        kawa.blocks.push_back(Block::Flags(Flags {
+            end_body: true,
+            end_chunk: false,
+            end_header: false,
+            end_stream: true,
+        }));
+
+        let data = Store::Static(b"hello world");
+        let cont = conv.call(Block::Chunk(Chunk { data }), &mut kawa);
+        assert!(
+            cont,
+            "yield must be suppressed when the next block is a closing Flags \
+             (end_stream = true) — otherwise END_STREAM strands in kawa.blocks"
+        );
+    }
+
+    #[test]
+    fn test_converter_yields_before_trailing_flags_without_end_stream() {
+        // Flags blocks without `end_stream=true` (e.g. inter-chunk
+        // `end_chunk` markers the H1 parser emits mid-body) must NOT
+        // suppress the yield — they do not terminate the stream.
+        let mut encoder = loona_hpack::Encoder::new();
+        let mut conv = test_converter(&mut encoder);
+        conv.incremental_mode = true;
+        conv.incremental_peer_count = 3;
+        conv.window = 4096;
+        let mut buf = vec![0u8; 8192];
+        let mut kawa = make_kawa(&mut buf, Kind::Response);
+
+        kawa.blocks.push_back(Block::Flags(Flags {
+            end_body: false,
+            end_chunk: true,
+            end_header: false,
+            end_stream: false,
+        }));
+
+        let data = Store::Static(b"chunked body");
+        let cont = conv.call(Block::Chunk(Chunk { data }), &mut kawa);
+        assert!(
+            !cont,
+            "yield still applies when next Flags is a non-terminal marker \
+             (end_chunk without end_stream)"
+        );
+    }
+
+    #[test]
+    fn test_converter_yields_before_chunk_block() {
+        // Sanity: the close-race guard only triggers on Block::Flags —
+        // a trailing Block::Chunk does NOT suppress the yield.
+        let mut encoder = loona_hpack::Encoder::new();
+        let mut conv = test_converter(&mut encoder);
+        conv.incremental_mode = true;
+        conv.incremental_peer_count = 3;
+        conv.window = 4096;
+        let mut buf = vec![0u8; 8192];
+        let mut kawa = make_kawa(&mut buf, Kind::Response);
+
+        kawa.blocks.push_back(Block::Chunk(Chunk {
+            data: Store::Static(b"next chunk"),
+        }));
+
+        let data = Store::Static(b"hello world");
+        let cont = conv.call(Block::Chunk(Chunk { data }), &mut kawa);
+        assert!(
+            !cont,
+            "back-to-back DATA must still yield — incremental rotation depends \
+             on the converter deferring the next DATA"
+        );
     }
 }

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -3577,6 +3577,7 @@ fn h2_frame_rx_metric_key(frame: &Frame) -> &'static str {
         Frame::GoAway(_) => "h2.frames.rx.goaway",
         Frame::WindowUpdate(_) => "h2.frames.rx.window_update",
         Frame::Continuation(_) => "h2.frames.rx.continuation",
+        Frame::PriorityUpdate(_) => "h2.frames.rx.priority_update",
         Frame::Unknown(_) => "h2.frames.rx.unknown",
     }
 }
@@ -3866,6 +3867,7 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             Frame::Ping(ping) => self.handle_ping_frame(ping),
             Frame::GoAway(goaway) => self.handle_goaway_frame(goaway, context, endpoint),
             Frame::WindowUpdate(wu) => self.handle_window_update_frame(wu, context, endpoint),
+            Frame::PriorityUpdate(pu) => self.handle_priority_update_frame(pu),
             Frame::Continuation(_) => {
                 // Unreachable: standalone CONTINUATION is rejected in
                 // `handle_header_state` (RFC 9113 §6.10) and in-block
@@ -4330,6 +4332,46 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                 return self.goaway(H2Error::ProtocolError);
             }
         }
+        MuxResult::Continue
+    }
+
+    /// RFC 9218 §7.1: PRIORITY_UPDATE reprioritizes an open or idle-soon
+    /// stream at the connection level. Decodes the priority field value
+    /// (same grammar as the `priority` request header, `parse_rfc9218_priority`)
+    /// and pushes it into the `Prioriser` through the same guarded path used
+    /// for standalone PRIORITY frames — the guard bounds memory against a
+    /// client spamming PRIORITY_UPDATE for far-future stream IDs.
+    ///
+    /// Prioritized stream ID `0` is a connection-level `PROTOCOL_ERROR`
+    /// (RFC 9218 §7.1). For any other ID that is not currently open or
+    /// within the idle look-ahead budget, the update is silently dropped
+    /// (matches the PRIORITY-frame guard semantics — no state change).
+    fn handle_priority_update_frame(&mut self, pu: parser::PriorityUpdate) -> MuxResult {
+        self.attribute_bytes_to_overhead();
+        if pu.prioritized_stream_id == 0 {
+            error!(
+                "{} PRIORITY_UPDATE with prioritized_stream_id=0 (RFC 9218 §7.1)",
+                log_context!(self)
+            );
+            return self.goaway(H2Error::ProtocolError);
+        }
+        let (urgency, incremental) = pkawa::parse_rfc9218_priority(&pu.priority_field_value);
+        trace!(
+            "{} PRIORITY_UPDATE stream={} urgency={} incremental={}",
+            log_context!(self),
+            pu.prioritized_stream_id,
+            urgency,
+            incremental
+        );
+        let _ = self.prioriser.push_priority_guarded(
+            pu.prioritized_stream_id,
+            parser::PriorityPart::Rfc9218 {
+                urgency,
+                incremental,
+            },
+            self.last_stream_id,
+            &self.streams,
+        );
         MuxResult::Continue
     }
 

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -2323,11 +2323,41 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             .prioriser
             .apply_incremental_rotation(&mut self.priorities_buf);
 
+        // RFC 9218 §4 refinement (Tier 3a): the connection-global
+        // `incremental_count` is too coarse for `converter.incremental_peer_count`.
+        // A solo `u=0, i` stream with an unrelated `u=7, i` peer in a
+        // different urgency bucket would still see `incremental_peer_count > 1`
+        // and voluntarily yield — stranding bytes the invariant-15/16 guards
+        // were meant to prevent. Scope the count to same-urgency streams that
+        // are actually ready to emit this pass (eligibility mirrors the check
+        // in the write loop below).
+        let mut ready_incremental_by_urgency: HashMap<u8, usize> = HashMap::new();
+        for &sid in self.priorities_buf.iter() {
+            let (urgency, is_incremental) = self.prioriser.get(&sid);
+            if !is_incremental {
+                continue;
+            }
+            let Some(&gid) = self.streams.get(&sid) else {
+                continue;
+            };
+            let wbuffer = match self.position {
+                Position::Server => &context.streams[gid].back,
+                Position::Client(..) => &context.streams[gid].front,
+            };
+            if wbuffer.is_main_phase()
+                || (wbuffer.is_terminated() && !wbuffer.is_completed())
+                || (wbuffer.is_error() && !self.rst_sent.contains(&sid))
+            {
+                *ready_incremental_by_urgency.entry(urgency).or_insert(0) += 1;
+            }
+        }
+
         trace!(
-            "{} PRIORITIES: {:?} (incremental_count={})",
+            "{} PRIORITIES: {:?} (incremental_count={}, per_bucket={:?})",
             log_context!(self),
             self.priorities_buf,
-            incremental_count
+            incremental_count,
+            ready_incremental_by_urgency
         );
         let mut socket_write = false;
         // RFC 9218 §4 round-robin: remember the first incremental stream we
@@ -2349,7 +2379,7 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                 );
                 continue;
             };
-            let (_, is_incremental) = self.prioriser.get(&stream_id);
+            let (urgency, is_incremental) = self.prioriser.get(&stream_id);
             let stream = &mut context.streams[global_stream_id];
             let stream_state = stream.state;
             let parts = stream.split(&self.position);
@@ -2364,11 +2394,18 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                 // RFC 9218 §4: incremental streams yield the converter after
                 // a single DATA frame so same-urgency peers interleave.
                 converter.incremental_mode = is_incremental;
-                // Solo-bucket guard: skip the yield when there is no peer
-                // to interleave with (prevents the `finalize_write`
-                // WRITABLE-withdrawal strand — see commit message + test
-                // `test_h2_solo_incremental_drains_fully`).
-                converter.incremental_peer_count = incremental_count;
+                // Same-urgency-bucket ready-peer count (Tier 3a, LIFECYCLE §9
+                // invariant 17). The converter skips the yield when there is
+                // no peer in the same bucket to interleave with — prevents
+                // the `finalize_write` WRITABLE-withdrawal strand (see
+                // `test_h2_solo_incremental_drains_fully`). A connection-wide
+                // count would wrongly yield for a solo incremental stream
+                // when another urgency bucket happens to contain an
+                // incremental peer.
+                converter.incremental_peer_count = ready_incremental_by_urgency
+                    .get(&urgency)
+                    .copied()
+                    .unwrap_or(0);
                 // Track RST_STREAM dedup: if kawa is in error state, the converter
                 // will generate a RST_STREAM frame. Mark it so we don't send a
                 // duplicate on the next writable cycle.

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -20,7 +20,7 @@ use crate::{
     L7ListenerHandler, ListenerHandler, Protocol, Readiness, SessionMetrics,
     protocol::mux::{
         BackendStatus, Context, DebugEvent, DebugHistory, Endpoint, GenericHttpStream,
-        GlobalStreamId, MuxResult, Position, StreamId, StreamState, converter,
+        GlobalStreamId, MuxResult, Position, Stream, StreamId, StreamState, converter,
         forcefully_terminate_answer,
         parser::{self, Frame, FrameHeader, FrameType, H2Error, Headers, WindowUpdate},
         pkawa, remove_backend_stream, serializer, set_default_answer,
@@ -552,6 +552,38 @@ fn distribute_overhead(
     metrics.bout += share_out;
     *overhead_bin -= share_in;
     *overhead_bout -= share_out;
+}
+
+/// LIFECYCLE §9 invariant 16 probe: returns `true` if any open stream still
+/// has outbound kawa bytes queued (`back.out` non-empty or `back.blocks`
+/// non-drained).
+///
+/// Used by `finalize_write` to preserve `Ready::WRITABLE` across a voluntary
+/// scheduler yield, and by `has_pending_write_full` to block shutdown-drain
+/// while bytes are still owed to the frontend.
+///
+/// `.get()` rather than direct indexing: an unknown `GlobalStreamId` is
+/// treated as "no pending bytes" rather than panicking — defence-in-depth
+/// against a stream-removal race during shutdown.
+fn any_stream_has_pending_back(
+    streams: &HashMap<StreamId, GlobalStreamId>,
+    context_streams: &[Stream],
+) -> bool {
+    any_stream_id_matches(streams, |gid| {
+        context_streams
+            .get(gid)
+            .is_some_and(|s| !s.back.out.is_empty() || !s.back.blocks.is_empty())
+    })
+}
+
+/// Iteration core of [`any_stream_has_pending_back`], split out so the
+/// invariant-16 dispatch is unit-testable without a full [`Stream`] fixture
+/// (the existing test module only covers `H2FloodDetector`).
+fn any_stream_id_matches<F>(streams: &HashMap<StreamId, GlobalStreamId>, mut probe: F) -> bool
+where
+    F: FnMut(GlobalStreamId) -> bool,
+{
+    streams.values().any(|gid| probe(*gid))
 }
 
 /// Detail of a flood-threshold violation returned by
@@ -2302,6 +2334,11 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         // served this pass so we can advance `Prioriser::incremental_cursor`
         // to it, causing the next pass to start with the stream just after.
         let mut first_incremental_fired: Option<StreamId> = None;
+        // Total outbound bytes emitted across all stream flushes this pass —
+        // `finalize_write` uses this to distinguish a voluntary scheduler
+        // yield (progress + pending back-buffer, LIFECYCLE §9 invariant 16)
+        // from a no-progress wait state (e.g. flow-control starvation).
+        let mut total_bytes_written: usize = 0;
         'outer: for idx in 0..self.priorities_buf.len() {
             let stream_id = self.priorities_buf[idx];
             let Some(&global_stream_id) = self.streams.get(&stream_id) else {
@@ -2378,6 +2415,7 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                     *t = Instant::now();
                 }
             }
+            total_bytes_written = total_bytes_written.saturating_add(stream_bytes);
             if outcome == FlushOutcome::Stalled {
                 self.expect_write = Some(H2StreamId::Other {
                     id: stream_id,
@@ -2451,7 +2489,7 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                 self.graceful_goaway()
             };
         }
-        self.finalize_write(socket_write, context)
+        self.finalize_write(socket_write, total_bytes_written, context)
     }
 
     /// Remove streams that completed their lifecycle from all tracking maps.
@@ -2648,9 +2686,29 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
 
     /// Post-write phase: check drain completion, flush TLS, and update readiness.
     ///
+    /// `bytes_written_this_pass` reports the total outbound bytes `write_streams`
+    /// pushed to the socket (across every stream), and is used to distinguish
+    /// two very different "no `expect_write`" states:
+    ///
+    /// - **Voluntary yield with progress**: at least one DATA/HEADERS frame
+    ///   emitted, but a stream left non-empty `back.out`/`back.blocks` because
+    ///   the converter yielded (e.g. RFC 9218 incremental rotation). LIFECYCLE
+    ///   §9 invariant 16: keep `Ready::WRITABLE` armed so the session loop can
+    ///   resume flushing on the next tick without waiting for an external
+    ///   wake-up that edge-triggered epoll will not deliver.
+    /// - **No progress at all**: converter pushed every block back (e.g. flow
+    ///   window exhausted, no HEADERS ready yet). Strip `Ready::WRITABLE` —
+    ///   forward progress must come from an external trigger
+    ///   (`WINDOW_UPDATE`, new request), not from looping writable().
+    ///
     /// Returns `MuxResult::Continue` in the normal case, or triggers a graceful
     /// GOAWAY when draining and all streams have completed.
-    fn finalize_write<L>(&mut self, socket_write: bool, context: &mut Context<L>) -> MuxResult
+    fn finalize_write<L>(
+        &mut self,
+        socket_write: bool,
+        bytes_written_this_pass: usize,
+        context: &mut Context<L>,
+    ) -> MuxResult
     where
         L: ListenerHandler + L7ListenerHandler,
     {
@@ -2668,13 +2726,29 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             // pending encrypted data (first check triggers flush, second re-checks).
             self.ensure_tls_flushed();
         } else if self.expect_write.is_none() {
-            // We wrote everything
-            #[cfg(debug_assertions)]
-            context.debug.push(DebugEvent::Str(format!(
-                "Wrote everything: {:?}",
-                self.streams
-            )));
-            self.readiness.interest.remove(Ready::WRITABLE);
+            // LIFECYCLE §9 invariant 16: retain `Ready::WRITABLE` when a
+            // voluntary scheduler yield leaves stranded bytes in a stream's
+            // `back.out`/`back.blocks` *after* the pass made forward
+            // progress. Requiring progress avoids the degenerate no-progress
+            // loop (e.g. flow-control-starved streams) that would otherwise
+            // busy-spin against the session dispatcher.
+            if bytes_written_this_pass > 0
+                && any_stream_has_pending_back(&self.streams, &context.streams)
+            {
+                #[cfg(debug_assertions)]
+                context.debug.push(DebugEvent::Str(
+                    "finalize_write: invariant 16 retained WRITABLE (pending back-buffer)"
+                        .to_owned(),
+                ));
+            } else {
+                // We wrote everything
+                #[cfg(debug_assertions)]
+                context.debug.push(DebugEvent::Str(format!(
+                    "Wrote everything: {:?}",
+                    self.streams
+                )));
+                self.readiness.interest.remove(Ready::WRITABLE);
+            }
         }
         MuxResult::Continue
     }
@@ -3609,6 +3683,10 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
     /// The TLS check is critical: `shutting_down()` uses this to prevent
     /// premature session close while response DATA is still in rustls's
     /// buffer (accepted by `socket_write_vectored` but not yet on the wire).
+    ///
+    /// Does NOT check per-stream `back.out`/`back.blocks`; use
+    /// [`Self::has_pending_write_full`] on paths that must honour
+    /// LIFECYCLE invariant 16 (e.g. shutdown-drain).
     pub fn has_pending_write(&self) -> bool {
         if self.peer_gone_after_final_goaway() {
             return false;
@@ -3616,6 +3694,18 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         self.expect_write.is_some()
             || !self.zero.storage.is_empty()
             || self.socket.socket_wants_write()
+    }
+
+    /// Connection-level [`Self::has_pending_write`] extended with a per-stream
+    /// back-buffer probe (LIFECYCLE §9 invariant 16). Used by shutdown-drain
+    /// paths that must not close while any open stream still has outbound
+    /// kawa bytes queued — a voluntary scheduler yield can leave `back.out`
+    /// or `back.blocks` non-empty without `expect_write` being set.
+    pub fn has_pending_write_full<L>(&self, context: &Context<L>) -> bool
+    where
+        L: ListenerHandler + L7ListenerHandler,
+    {
+        self.has_pending_write() || any_stream_has_pending_back(&self.streams, &context.streams)
     }
 
     /// Flush the zero buffer to the socket, counting bytes as connection overhead.
@@ -5140,7 +5230,10 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
 
 #[cfg(test)]
 mod tests {
+    use std::{cell::RefCell, rc::Rc};
+
     use super::*;
+    use crate::{pool::Pool, protocol::kawa_h1::editor::HttpContext};
 
     // ── H2FloodDetector ──────────────────────────────────────────────────
 
@@ -6752,5 +6845,178 @@ mod tests {
             assert_eq!(server_id & 1, 0);
             assert_eq!(client_id.abs_diff(server_id), 1);
         }
+    }
+
+    // ── LIFECYCLE §9 invariant 16: any_stream_id_matches ─────────────────
+    //
+    // Covers the iteration dispatch used by `any_stream_has_pending_back`.
+    // Testing the probe directly against a synthetic closure keeps the
+    // tests independent of the full `Stream` fixture (which requires a
+    // `Pool` and a fully-built `HttpContext`).
+
+    #[test]
+    fn test_any_stream_id_matches_empty_map_is_false() {
+        let streams: HashMap<StreamId, GlobalStreamId> = HashMap::new();
+        assert!(!any_stream_id_matches(&streams, |_| true));
+    }
+
+    #[test]
+    fn test_any_stream_id_matches_all_probe_false_is_false() {
+        let mut streams: HashMap<StreamId, GlobalStreamId> = HashMap::new();
+        streams.insert(1, 0);
+        streams.insert(3, 1);
+        streams.insert(5, 2);
+        assert!(!any_stream_id_matches(&streams, |_| false));
+    }
+
+    #[test]
+    fn test_any_stream_id_matches_any_probe_true_is_true() {
+        let mut streams: HashMap<StreamId, GlobalStreamId> = HashMap::new();
+        streams.insert(1, 0);
+        streams.insert(3, 1);
+        streams.insert(5, 2);
+        // Probe is true only for GlobalStreamId == 1 (i.e. StreamId 3).
+        assert!(any_stream_id_matches(&streams, |gid| gid == 1));
+    }
+
+    #[test]
+    fn test_any_stream_id_matches_single_entry() {
+        let mut streams: HashMap<StreamId, GlobalStreamId> = HashMap::new();
+        streams.insert(42, 7);
+        assert!(any_stream_id_matches(&streams, |gid| gid == 7));
+        assert!(!any_stream_id_matches(&streams, |gid| gid == 8));
+    }
+
+    #[test]
+    fn test_any_stream_id_matches_short_circuits() {
+        let mut streams: HashMap<StreamId, GlobalStreamId> = HashMap::new();
+        streams.insert(1, 0);
+        streams.insert(3, 1);
+        streams.insert(5, 2);
+        streams.insert(7, 3);
+        let mut calls = 0usize;
+        let result = any_stream_id_matches(&streams, |_| {
+            calls += 1;
+            true
+        });
+        assert!(result);
+        // `Iterator::any` short-circuits on the first `true` — so the probe
+        // must fire at most once in this construction.
+        assert_eq!(calls, 1);
+    }
+
+    // ── LIFECYCLE §9 invariant 16: any_stream_has_pending_back ───────────
+
+    /// Build a minimal `Stream` for invariant-16 probing. Uses the pool
+    /// plumbing so `back.blocks` / `back.out` exist; every other field is
+    /// default-valued because the predicate only reads the back buffer.
+    fn make_stream_for_invariant_16(pool: &Rc<RefCell<Pool>>, session_ulid: Ulid) -> Stream {
+        let http_ctx = HttpContext {
+            keep_alive_backend: true,
+            keep_alive_frontend: true,
+            sticky_session_found: None,
+            method: None,
+            authority: None,
+            path: None,
+            status: None,
+            reason: None,
+            user_agent: None,
+            x_request_id: None,
+            xff_chain: None,
+            #[cfg(feature = "opentelemetry")]
+            otel: None,
+            closing: false,
+            session_id: session_ulid,
+            id: Ulid::generate(),
+            backend_id: None,
+            cluster_id: None,
+            protocol: Protocol::HTTPS,
+            public_address: "127.0.0.1:0".parse().unwrap(),
+            session_address: None,
+            sticky_name: String::new(),
+            sticky_session: None,
+            backend_address: None,
+            tls_server_name: None,
+            strict_sni_binding: false,
+            tls_version: None,
+            tls_cipher: None,
+            tls_alpn: None,
+            sozu_id_header: String::from("Sozu-Id"),
+        };
+        Stream::new(Rc::downgrade(pool), http_ctx, 65_535)
+            .expect("pool should have capacity for two buffers")
+    }
+
+    fn make_pool_for_invariant_16() -> Rc<RefCell<Pool>> {
+        // Two buffer slots per stream (front + back), ten stream slots is
+        // plenty for the tests below.
+        Rc::new(RefCell::new(Pool::with_capacity(4, 20, 16_384)))
+    }
+
+    #[test]
+    fn test_any_stream_has_pending_back_empty_map_is_false() {
+        let pool = make_pool_for_invariant_16();
+        let ulid = Ulid::generate();
+        let streams_map: HashMap<StreamId, GlobalStreamId> = HashMap::new();
+        let context_streams = vec![make_stream_for_invariant_16(&pool, ulid)];
+        assert!(!any_stream_has_pending_back(&streams_map, &context_streams));
+    }
+
+    #[test]
+    fn test_any_stream_has_pending_back_all_drained_is_false() {
+        let pool = make_pool_for_invariant_16();
+        let ulid = Ulid::generate();
+        let context_streams = vec![
+            make_stream_for_invariant_16(&pool, ulid),
+            make_stream_for_invariant_16(&pool, ulid),
+        ];
+        let mut streams_map: HashMap<StreamId, GlobalStreamId> = HashMap::new();
+        streams_map.insert(1, 0);
+        streams_map.insert(3, 1);
+        // Both freshly-built streams have empty back.out and back.blocks
+        // (Kawa::new starts with empty deques).
+        assert!(!any_stream_has_pending_back(&streams_map, &context_streams));
+    }
+
+    #[test]
+    fn test_any_stream_has_pending_back_unknown_gid_is_false() {
+        // LIFECYCLE invariant 16 defence-in-depth: an unknown
+        // `GlobalStreamId` during a stream-removal race must not panic;
+        // `.get()` must short-circuit to `false`.
+        let pool = make_pool_for_invariant_16();
+        let ulid = Ulid::generate();
+        let context_streams = vec![make_stream_for_invariant_16(&pool, ulid)];
+        let mut streams_map: HashMap<StreamId, GlobalStreamId> = HashMap::new();
+        // GlobalStreamId 42 is out of range for the 1-element slice above.
+        streams_map.insert(7, 42);
+        assert!(!any_stream_has_pending_back(&streams_map, &context_streams));
+    }
+
+    #[test]
+    fn test_any_stream_has_pending_back_with_pending_blocks_is_true() {
+        let pool = make_pool_for_invariant_16();
+        let ulid = Ulid::generate();
+        let mut stream = make_stream_for_invariant_16(&pool, ulid);
+        // Push one dummy block — any Block variant is fine; the predicate
+        // only checks `blocks.is_empty()`.
+        stream.back.blocks.push_back(kawa::Block::StatusLine);
+        let mut streams_map: HashMap<StreamId, GlobalStreamId> = HashMap::new();
+        streams_map.insert(1, 0);
+        assert!(any_stream_has_pending_back(&streams_map, &[stream]));
+    }
+
+    #[test]
+    fn test_any_stream_has_pending_back_with_pending_out_is_true() {
+        let pool = make_pool_for_invariant_16();
+        let ulid = Ulid::generate();
+        let mut stream = make_stream_for_invariant_16(&pool, ulid);
+        // Non-empty out buffer with no blocks.
+        stream
+            .back
+            .out
+            .push_back(kawa::OutBlock::Store(kawa::Store::Static(b"partial frame")));
+        let mut streams_map: HashMap<StreamId, GlobalStreamId> = HashMap::new();
+        streams_map.insert(1, 0);
+        assert!(any_stream_has_pending_back(&streams_map, &[stream]));
     }
 }

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -587,7 +587,14 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Mux<Front, L>
 impl<Front: SocketHandler + std::fmt::Debug, L: ListenerHandler + L7ListenerHandler> Mux<Front, L> {
     fn delay_close_for_frontend_flush(&mut self, reason: &'static str) -> bool {
         let _ = self.frontend.initiate_close_notify();
-        if self.frontend.has_pending_write() {
+        // LIFECYCLE §9 invariant 16: consult per-stream back-buffers in
+        // addition to the connection-level pending-write predicate so
+        // shutdown does not close while any open H2 stream still has
+        // kawa bytes queued after a voluntary scheduler yield.
+        if self
+            .frontend
+            .has_pending_write_including_streams(&self.context)
+        {
             let readiness = self.frontend.readiness_mut();
             readiness.interest = Ready::WRITABLE | Ready::HUP | Ready::ERROR;
             readiness.signal_pending_write();

--- a/lib/src/protocol/mux/parser.rs
+++ b/lib/src/protocol/mux/parser.rs
@@ -85,10 +85,14 @@ pub enum FrameType {
     GoAway,
     WindowUpdate,
     Continuation,
+    /// RFC 9218 §7.1 — PRIORITY_UPDATE frame (type 0x10). Carries a new
+    /// priority signal for a prioritized stream, replacing the deprecated
+    /// `Priority` frame at the connection level.
+    PriorityUpdate,
     /// Frame of unknown type per RFC 9113 §5.5. Implementations MUST ignore
-    /// and discard these frames so H2 extensions (e.g. RFC 9218
-    /// PRIORITY_UPDATE, frame type 0x10) do not break interoperability.
-    /// The associated `u8` is the raw type byte for diagnostics only.
+    /// and discard these frames so future H2 extensions do not break
+    /// interoperability. The associated `u8` is the raw type byte for
+    /// diagnostics only.
     Unknown(u8),
 }
 
@@ -278,7 +282,11 @@ pub fn frame_header(input: &[u8], max_frame_size: u32) -> IResult<&[u8], FrameHe
         | FrameType::RstStream
         | FrameType::PushPromise
         | FrameType::Continuation => stream_id != 0,
-        FrameType::Settings | FrameType::Ping | FrameType::GoAway => stream_id == 0,
+        // RFC 9218 §7.1: PRIORITY_UPDATE is a connection-scoped signal
+        // (the *prioritized* stream ID lives in the payload).
+        FrameType::Settings | FrameType::Ping | FrameType::GoAway | FrameType::PriorityUpdate => {
+            stream_id == 0
+        }
         FrameType::WindowUpdate | FrameType::Unknown(_) => true,
     };
     if !valid_stream_id {
@@ -315,6 +323,8 @@ fn convert_frame_type(t: u8) -> FrameType {
         7 => FrameType::GoAway,
         8 => FrameType::WindowUpdate,
         9 => FrameType::Continuation,
+        // RFC 9218 §7.1 PRIORITY_UPDATE
+        0x10 => FrameType::PriorityUpdate,
         other => FrameType::Unknown(other),
     }
 }
@@ -331,9 +341,26 @@ pub enum Frame {
     GoAway(GoAway),
     WindowUpdate(WindowUpdate),
     Continuation(Continuation),
+    /// RFC 9218 §7.1 PRIORITY_UPDATE — connection-scoped signal that
+    /// re-prioritizes a specific stream. Payload carries the prioritized
+    /// stream ID and the verbatim priority field value (structured field).
+    PriorityUpdate(PriorityUpdate),
     /// Unknown frame type (RFC 9113 §5.5) — payload already consumed, the
     /// state machine MUST ignore it.
     Unknown(u8),
+}
+
+/// RFC 9218 §7.1 PRIORITY_UPDATE frame payload.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PriorityUpdate {
+    /// Identifier of the stream being re-prioritized (31-bit, reserved high
+    /// bit masked off). `0` MUST be treated as a connection error
+    /// (`PROTOCOL_ERROR`) by the handler.
+    pub prioritized_stream_id: u32,
+    /// Verbatim priority field value (SF-Item / ASCII). The handler passes
+    /// this through the same `parse_rfc9218_priority` helper used for the
+    /// `priority` request header.
+    pub priority_field_value: Vec<u8>,
 }
 
 pub fn frame_body<'a>(
@@ -408,6 +435,8 @@ pub fn frame_body<'a>(
             }
             window_update_frame(i, header)?
         }
+        // RFC 9218 §7.1: PRIORITY_UPDATE payload must be ≥ 4 bytes.
+        FrameType::PriorityUpdate => priority_update_frame(i, header)?,
         // RFC 9113 §5.5: silently consume unknown frame payloads.
         FrameType::Unknown(_) => unknown_frame(i, header)?,
     };
@@ -800,8 +829,8 @@ pub fn continuation_frame<'a>(
 
 /// Silently consume the payload of a frame whose type byte is not recognised,
 /// per RFC 9113 §5.5 ("Implementations MUST ignore and discard frames of
-/// unknown type"). This is how H2 extensions (e.g. RFC 9218 PRIORITY_UPDATE,
-/// type 0x10) remain interoperable with sozu.
+/// unknown type"). Previously covered RFC 9218 PRIORITY_UPDATE (type 0x10);
+/// PRIORITY_UPDATE is now parsed through [`priority_update_frame`].
 pub fn unknown_frame<'a>(
     input: &'a [u8],
     header: &FrameHeader,
@@ -813,6 +842,54 @@ pub fn unknown_frame<'a>(
     };
     Ok((remaining, Frame::Unknown(raw)))
 }
+
+/// RFC 9218 §7.1 PRIORITY_UPDATE frame parser. Payload layout:
+///
+/// ```text
+/// +-+-------------------------------------------------------------+
+/// |R|              Prioritized Stream ID (31)                     |
+/// +-+-------------------------------------------------------------+
+/// |                    Priority Field Value (*)                 ...
+/// +---------------------------------------------------------------+
+/// ```
+///
+/// - 4-byte prioritized stream ID (reserved high bit masked off).
+/// - Remainder: verbatim priority field value (ASCII / SF-Item).
+///
+/// A payload shorter than 4 bytes is `FRAME_SIZE_ERROR` per §7.1. Stream
+/// ID value `0` is rejected by the handler (connection-level
+/// `PROTOCOL_ERROR`), not here — keep the parser purely structural.
+pub fn priority_update_frame<'a>(
+    input: &'a [u8],
+    header: &FrameHeader,
+) -> IResult<&'a [u8], Frame, ParserError<'a>> {
+    if header.payload_len < PRIORITY_UPDATE_MIN_PAYLOAD {
+        return Err(Err::Failure(ParserError::new_h2(
+            input,
+            H2Error::FrameSizeError,
+        )));
+    }
+    let (remaining, payload) = take(header.payload_len)(input)?;
+    let (raw_id_bytes, value_bytes) = payload.split_at(PRIORITY_UPDATE_MIN_PAYLOAD as usize);
+    let prioritized_stream_id = u32::from_be_bytes([
+        raw_id_bytes[0],
+        raw_id_bytes[1],
+        raw_id_bytes[2],
+        raw_id_bytes[3],
+    ]) & STREAM_ID_MASK;
+    Ok((
+        remaining,
+        Frame::PriorityUpdate(PriorityUpdate {
+            prioritized_stream_id,
+            priority_field_value: value_bytes.to_vec(),
+        }),
+    ))
+}
+
+/// Minimum payload size for a PRIORITY_UPDATE frame (RFC 9218 §7.1):
+/// the 4-byte prioritized stream ID. The priority field value is allowed
+/// to be empty (defaults to the RFC 9218 §4 defaults).
+pub const PRIORITY_UPDATE_MIN_PAYLOAD: u32 = 4;
 
 #[cfg(test)]
 mod tests {
@@ -1000,23 +1077,114 @@ mod tests {
         }
     }
 
-    /// RFC 9218 PRIORITY_UPDATE (frame type 0x10) is the canonical example of
-    /// an H2 extension we must accept-and-ignore rather than kill the
-    /// connection over.
+    /// RFC 9218 §7.1: PRIORITY_UPDATE with an empty priority field value +
+    /// prioritized stream ID = 1 is a well-formed frame. The parser yields
+    /// `Frame::PriorityUpdate` with an empty `priority_field_value` — the
+    /// handler supplies the RFC 9218 §4 defaults.
     #[test]
-    fn test_priority_update_is_ignored() {
+    fn test_priority_update_empty_field_parses() {
         let input = [
-            0x00, 0x00, 0x00, // payload_len = 0
+            0x00, 0x00, 0x04, // payload_len = 4
             0x10, // type = PRIORITY_UPDATE (0x10)
             0x00, // flags = 0
-            0x00, 0x00, 0x00, 0x00, // stream_id = 0
+            0x00, 0x00, 0x00, 0x00, // stream_id = 0 (connection-scoped)
+            // prioritized stream ID (big-endian, 31-bit with reserved MSB)
+            0x00, 0x00, 0x00, 0x01,
         ];
 
         let (remaining, header) = frame_header(&input, DEFAULT_MAX_FRAME_SIZE)
             .expect("PRIORITY_UPDATE header must parse");
-        assert!(matches!(header.frame_type, FrameType::Unknown(0x10)));
+        assert!(matches!(header.frame_type, FrameType::PriorityUpdate));
         let (_, frame) = frame_body(remaining, &header).expect("body must be consumed");
-        assert!(matches!(frame, Frame::Unknown(0x10)));
+        match frame {
+            Frame::PriorityUpdate(PriorityUpdate {
+                prioritized_stream_id,
+                ref priority_field_value,
+            }) => {
+                assert_eq!(prioritized_stream_id, 1);
+                assert!(priority_field_value.is_empty());
+            }
+            other => panic!("expected Frame::PriorityUpdate, got {other:?}"),
+        }
+    }
+
+    /// RFC 9218 §7.1: PRIORITY_UPDATE with a non-empty SF-Item priority
+    /// field value. The parser preserves the raw bytes verbatim; the
+    /// handler re-uses `parse_rfc9218_priority` to extract `(urgency, i)`.
+    #[test]
+    fn test_priority_update_with_priority_field_parses() {
+        let value = b"u=0, i";
+        let mut input = vec![
+            0x00,
+            0x00,
+            0x04 + value.len() as u8, // payload_len = 4 + value
+            0x10,                     // type = PRIORITY_UPDATE
+            0x00,                     // flags = 0
+            0x00,
+            0x00,
+            0x00,
+            0x00, // connection stream
+            0x00,
+            0x00,
+            0x00,
+            0x05, // prioritized stream 5
+        ];
+        input.extend_from_slice(value);
+
+        let (remaining, header) =
+            frame_header(&input, DEFAULT_MAX_FRAME_SIZE).expect("header parses");
+        assert!(matches!(header.frame_type, FrameType::PriorityUpdate));
+        let (_, frame) = frame_body(remaining, &header).expect("body parses");
+        match frame {
+            Frame::PriorityUpdate(PriorityUpdate {
+                prioritized_stream_id,
+                ref priority_field_value,
+            }) => {
+                assert_eq!(prioritized_stream_id, 5);
+                assert_eq!(priority_field_value.as_slice(), value);
+            }
+            other => panic!("expected Frame::PriorityUpdate, got {other:?}"),
+        }
+    }
+
+    /// RFC 9218 §7.1: PRIORITY_UPDATE MUST carry at least the 4-byte
+    /// prioritized stream ID. Shorter payloads are `FRAME_SIZE_ERROR`.
+    #[test]
+    fn test_priority_update_payload_below_min_is_frame_size_error() {
+        let input = [
+            0x00, 0x00, 0x03, // payload_len = 3 (one byte short)
+            0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        let (remaining, header) =
+            frame_header(&input, DEFAULT_MAX_FRAME_SIZE).expect("header parses");
+        let result = frame_body(remaining, &header);
+        match result {
+            Err(Err::Failure(e)) => {
+                assert_eq!(e.kind, ParserErrorKind::H2(H2Error::FrameSizeError));
+            }
+            other => panic!("expected FRAME_SIZE_ERROR, got {other:?}"),
+        }
+    }
+
+    /// RFC 9218 §7.1: PRIORITY_UPDATE MUST be sent on stream 0 (the
+    /// connection control stream). Any other stream ID is a connection
+    /// `PROTOCOL_ERROR`, rejected at `frame_header` time via the
+    /// frame_type ↔ stream_id cross-check.
+    #[test]
+    fn test_priority_update_on_non_zero_stream_is_protocol_error() {
+        let input = [
+            0x00, 0x00, 0x04, // payload_len = 4
+            0x10, // type = PRIORITY_UPDATE
+            0x00, // flags
+            0x00, 0x00, 0x00, 0x07, // stream_id = 7 (invalid for PRIORITY_UPDATE)
+            0x00, 0x00, 0x00, 0x01, // prioritized_stream_id
+        ];
+        match frame_header(&input, DEFAULT_MAX_FRAME_SIZE) {
+            Err(Err::Failure(e)) => {
+                assert_eq!(e.kind, ParserErrorKind::H2(H2Error::ProtocolError));
+            }
+            other => panic!("expected PROTOCOL_ERROR, got {other:?}"),
+        }
     }
 
     // ---- SETTINGS with odd payload size (not a multiple of 6) ----

--- a/lib/src/protocol/mux/pkawa.rs
+++ b/lib/src/protocol/mux/pkawa.rs
@@ -464,7 +464,11 @@ fn trim_ows(input: &[u8]) -> &[u8] {
 ///
 /// Values outside the valid range are clamped (urgency to 0-7).
 /// Malformed tokens are silently ignored, falling back to defaults.
-fn parse_rfc9218_priority(value: &[u8]) -> (u8, bool) {
+///
+/// Re-used by the RFC 9218 §7.1 PRIORITY_UPDATE frame handler
+/// (`h2::ConnectionH2::handle_priority_update_frame`) to decode the
+/// priority field value payload — same wire format as the request header.
+pub(super) fn parse_rfc9218_priority(value: &[u8]) -> (u8, bool) {
     let mut urgency: u8 = 3; // RFC 9218 §4: default urgency
     let mut incremental = false;
 

--- a/lib/src/protocol/mux/serializer.rs
+++ b/lib/src/protocol/mux/serializer.rs
@@ -47,6 +47,11 @@ pub fn serialize_frame_type(f: &FrameType) -> u8 {
         FrameType::GoAway => 7,
         FrameType::WindowUpdate => 8,
         FrameType::Continuation => 9,
+        // RFC 9218 §7.1 PRIORITY_UPDATE. Sozu only ingests this frame
+        // (see `h2::ConnectionH2::handle_priority_update_frame`) and never
+        // emits one toward the peer, but the arm keeps the type-byte map
+        // round-trippable for tests / future use.
+        FrameType::PriorityUpdate => 0x10,
         // FrameType::Unknown is a parser-only variant used to ignore
         // extension frames per RFC 9113 §5.5; sozu never emits them.
         FrameType::Unknown(t) => t,


### PR DESCRIPTION
## Summary

Four-part hardening of the Sōzu HTTP/2 RFC 9218 scheduler (defence-in-depth follow-up to the Zeus Invest incident fix in PR #1227, which is already shipped). Each commit is independently reviewable and carries its own LIFECYCLE.md invariant + tests.

- **Tier 2 — LIFECYCLE §9 invariant 16 enforcement** (`164ba27a`) — turns the documented-but-unenforced "never withdraw `Ready::WRITABLE` with pending back-buffer" policy into a runtime guarantee. `finalize_write` now preserves WRITABLE when the pass made forward progress AND any open stream still has outbound kawa bytes queued; shutdown-drain (`delay_close_for_frontend_flush`) picks up a matching `has_pending_write_full` so a session close does not race ahead of a stream's trailing bytes.
- **Tier 3a — Same-bucket incremental peer count** (`3f9f5e38`) — scopes `converter.incremental_peer_count` to the same urgency bucket AND to streams actually ready to emit this pass. The previous connection-global count would spuriously yield a solo `u=0, i` stream when an unrelated `u=7, i` peer existed elsewhere, regressing the invariant-15 solo-bucket fast path.
- **Tier 3b — PRIORITY_UPDATE** (`7ddf1f30`) — parses RFC 9218 §7.1 frame type `0x10` (was silently dropped through the unknown-frame catch-all). Rejects prioritized-stream-id = 0 with GOAWAY(PROTOCOL_ERROR); valid frames push through the memory-guarded `Prioriser::push_priority_guarded` path. Enables mid-stream reprioritization from modern browsers.
- **Tier 3c — Close-race suppression** (`8d226b88`) — the incremental-mode converter no longer yields when the next block is a closing `Block::Flags { end_stream: true }`. Prevents one event-loop round-trip per short incremental response; complements invariant 16's correctness guard.

## LIFECYCLE.md invariants added

- §9 invariant 16 — rewritten to reflect runtime enforcement + progress-aware guard.
- §9 invariant 17 — bucket-scoped, ready-only `incremental_peer_count`.
- §9 invariant 18 — PRIORITY_UPDATE parse + reject semantics.
- §9 invariant 19 — converter close-race guard (no yield before closing Flags).

## Validation

- `cargo build --all-features --locked`: clean.
- `cargo clippy --all-targets --all-features --locked`: no new warnings.
- `cargo +nightly fmt --all -- --check`: clean.
- `cargo test --workspace --all-features --locked`: 770 tests pass, 0 failures (6 ignored = fuzz targets).
- PR #1227 regression suite (7 e2e tests) all green — invariant 16 enforcement does not regress the incremental round-robin, non-incremental sequential, solo-bucket, or Firefox/Chrome/PHP-Apache shapes.

## New tests

Unit (lib):
- `protocol::mux::h2::tests::test_any_stream_id_matches_*` (5) + `test_any_stream_has_pending_back_*` (5) — invariant 16 predicate.
- `protocol::mux::parser::tests::test_priority_update_*` (4) — PRIORITY_UPDATE parser + stream-id validation.
- `protocol::mux::converter::tests::test_converter_suppresses_yield_before_closing_end_stream_flags` / `..yields_before_trailing_flags_without_end_stream` / `..yields_before_chunk_block` — Tier 3c close-race guard.

E2E (sozu-e2e):
- `test_h2_rfc9218_incremental_multi_bucket_drains_sequentially` — Tier 3a bucket scoping.
- `test_h2_priority_update_on_open_stream_is_accepted` / `..on_stream_zero_is_protocol_error` — Tier 3b.
- `test_h2_incremental_round_robin_closes_every_stream` — Tier 3c close-race.

## Security

All changes live in `lib/src/protocol/mux/` (security-sensitive per repo CLAUDE.md).
- Invariant 16 guard is pure read + conditional strip; no new `unsafe`, no new `Arc<Mutex>`, no flood-detector interaction.
- PRIORITY_UPDATE reuses the existing `Prioriser::push_priority_guarded` memory bound (`MAX_PRIORITIES` + idle look-ahead), so a flood cannot pin more than the pre-existing ceiling.
- Same-bucket scoping check is O(ready-incremental-streams) per write pass, early-returns per stream.
- Close-race guard is a single `matches!` peek on `kawa.blocks.front()`.

## Test plan
- [x] `cargo build --all-features --locked`
- [x] `cargo clippy --all-targets --all-features --locked`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo test --workspace --all-features --locked`
- [x] PR #1227 e2e regression (7 tests)
- [x] New Tier 2 / 3a / 3b / 3c tests (19 total, unit + e2e)