### PR TITLE
feat: HTTP answer templates, URL rewrite, redirect, custom headers, basic auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,107 @@
 
 See milestone [`v1.1.0`](https://github.com/sozu-proxy/sozu/projects/3?card_filter_query=milestone%3Av1.1.0)
 
+## feat/answer-templates-rewrite-auth - Unreleased
+
+Brings the upstream answer-template / URL-rewrite / basic-auth feature stack
+(originally proposed across PRs #1206, #1207, #1208, #1210) onto current `main`
+without unwinding the `feat/h2-mux` work merged in #1209. The features are
+re-implemented at the active `mux/` layer instead of the legacy `kawa_h1/`
+session path the upstream PRs targeted, so every running session benefits.
+
+### 🌟 Added
+
+- **Flexible HTTP answer templates per listener and per cluster**: the proto
+  schema for `HttpListenerConfig`, `HttpsListenerConfig`, and `Cluster` gains
+  a `map<string, string> answers` field keyed by HTTP status code. The legacy
+  `optional CustomHttpAnswers http_answers` field is preserved on the wire so
+  existing state files round-trip (the runtime merges both for one minor).
+  The new template engine (`lib/src/protocol/kawa_h1/answers.rs`) supports
+  variable substitution via `%ROUTE`, `%REQUEST_ID`, `%CLUSTER_ID`,
+  `%BACKEND_ID`, `%DURATION`, `%CAPACITY`, `%PHASE`, `%SUCCESSFULLY_PARSED`,
+  `%PARTIALLY_PARSED`, `%INVALID` (repeatable), `%REDIRECT_LOCATION`,
+  `%MESSAGE`, `%TEMPLATE_NAME` (single-use), `%WWW_AUTHENTICATE`
+  (header-only, elides the line when the realm is empty), and an
+  auto-injected `Content-Length`. Per-cluster overrides hot-swap via
+  `AddCluster` / `RemoveCluster`. HAProxy parallel: `errorfile NNN /path`.
+
+- **URL rewrite, redirect, and per-frontend custom headers**: new
+  `RequestHttpFrontend` fields (`redirect`, `redirect_scheme`,
+  `redirect_template`, `rewrite_host`, `rewrite_path`, `rewrite_port`,
+  `headers`, `required_auth`) drive frontend-level routing decisions.
+  `RedirectPolicy::PERMANENT` emits a 301 with a resolved `Location` header
+  built from `redirect_scheme` (USE_SAME / USE_HTTP / USE_HTTPS) and the
+  cluster's optional `https_redirect_port`. `RedirectPolicy::UNAUTHORIZED`
+  (or a clusterless `FORWARD`) emits a 401. `Header { position, key, val }`
+  carries request- or response-side header edits; an empty `val` deletes
+  the header by name (HAProxy `del-header` parity).
+
+- **HTTP Basic authentication on a per-frontend basis**: clusters gain
+  `authorized_hashes: repeated string` (entries shaped
+  `username:hex(sha256(password))`) and `www_authenticate: optional string`
+  (realm). Frontends with `required_auth = true` invoke
+  `mux::auth::check_basic`, which extracts the `Authorization: Basic`
+  header, base64-decodes the token, hashes the password with SHA-256,
+  and compares against every entry in `authorized_hashes` using
+  `subtle::ConstantTimeEq` over the full list (no early exit). Failure
+  produces a 401 with a `WWW-Authenticate: Basic realm="<realm>"` header
+  rendered through the answer-template engine. The credential boundary
+  is hardened against the timing side-channel that PR #1210's review fix
+  (`171a31ce` upstream) was designed to prevent. New workspace dependencies
+  `base64 = ^0.22.1` and `subtle = ^2.6.1`.
+
+- **Pattern-trie segment regex anchoring with capture propagation**: every
+  segment-level regex inserted into the routing trie is now wrapped with
+  `\A...\z` at insert time so a pattern like `cdn[0-9]+` matches `cdn1`
+  exactly but not `cdn1xxx`. A new `lookup_with_path` helper records the
+  non-literal segments matched during traversal (`TrieSubMatch::Wildcard`
+  / `TrieSubMatch::Regexp`) so the routing layer can re-run
+  `Regex::captures` on the matched bytes and feed the captures into
+  rewrite templates (`$HOST[n]` / `$PATH[n]` placeholders).
+
+- **`Frontend` and `RouteResult` types in the routing layer**: the bare
+  `Route::ClusterId` / `Route::Deny` decision is replaced by a richer
+  `Frontend` (per-frontend policy, cached header-edit slices, capture
+  capacity counts) and `RouteResult` (resolved policy plus substituted
+  rewritten host/path). The `L7ListenerHandler::frontend_from_request`
+  trait return type changes to `Result<RouteResult, _>`. Legacy
+  `Route::ClusterId` and `Route::Deny` variants remain so existing
+  match arms still compile; a follow-up will retire them.
+
+### 🔄 Changed
+
+- `HttpAnswers::new` now takes `&BTreeMap<String, String>` instead of
+  `&Option<CustomHttpAnswers>`. `HttpAnswers::get` returns
+  `(u16, bool, DefaultAnswerStream)` so the rendered template's
+  `Connection` header can drive the frontend keep-alive bit (templates
+  that ship `Connection: close` flip the flag; operators can opt back
+  into keep-alive by shipping a custom template without that header).
+  All in-tree call sites update in lockstep; legacy state files merge
+  the populated `CustomHttpAnswers` fields into the new map at load.
+
+- `mux/answers.rs::default_answer_for_code` becomes a pure builder that
+  takes the redirect URL and `WWW-Authenticate` realm as parameters.
+  `set_default_answer` reads them from `HttpContext.redirect_location`
+  and `HttpContext.www_authenticate` (stashed by the routing layer)
+  before falling back to the legacy `https://<authority><path>` shape.
+
+- `CachedTags` derives `PartialEq + Eq + Clone` so `RouteResult` can
+  derive `PartialEq` for assertions in router unit tests.
+
+### ⚠️ Behaviour-affecting
+
+- Pattern-trie domain regexes now match the entire segment. Operators
+  who relied on partial-segment matching (e.g. a `cdn[0-9]+` rule
+  inadvertently matching `cdn123xxx`) need to widen their patterns
+  explicitly. Every pre-existing in-tree regex test passes unchanged
+  with the new anchoring.
+
+- The HAProxy-style `del-header` semantic (empty `Header.val` removes
+  the named header) is **not** a no-op. Operators who already configured
+  custom headers with the empty string as a value should set a
+  whitespace-only value instead — though that is malformed per RFC 9110
+  §5.5 and should be reviewed.
+
 ## feat/h2-mux - Unreleased
 
 ### 🌟 Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,19 @@ session path the upstream PRs targeted, so every running session benefits.
 
 - **Flexible HTTP answer templates per listener and per cluster**: the proto
   schema for `HttpListenerConfig`, `HttpsListenerConfig`, and `Cluster` gains
-  a `map<string, string> answers` field keyed by HTTP status code. The legacy
-  `optional CustomHttpAnswers http_answers` field is preserved on the wire so
-  existing state files round-trip (the runtime merges both for one minor).
-  The new template engine (`lib/src/protocol/kawa_h1/answers.rs`) supports
-  variable substitution via `%ROUTE`, `%REQUEST_ID`, `%CLUSTER_ID`,
-  `%BACKEND_ID`, `%DURATION`, `%CAPACITY`, `%PHASE`, `%SUCCESSFULLY_PARSED`,
+  a `map<string, string> answers` field keyed by HTTP status code. The
+  listener-level map is the global default; the cluster-level map overrides
+  it for the matching status code on requests routed to that cluster. The
+  deprecated `optional CustomHttpAnswers http_answers` field is preserved on
+  the wire so existing state files round-trip (the runtime merges both for
+  one minor). Each map value is **either a filesystem path or an
+  `inline:<body>` literal** — the inline form skips disk I/O entirely,
+  useful for short canned responses, secrets-free containers, and test
+  rigs (`sozu cluster add --answer 503='inline:HTTP/1.1 503 ...'`,
+  `[listeners.https.answers] "503" = "inline:..."`). The new template
+  engine (`lib/src/protocol/kawa_h1/answers.rs`) supports variable
+  substitution via `%ROUTE`, `%REQUEST_ID`, `%CLUSTER_ID`, `%BACKEND_ID`,
+  `%DURATION`, `%CAPACITY`, `%PHASE`, `%SUCCESSFULLY_PARSED`,
   `%PARTIALLY_PARSED`, `%INVALID` (repeatable), `%REDIRECT_LOCATION`,
   `%MESSAGE`, `%TEMPLATE_NAME` (single-use), `%WWW_AUTHENTICATE`
   (header-only, elides the line when the realm is empty), and an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,15 @@ session path the upstream PRs targeted, so every running session benefits.
   (`171a31ce` upstream) was designed to prevent. New workspace dependencies
   `base64 = ^0.22.1` and `subtle = ^2.6.1`.
 
+  The maximum decoded credential length is operator-tunable via the new
+  main-config field `basic_auth_max_credential_bytes` (default 4096).
+  Lower values (256 / 512) bound the per-failed-auth allocation tighter
+  for hardened tenants. Setting `0` is a no-op so an explicit zero
+  cannot disable the cap by accident. The config validator emits a
+  `warn!` at boot when the configured cap is `>= buffer_size / 3` —
+  informational only, but flags the back-pressure trade-off
+  (a single failed auth pinning ~33% of the per-frontend buffer).
+
 - **Pattern-trie segment regex anchoring with capture propagation**: every
   segment-level regex inserted into the routing trie is now wrapped with
   `\A...\z` at insert time so a pattern like `cdn[0-9]+` matches `cdn1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,18 +21,24 @@ session path the upstream PRs targeted, so every running session benefits.
   it for the matching status code on requests routed to that cluster. The
   deprecated `optional CustomHttpAnswers http_answers` field is preserved on
   the wire so existing state files round-trip (the runtime merges both for
-  one minor). Each map value is **either a filesystem path or an
-  `inline:<body>` literal** — the inline form skips disk I/O entirely,
-  useful for short canned responses, secrets-free containers, and test
-  rigs (`sozu cluster add --answer 503='inline:HTTP/1.1 503 ...'`,
-  `[listeners.https.answers] "503" = "inline:..."`). The new template
+  one minor). Each map value is **either an inline literal body (the
+  default) or `file://<path>` to load off disk** — the inline form
+  skips disk I/O entirely, useful for short canned responses,
+  secrets-free containers, and test rigs
+  (`sozu cluster add --answer 503='HTTP/1.1 503 ...'` or
+  `[listeners.https.answers] "503" = "..."` for inline,
+  `--answer 503=file:///etc/sozu/503.http` for path). The new template
   engine (`lib/src/protocol/kawa_h1/answers.rs`) supports variable
   substitution via `%ROUTE`, `%REQUEST_ID`, `%CLUSTER_ID`, `%BACKEND_ID`,
   `%DURATION`, `%CAPACITY`, `%PHASE`, `%SUCCESSFULLY_PARSED`,
   `%PARTIALLY_PARSED`, `%INVALID` (repeatable), `%REDIRECT_LOCATION`,
   `%MESSAGE`, `%TEMPLATE_NAME` (single-use), `%WWW_AUTHENTICATE`
-  (header-only, elides the line when the realm is empty), and an
-  auto-injected `Content-Length`. Per-cluster overrides hot-swap via
+  (header-only, elides the line when the realm is empty). When the
+  template carries a literal `Content-Length`, the engine recomputes
+  the value from the actual rendered body size after `%`-substitutions
+  — closing the RFC 9110 §8.6 / RFC 7230 §3.3.2 anti-smuggling drift.
+  Templates that omit `Content-Length` keep their byte-for-byte shape;
+  nothing is synthesised. Per-cluster overrides hot-swap via
   `AddCluster` / `RemoveCluster`. HAProxy parallel: `errorfile NNN /path`.
 
 - **URL rewrite, redirect, and per-frontend custom headers**: new

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1967,6 +1967,7 @@ dependencies = [
 name = "sozu-e2e"
 version = "1.1.1"
 dependencies = [
+ "base64 0.22.1",
  "flate2",
  "futures",
  "http-body-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,7 +741,7 @@ version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "byteorder",
  "crossbeam-channel",
  "flate2",
@@ -1984,6 +1990,7 @@ name = "sozu-lib"
 version = "1.1.1"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "cookie-factory",
  "criterion",
  "hdrhistogram",
@@ -2008,6 +2015,7 @@ dependencies = [
  "slab",
  "socket2",
  "sozu-command-lib",
+ "subtle",
  "thiserror 2.0.18",
  "time",
  "tiny_http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2" # consistent with rust edition 2024, see https://doc.rust-lang.or
 
 [workspace.dependencies]
 anyhow = "^1.0.102"
+base64 = "^0.22.1"
 clap = "^4.6.1"
 cookie-factory = "^0.3.3"
 flate2 = "^1.1"
@@ -52,6 +53,7 @@ slab = "^0.4.12"
 socket2 = "^0.6.3"
 sozu-command-lib = { version = "^1.1.1", path = "command" }
 sozu-lib = { version = "^1.1.1", path = "lib" }
+subtle = "^2.6.1"
 tempfile = "^3.27.0"
 termion = "^4.0.6"
 thiserror = "^2.0.18"

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -324,7 +324,7 @@ pub enum ClusterCmd {
         authorized_hash: Vec<String>,
         #[clap(
             long = "answer",
-            help = "Per-status HTTP answer template for this cluster, formatted as <code>=<path-to-template>. Repeatable (e.g. --answer 503=/etc/sozu/503.http)."
+            help = "Per-status HTTP answer template for this cluster. Format: <code>=<path-to-template> for an on-disk template, or <code>=inline:<body> for an inline literal (the body after `inline:` is taken verbatim, no file I/O). Repeatable. Examples: --answer 503=/etc/sozu/503.http , --answer 503='inline:HTTP/1.1 503 Service Unavailable\\r\\n\\r\\nbusy'."
         )]
         answer: Vec<String>,
     },

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -307,6 +307,26 @@ pub enum ClusterCmd {
             help = "Use HTTP/2 for backend connections to this cluster"
         )]
         http2: bool,
+        #[clap(
+            long = "https-redirect-port",
+            help = "Port to use when building the Location header for an https_redirect (defaults to the listener's effective HTTPS port)"
+        )]
+        https_redirect_port: Option<u32>,
+        #[clap(
+            long = "www-authenticate",
+            help = "Realm string emitted in the WWW-Authenticate header on a 401 response (e.g. 'Basic realm=\"sozu\"')"
+        )]
+        www_authenticate: Option<String>,
+        #[clap(
+            long = "authorized-hash",
+            help = "Authorized credential, formatted as 'username:hex(sha256(password))'. Repeatable. Generate with: printf 'user:pass' | sed -n 's/^[^:]*://p' | { read p; printf 'user:%s' \"$(printf %s \"$p\" | sha256sum | cut -d' ' -f1)\"; }"
+        )]
+        authorized_hash: Vec<String>,
+        #[clap(
+            long = "answer",
+            help = "Per-status HTTP answer template for this cluster, formatted as <code>=<path-to-template>. Repeatable (e.g. --answer 503=/etc/sozu/503.http)."
+        )]
+        answer: Vec<String>,
     },
     #[clap(
         name = "h2",

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -475,6 +475,46 @@ pub enum HttpFrontendCmd {
         method: Option<String>,
         #[clap(long = "tags", help = "Specify tag (key-value pair) to apply on front-end (example: 'key=value, other-key=other-value')", value_parser = parse_tags)]
         tags: Option<BTreeMap<String, String>>,
+        #[clap(
+            long = "redirect",
+            help = "Redirect policy. Possible values: 'forward' (default), 'permanent', 'unauthorized'"
+        )]
+        redirect: Option<String>,
+        #[clap(
+            long = "redirect-scheme",
+            help = "Scheme for permanent-redirect Location URLs. Possible values: 'use-same' (default), 'use-http', 'use-https'"
+        )]
+        redirect_scheme: Option<String>,
+        #[clap(
+            long = "redirect-template",
+            help = "Optional template applied when emitting a permanent redirect. Supports %REDIRECT_LOCATION / %STATUS_CODE."
+        )]
+        redirect_template: Option<String>,
+        #[clap(
+            long = "rewrite-host",
+            help = "Rewrite request host with this template. Supports $HOST[n] / $PATH[n] capture placeholders."
+        )]
+        rewrite_host: Option<String>,
+        #[clap(
+            long = "rewrite-path",
+            help = "Rewrite request path with this template. Same grammar as --rewrite-host."
+        )]
+        rewrite_path: Option<String>,
+        #[clap(
+            long = "rewrite-port",
+            help = "Override the port in the rewritten URL (1..=65535)."
+        )]
+        rewrite_port: Option<u32>,
+        #[clap(
+            long = "required-auth",
+            help = "Require a valid Authorization: Basic header on this frontend."
+        )]
+        required_auth: bool,
+        #[clap(
+            long = "header",
+            help = "Header mutation, format: <position>=<name>=<value>. Position is 'request', 'response', or 'both'. Empty <value> deletes the header (HAProxy del-header parity). Repeatable."
+        )]
+        header: Vec<String>,
     },
     #[clap(name = "remove")]
     Remove {

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -324,7 +324,7 @@ pub enum ClusterCmd {
         authorized_hash: Vec<String>,
         #[clap(
             long = "answer",
-            help = "Per-status HTTP answer template for this cluster. Format: <code>=<path-to-template> for an on-disk template, or <code>=inline:<body> for an inline literal (the body after `inline:` is taken verbatim, no file I/O). Repeatable. Examples: --answer 503=/etc/sozu/503.http , --answer 503='inline:HTTP/1.1 503 Service Unavailable\\r\\n\\r\\nbusy'."
+            help = "Per-status HTTP answer template for this cluster. Format: <code>=<body> for an inline literal (the value is taken verbatim, no disk I/O), or <code>=file://<path> to load the body off disk. Repeatable. Examples: --answer 503='HTTP/1.1 503 Service Unavailable\\r\\n\\r\\nbusy' , --answer 503=file:///etc/sozu/503.http ."
         )]
         answer: Vec<String>,
     },

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -512,7 +512,7 @@ pub enum HttpFrontendCmd {
         required_auth: bool,
         #[clap(
             long = "header",
-            help = "Header mutation, format: <position>=<name>=<value>. Position is 'request', 'response', or 'both'. Empty <value> deletes the header (HAProxy del-header parity). Repeatable."
+            help = "Header mutation, format: <position>=<name>=<value>. Position is 'request', 'response', or 'both'. Empty <value> deletes the header (HAProxy del-header parity). Repeatable. To replace a header, pass it twice: first with an empty value (deletes the existing one), then with the new value (sets it). The runtime applies all deletes before any sets."
         )]
         header: Vec<String>,
     },

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -153,6 +153,10 @@ impl CommandManager {
                 expect_proxy,
                 load_balancing_policy,
                 http2,
+                https_redirect_port,
+                www_authenticate,
+                authorized_hash,
+                answer,
             } => {
                 let proxy_protocol = match (send_proxy, expect_proxy) {
                     (true, true) => Some(ProxyProtocolConfig::RelayHeader),
@@ -160,6 +164,62 @@ impl CommandManager {
                     (false, true) => Some(ProxyProtocolConfig::ExpectHeader),
                     _ => None,
                 };
+
+                // Validate every authorized hash matches `<user>:<hex64>`
+                // before sending so a typo (missing colon, lowercase off,
+                // non-hex chars) surfaces here with a friendly message
+                // rather than silently rejecting traffic on the worker.
+                // Inline check: split on first `:`, then assert the right
+                // half is exactly 64 lowercase hex digits.
+                fn looks_like_authorized_hash(s: &str) -> bool {
+                    let Some((user, hex)) = s.split_once(':') else {
+                        return false;
+                    };
+                    !user.is_empty()
+                        && user
+                            .bytes()
+                            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+                        && hex.len() == 64
+                        && hex
+                            .bytes()
+                            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+                }
+                for hash in &authorized_hash {
+                    if !looks_like_authorized_hash(hash) {
+                        return Err(CtlError::ArgsNeeded(
+                            "valid `username:hex(sha256(password))`".to_string(),
+                            format!(
+                                "got {hash:?}; produce one with: \
+                                 printf '<password>' | sha256sum"
+                            ),
+                        ));
+                    }
+                }
+
+                // Read each `--answer code=path` template body off disk and
+                // collect into the cluster's `answers` map. The right-hand
+                // side is a path, mirroring the legacy `--answer-503`
+                // flow (see `read_http_answer_file` callers above).
+                let mut answers_map = std::collections::BTreeMap::new();
+                for entry in &answer {
+                    let (code, path) = match entry.split_once('=') {
+                        Some((c, p)) if !p.is_empty() => (c, p),
+                        _ => {
+                            return Err(CtlError::ArgsNeeded(
+                                "<code>=<path>".to_string(),
+                                format!("got {entry:?}"),
+                            ));
+                        }
+                    };
+                    let body = std::fs::read_to_string(path).map_err(|e| {
+                        CtlError::ArgsNeeded(
+                            "readable template path".to_string(),
+                            format!("{path:?}: {e}"),
+                        )
+                    })?;
+                    answers_map.insert(code.to_owned(), body);
+                }
+
                 self.send_request(
                     RequestType::AddCluster(Cluster {
                         cluster_id: id,
@@ -168,6 +228,10 @@ impl CommandManager {
                         proxy_protocol: proxy_protocol.map(|pp| pp as i32),
                         load_balancing: load_balancing_policy as i32,
                         http2: if http2 { Some(true) } else { None },
+                        answers: answers_map,
+                        https_redirect_port,
+                        authorized_hashes: authorized_hash,
+                        www_authenticate,
                         ..Default::default()
                     })
                     .into(),

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -277,6 +277,7 @@ impl CommandManager {
                     method,
                     position: RulePosition::Tree.into(),
                     tags: tags.unwrap_or_default(),
+                    ..Default::default()
                 })
                 .into(),
             ),
@@ -322,6 +323,7 @@ impl CommandManager {
                     method,
                     position: RulePosition::Tree.into(),
                     tags: tags.unwrap_or_default(),
+                    ..Default::default()
                 })
                 .into(),
             ),
@@ -731,6 +733,7 @@ impl CommandManager {
             h2_graceful_shutdown_deadline_seconds,
             h2_max_window_update_stream0_per_window,
             sozu_id_header,
+            ..Default::default()
         };
         self.send_request(RequestType::UpdateHttpListener(patch).into())
     }
@@ -853,6 +856,7 @@ impl CommandManager {
             h2_graceful_shutdown_deadline_seconds,
             h2_max_window_update_stream0_per_window,
             sozu_id_header,
+            ..Default::default()
         };
         self.send_request(RequestType::UpdateHttpsListener(patch).into())
     }

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -195,23 +195,24 @@ impl CommandManager {
                     }
                 }
 
-                // Resolve each `--answer code=value` entry. The right-hand
-                // side is either a filesystem path or the literal
-                // template body when prefixed with `inline:`. Funnels
-                // through the canonical `resolve_answer_source` helper so
-                // the CLI and TOML loader stay in sync.
+                // Resolve each `--answer code=value` entry. The
+                // right-hand side is the literal template body by
+                // default; `file://<path>` opts into reading the body
+                // off disk. Funnels through the canonical
+                // `resolve_answer_source` helper so the CLI and TOML
+                // loader stay in sync.
                 //
                 // Cluster-level entries override the listener-level
                 // `answers` map (which itself is the global default for
                 // every status code on that listener). Both layers
-                // accept the same `path | inline:<body>` value form.
+                // accept the same `<body> | file://<path>` value form.
                 let mut answers_map = std::collections::BTreeMap::new();
                 for entry in &answer {
                     let (code, value) = match entry.split_once('=') {
                         Some((c, v)) if !v.is_empty() => (c, v),
                         _ => {
                             return Err(CtlError::ArgsNeeded(
-                                "<code>=<path|inline:body>".to_string(),
+                                "<code>=<body>|file://<path>".to_string(),
                                 format!("got {entry:?}"),
                             ));
                         }
@@ -219,7 +220,7 @@ impl CommandManager {
                     let body =
                         sozu_command_lib::config::resolve_answer_source(value).map_err(|e| {
                             CtlError::ArgsNeeded(
-                                "readable template path or inline:<body>".to_string(),
+                                "literal body or readable file://<path>".to_string(),
                                 format!("{value:?}: {e}"),
                             )
                         })?;

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -195,27 +195,34 @@ impl CommandManager {
                     }
                 }
 
-                // Read each `--answer code=path` template body off disk and
-                // collect into the cluster's `answers` map. The right-hand
-                // side is a path, mirroring the legacy `--answer-503`
-                // flow (see `read_http_answer_file` callers above).
+                // Resolve each `--answer code=value` entry. The right-hand
+                // side is either a filesystem path or the literal
+                // template body when prefixed with `inline:`. Funnels
+                // through the canonical `resolve_answer_source` helper so
+                // the CLI and TOML loader stay in sync.
+                //
+                // Cluster-level entries override the listener-level
+                // `answers` map (which itself is the global default for
+                // every status code on that listener). Both layers
+                // accept the same `path | inline:<body>` value form.
                 let mut answers_map = std::collections::BTreeMap::new();
                 for entry in &answer {
-                    let (code, path) = match entry.split_once('=') {
-                        Some((c, p)) if !p.is_empty() => (c, p),
+                    let (code, value) = match entry.split_once('=') {
+                        Some((c, v)) if !v.is_empty() => (c, v),
                         _ => {
                             return Err(CtlError::ArgsNeeded(
-                                "<code>=<path>".to_string(),
+                                "<code>=<path|inline:body>".to_string(),
                                 format!("got {entry:?}"),
                             ));
                         }
                     };
-                    let body = std::fs::read_to_string(path).map_err(|e| {
-                        CtlError::ArgsNeeded(
-                            "readable template path".to_string(),
-                            format!("{path:?}: {e}"),
-                        )
-                    })?;
+                    let body =
+                        sozu_command_lib::config::resolve_answer_source(value).map_err(|e| {
+                            CtlError::ArgsNeeded(
+                                "readable template path or inline:<body>".to_string(),
+                                format!("{value:?}: {e}"),
+                            )
+                        })?;
                     answers_map.insert(code.to_owned(), body);
                 }
 

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -1236,15 +1236,22 @@ fn build_http_frontend_add(cmd: HttpFrontendCmd) -> Result<RequestHttpFrontend, 
                 ));
             }
         };
-        // Reject CRLF / NUL / other C0 controls in either field. CRLF in
-        // the value would let an operator (or a misuse via piped CLI args)
-        // splice arbitrary header / request lines into the H1 wire on the
-        // backend side (CWE-113 / request smuggling). The H2 emission path
-        // filters at runtime; the H1 path serialises raw, so we reject at
-        // CLI parse time as a defense in depth and to give a clear error.
-        if header_value_has_control_byte(key.as_bytes()) {
+        // Reject CRLF / NUL / other C0 controls. CRLF in the value would
+        // let an operator (or a misuse via piped CLI args) splice
+        // arbitrary header / request lines into the H1 wire on the
+        // backend side (CWE-113 / request smuggling). The H2 emission
+        // path filters values at runtime; the H1 path serialises raw,
+        // so we reject at CLI parse time as a defense in depth and to
+        // give a clear error.
+        //
+        // The KEY check is stricter than the value check — RFC 9110
+        // §5.1 field names follow the `token` grammar (no HTAB, no SP,
+        // no C0 controls); reusing the value-side predicate would let
+        // `Host\t` slip through and produce an invalid header line on
+        // the wire (security review follow-up on `da845c71`).
+        if !is_valid_header_name(key.as_bytes()) {
             return Err(CtlError::ArgsNeeded(
-                "header key without control characters (NUL / CR / LF / other C0)".to_owned(),
+                "header key matching RFC 9110 token grammar (alphanumeric or one of !#$%&'*+-.^_`|~)".to_owned(),
                 format!("--header[{index}] key={key:?}"),
             ));
         }
@@ -1280,16 +1287,45 @@ fn build_http_frontend_add(cmd: HttpFrontendCmd) -> Result<RequestHttpFrontend, 
     })
 }
 
-/// Reject NUL / CR / LF / other C0 controls in a header key or value.
-/// Mirrors `command::config::header_bytes_contain_forbidden_controls`
-/// (and `lib::protocol::mux::converter::call`'s runtime filter) so the
-/// CLI rejects header injection vectors at parse time rather than
-/// letting them slip through to the H1 emission path, which serialises
-/// raw bytes onto the backend wire.
+/// Reject NUL / CR / LF / other C0 controls in a header value. HTAB
+/// (`\x09`) is permitted per RFC 9110 §5.5 and matches the runtime
+/// filter at `lib::protocol::mux::converter::call`.
 fn header_value_has_control_byte(bytes: &[u8]) -> bool {
     bytes
         .iter()
         .any(|&b| matches!(b, 0x00..=0x08 | 0x0A..=0x1F | 0x7F))
+}
+
+/// Header field names follow the RFC 9110 §5.1 `token` grammar: a
+/// non-empty sequence of `tchar` bytes (alphanumeric plus a closed
+/// punctuation list). HTAB and SP are NOT tchar — they belong to
+/// field-VALUE grammar. Reusing `header_value_has_control_byte` for
+/// keys would let `Host\t` slip through and produce an invalid header
+/// line on the H1 backend wire.
+fn is_valid_header_name(bytes: &[u8]) -> bool {
+    if bytes.is_empty() {
+        return false;
+    }
+    bytes.iter().all(|&b| {
+        b.is_ascii_alphanumeric()
+            || matches!(
+                b,
+                b'!' | b'#'
+                    | b'$'
+                    | b'%'
+                    | b'&'
+                    | b'\''
+                    | b'*'
+                    | b'+'
+                    | b'-'
+                    | b'.'
+                    | b'^'
+                    | b'_'
+                    | b'`'
+                    | b'|'
+                    | b'~'
+            )
+    })
 }
 
 /// Validate that `s` matches the canonical `<user>:<hex(sha256)>` form

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -1236,6 +1236,24 @@ fn build_http_frontend_add(cmd: HttpFrontendCmd) -> Result<RequestHttpFrontend, 
                 ));
             }
         };
+        // Reject CRLF / NUL / other C0 controls in either field. CRLF in
+        // the value would let an operator (or a misuse via piped CLI args)
+        // splice arbitrary header / request lines into the H1 wire on the
+        // backend side (CWE-113 / request smuggling). The H2 emission path
+        // filters at runtime; the H1 path serialises raw, so we reject at
+        // CLI parse time as a defense in depth and to give a clear error.
+        if header_value_has_control_byte(key.as_bytes()) {
+            return Err(CtlError::ArgsNeeded(
+                "header key without control characters (NUL / CR / LF / other C0)".to_owned(),
+                format!("--header[{index}] key={key:?}"),
+            ));
+        }
+        if header_value_has_control_byte(val.as_bytes()) {
+            return Err(CtlError::ArgsNeeded(
+                "header value without control characters (NUL / CR / LF / other C0)".to_owned(),
+                format!("--header[{index}] val={val:?}"),
+            ));
+        }
         headers_proto.push(sozu_command_lib::proto::command::Header {
             position: position_proto,
             key: key.to_owned(),
@@ -1260,6 +1278,18 @@ fn build_http_frontend_add(cmd: HttpFrontendCmd) -> Result<RequestHttpFrontend, 
         required_auth: if required_auth { Some(true) } else { None },
         headers: headers_proto,
     })
+}
+
+/// Reject NUL / CR / LF / other C0 controls in a header key or value.
+/// Mirrors `command::config::header_bytes_contain_forbidden_controls`
+/// (and `lib::protocol::mux::converter::call`'s runtime filter) so the
+/// CLI rejects header injection vectors at parse time rather than
+/// letting them slip through to the H1 emission path, which serialises
+/// raw bytes onto the backend wire.
+fn header_value_has_control_byte(bytes: &[u8]) -> bool {
+    bytes
+        .iter()
+        .any(|&b| matches!(b, 0x00..=0x08 | 0x0A..=0x1F | 0x7F))
 }
 
 /// Validate that `s` matches the canonical `<user>:<hex(sha256)>` form

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -322,28 +322,10 @@ impl CommandManager {
 
     pub fn http_frontend_command(&mut self, cmd: HttpFrontendCmd) -> Result<(), CtlError> {
         match cmd {
-            HttpFrontendCmd::Add {
-                hostname,
-                path_prefix,
-                path_regex,
-                path_equals,
-                address,
-                method,
-                cluster_id: route,
-                tags,
-            } => self.send_request(
-                RequestType::AddHttpFrontend(RequestHttpFrontend {
-                    cluster_id: route.into(),
-                    address: address.into(),
-                    hostname,
-                    path: PathRule::from_cli_options(path_prefix, path_regex, path_equals),
-                    method,
-                    position: RulePosition::Tree.into(),
-                    tags: tags.unwrap_or_default(),
-                    ..Default::default()
-                })
-                .into(),
-            ),
+            HttpFrontendCmd::Add { .. } => {
+                let frontend = build_http_frontend_add(cmd)?;
+                self.send_request(RequestType::AddHttpFrontend(frontend).into())
+            }
             HttpFrontendCmd::Remove {
                 hostname,
                 path_prefix,
@@ -368,28 +350,10 @@ impl CommandManager {
 
     pub fn https_frontend_command(&mut self, cmd: HttpFrontendCmd) -> Result<(), CtlError> {
         match cmd {
-            HttpFrontendCmd::Add {
-                hostname,
-                path_prefix,
-                path_regex,
-                path_equals,
-                address,
-                method,
-                cluster_id: route,
-                tags,
-            } => self.send_request(
-                RequestType::AddHttpsFrontend(RequestHttpFrontend {
-                    cluster_id: route.into(),
-                    address: address.into(),
-                    hostname,
-                    path: PathRule::from_cli_options(path_prefix, path_regex, path_equals),
-                    method,
-                    position: RulePosition::Tree.into(),
-                    tags: tags.unwrap_or_default(),
-                    ..Default::default()
-                })
-                .into(),
-            ),
+            HttpFrontendCmd::Add { .. } => {
+                let frontend = build_http_frontend_add(cmd)?;
+                self.send_request(RequestType::AddHttpsFrontend(frontend).into())
+            }
             HttpFrontendCmd::Remove {
                 hostname,
                 path_prefix,
@@ -1160,6 +1124,142 @@ fn find_cluster_configuration(content_type: ContentType, cluster_id: &str) -> Op
         }
         _ => None,
     }
+}
+
+/// Build a [`RequestHttpFrontend`] from the policy fields collected by
+/// `HttpFrontendCmd::Add`. The same builder feeds both
+/// `RequestType::AddHttpFrontend` and `RequestType::AddHttpsFrontend` so
+/// the two `frontend {http,https} add` paths stay in lock-step.
+///
+/// Validates each policy field up front and returns a typed
+/// [`CtlError::ArgsNeeded`] on a malformed input rather than letting a
+/// silent default reach the worker.
+fn build_http_frontend_add(cmd: HttpFrontendCmd) -> Result<RequestHttpFrontend, CtlError> {
+    let HttpFrontendCmd::Add {
+        hostname,
+        path_prefix,
+        path_regex,
+        path_equals,
+        address,
+        method,
+        cluster_id: route,
+        tags,
+        redirect,
+        redirect_scheme,
+        redirect_template,
+        rewrite_host,
+        rewrite_path,
+        rewrite_port,
+        required_auth,
+        header,
+    } = cmd
+    else {
+        return Err(CtlError::ArgsNeeded(
+            "HttpFrontendCmd::Add".to_owned(),
+            "got non-Add variant — should be unreachable".to_owned(),
+        ));
+    };
+
+    // Map `--redirect <forward|permanent|unauthorized>` onto the proto
+    // enum. Unknown / mistyped value surfaces a typed error here.
+    let redirect_proto = match redirect.as_deref() {
+        None => None,
+        Some(s) => Some(match s.to_ascii_lowercase().as_str() {
+            "forward" => sozu_command_lib::proto::command::RedirectPolicy::Forward as i32,
+            "permanent" => sozu_command_lib::proto::command::RedirectPolicy::Permanent as i32,
+            "unauthorized" => sozu_command_lib::proto::command::RedirectPolicy::Unauthorized as i32,
+            other => {
+                return Err(CtlError::ArgsNeeded(
+                    "redirect in {forward, permanent, unauthorized}".to_owned(),
+                    format!("got --redirect={other:?}"),
+                ));
+            }
+        }),
+    };
+
+    let redirect_scheme_proto = match redirect_scheme.as_deref() {
+        None => None,
+        Some(s) => Some(match s.to_ascii_lowercase().as_str() {
+            "use-same" | "use_same" => {
+                sozu_command_lib::proto::command::RedirectScheme::UseSame as i32
+            }
+            "use-http" | "use_http" => {
+                sozu_command_lib::proto::command::RedirectScheme::UseHttp as i32
+            }
+            "use-https" | "use_https" => {
+                sozu_command_lib::proto::command::RedirectScheme::UseHttps as i32
+            }
+            other => {
+                return Err(CtlError::ArgsNeeded(
+                    "redirect-scheme in {use-same, use-http, use-https}".to_owned(),
+                    format!("got --redirect-scheme={other:?}"),
+                ));
+            }
+        }),
+    };
+
+    if let Some(port) = rewrite_port {
+        if port == 0 || port > u16::MAX as u32 {
+            return Err(CtlError::ArgsNeeded(
+                "TCP port in 1..=65535".to_owned(),
+                format!("got rewrite_port={port}"),
+            ));
+        }
+    }
+
+    // Each `--header` entry is `<position>=<key>=<value>`. Split on the
+    // first two `=` so the value may contain further `=` bytes (common
+    // in cookie / quoted strings). Empty value preserves HAProxy
+    // `del-header` parity.
+    let mut headers_proto = Vec::with_capacity(header.len());
+    for (index, raw) in header.iter().enumerate() {
+        let (position, rest) = raw.split_once('=').ok_or_else(|| {
+            CtlError::ArgsNeeded(
+                "<position>=<name>=<value>".to_owned(),
+                format!("--header[{index}] = {raw:?} (missing first `=`)"),
+            )
+        })?;
+        let (key, val) = rest.split_once('=').ok_or_else(|| {
+            CtlError::ArgsNeeded(
+                "<position>=<name>=<value>".to_owned(),
+                format!("--header[{index}] = {raw:?} (missing second `=`)"),
+            )
+        })?;
+        let position_proto = match position.to_ascii_lowercase().as_str() {
+            "request" => sozu_command_lib::proto::command::HeaderPosition::Request as i32,
+            "response" => sozu_command_lib::proto::command::HeaderPosition::Response as i32,
+            "both" => sozu_command_lib::proto::command::HeaderPosition::Both as i32,
+            other => {
+                return Err(CtlError::ArgsNeeded(
+                    "header position in {request, response, both}".to_owned(),
+                    format!("--header[{index}] position={other:?}"),
+                ));
+            }
+        };
+        headers_proto.push(sozu_command_lib::proto::command::Header {
+            position: position_proto,
+            key: key.to_owned(),
+            val: val.to_owned(),
+        });
+    }
+
+    Ok(RequestHttpFrontend {
+        cluster_id: route.into(),
+        address: address.into(),
+        hostname,
+        path: PathRule::from_cli_options(path_prefix, path_regex, path_equals),
+        method,
+        position: RulePosition::Tree.into(),
+        tags: tags.unwrap_or_default(),
+        redirect: redirect_proto,
+        redirect_scheme: redirect_scheme_proto,
+        redirect_template,
+        rewrite_host,
+        rewrite_path,
+        rewrite_port,
+        required_auth: if required_auth { Some(true) } else { None },
+        headers: headers_proto,
+    })
 }
 
 /// Validate that `s` matches the canonical `<user>:<hex(sha256)>` form

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -169,21 +169,6 @@ impl CommandManager {
                 // before sending so a typo (missing colon, lowercase off,
                 // non-hex chars) surfaces here with a friendly message
                 // rather than silently rejecting traffic on the worker.
-                // Inline check: split on first `:`, then assert the right
-                // half is exactly 64 lowercase hex digits.
-                fn looks_like_authorized_hash(s: &str) -> bool {
-                    let Some((user, hex)) = s.split_once(':') else {
-                        return false;
-                    };
-                    !user.is_empty()
-                        && user
-                            .bytes()
-                            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
-                        && hex.len() == 64
-                        && hex
-                            .bytes()
-                            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
-                }
                 for hash in &authorized_hash {
                     if !looks_like_authorized_hash(hash) {
                         return Err(CtlError::ArgsNeeded(
@@ -192,6 +177,20 @@ impl CommandManager {
                                 "got {hash:?}; produce one with: \
                                  printf '<password>' | sha256sum"
                             ),
+                        ));
+                    }
+                }
+
+                // The proto carries `https_redirect_port` as `u32` (matches
+                // the rewrite_port shape on the frontend) but real TCP
+                // ports are 16-bit. Reject out-of-range values up front so
+                // a typo doesn't render `Location: https://host:70000/...`
+                // on the wire.
+                if let Some(port) = https_redirect_port {
+                    if port == 0 || port > u16::MAX as u32 {
+                        return Err(CtlError::ArgsNeeded(
+                            "TCP port in 1..=65535".to_string(),
+                            format!("got https_redirect_port={port}"),
                         ));
                     }
                 }
@@ -1163,6 +1162,24 @@ fn find_cluster_configuration(content_type: ContentType, cluster_id: &str) -> Op
     }
 }
 
+/// Validate that `s` matches the canonical `<user>:<hex(sha256)>` form
+/// the worker stores in `Cluster.authorized_hashes`. Equivalent to the
+/// regex `^[A-Za-z0-9_\-]+:[0-9a-f]{64}$`; inlined as bytes so we don't
+/// pull `regex` in here for a one-line validator.
+pub(crate) fn looks_like_authorized_hash(s: &str) -> bool {
+    let Some((user, hex)) = s.split_once(':') else {
+        return false;
+    };
+    !user.is_empty()
+        && user
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+        && hex.len() == 64
+        && hex
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
 /// Load the content of an HTTP-answer file path. Returns `None` if the path is
 /// `None`. Mirrors the logic in `command/src/config.rs::read_http_answer_file`.
 fn read_answer_path(path: &Option<PathBuf>) -> Result<Option<String>, CtlError> {
@@ -1330,5 +1347,43 @@ mod tests {
             find_cluster_configuration(clusters_response(vec![cluster("other", false)]), "target");
 
         assert!(found.is_none());
+    }
+
+    #[test]
+    fn accepts_canonical_user_hex64() {
+        assert!(looks_like_authorized_hash(
+            "admin:2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b"
+        ));
+    }
+
+    #[test]
+    fn rejects_missing_colon() {
+        assert!(!looks_like_authorized_hash("admin"));
+    }
+
+    #[test]
+    fn rejects_short_hex_tail() {
+        assert!(!looks_like_authorized_hash("admin:deadbeef"));
+    }
+
+    #[test]
+    fn rejects_uppercase_hex() {
+        assert!(!looks_like_authorized_hash(
+            "admin:2BB80D537B1DA3E38BD30361AA855686BDE0EACD7162FEF6A25FE97BF527A25B"
+        ));
+    }
+
+    #[test]
+    fn rejects_empty_username() {
+        assert!(!looks_like_authorized_hash(
+            ":2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b"
+        ));
+    }
+
+    #[test]
+    fn rejects_non_alnum_username() {
+        assert!(!looks_like_authorized_hash(
+            "admin user:2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b"
+        ));
     }
 }

--- a/command/build.rs
+++ b/command/build.rs
@@ -30,6 +30,16 @@ pub fn main() {
         .message_attribute("Response", "#[derive(Hash, Eq)]")
         .message_attribute("InitialState", "#[derive(Hash, Eq)]")
         .message_attribute("ProtobufAccessLog", "#[derive(Hash, Eq)]")
+        // The messages below carry at least one `map<string, string>` field
+        // (`tags`, `answers`) or a nested `Header` value. prost stops
+        // auto-deriving `Hash`/`Eq` once a map appears, and downstream code
+        // (state-diff hashing, IPC framing, request fan-out) needs both
+        // traits, so re-attach them explicitly here.
+        .message_attribute("Cluster", "#[derive(Hash, Eq)]")
+        .message_attribute("HttpListenerConfig", "#[derive(Hash, Eq)]")
+        .message_attribute("HttpsListenerConfig", "#[derive(Hash, Eq)]")
+        .message_attribute("UpdateHttpListenerConfig", "#[derive(Hash, Eq)]")
+        .message_attribute("UpdateHttpsListenerConfig", "#[derive(Hash, Eq)]")
         .enum_attribute(".", "#[serde(rename_all = \"SCREAMING_SNAKE_CASE\")]")
         .enum_attribute(
             "ResponseContent.content_type",

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -674,6 +674,11 @@ message RequestHttpFrontend {
     // Header mutations applied to requests and/or responses passing through
     // this frontend. See `Header` for delete semantics.
     repeated Header headers = 15;
+
+    // Field numbers 16-19 are reserved for the next iteration so an
+    // accidental reuse during a future migration fails at proto compile
+    // time rather than silently aliasing an old field number.
+    reserved 16 to 19;
 }
 
 message RequestTcpFrontend {
@@ -826,6 +831,11 @@ message Cluster {
     // unauthenticated request is rejected. Treated as an opaque value (no
     // template substitution). Defaults to a generic realm if unset.
     optional string www_authenticate = 12;
+
+    // Field numbers 13-19 are open for the next iteration; reserve them
+    // so an accidental reuse during a future migration fails at proto
+    // compile time rather than silently aliasing an old field number.
+    reserved 13 to 19;
 }
 
 enum LoadBalancingAlgorithms {

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -674,11 +674,6 @@ message RequestHttpFrontend {
     // Header mutations applied to requests and/or responses passing through
     // this frontend. See `Header` for delete semantics.
     repeated Header headers = 15;
-
-    // Field numbers 16-19 are reserved for the next iteration so an
-    // accidental reuse during a future migration fails at proto compile
-    // time rather than silently aliasing an old field number.
-    reserved 16 to 19;
 }
 
 message RequestTcpFrontend {
@@ -831,11 +826,6 @@ message Cluster {
     // unauthenticated request is rejected. Treated as an opaque value (no
     // template substitution). Defaults to a generic realm if unset.
     optional string www_authenticate = 12;
-
-    // Field numbers 13-19 are open for the next iteration; reserve them
-    // so an accidental reuse during a future migration fails at proto
-    // compile time rather than silently aliasing an old field number.
-    reserved 13 to 19;
 }
 
 enum LoadBalancingAlgorithms {

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -147,6 +147,9 @@ message UpdateHttpListenerConfig {
     optional uint32 connect_timeout = 7;
     // max time to send a complete request, in seconds
     optional uint32 request_timeout = 8;
+    // DEPRECATED: per-status answer message. Prefer the `answers` map at
+    // field 38. Kept on the wire so older managers can still patch a running
+    // listener for one minor; on the worker side both fields are merged.
     optional CustomHttpAnswers http_answers = 9;
 
     // H2 flood thresholds — see HttpListenerConfig for semantics & CVE refs.
@@ -187,6 +190,12 @@ message UpdateHttpListenerConfig {
     optional uint32 h2_max_window_update_stream0_per_window = 36;
     // Name of the correlation header injected per request (e.g. "Sozu-Id")
     optional string sozu_id_header                   = 37;
+    // Per-status HTTP answer template bodies, keyed by HTTP status code
+    // (e.g. "503"). Replaces the per-field shape of `CustomHttpAnswers` (field
+    // 9). An entry with an empty value is treated as "preserve current"; an
+    // entry with a non-empty value replaces the listener's stored template
+    // for that status. To clear a status template, recreate the listener.
+    map<string, string> answers                     = 38;
 }
 
 // Partial-update patch for a running HTTPS listener.
@@ -211,6 +220,9 @@ message UpdateHttpsListenerConfig {
     optional uint32 connect_timeout = 7;
     // max time to send a complete request, in seconds
     optional uint32 request_timeout = 8;
+    // DEPRECATED: per-status answer message. Prefer the `answers` map at
+    // field 38. Kept on the wire so older managers can still patch a running
+    // listener for one minor; on the worker side both fields are merged.
     optional CustomHttpAnswers http_answers = 9;
 
     // ALPN protocols to advertise during TLS handshake.
@@ -261,6 +273,12 @@ message UpdateHttpsListenerConfig {
     optional uint32 h2_max_window_update_stream0_per_window = 36;
     // Name of the correlation header injected per request (e.g. "Sozu-Id")
     optional string sozu_id_header                   = 37;
+    // Per-status HTTP answer template bodies, keyed by HTTP status code
+    // (e.g. "503"). Replaces the per-field shape of `CustomHttpAnswers` (field
+    // 9). An entry with an empty value is treated as "preserve current"; an
+    // entry with a non-empty value replaces the listener's stored template
+    // for that status. To clear a status template, recreate the listener.
+    map<string, string> answers                     = 38;
 }
 
 // Partial-update patch for a running TCP listener.
@@ -297,6 +315,9 @@ message HttpListenerConfig {
     required uint32 request_timeout = 10 [default = 10];
     // wether the listener is actively listening on its socket
     required bool active = 11 [default = false];
+    // DEPRECATED: per-status answer message. Prefer the `answers` map at
+    // field 31. Kept on the wire so legacy state files round-trip cleanly;
+    // workers populate both fields and treat them as equivalent on read.
     optional CustomHttpAnswers http_answers = 12;
     // H2 flood detection thresholds (CVE mitigations).
     // All are optional; when absent, built-in defaults are used.
@@ -365,6 +386,11 @@ message HttpListenerConfig {
     // response to carry the per-request ULID. Default: "Sozu-Id". Operators
     // who want to rebrand can set e.g. "X-Edge-Id" or "X-Request-Trace".
     optional string sozu_id_header = 30;
+    // Per-status HTTP answer template bodies, keyed by HTTP status code
+    // (e.g. "404", "503"). Replaces the per-field shape of `CustomHttpAnswers`
+    // (field 12). The new field is populated alongside `http_answers` so
+    // legacy state files round-trip; new code should read this map.
+    map<string, string> answers = 31;
 }
 
 // details of an HTTPS listener
@@ -396,6 +422,9 @@ message HttpsListenerConfig {
     // The tickets allow the client to resume a session. This protects the client
     // agains session tracking. Defaults to 4.
     required uint64 send_tls13_tickets = 20;
+    // DEPRECATED: per-status answer message. Prefer the `answers` map at
+    // field 43. Kept on the wire so legacy state files round-trip cleanly;
+    // workers populate both fields and treat them as equivalent on read.
     optional CustomHttpAnswers http_answers = 21;
     // ALPN protocols to advertise during TLS handshake, in order of preference.
     // Valid values: "h2", "http/1.1". Defaults to ["h2", "http/1.1"].
@@ -479,6 +508,11 @@ message HttpsListenerConfig {
     // response to carry the per-request ULID. Default: "Sozu-Id". Operators
     // who want to rebrand can set e.g. "X-Edge-Id" or "X-Request-Trace".
     optional string sozu_id_header = 42;
+    // Per-status HTTP answer template bodies, keyed by HTTP status code
+    // (e.g. "404", "503"). Replaces the per-field shape of `CustomHttpAnswers`
+    // (field 21). The new field is populated alongside `http_answers` so
+    // legacy state files round-trip; new code should read this map.
+    map<string, string> answers = 43;
 }
 
 // details of an TCP listener
@@ -556,6 +590,51 @@ message ListenersList {
     map<string, TcpListenerConfig> tcp_listeners = 3;
 }
 
+// Frontend-level redirect policy. Mirrors HAProxy's
+// `http-request redirect|deny|auth` directives.
+// FORWARD routes to the backend (default).
+// PERMANENT returns 301 with a `Location` header derived from
+// `redirect_scheme`, optional `rewrite_*` fields, and `cluster.https_redirect_port`.
+// UNAUTHORIZED returns 401 with `WWW-Authenticate: Basic realm=...`
+// using `cluster.www_authenticate`; suitable for blanket deny-by-default
+// routes that still want to surface a login prompt.
+enum RedirectPolicy {
+    FORWARD = 0;
+    PERMANENT = 1;
+    UNAUTHORIZED = 2;
+}
+
+// Scheme to use when building the `Location` header for a permanent redirect.
+// USE_SAME preserves the request scheme (default), USE_HTTP forces `http://`,
+// USE_HTTPS forces `https://`.
+enum RedirectScheme {
+    USE_SAME = 0;
+    USE_HTTP = 1;
+    USE_HTTPS = 2;
+}
+
+// Where a `Header` mutation applies. `BOTH` applies the same edit on the
+// request side (before backend connect) and the response side (before kawa
+// preparation). Mirrors HAProxy `http-request set-header` /
+// `http-response set-header` parity.
+enum HeaderPosition {
+    REQUEST = 1;
+    RESPONSE = 2;
+    BOTH = 3;
+}
+
+// A single header mutation applied to a request, response, or both.
+//
+// An empty `val` deletes the header by name (HAProxy `del-header` parity).
+// A non-empty `val` performs a set/replace; a header with the same name is
+// overwritten. Header names are matched case-insensitively per RFC 9110 §5.1.
+message Header {
+    required HeaderPosition position = 1;
+    required string key = 2;
+    // Empty `val` deletes the header by name (HAProxy `del-header` parity).
+    required string val = 3;
+}
+
 // An HTTP or HTTPS frontend, as order to, or received from, Sōzu
 message RequestHttpFrontend {
     optional string cluster_id = 1;
@@ -566,6 +645,29 @@ message RequestHttpFrontend {
     required RulePosition position = 6 [default = TREE];
     // custom tags to identify the frontend in the access logs
     map<string, string> tags = 7;
+    // Redirect policy for this frontend. Default `FORWARD` (no redirect).
+    optional RedirectPolicy redirect = 8 [default = FORWARD];
+    // When true, requests routed through this frontend must carry a valid
+    // `Authorization: Basic <user:pass>` header whose hash matches one of
+    // `cluster.authorized_hashes`. Default: false.
+    optional bool required_auth = 9;
+    // Scheme to use when emitting a 301 `Location` header. Default `USE_SAME`
+    // (preserve the request scheme).
+    optional RedirectScheme redirect_scheme = 10 [default = USE_SAME];
+    // Optional template applied when emitting a permanent redirect. Supports
+    // `%REDIRECT_LOCATION` / `%STATUS_CODE` etc. — see `doc/configure.md`.
+    optional string redirect_template = 11;
+    // Rewrite host template. Supports `$HOST[n]` / `$PATH[n]` placeholders
+    // populated from regex captures collected during routing. When set, both
+    // the backend authority/path and the wire request line are rewritten.
+    optional string rewrite_host = 12;
+    // Rewrite path template. Same grammar as `rewrite_host`.
+    optional string rewrite_path = 13;
+    // Optional literal port override on the rewritten URL.
+    optional uint32 rewrite_port = 14;
+    // Header mutations applied to requests and/or responses passing through
+    // this frontend. See `Header` for delete semantics.
+    repeated Header headers = 15;
 }
 
 message RequestTcpFrontend {
@@ -699,6 +801,25 @@ message Cluster {
     // This does NOT gate H2 acceptance at the frontend — frontend H2 is negotiated via
     // TLS ALPN independently of per-cluster configuration (see alpn_protocols on the listener).
     optional bool http2 = 8;
+    // Per-cluster HTTP answer template overrides keyed by HTTP status code
+    // (e.g. "503"). Override a listener-level answer for this cluster only.
+    map<string, string> answers = 9;
+    // Optional explicit port to use when building the `Location` header for
+    // an `https_redirect`. When unset, the listener's effective HTTPS port is
+    // used. Lets operators front a non-standard HTTPS port (e.g. 8443) on
+    // the redirect target while keeping `https_redirect = true`.
+    optional uint32 https_redirect_port = 10;
+    // Authorized credentials for HTTP basic authentication. Each entry is
+    // formatted as `username:hex(sha256(password))` (lower-case hex). The
+    // mux compares the supplied `Authorization: Basic` header in
+    // constant-time against the full list. Empty list disables auth even
+    // when a frontend sets `required_auth = true` — those requests are
+    // rejected with a 401.
+    repeated string authorized_hashes = 11;
+    // Realm string emitted in `WWW-Authenticate: Basic realm="…"` when an
+    // unauthenticated request is rejected. Treated as an opaque value (no
+    // template substitution). Defaults to a generic realm if unset.
+    optional string www_authenticate = 12;
 }
 
 enum LoadBalancingAlgorithms {

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -1264,6 +1264,16 @@ message ServerConfig {
     // [2, 32] at config-load time. The previous compile-time constant was
     // 4 and remains the default.
     optional uint64 slab_entries_per_connection = 20;
+    // Maximum length, in bytes, of a base64-decoded `Authorization: Basic`
+    // payload accepted by `mux::auth`. Caps the per-failed-auth allocation
+    // so a hostile peer cannot force the worker to decode arbitrarily
+    // large tokens. RFC 7617 imposes no upper bound; the default is 4096
+    // (well above the realistic shape `username:password`). Operators on
+    // tight memory budgets can lower this to 256-512; values that approach
+    // the per-frontend `buffer_size` raise a warning at config-load time
+    // (see config.rs validation). Set once at worker boot via
+    // `mux::auth::set_max_decoded_credential_bytes`.
+    optional uint64 basic_auth_max_credential_bytes = 21;
 }
 
 enum ProtobufAccessLogFormat {

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -618,6 +618,12 @@ enum RedirectScheme {
 // preparation). Mirrors HAProxy `http-request set-header` /
 // `http-response set-header` parity.
 enum HeaderPosition {
+    // Reserve 0 for the proto-default-encoded shape so a `Header` written
+    // by `..Default::default()` (or by an older client) deserialises into
+    // an explicit "unset" rather than failing `HeaderPosition::try_from(0)`.
+    // The runtime treats this as a hard config error and rejects the
+    // header rather than guessing a position.
+    HEADER_POSITION_UNSPECIFIED = 0;
     REQUEST = 1;
     RESPONSE = 2;
     BOTH = 3;

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -811,6 +811,7 @@ impl ListenerBuilder {
             h2_stream_idle_timeout_seconds: self.h2_stream_idle_timeout_seconds,
             h2_graceful_shutdown_deadline_seconds: self.h2_graceful_shutdown_deadline_seconds,
             sozu_id_header: self.sozu_id_header.clone(),
+            ..Default::default()
         };
 
         Ok(https_listener_config)
@@ -1234,6 +1235,7 @@ impl HttpFrontendConfig {
                     method: self.method.clone(),
                     position: self.position.into(),
                     tags,
+                    ..Default::default()
                 })
                 .into(),
             );
@@ -1248,6 +1250,7 @@ impl HttpFrontendConfig {
                     method: self.method.clone(),
                     position: self.position.into(),
                     tags,
+                    ..Default::default()
                 })
                 .into(),
             );
@@ -1283,6 +1286,7 @@ impl HttpClusterConfig {
                 answer_503: self.answer_503.clone(),
                 load_metric: self.load_metric.map(|s| s as i32),
                 http2: self.http2,
+                ..Default::default()
             })
             .into(),
         ];
@@ -1345,6 +1349,7 @@ impl TcpClusterConfig {
                 load_metric: self.load_metric.map(|s| s as i32),
                 answer_503: None,
                 http2: None,
+                ..Default::default()
             })
             .into(),
         ];

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -63,11 +63,12 @@ use crate::{
     logging::AccessLogFormat,
     proto::command::{
         ActivateListener, AddBackend, AddCertificate, CertificateAndKey, Cluster,
-        CustomHttpAnswers, HttpListenerConfig, HttpsListenerConfig, ListenerType,
-        LoadBalancingAlgorithms, LoadBalancingParams, LoadMetric, MetricDetail,
-        MetricsConfiguration, PathRule, ProtobufAccessLogFormat, ProxyProtocolConfig, Request,
-        RequestHttpFrontend, RequestTcpFrontend, RulePosition, ServerConfig, ServerMetricsConfig,
-        SocketAddress, TcpListenerConfig, TlsVersion, WorkerRequest, request::RequestType,
+        CustomHttpAnswers, Header, HeaderPosition, HttpListenerConfig, HttpsListenerConfig,
+        ListenerType, LoadBalancingAlgorithms, LoadBalancingParams, LoadMetric, MetricDetail,
+        MetricsConfiguration, PathRule, ProtobufAccessLogFormat, ProxyProtocolConfig,
+        RedirectPolicy, RedirectScheme, Request, RequestHttpFrontend, RequestTcpFrontend,
+        RulePosition, ServerConfig, ServerMetricsConfig, SocketAddress, TcpListenerConfig,
+        TlsVersion, WorkerRequest, request::RequestType,
     },
 };
 
@@ -279,6 +280,25 @@ pub enum ConfigError {
         minimum: u64,
         listeners: usize,
     },
+    /// `redirect = "<value>"` on a frontend used a value the parser doesn't
+    /// recognise. Accepted values are `forward`, `permanent`, `unauthorized`
+    /// (case-insensitive).
+    #[error(
+        "invalid redirect policy '{0}'. Valid values: \"forward\", \"permanent\", \"unauthorized\""
+    )]
+    InvalidRedirectPolicy(String),
+    /// `redirect_scheme = "<value>"` on a frontend used a value the parser
+    /// doesn't recognise. Accepted values are `use-same`, `use-http`,
+    /// `use-https` (case-insensitive).
+    #[error(
+        "invalid redirect scheme '{0}'. Valid values: \"use-same\", \"use-http\", \"use-https\""
+    )]
+    InvalidRedirectScheme(String),
+    /// A `[[clusters.<id>.frontends.headers]]` entry carried an unknown
+    /// `position` value. Accepted values are `request`, `response`, `both`
+    /// (case-insensitive).
+    #[error("invalid header position '{0}'. Valid values: \"request\", \"response\", \"both\"")]
+    InvalidHeaderPosition(String),
 }
 
 /// An HTTP, HTTPS or TCP listener as parsed from the `Listeners` section in the toml
@@ -391,6 +411,15 @@ pub struct ListenerBuilder {
     /// that omit ALPN entirely) are dropped at handshake instead of
     /// silently downgrading to HTTP/1.1. Default: false.
     pub disable_http11: Option<bool>,
+    /// Per-status HTTP answer template files at listener scope. Map key is
+    /// the HTTP status code (e.g. `"503"`); map value is a filesystem path
+    /// to the template body that will be loaded into
+    /// [`HttpListenerConfig::answers`] / [`HttpsListenerConfig::answers`]
+    /// at build time via [`load_answers`]. The legacy per-status
+    /// `answer_NNN` fields are still honoured for backwards compatibility
+    /// but are equivalent to a one-line entry in this map; new code
+    /// should prefer `[listeners.answers]`.
+    pub answers: Option<BTreeMap<String, String>>,
 }
 
 pub fn default_sticky_name() -> String {
@@ -468,6 +497,7 @@ impl ListenerBuilder {
             h2_graceful_shutdown_deadline_seconds: None,
             strict_sni_binding: None,
             disable_http11: None,
+            answers: None,
         }
     }
 
@@ -574,6 +604,28 @@ impl ListenerBuilder {
         self
     }
 
+    /// Register a single per-status answer template file path on this
+    /// listener. The path is read off disk into the resulting listener's
+    /// `answers` map at build time via [`load_answers`]. Repeated calls
+    /// with the same status code overwrite the prior entry.
+    pub fn with_answer<S, P>(&mut self, code: S, path: P) -> &mut Self
+    where
+        S: ToString,
+        P: ToString,
+    {
+        self.answers
+            .get_or_insert_with(BTreeMap::new)
+            .insert(code.to_string(), path.to_string());
+        self
+    }
+
+    /// Replace the listener-scope answer-template path map. See
+    /// [`Self::with_answer`].
+    pub fn with_answers(&mut self, answers: BTreeMap<String, String>) -> &mut Self {
+        self.answers = Some(answers);
+        self
+    }
+
     /// Get the custom HTTP answers from the file system using the provided paths
     fn get_http_answers(&self) -> Result<Option<CustomHttpAnswers>, ConfigError> {
         let http_answers = CustomHttpAnswers {
@@ -590,6 +642,45 @@ impl ListenerBuilder {
             answer_507: read_http_answer_file(&self.answer_507)?,
         };
         Ok(Some(http_answers))
+    }
+
+    /// Build the proto-side `answers` map for this listener.
+    ///
+    /// Merges, in order:
+    /// 1. legacy per-status `answer_NNN` fields (if set), so legacy state
+    ///    files round-trip into the new shape;
+    /// 2. the explicit `[listeners.answers]` map (loaded via [`load_answers`]),
+    ///    so new entries take precedence over legacy ones.
+    fn get_listener_answers(&self) -> Result<BTreeMap<String, String>, ConfigError> {
+        let mut out = BTreeMap::new();
+
+        // Pull bodies from the legacy per-status fields first so the new map
+        // takes precedence on collision. Empty bodies are skipped to keep the
+        // proto map minimal.
+        macro_rules! merge_legacy {
+            ($code:literal, $field:ident) => {
+                if let Some(body) = read_http_answer_file(&self.$field)? {
+                    out.insert($code.to_owned(), body);
+                }
+            };
+        }
+        merge_legacy!("301", answer_301);
+        merge_legacy!("400", answer_400);
+        merge_legacy!("401", answer_401);
+        merge_legacy!("404", answer_404);
+        merge_legacy!("408", answer_408);
+        merge_legacy!("413", answer_413);
+        merge_legacy!("421", answer_421);
+        merge_legacy!("502", answer_502);
+        merge_legacy!("503", answer_503);
+        merge_legacy!("504", answer_504);
+        merge_legacy!("507", answer_507);
+
+        if let Some(map) = &self.answers {
+            let loaded = load_answers(map)?;
+            out.extend(loaded);
+        }
+        Ok(out)
     }
 
     /// Assign the timeouts of the config to this listener, only if timeouts did not exist
@@ -614,6 +705,7 @@ impl ListenerBuilder {
         }
 
         let http_answers = self.get_http_answers()?;
+        let answers = self.get_listener_answers()?;
 
         let configuration = HttpListenerConfig {
             address: self.address.into(),
@@ -625,6 +717,7 @@ impl ListenerBuilder {
             connect_timeout: self.connect_timeout.unwrap_or(DEFAULT_CONNECT_TIMEOUT),
             request_timeout: self.request_timeout.unwrap_or(DEFAULT_REQUEST_TIMEOUT),
             http_answers,
+            answers,
             h2_max_rst_stream_per_window: self.h2_max_rst_stream_per_window,
             h2_max_ping_per_window: self.h2_max_ping_per_window,
             h2_max_settings_per_window: self.h2_max_settings_per_window,
@@ -763,6 +856,7 @@ impl ListenerBuilder {
             .unwrap_or_default();
 
         let http_answers = self.get_http_answers()?;
+        let answers = self.get_listener_answers()?;
 
         if let Some(config) = config {
             self.assign_config_timeouts(config);
@@ -790,6 +884,7 @@ impl ListenerBuilder {
                 .send_tls13_tickets
                 .unwrap_or(DEFAULT_SEND_TLS_13_TICKETS),
             http_answers,
+            answers,
             alpn_protocols,
             h2_max_rst_stream_per_window: self.h2_max_rst_stream_per_window,
             h2_max_ping_per_window: self.h2_max_ping_per_window,
@@ -811,7 +906,6 @@ impl ListenerBuilder {
             h2_stream_idle_timeout_seconds: self.h2_stream_idle_timeout_seconds,
             h2_graceful_shutdown_deadline_seconds: self.h2_graceful_shutdown_deadline_seconds,
             sozu_id_header: self.sozu_id_header.clone(),
-            ..Default::default()
         };
 
         Ok(https_listener_config)
@@ -862,6 +956,42 @@ fn read_http_answer_file(path: &Option<String>) -> Result<Option<String>, Config
         }
         None => Ok(None),
     }
+}
+
+/// Load every per-status template referenced by `answers` from disk.
+///
+/// `answers` maps an HTTP status code (e.g. `"503"`) to a filesystem path.
+/// Each path is read into a body string and inserted into the returned
+/// map under the same key, ready to be assigned to the proto-level
+/// `answers` field on a [`HttpListenerConfig`] / [`HttpsListenerConfig`]
+/// / [`Cluster`]. Empty path values are skipped (treated as
+/// "preserve current") so the caller can use them as a no-op stub in
+/// example configs.
+///
+/// Errors map to the existing `ConfigError::FileOpen` / `ConfigError::FileRead`
+/// variants so the operator gets the same diagnostics as the legacy
+/// `read_http_answer_file` flow.
+pub fn load_answers(
+    answers: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, String>, ConfigError> {
+    let mut out = BTreeMap::new();
+    for (code, path) in answers {
+        if path.is_empty() {
+            continue;
+        }
+        let mut content = String::new();
+        let mut file = File::open(path).map_err(|io_error| ConfigError::FileOpen {
+            path_to_open: path.to_owned(),
+            io_error,
+        })?;
+        file.read_to_string(&mut content)
+            .map_err(|io_error| ConfigError::FileRead {
+                path_to_read: path.to_owned(),
+                io_error,
+            })?;
+        out.insert(code.to_owned(), content);
+    }
+    Ok(out)
 }
 
 /// Cardinality knob for metrics labels in the StatsD network drain.
@@ -959,6 +1089,48 @@ pub struct FileClusterFrontendConfig {
     #[serde(default)]
     pub position: RulePosition,
     pub tags: Option<BTreeMap<String, String>>,
+    /// Frontend-level redirect policy. Accepted values are `forward`
+    /// (default — route to the backend), `permanent` (return 301 with the
+    /// computed `Location`), or `unauthorized` (return 401 with
+    /// `WWW-Authenticate: Basic realm=…`). Case-insensitive.
+    pub redirect: Option<String>,
+    /// Scheme used when emitting a permanent redirect's `Location`. Accepted
+    /// values are `use-same` (default — preserve request scheme), `use-http`,
+    /// `use-https`. Case-insensitive.
+    pub redirect_scheme: Option<String>,
+    /// Optional template applied to the emitted permanent-redirect response
+    /// body. Supports the `%REDIRECT_LOCATION` / `%STATUS_CODE` etc.
+    /// variables documented in `doc/configure.md`.
+    pub redirect_template: Option<String>,
+    /// Rewrite host template. Supports `$HOST[n]` / `$PATH[n]` placeholders
+    /// populated from regex captures collected during routing.
+    pub rewrite_host: Option<String>,
+    /// Rewrite path template. Same grammar as `rewrite_host`.
+    pub rewrite_path: Option<String>,
+    /// Optional literal port override on the rewritten URL.
+    pub rewrite_port: Option<u32>,
+    /// When true, requests routed through this frontend must carry a valid
+    /// `Authorization: Basic <user:pass>` header whose hash matches one of
+    /// the cluster's `authorized_hashes`. Default: false.
+    pub required_auth: Option<bool>,
+    /// Header mutations applied to requests and/or responses passing through
+    /// this frontend. See [`HeaderEditConfig`] for the empty-value-deletes
+    /// semantics (HAProxy `del-header` parity).
+    pub headers: Option<Vec<HeaderEditConfig>>,
+}
+
+/// A single header mutation as serialised under
+/// `[[clusters.<id>.frontends.headers]]`. Maps to the proto [`Header`]
+/// message at request-build time.
+///
+/// `position` accepts `request`, `response`, or `both` (case-insensitive).
+/// An empty `value` deletes the header by name (HAProxy `del-header` parity).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HeaderEditConfig {
+    pub position: String,
+    pub key: String,
+    pub value: String,
 }
 
 impl FileClusterFrontendConfig {
@@ -1033,6 +1205,26 @@ impl FileClusterFrontendConfig {
             (Some(s), None) => PathRule::prefix(s.clone()),
         };
 
+        let redirect = match self.redirect.as_deref() {
+            Some(v) => Some(parse_redirect_policy(v)?),
+            None => None,
+        };
+        let redirect_scheme = match self.redirect_scheme.as_deref() {
+            Some(v) => Some(parse_redirect_scheme(v)?),
+            None => None,
+        };
+
+        let headers = match self.headers.as_ref() {
+            Some(entries) => {
+                let mut out = Vec::with_capacity(entries.len());
+                for entry in entries {
+                    out.push(parse_header_edit(entry)?);
+                }
+                out
+            }
+            None => Vec::new(),
+        };
+
         Ok(HttpFrontendConfig {
             address: self.address,
             hostname,
@@ -1044,8 +1236,53 @@ impl FileClusterFrontendConfig {
             path,
             method: self.method.clone(),
             tags: self.tags.clone(),
+            redirect,
+            redirect_scheme,
+            redirect_template: self.redirect_template.clone(),
+            rewrite_host: self.rewrite_host.clone(),
+            rewrite_path: self.rewrite_path.clone(),
+            rewrite_port: self.rewrite_port,
+            required_auth: self.required_auth,
+            headers,
         })
     }
+}
+
+/// Parse a `redirect` TOML value (case-insensitive) into the proto enum.
+pub(crate) fn parse_redirect_policy(value: &str) -> Result<RedirectPolicy, ConfigError> {
+    match value.to_ascii_lowercase().as_str() {
+        "forward" => Ok(RedirectPolicy::Forward),
+        "permanent" => Ok(RedirectPolicy::Permanent),
+        "unauthorized" => Ok(RedirectPolicy::Unauthorized),
+        _ => Err(ConfigError::InvalidRedirectPolicy(value.to_owned())),
+    }
+}
+
+/// Parse a `redirect_scheme` TOML value (case-insensitive) into the proto enum.
+pub(crate) fn parse_redirect_scheme(value: &str) -> Result<RedirectScheme, ConfigError> {
+    match value.to_ascii_lowercase().as_str() {
+        "use-same" | "use_same" => Ok(RedirectScheme::UseSame),
+        "use-http" | "use_http" => Ok(RedirectScheme::UseHttp),
+        "use-https" | "use_https" => Ok(RedirectScheme::UseHttps),
+        _ => Err(ConfigError::InvalidRedirectScheme(value.to_owned())),
+    }
+}
+
+/// Parse a `[[clusters.<id>.frontends.headers]]` entry into the proto
+/// [`Header`] message. An empty `value` is the HAProxy `del-header` parity
+/// (deletes the header by name); the proto carries the empty string verbatim.
+pub(crate) fn parse_header_edit(entry: &HeaderEditConfig) -> Result<Header, ConfigError> {
+    let position = match entry.position.to_ascii_lowercase().as_str() {
+        "request" => HeaderPosition::Request,
+        "response" => HeaderPosition::Response,
+        "both" => HeaderPosition::Both,
+        _ => return Err(ConfigError::InvalidHeaderPosition(entry.position.clone())),
+    };
+    Ok(Header {
+        position: position as i32,
+        key: entry.key.clone(),
+        val: entry.value.clone(),
+    })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -1081,6 +1318,26 @@ pub struct FileClusterConfig {
     /// Backend-capability hint: `true` when the backend speaks HTTP/2 (h2c or h2+TLS once #1218 lands).
     /// Does NOT gate H2 at the frontend — frontend H2 is ALPN-negotiated independently (see `alpn_protocols`).
     pub http2: Option<bool>,
+    /// Per-cluster HTTP answer template overrides keyed by HTTP status
+    /// code (e.g. `"503"`). Map values are filesystem paths to the template
+    /// body, loaded into [`Cluster::answers`] at build time via
+    /// [`load_answers`]. An entry on a cluster overrides the same status
+    /// code on the listener.
+    pub answers: Option<BTreeMap<String, String>>,
+    /// Optional explicit port to use when building the `Location` header
+    /// for an `https_redirect`. When unset, the listener's effective HTTPS
+    /// port is used. Lets operators front a non-standard HTTPS port (e.g.
+    /// 8443) on the redirect target while keeping `https_redirect = true`.
+    pub https_redirect_port: Option<u32>,
+    /// Authorized credentials for HTTP basic authentication, formatted as
+    /// `username:hex(sha256(password))` (lower-case hex). Empty list
+    /// disables auth even when a frontend sets `required_auth = true` —
+    /// such requests are rejected with 401.
+    pub authorized_hashes: Option<Vec<String>>,
+    /// Realm string emitted in `WWW-Authenticate: Basic realm="…"` when
+    /// an unauthenticated request is rejected. Treated as an opaque
+    /// value (no template substitution).
+    pub www_authenticate: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -1142,6 +1399,11 @@ impl FileClusterConfig {
                     _ => None,
                 };
 
+                let answers = match self.answers.as_ref() {
+                    Some(map) => load_answers(map)?,
+                    None => BTreeMap::new(),
+                };
+
                 Ok(ClusterConfig::Tcp(TcpClusterConfig {
                     cluster_id: cluster_id.to_string(),
                     frontends,
@@ -1149,6 +1411,10 @@ impl FileClusterConfig {
                     proxy_protocol,
                     load_balancing: self.load_balancing,
                     load_metric: self.load_metric,
+                    answers,
+                    https_redirect_port: self.https_redirect_port,
+                    authorized_hashes: self.authorized_hashes.unwrap_or_default(),
+                    www_authenticate: self.www_authenticate,
                 }))
             }
             FileClusterProtocolConfig::Http => {
@@ -1167,6 +1433,11 @@ impl FileClusterConfig {
                         .ok()
                 });
 
+                let answers = match self.answers.as_ref() {
+                    Some(map) => load_answers(map)?,
+                    None => BTreeMap::new(),
+                };
+
                 Ok(ClusterConfig::Http(HttpClusterConfig {
                     cluster_id: cluster_id.to_string(),
                     frontends,
@@ -1177,6 +1448,10 @@ impl FileClusterConfig {
                     load_metric: self.load_metric,
                     answer_503,
                     http2: self.http2,
+                    answers,
+                    https_redirect_port: self.https_redirect_port,
+                    authorized_hashes: self.authorized_hashes.unwrap_or_default(),
+                    www_authenticate: self.www_authenticate,
                 }))
             }
         }
@@ -1198,6 +1473,26 @@ pub struct HttpFrontendConfig {
     #[serde(default)]
     pub position: RulePosition,
     pub tags: Option<BTreeMap<String, String>>,
+    /// Resolved redirect policy. `None` keeps the proto-default `FORWARD`.
+    #[serde(default)]
+    pub redirect: Option<RedirectPolicy>,
+    /// Resolved redirect scheme. `None` keeps the proto-default `USE_SAME`.
+    #[serde(default)]
+    pub redirect_scheme: Option<RedirectScheme>,
+    #[serde(default)]
+    pub redirect_template: Option<String>,
+    #[serde(default)]
+    pub rewrite_host: Option<String>,
+    #[serde(default)]
+    pub rewrite_path: Option<String>,
+    #[serde(default)]
+    pub rewrite_port: Option<u32>,
+    #[serde(default)]
+    pub required_auth: Option<bool>,
+    /// Header mutations applied to requests and/or responses passing through
+    /// this frontend. Empty by default.
+    #[serde(default)]
+    pub headers: Vec<Header>,
 }
 
 impl HttpFrontendConfig {
@@ -1235,7 +1530,14 @@ impl HttpFrontendConfig {
                     method: self.method.clone(),
                     position: self.position.into(),
                     tags,
-                    ..Default::default()
+                    redirect: self.redirect.map(|r| r as i32),
+                    required_auth: self.required_auth,
+                    redirect_scheme: self.redirect_scheme.map(|s| s as i32),
+                    redirect_template: self.redirect_template.clone(),
+                    rewrite_host: self.rewrite_host.clone(),
+                    rewrite_path: self.rewrite_path.clone(),
+                    rewrite_port: self.rewrite_port,
+                    headers: self.headers.clone(),
                 })
                 .into(),
             );
@@ -1250,7 +1552,14 @@ impl HttpFrontendConfig {
                     method: self.method.clone(),
                     position: self.position.into(),
                     tags,
-                    ..Default::default()
+                    redirect: self.redirect.map(|r| r as i32),
+                    required_auth: self.required_auth,
+                    redirect_scheme: self.redirect_scheme.map(|s| s as i32),
+                    redirect_template: self.redirect_template.clone(),
+                    rewrite_host: self.rewrite_host.clone(),
+                    rewrite_path: self.rewrite_path.clone(),
+                    rewrite_port: self.rewrite_port,
+                    headers: self.headers.clone(),
                 })
                 .into(),
             );
@@ -1272,6 +1581,16 @@ pub struct HttpClusterConfig {
     pub load_metric: Option<LoadMetric>,
     pub answer_503: Option<String>,
     pub http2: Option<bool>,
+    /// Per-status template body map (already loaded from disk). Maps to
+    /// the proto [`Cluster::answers`] field.
+    #[serde(default)]
+    pub answers: BTreeMap<String, String>,
+    #[serde(default)]
+    pub https_redirect_port: Option<u32>,
+    #[serde(default)]
+    pub authorized_hashes: Vec<String>,
+    #[serde(default)]
+    pub www_authenticate: Option<String>,
 }
 
 impl HttpClusterConfig {
@@ -1286,7 +1605,10 @@ impl HttpClusterConfig {
                 answer_503: self.answer_503.clone(),
                 load_metric: self.load_metric.map(|s| s as i32),
                 http2: self.http2,
-                ..Default::default()
+                answers: self.answers.clone(),
+                https_redirect_port: self.https_redirect_port,
+                authorized_hashes: self.authorized_hashes.clone(),
+                www_authenticate: self.www_authenticate.clone(),
             })
             .into(),
         ];
@@ -1335,6 +1657,17 @@ pub struct TcpClusterConfig {
     pub proxy_protocol: Option<ProxyProtocolConfig>,
     pub load_balancing: LoadBalancingAlgorithms,
     pub load_metric: Option<LoadMetric>,
+    /// Per-status template body map (already loaded from disk). Even
+    /// though TCP clusters do not emit HTTP responses, the field is
+    /// carried for shape uniformity with [`HttpClusterConfig`].
+    #[serde(default)]
+    pub answers: BTreeMap<String, String>,
+    #[serde(default)]
+    pub https_redirect_port: Option<u32>,
+    #[serde(default)]
+    pub authorized_hashes: Vec<String>,
+    #[serde(default)]
+    pub www_authenticate: Option<String>,
 }
 
 impl TcpClusterConfig {
@@ -1349,7 +1682,10 @@ impl TcpClusterConfig {
                 load_metric: self.load_metric.map(|s| s as i32),
                 answer_503: None,
                 http2: None,
-                ..Default::default()
+                answers: self.answers.clone(),
+                https_redirect_port: self.https_redirect_port,
+                authorized_hashes: self.authorized_hashes.clone(),
+                www_authenticate: self.www_authenticate.clone(),
             })
             .into(),
         ];

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -1884,6 +1884,17 @@ pub struct FileConfig {
     /// that exceed 4 backends per session — clamped to [2, 32] at load.
     #[serde(default)]
     pub slab_entries_per_connection: Option<u64>,
+    /// Maximum length, in bytes, of a base64-decoded `Authorization: Basic`
+    /// payload accepted by the worker's `mux::auth` module. Caps the
+    /// per-failed-auth allocation so a hostile peer cannot force the worker
+    /// to decode arbitrarily large tokens. RFC 7617 imposes no upper bound
+    /// — defaults to 4096, which is well above the realistic
+    /// `username:password` shape. Operators running hardened tenants can
+    /// lower this to e.g. 256 or 512 to bound the allocation tighter.
+    /// Values >= `buffer_size / 3` emit a warning at config-load time
+    /// (the credential cap shouldn't dominate the per-frontend buffer).
+    #[serde(default)]
+    pub basic_auth_max_credential_bytes: Option<u64>,
     /// Optional UID allowlist for command-socket requests. `None` (default)
     /// preserves historical behaviour: any same-UID local process can
     /// invoke any verb. When set, requests whose `SO_PEERCRED` UID is not
@@ -2079,6 +2090,7 @@ impl ConfigBuilder {
                 )
             }),
             command_allowed_uids: file_config.command_allowed_uids.clone(),
+            basic_auth_max_credential_bytes: file_config.basic_auth_max_credential_bytes,
             ..Default::default()
         };
 
@@ -2273,6 +2285,28 @@ impl ConfigBuilder {
             });
         }
 
+        // Warn (no hard reject) when the configured Basic-auth credential
+        // cap is large enough to dominate the per-frontend buffer. The
+        // worker copies a decoded credential into a transient allocation
+        // sized by this cap; values >= 33% of `buffer_size` mean a single
+        // failed-auth attempt can hold a third of the buffer's worth of
+        // bytes, which combined with in-flight request/response framing
+        // pushes the buffer toward back-pressure under load. Log only —
+        // operators with deliberate threat models may choose this
+        // trade-off, but the surprise needs to be visible.
+        if let Some(cap) = self.built.basic_auth_max_credential_bytes {
+            let third = self.built.buffer_size / 3;
+            if cap >= third {
+                warn!(
+                    "basic_auth_max_credential_bytes = {} is >= buffer_size / 3 ({}); \
+                     a hostile peer can pin ~33% of the per-frontend buffer per failed auth \
+                     attempt. Consider lowering basic_auth_max_credential_bytes (typical \
+                     credentials are <100 bytes) or raising buffer_size.",
+                    cap, third
+                );
+            }
+        }
+
         let command_socket_path = self.file.command_socket.clone().unwrap_or({
             let mut path = env::current_dir().map_err(|e| ConfigError::Env(e.to_string()))?;
             path.push("sozu.sock");
@@ -2365,6 +2399,12 @@ pub struct Config {
     /// not in the list is rejected before reaching dispatch.
     #[serde(default)]
     pub command_allowed_uids: Option<Vec<u32>>,
+    /// Maximum length, in bytes, of a base64-decoded `Authorization: Basic`
+    /// payload accepted by `mux::auth`. `None` keeps the compile-time
+    /// default of 4096. Set once on each worker at boot via
+    /// [`ServerConfig::basic_auth_max_credential_bytes`].
+    #[serde(default)]
+    pub basic_auth_max_credential_bytes: Option<u64>,
 }
 
 fn default_front_timeout() -> u32 {
@@ -2743,6 +2783,7 @@ impl From<&Config> for ServerConfig {
             access_log_format: ProtobufAccessLogFormat::from(&config.access_logs_format) as i32,
             log_colored: config.log_colored,
             slab_entries_per_connection: config.slab_entries_per_connection,
+            basic_auth_max_credential_bytes: config.basic_auth_max_credential_bytes,
         }
     }
 }

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -297,8 +297,10 @@ pub enum ConfigError {
     /// A `[[clusters.<id>.frontends.headers]]` entry carried an unknown
     /// `position` value. Accepted values are `request`, `response`, `both`
     /// (case-insensitive).
-    #[error("invalid header position '{0}'. Valid values: \"request\", \"response\", \"both\"")]
-    InvalidHeaderPosition(String),
+    #[error(
+        "invalid header position '{position}' at headers[{index}]. Valid values: \"request\", \"response\", \"both\""
+    )]
+    InvalidHeaderPosition { index: usize, position: String },
 }
 
 /// An HTTP, HTTPS or TCP listener as parsed from the `Listeners` section in the toml
@@ -1217,8 +1219,8 @@ impl FileClusterFrontendConfig {
         let headers = match self.headers.as_ref() {
             Some(entries) => {
                 let mut out = Vec::with_capacity(entries.len());
-                for entry in entries {
-                    out.push(parse_header_edit(entry)?);
+                for (index, entry) in entries.iter().enumerate() {
+                    out.push(parse_header_edit(index, entry)?);
                 }
                 out
             }
@@ -1269,14 +1271,25 @@ pub(crate) fn parse_redirect_scheme(value: &str) -> Result<RedirectScheme, Confi
 }
 
 /// Parse a `[[clusters.<id>.frontends.headers]]` entry into the proto
-/// [`Header`] message. An empty `value` is the HAProxy `del-header` parity
-/// (deletes the header by name); the proto carries the empty string verbatim.
-pub(crate) fn parse_header_edit(entry: &HeaderEditConfig) -> Result<Header, ConfigError> {
+/// [`Header`] message. `index` is the zero-based position of `entry` in
+/// the source array — surfaced into the error so a multi-entry config
+/// pinpoints the bad row instead of just naming the unknown position.
+/// An empty `value` is the HAProxy `del-header` parity (deletes the
+/// header by name); the proto carries the empty string verbatim.
+pub(crate) fn parse_header_edit(
+    index: usize,
+    entry: &HeaderEditConfig,
+) -> Result<Header, ConfigError> {
     let position = match entry.position.to_ascii_lowercase().as_str() {
         "request" => HeaderPosition::Request,
         "response" => HeaderPosition::Response,
         "both" => HeaderPosition::Both,
-        _ => return Err(ConfigError::InvalidHeaderPosition(entry.position.clone())),
+        _ => {
+            return Err(ConfigError::InvalidHeaderPosition {
+                index,
+                position: entry.position.clone(),
+            });
+        }
     };
     Ok(Header {
         position: position as i32,

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -1302,13 +1302,13 @@ pub(crate) fn parse_header_edit(
             });
         }
     };
-    if header_bytes_contain_forbidden_controls(entry.key.as_bytes()) {
+    if !header_name_is_valid_token(entry.key.as_bytes()) {
         return Err(ConfigError::InvalidHeaderBytes {
             index,
             field: "key",
         });
     }
-    if header_bytes_contain_forbidden_controls(entry.value.as_bytes()) {
+    if header_value_contains_forbidden_controls(entry.value.as_bytes()) {
         return Err(ConfigError::InvalidHeaderBytes {
             index,
             field: "value",
@@ -1321,14 +1321,51 @@ pub(crate) fn parse_header_edit(
     })
 }
 
-/// Reject any byte value that would let a header injection escape the
-/// header block on the wire (RFC 9110 §5.5 / RFC 9113 §8.2.1):
-/// `\0..=\x08`, `\x0A..=\x1F`, and `\x7F` (so the entire C0 control set
+/// Field names follow the RFC 9110 §5.1 `token` grammar: non-empty,
+/// composed of `tchar` bytes (alphanumeric plus a closed punctuation
+/// list). HTAB and SP are NOT tchar — they belong to field-value
+/// grammar and must be rejected in the name. Reusing the more
+/// permissive value-side filter would let `Host\t` slip through and
+/// produce an invalid header line on the H1 wire (security review
+/// LISA-002 follow-up).
+pub(crate) fn header_name_is_valid_token(bytes: &[u8]) -> bool {
+    if bytes.is_empty() {
+        return false;
+    }
+    bytes.iter().all(|&b| is_tchar(b))
+}
+
+/// `tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /
+/// "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA` per RFC 9110 §5.6.2.
+fn is_tchar(b: u8) -> bool {
+    b.is_ascii_alphanumeric()
+        || matches!(
+            b,
+            b'!' | b'#'
+                | b'$'
+                | b'%'
+                | b'&'
+                | b'\''
+                | b'*'
+                | b'+'
+                | b'-'
+                | b'.'
+                | b'^'
+                | b'_'
+                | b'`'
+                | b'|'
+                | b'~'
+        )
+}
+
+/// Reject any byte that would let a header injection escape the value
+/// block on the wire (RFC 9110 §5.5 / RFC 9113 §8.2.1):
+/// `\0..=\x08`, `\x0A..=\x1F`, and `\x7F` — the entire C0 control set
 /// minus horizontal tab `\x09`, which RFC 9110 explicitly permits in
-/// field values). Mirrors the runtime filter at
+/// field values. Mirrors the runtime filter at
 /// `lib/src/protocol/mux/converter.rs::call` so config-load and runtime
 /// agree on which header values may travel.
-pub(crate) fn header_bytes_contain_forbidden_controls(bytes: &[u8]) -> bool {
+pub(crate) fn header_value_contains_forbidden_controls(bytes: &[u8]) -> bool {
     bytes
         .iter()
         .any(|&b| matches!(b, 0x00..=0x08 | 0x0A..=0x1F | 0x7F))
@@ -3054,9 +3091,10 @@ mod tests {
     }
 
     /// Horizontal tab `\t` (0x09) is permitted in field values per
-    /// RFC 9110 §5.5 (folded-header obs-fold parts). The validator
-    /// must NOT reject it — otherwise legitimate operator configs
-    /// (e.g. `Authorization: Basic\tCREDENTIALS`) become unusable.
+    /// RFC 9110 §5.5 (folded-header obs-fold parts). The value-side
+    /// validator must NOT reject it — otherwise legitimate operator
+    /// configs (e.g. `Authorization: Basic\tCREDENTIALS`) become
+    /// unusable. The key-side validator IS stricter (token grammar).
     #[test]
     fn parse_header_edit_accepts_tab_in_value() {
         let entry = HeaderEditConfig {
@@ -3066,6 +3104,51 @@ mod tests {
         };
         let header = parse_header_edit(0, &entry).expect("tab in value must be accepted");
         assert_eq!(header.val, "with\ttab");
+    }
+
+    /// Header NAMES follow `token` grammar per RFC 9110 §5.1. HTAB and
+    /// SP are NOT tchar; the key-side validator must reject them even
+    /// though the value-side validator permits HTAB. Without this,
+    /// an operator entry like `key = "Host\t"` would emit `Host\t: …`
+    /// on the H1 wire and produce an invalid (but parser-tolerant)
+    /// header line that some backends silently accept as `Host:`.
+    #[test]
+    fn parse_header_edit_rejects_tab_in_key() {
+        let entry = HeaderEditConfig {
+            position: "request".to_owned(),
+            key: "Host\t".to_owned(),
+            value: "ok".to_owned(),
+        };
+        let err = parse_header_edit(0, &entry).expect_err("HTAB in key must be rejected");
+        match err {
+            ConfigError::InvalidHeaderBytes { field, .. } => assert_eq!(field, "key"),
+            other => panic!("expected InvalidHeaderBytes{{field=\"key\"}}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_header_edit_rejects_space_in_key() {
+        let entry = HeaderEditConfig {
+            position: "request".to_owned(),
+            key: "X Test".to_owned(),
+            value: "ok".to_owned(),
+        };
+        let err = parse_header_edit(0, &entry).expect_err("SP in key must be rejected");
+        assert!(matches!(err, ConfigError::InvalidHeaderBytes { .. }));
+    }
+
+    #[test]
+    fn parse_header_edit_rejects_empty_key() {
+        let entry = HeaderEditConfig {
+            position: "request".to_owned(),
+            key: String::new(),
+            value: "ok".to_owned(),
+        };
+        let err = parse_header_edit(0, &entry).expect_err("empty key must be rejected");
+        assert!(matches!(
+            err,
+            ConfigError::InvalidHeaderBytes { field: "key", .. }
+        ));
     }
 
     #[test]

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -301,6 +301,17 @@ pub enum ConfigError {
         "invalid header position '{position}' at headers[{index}]. Valid values: \"request\", \"response\", \"both\""
     )]
     InvalidHeaderPosition { index: usize, position: String },
+    /// A `[[clusters.<id>.frontends.headers]]` entry contains a forbidden
+    /// byte (NUL, CR, LF, or another C0 control) in its key or value.
+    /// Accepting these would produce HTTP request/response splitting on
+    /// the wire (CWE-113) — the worker's H2 emission path filters them
+    /// at runtime, but the H1 path serialises raw, so we reject at
+    /// config-load time as a defense in depth.
+    #[error(
+        "invalid header bytes in {field} at headers[{index}]: control characters \
+         (NUL / CR / LF / other C0) are forbidden in header keys and values"
+    )]
+    InvalidHeaderBytes { index: usize, field: &'static str },
 }
 
 /// An HTTP, HTTPS or TCP listener as parsed from the `Listeners` section in the toml
@@ -1291,11 +1302,36 @@ pub(crate) fn parse_header_edit(
             });
         }
     };
+    if header_bytes_contain_forbidden_controls(entry.key.as_bytes()) {
+        return Err(ConfigError::InvalidHeaderBytes {
+            index,
+            field: "key",
+        });
+    }
+    if header_bytes_contain_forbidden_controls(entry.value.as_bytes()) {
+        return Err(ConfigError::InvalidHeaderBytes {
+            index,
+            field: "value",
+        });
+    }
     Ok(Header {
         position: position as i32,
         key: entry.key.clone(),
         val: entry.value.clone(),
     })
+}
+
+/// Reject any byte value that would let a header injection escape the
+/// header block on the wire (RFC 9110 §5.5 / RFC 9113 §8.2.1):
+/// `\0..=\x08`, `\x0A..=\x1F`, and `\x7F` (so the entire C0 control set
+/// minus horizontal tab `\x09`, which RFC 9110 explicitly permits in
+/// field values). Mirrors the runtime filter at
+/// `lib/src/protocol/mux/converter.rs::call` so config-load and runtime
+/// agree on which header values may travel.
+pub(crate) fn header_bytes_contain_forbidden_controls(bytes: &[u8]) -> bool {
+    bytes
+        .iter()
+        .any(|&b| matches!(b, 0x00..=0x08 | 0x0A..=0x1F | 0x7F))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -2963,5 +2999,84 @@ mod tests {
         builder.with_alpn_protocols(Some(vec!["http/1.1".to_owned(), "h2".to_owned()]));
         let config = builder.to_tls(None).expect("to_tls should succeed");
         assert_eq!(config.alpn_protocols, vec!["http/1.1", "h2"]);
+    }
+
+    /// CRLF or NUL in a `[[clusters.<id>.frontends.headers]]` value
+    /// would let an operator-supplied config splice arbitrary
+    /// header / request lines into the H1 wire on the backend side
+    /// (CWE-113). The H2 emission path filters at runtime; we reject
+    /// at config-load time as a defense in depth.
+    #[test]
+    fn parse_header_edit_rejects_crlf_in_value() {
+        let entry = HeaderEditConfig {
+            position: "request".to_owned(),
+            key: "X-Test".to_owned(),
+            value: "value\r\nEvil-Header: stolen".to_owned(),
+        };
+        let err = parse_header_edit(0, &entry).expect_err("CRLF in value must be rejected");
+        match err {
+            ConfigError::InvalidHeaderBytes { index, field } => {
+                assert_eq!(index, 0);
+                assert_eq!(field, "value");
+            }
+            other => panic!("expected InvalidHeaderBytes, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_header_edit_rejects_lf_in_key() {
+        let entry = HeaderEditConfig {
+            position: "response".to_owned(),
+            key: "X-\nTest".to_owned(),
+            value: "ok".to_owned(),
+        };
+        let err = parse_header_edit(2, &entry).expect_err("LF in key must be rejected");
+        match err {
+            ConfigError::InvalidHeaderBytes { index, field } => {
+                assert_eq!(index, 2);
+                assert_eq!(field, "key");
+            }
+            other => panic!("expected InvalidHeaderBytes, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_header_edit_rejects_nul() {
+        let entry = HeaderEditConfig {
+            position: "both".to_owned(),
+            key: "X-Test".to_owned(),
+            value: "with\0nul".to_owned(),
+        };
+        assert!(matches!(
+            parse_header_edit(0, &entry),
+            Err(ConfigError::InvalidHeaderBytes { .. })
+        ));
+    }
+
+    /// Horizontal tab `\t` (0x09) is permitted in field values per
+    /// RFC 9110 §5.5 (folded-header obs-fold parts). The validator
+    /// must NOT reject it — otherwise legitimate operator configs
+    /// (e.g. `Authorization: Basic\tCREDENTIALS`) become unusable.
+    #[test]
+    fn parse_header_edit_accepts_tab_in_value() {
+        let entry = HeaderEditConfig {
+            position: "request".to_owned(),
+            key: "X-Test".to_owned(),
+            value: "with\ttab".to_owned(),
+        };
+        let header = parse_header_edit(0, &entry).expect("tab in value must be accepted");
+        assert_eq!(header.val, "with\ttab");
+    }
+
+    #[test]
+    fn parse_header_edit_accepts_clean_value() {
+        let entry = HeaderEditConfig {
+            position: "request".to_owned(),
+            key: "X-Tenant".to_owned(),
+            value: "alpha".to_owned(),
+        };
+        let header = parse_header_edit(0, &entry).expect("clean value must be accepted");
+        assert_eq!(header.key, "X-Tenant");
+        assert_eq!(header.val, "alpha");
     }
 }

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -988,33 +988,32 @@ fn read_http_answer_file(path: &Option<String>) -> Result<Option<String>, Config
 ///   routed to that cluster.
 ///
 /// Two source forms are accepted:
-/// * **Inline literal** — the value starts with the `inline:` prefix.
-///   The remainder of the value (everything after the colon) is taken
-///   as the template body verbatim. Useful for short canned responses,
-///   secrets-free containers where mounting a file is awkward, and
-///   automated test rigs that want to avoid disk I/O entirely.
-/// * **Filesystem path** — anything else. The path is opened and read
-///   into a string. Mirrors the on-disk loading the per-status
-///   [`read_http_answer_file`] helper performs for the deprecated
-///   `answer_301`..`answer_507` fields.
-///
-/// An empty inline body (`"inline:"`) is a legitimate template (a 0-byte
-/// response payload — typical with `Connection: close` and no headers).
+/// * **Filesystem path** — the value starts with the `file://` URI
+///   scheme. Everything after the prefix is treated as a path; the
+///   path is opened and read into a string. Mirrors the on-disk
+///   loading the per-status [`read_http_answer_file`] helper performs
+///   for the deprecated `answer_301`..`answer_507` fields.
+/// * **Inline literal** (default) — anything else. The value is taken
+///   verbatim as the template body, including an empty string (a
+///   0-byte response payload, typical with `Connection: close` and no
+///   headers). The bare-string default keeps the common case — a
+///   short canned response — typing-light; operators who need a file
+///   say so explicitly with `file://`.
 pub fn resolve_answer_source(value: &str) -> Result<String, ConfigError> {
-    if let Some(body) = value.strip_prefix("inline:") {
-        return Ok(body.to_owned());
-    }
-    let mut content = String::new();
-    let mut file = File::open(value).map_err(|io_error| ConfigError::FileOpen {
-        path_to_open: value.to_owned(),
-        io_error,
-    })?;
-    file.read_to_string(&mut content)
-        .map_err(|io_error| ConfigError::FileRead {
-            path_to_read: value.to_owned(),
+    if let Some(path) = value.strip_prefix("file://") {
+        let mut content = String::new();
+        let mut file = File::open(path).map_err(|io_error| ConfigError::FileOpen {
+            path_to_open: path.to_owned(),
             io_error,
         })?;
-    Ok(content)
+        file.read_to_string(&mut content)
+            .map_err(|io_error| ConfigError::FileRead {
+                path_to_read: path.to_owned(),
+                io_error,
+            })?;
+        return Ok(content);
+    }
+    Ok(value.to_owned())
 }
 
 /// Load every per-status template referenced by `answers`.
@@ -3207,30 +3206,38 @@ mod tests {
         assert_eq!(header.val, "alpha");
     }
 
-    /// `inline:` strips the prefix and treats the rest as the literal
-    /// template body — useful for short canned responses, secrets-free
-    /// containers, and test rigs that want zero disk I/O.
+    /// A bare string with no scheme prefix is the inline literal body.
+    /// This is the common case — short canned responses inline in TOML
+    /// or a `--answer` flag, no disk I/O.
     #[test]
-    fn resolve_answer_source_inline_returns_literal_body() {
-        let body = resolve_answer_source("inline:HTTP/1.1 503 Service Unavailable\r\n\r\nbusy")
-            .expect("inline source must resolve");
+    fn resolve_answer_source_bare_string_is_literal() {
+        let body = resolve_answer_source("HTTP/1.1 503 Service Unavailable\r\n\r\nbusy")
+            .expect("bare-string source must resolve");
         assert_eq!(body, "HTTP/1.1 503 Service Unavailable\r\n\r\nbusy");
     }
 
     #[test]
-    fn resolve_answer_source_inline_empty_is_legitimate() {
-        let body = resolve_answer_source("inline:").expect("empty inline source must resolve");
+    fn resolve_answer_source_empty_string_is_legitimate() {
+        let body = resolve_answer_source("").expect("empty source must resolve");
         assert_eq!(body, "");
     }
 
-    /// Anything without the `inline:` prefix is read as a filesystem
-    /// path. A non-existent path bubbles up as `ConfigError::FileOpen`
-    /// so the operator gets the same diagnostics as the existing
-    /// per-status `answer_NNN` flow.
+    /// `file://` opts into reading the path off disk. A non-existent
+    /// path bubbles up as `ConfigError::FileOpen` so the operator gets
+    /// the same diagnostics as the existing per-status `answer_NNN`
+    /// flow.
     #[test]
-    fn resolve_answer_source_path_missing_file_errors() {
-        let err = resolve_answer_source("/nonexistent/sozu-test/never.http")
+    fn resolve_answer_source_file_scheme_missing_file_errors() {
+        let err = resolve_answer_source("file:///nonexistent/sozu-test/never.http")
             .expect_err("missing path must error");
+        assert!(matches!(err, ConfigError::FileOpen { .. }));
+    }
+
+    /// `file://` strips the scheme; an empty path after the scheme is
+    /// rejected (empty path on filesystem read).
+    #[test]
+    fn resolve_answer_source_file_scheme_empty_path_errors() {
+        let err = resolve_answer_source("file://").expect_err("empty path must error");
         assert!(matches!(err, ConfigError::FileOpen { .. }));
     }
 }

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -424,14 +424,20 @@ pub struct ListenerBuilder {
     /// that omit ALPN entirely) are dropped at handshake instead of
     /// silently downgrading to HTTP/1.1. Default: false.
     pub disable_http11: Option<bool>,
-    /// Per-status HTTP answer template files at listener scope. Map key is
-    /// the HTTP status code (e.g. `"503"`); map value is a filesystem path
-    /// to the template body that will be loaded into
+    /// Per-status HTTP answer templates at listener scope — the **global
+    /// default** that fires whenever no cluster-level override matches.
+    /// Map key is the HTTP status code (e.g. `"503"`); map value is
+    /// either a filesystem path or an `inline:<body>` literal, see
+    /// [`resolve_answer_source`]. Loaded into
     /// [`HttpListenerConfig::answers`] / [`HttpsListenerConfig::answers`]
-    /// at build time via [`load_answers`]. The legacy per-status
-    /// `answer_NNN` fields are still honoured for backwards compatibility
-    /// but are equivalent to a one-line entry in this map; new code
-    /// should prefer `[listeners.answers]`.
+    /// at build time via [`load_answers`].
+    ///
+    /// Cluster-level [`FileClusterConfig::answers`] entries override the
+    /// matching status here for requests routed to that cluster.
+    ///
+    /// The deprecated per-status `answer_NNN` fields are still honoured
+    /// for backwards compatibility but are equivalent to a one-line entry
+    /// in this map; new configs should prefer `[listeners.answers]`.
     pub answers: Option<BTreeMap<String, String>>,
 }
 
@@ -971,38 +977,71 @@ fn read_http_answer_file(path: &Option<String>) -> Result<Option<String>, Config
     }
 }
 
-/// Load every per-status template referenced by `answers` from disk.
+/// Resolve a single `answers` map entry into the literal template body
+/// the proto layer expects.
 ///
-/// `answers` maps an HTTP status code (e.g. `"503"`) to a filesystem path.
-/// Each path is read into a body string and inserted into the returned
-/// map under the same key, ready to be assigned to the proto-level
+/// The same resolution rule applies to entries at every layer:
+/// * **Listener-level** `[listeners.<id>.answers]` — the global default
+///   that fires whenever no more specific override matches.
+/// * **Cluster-level** `[clusters.<id>.answers]` — overrides the
+///   listener-level default for the matching status code on requests
+///   routed to that cluster.
+///
+/// Two source forms are accepted:
+/// * **Inline literal** — the value starts with the `inline:` prefix.
+///   The remainder of the value (everything after the colon) is taken
+///   as the template body verbatim. Useful for short canned responses,
+///   secrets-free containers where mounting a file is awkward, and
+///   automated test rigs that want to avoid disk I/O entirely.
+/// * **Filesystem path** — anything else. The path is opened and read
+///   into a string. Mirrors the on-disk loading the per-status
+///   [`read_http_answer_file`] helper performs for the deprecated
+///   `answer_301`..`answer_507` fields.
+///
+/// An empty inline body (`"inline:"`) is a legitimate template (a 0-byte
+/// response payload — typical with `Connection: close` and no headers).
+pub fn resolve_answer_source(value: &str) -> Result<String, ConfigError> {
+    if let Some(body) = value.strip_prefix("inline:") {
+        return Ok(body.to_owned());
+    }
+    let mut content = String::new();
+    let mut file = File::open(value).map_err(|io_error| ConfigError::FileOpen {
+        path_to_open: value.to_owned(),
+        io_error,
+    })?;
+    file.read_to_string(&mut content)
+        .map_err(|io_error| ConfigError::FileRead {
+            path_to_read: value.to_owned(),
+            io_error,
+        })?;
+    Ok(content)
+}
+
+/// Load every per-status template referenced by `answers`.
+///
+/// `answers` maps an HTTP status code (e.g. `"503"`) to either a
+/// filesystem path or an `inline:<body>` literal — see
+/// [`resolve_answer_source`] for the resolution rules. Each entry is
+/// resolved into a body string and inserted into the returned map
+/// under the same key, ready to be assigned to the proto-level
 /// `answers` field on a [`HttpListenerConfig`] / [`HttpsListenerConfig`]
-/// / [`Cluster`]. Empty path values are skipped (treated as
-/// "preserve current") so the caller can use them as a no-op stub in
-/// example configs.
+/// / [`Cluster`]. Empty values are skipped (treated as "preserve
+/// current") so the caller can use them as a no-op stub in example
+/// configs.
 ///
-/// Errors map to the existing `ConfigError::FileOpen` / `ConfigError::FileRead`
-/// variants so the operator gets the same diagnostics as the legacy
-/// `read_http_answer_file` flow.
+/// Errors map to the existing `ConfigError::FileOpen` /
+/// `ConfigError::FileRead` variants so the operator gets the same
+/// diagnostics whether the path comes from this map or from the
+/// deprecated per-status `answer_301`..`answer_507` fields.
 pub fn load_answers(
     answers: &BTreeMap<String, String>,
 ) -> Result<BTreeMap<String, String>, ConfigError> {
     let mut out = BTreeMap::new();
-    for (code, path) in answers {
-        if path.is_empty() {
+    for (code, value) in answers {
+        if value.is_empty() {
             continue;
         }
-        let mut content = String::new();
-        let mut file = File::open(path).map_err(|io_error| ConfigError::FileOpen {
-            path_to_open: path.to_owned(),
-            io_error,
-        })?;
-        file.read_to_string(&mut content)
-            .map_err(|io_error| ConfigError::FileRead {
-                path_to_read: path.to_owned(),
-                io_error,
-            })?;
-        out.insert(code.to_owned(), content);
+        out.insert(code.to_owned(), resolve_answer_source(value)?);
     }
     Ok(out)
 }
@@ -1405,10 +1444,15 @@ pub struct FileClusterConfig {
     /// Does NOT gate H2 at the frontend — frontend H2 is ALPN-negotiated independently (see `alpn_protocols`).
     pub http2: Option<bool>,
     /// Per-cluster HTTP answer template overrides keyed by HTTP status
-    /// code (e.g. `"503"`). Map values are filesystem paths to the template
-    /// body, loaded into [`Cluster::answers`] at build time via
-    /// [`load_answers`]. An entry on a cluster overrides the same status
-    /// code on the listener.
+    /// code (e.g. `"503"`). Each value is either a filesystem path or an
+    /// `inline:<body>` literal — see [`resolve_answer_source`]. Loaded
+    /// into [`Cluster::answers`] at build time via [`load_answers`].
+    ///
+    /// Layering: an entry here overrides the listener-level
+    /// `[listeners.<id>.answers]` default for the matching status on
+    /// requests routed to this cluster. The listener-level map is the
+    /// global default; the cluster-level map is the per-cluster
+    /// override.
     pub answers: Option<BTreeMap<String, String>>,
     /// Optional explicit port to use when building the `Location` header
     /// for an `https_redirect`. When unset, the listener's effective HTTPS
@@ -3161,5 +3205,32 @@ mod tests {
         let header = parse_header_edit(0, &entry).expect("clean value must be accepted");
         assert_eq!(header.key, "X-Tenant");
         assert_eq!(header.val, "alpha");
+    }
+
+    /// `inline:` strips the prefix and treats the rest as the literal
+    /// template body — useful for short canned responses, secrets-free
+    /// containers, and test rigs that want zero disk I/O.
+    #[test]
+    fn resolve_answer_source_inline_returns_literal_body() {
+        let body = resolve_answer_source("inline:HTTP/1.1 503 Service Unavailable\r\n\r\nbusy")
+            .expect("inline source must resolve");
+        assert_eq!(body, "HTTP/1.1 503 Service Unavailable\r\n\r\nbusy");
+    }
+
+    #[test]
+    fn resolve_answer_source_inline_empty_is_legitimate() {
+        let body = resolve_answer_source("inline:").expect("empty inline source must resolve");
+        assert_eq!(body, "");
+    }
+
+    /// Anything without the `inline:` prefix is read as a filesystem
+    /// path. A non-existent path bubbles up as `ConfigError::FileOpen`
+    /// so the operator gets the same diagnostics as the existing
+    /// per-status `answer_NNN` flow.
+    #[test]
+    fn resolve_answer_source_path_missing_file_errors() {
+        let err = resolve_answer_source("/nonexistent/sozu-test/never.http")
+            .expect_err("missing path must error");
+        assert!(matches!(err, ConfigError::FileOpen { .. }));
     }
 }

--- a/command/src/logging/access_logs.rs
+++ b/command/src/logging/access_logs.rs
@@ -107,7 +107,7 @@ pub enum EndpointRecord<'a> {
 }
 
 /// used to aggregate tags in a session
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CachedTags {
     pub tags: BTreeMap<String, String>,
     pub concatenated: String,

--- a/command/src/request.rs
+++ b/command/src/request.rs
@@ -177,6 +177,14 @@ impl RequestHttpFrontend {
                 }
             })?,
             tags: Some(self.tags),
+            redirect: self.redirect,
+            redirect_scheme: self.redirect_scheme,
+            redirect_template: self.redirect_template,
+            rewrite_host: self.rewrite_host,
+            rewrite_path: self.rewrite_path,
+            rewrite_port: self.rewrite_port,
+            required_auth: self.required_auth,
+            headers: self.headers,
         })
     }
 }

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -2,7 +2,7 @@ use std::{cmp::Ordering, collections::BTreeMap, fmt, net::SocketAddr};
 
 use crate::{
     proto::command::{
-        AddBackend, FilteredTimeSerie, LoadBalancingParams, PathRule, PathRuleKind,
+        AddBackend, FilteredTimeSerie, Header, LoadBalancingParams, PathRule, PathRuleKind,
         RequestHttpFrontend, RequestTcpFrontend, Response, ResponseContent, ResponseStatus,
         RulePosition, RunState, WorkerResponse,
     },
@@ -39,6 +39,35 @@ pub struct HttpFrontend {
     #[serde(default)]
     pub position: RulePosition,
     pub tags: Option<BTreeMap<String, String>>,
+    /// Resolved frontend-level policy carried over from
+    /// [`RequestHttpFrontend`]. The router consults these to build a
+    /// [`Route::Frontend(Rc<Frontend>)`] when any are non-default,
+    /// otherwise falls back to the legacy `Route::ClusterId` /
+    /// `Route::Deny` shapes.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redirect: Option<i32>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redirect_scheme: Option<i32>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redirect_template: Option<String>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rewrite_host: Option<String>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rewrite_path: Option<String>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rewrite_port: Option<u32>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required_auth: Option<bool>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub headers: Vec<Header>,
 }
 
 impl From<HttpFrontend> for RequestHttpFrontend {
@@ -51,7 +80,14 @@ impl From<HttpFrontend> for RequestHttpFrontend {
             method: val.method,
             position: val.position.into(),
             tags: val.tags.unwrap_or_default(),
-            ..Default::default()
+            redirect: val.redirect,
+            redirect_scheme: val.redirect_scheme,
+            redirect_template: val.redirect_template,
+            rewrite_host: val.rewrite_host,
+            rewrite_path: val.rewrite_path,
+            rewrite_port: val.rewrite_port,
+            required_auth: val.required_auth,
+            headers: val.headers,
         }
     }
 }

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -51,6 +51,7 @@ impl From<HttpFrontend> for RequestHttpFrontend {
             method: val.method,
             position: val.position.into(),
             tags: val.tags.unwrap_or_default(),
+            ..Default::default()
         }
     }
 }

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -533,23 +533,23 @@ scope — the **global default** that fires whenever no cluster-level
 override matches — or as a `[clusters.<id>.answers]` map at cluster
 scope, which overrides the matching listener entry on requests routed
 through that cluster. Both layers accept the same key/value shape: the
-key is the HTTP status code (e.g. `"503"`); the value is **either** a
-filesystem path **or** an `inline:<body>` literal where everything
-after the colon is taken verbatim as the template body (no file I/O).
-The inline form is convenient for short canned responses, secrets-free
-containers where mounting a template directory is awkward, and test
-rigs that want to avoid disk dependencies.
+key is the HTTP status code (e.g. `"503"`); the value is **either** an
+inline literal body (the default — the value is taken verbatim) **or**
+`file://<path>` to load the body off disk. The inline form is
+convenient for short canned responses, secrets-free containers where
+mounting a template directory is awkward, and test rigs that want to
+avoid disk dependencies.
 
 ```toml
 # listener-level: global default for every status not overridden by a cluster.
 [listeners.https.answers]
-"401" = "/etc/sozu/templates/401.http"               # filesystem path
-"404" = "/etc/sozu/templates/404.http"
-"503" = """inline:HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\nContent-Length: 4\r\n\r\nbusy"""
+"401" = "file:///etc/sozu/templates/401.http"        # load from disk
+"404" = "file:///etc/sozu/templates/404.http"
+"503" = """HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\nContent-Length: 4\r\n\r\nbusy"""  # inline literal (no prefix)
 
 # cluster-level: overrides the listener default for THIS cluster only.
 [clusters.MyCluster.answers]
-"503" = "/etc/sozu/templates/MyCluster.503.http"
+"503" = "file:///etc/sozu/templates/MyCluster.503.http"
 ```
 
 Each template is a complete HTTP response (status line + headers + body) with
@@ -566,8 +566,14 @@ optional placeholders. Sōzu substitutes the placeholders at render time:
 | `%WWW_AUTHENTICATE` | header only | Realm string for 401 (header is elided when empty) |
 | `%MESSAGE`, `%PHASE`, `%SUCCESSFULLY_PARSED`, `%PARTIALLY_PARSED`, `%INVALID`, `%CAPACITY`, `%DURATION` | varies | Diagnostic detail for parse / size / timeout errors |
 
-A `Content-Length` header is auto-injected from the rendered body size when
-the template does not already carry one.
+When the template carries a `Content-Length: <N>` header, the engine
+recomputes the value from the actual rendered body size after
+`%`-substitutions — so a literal value that drifted from the body
+length cannot land on the wire (RFC 9110 §8.6 / RFC 7230 §3.3.2 anti-
+smuggling). Templates that omit `Content-Length` keep the byte-for-byte
+shape they were written with; nothing is synthesised. Operators who
+want a Content-Length include one; those who rely on `Connection:
+close` for body framing get a clean header-only response.
 
 When a template carries `Connection: close`, the response will close the
 frontend connection after delivery; a custom template without that header

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -525,6 +525,136 @@ Operators monitoring logs should expect the following classification:
 
 In particular, the recurring `Could not look up a certificate for server name "<name>"` line (issue #774) is emitted at `warn` when the `rustls::server::ClientHello` SNI does not match any configured frontend — the usual culprit is a generic scanner (Shodan, ssllabs, Censys) probing `default.example` or an IP-only hello. No action required unless the name matches a frontend you expect to serve.
 
+## Custom HTTP answer templates
+
+Sōzu lets operators replace any default error response with a templated body
+loaded from disk. Templates are specified as a `[listeners.answers]` map at
+listener scope or as a `[clusters.<id>.answers]` map at cluster scope; the
+key is the HTTP status code (e.g. `"503"`) and the value is the path to a
+template file. Cluster-level entries override the listener-level template
+for the same status code on requests routed through that cluster.
+
+```toml
+[listeners.https.answers]
+"401" = "/etc/sozu/templates/401.http"
+"404" = "/etc/sozu/templates/404.http"
+"503" = "/etc/sozu/templates/503.http"
+
+[clusters.MyCluster.answers]
+"503" = "/etc/sozu/templates/MyCluster.503.http"
+```
+
+Each template is a complete HTTP response (status line + headers + body) with
+optional placeholders. Sōzu substitutes the placeholders at render time:
+
+| Placeholder | Scope | Meaning |
+|-------------|-------|---------|
+| `%STATUS_CODE` | header & body | Resolved HTTP status (e.g. `503`) |
+| `%REQUEST_ID` | header & body | Per-request ULID (matches `Sozu-Id`) |
+| `%CLUSTER_ID` | header & body | Cluster the request was routed to (or empty) |
+| `%BACKEND_ID` | header & body | Backend the request was forwarded to (or empty) |
+| `%ROUTE` | header & body | Request method + authority + path |
+| `%REDIRECT_LOCATION` | header & body | Resolved `Location` URL (301 only) |
+| `%WWW_AUTHENTICATE` | header only | Realm string for 401 (header is elided when empty) |
+| `%MESSAGE`, `%PHASE`, `%SUCCESSFULLY_PARSED`, `%PARTIALLY_PARSED`, `%INVALID`, `%CAPACITY`, `%DURATION` | varies | Diagnostic detail for parse / size / timeout errors |
+
+A `Content-Length` header is auto-injected from the rendered body size when
+the template does not already carry one.
+
+When a template carries `Connection: close`, the response will close the
+frontend connection after delivery; a custom template without that header
+keeps frontend keep-alive on. The HAProxy parallel is `errorfile NNN /path`.
+
+The legacy `answer_NNN = "/path"` per-status fields under
+`[listeners.<name>]` continue to work — they are merged into the new map at
+load time so existing state files round-trip cleanly. New configs should
+prefer the `[listeners.<name>.answers]` shape.
+
+## Frontend redirect, URL rewrite, and custom headers
+
+Each frontend can carry a routing decision richer than "forward to a cluster".
+Three top-level knobs drive different policies:
+
+```toml
+[[clusters.MyCluster.frontends]]
+address  = "0.0.0.0:80"
+hostname = "old.example.com"
+# Force a permanent 301 to the canonical name on a different port.
+redirect        = "permanent"      # forward (default) | permanent | unauthorized
+redirect_scheme = "use-https"      # use-same (default) | use-http | use-https
+rewrite_host    = "new.example.com"
+rewrite_port    = 8443             # paired with `cluster.https_redirect_port`
+```
+
+`redirect = "permanent"` returns a 301 with a resolved `Location` URL built
+from `redirect_scheme`, the (optionally rewritten) host, the cluster's
+`https_redirect_port` (or the rewritten `rewrite_port`), and the original
+request path. `redirect = "unauthorized"` returns 401 unconditionally —
+useful for blanket deny-by-default frontends that still want to surface a
+login prompt with the cluster's `www_authenticate` realm.
+
+`rewrite_host` and `rewrite_path` accept a small template grammar:
+`$HOST[n]` references the n-th host capture (0 is the full hostname; 1+ are
+regex / wildcard subgroups), and `$PATH[n]` references the n-th path
+capture. When the host is rewritten, Sōzu injects the original host into
+`X-Forwarded-Host` so backends can reconstruct the request URL.
+
+Custom headers attach to the same frontend:
+
+```toml
+[[clusters.MyCluster.frontends.headers]]
+position = "request"               # request | response | both
+key      = "X-Forwarded-Proto"
+value    = "https"
+
+[[clusters.MyCluster.frontends.headers]]
+position = "response"
+key      = "X-Cache-Backend"
+value    = ""                      # empty value DELETES the header by name
+                                   # (HAProxy `del-header` parity)
+```
+
+HAProxy parallels: `http-request redirect` (permanent / scheme), `set-uri`
+and `set-path` (rewrite), `http-request set-header` and
+`http-request del-header` (custom headers).
+
+## HTTP Basic authentication on a frontend
+
+Operators can require a valid `Authorization: Basic` header on a frontend
+and validate it against a list of pre-hashed credentials on the cluster.
+The mux iterates the entire authorized list in constant time (via
+`subtle::ConstantTimeEq`), so neither the matching index nor a successful
+lookup leak through the time spent validating.
+
+```toml
+[clusters.MyCluster]
+# Realm rendered into `WWW-Authenticate: Basic realm="…"` on a 401.
+www_authenticate = 'Basic realm="MyCluster"'
+# Each entry is `username:hex(sha256(password))` — generate with
+# `printf 'admin:secret' | sha256sum` then prefix with `admin:`.
+authorized_hashes = [
+    "admin:2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b",
+]
+
+[[clusters.MyCluster.frontends]]
+address       = "0.0.0.0:80"
+hostname      = "secured.example.com"
+required_auth = true               # gate this frontend on basic-auth
+```
+
+Failure modes:
+
+- Missing `Authorization: Basic` header → 401 with the cluster's realm
+- Malformed credential (bad base64, missing `:`) → 401
+- Wrong username or password → 401
+- Empty `authorized_hashes` while the frontend has `required_auth = true`
+  → 401 (closed-by-default policy)
+
+The `WWW-Authenticate` header is rendered through the answer template's
+`%WWW_AUTHENTICATE` placeholder; when no realm is configured the entire
+header line is elided from the 401 response. HAProxy parallel:
+`http-request auth realm Foo unless { http_auth(...) }`.
+
 ## Runtime patch — `sozu listener update`
 
 `sozu listener {http,https,tcp} update` patches a live listener **in place** without cycling the listening socket. Only the fields you pass are written; all others are preserved exactly as they are. Existing sessions continue with their configuration snapshot; only new sessions, connections, or TLS handshakes — depending on the field — pick up the new values. Use `sozu listener list` to inspect current values before patching.

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -669,6 +669,34 @@ The `WWW-Authenticate` header is rendered through the answer template's
 header line is elided from the 401 response. HAProxy parallel:
 `http-request auth realm Foo unless { http_auth(...) }`.
 
+### Tuning the credential decode cap
+
+A hostile peer can send arbitrarily long `Authorization: Basic <token>`
+values. Sōzu base64-decodes the token in a transient allocation; an
+unbounded decode per failed-auth attempt is a memory pressure vector.
+The worker caps the decoded length to **4096 bytes by default** —
+well above the realistic `username:password` shape (typical credentials
+are <100 bytes). Operators running hardened tenants can lower this in
+the main TOML config:
+
+```toml
+# in the top-level config (alongside `buffer_size`, `max_connections`, etc.)
+basic_auth_max_credential_bytes = 256
+```
+
+The override is committed once on each worker at boot and applies to
+every cluster. Setting `0` is a no-op (the built-in default stays in
+force) so an explicit zero in a config file does not accidentally
+disable the cap.
+
+The config validator emits a `warn!` line at boot when the configured
+cap is **>= `buffer_size / 3`**: at that point a single failed-auth
+attempt can pin ~33% of the per-frontend buffer's worth of bytes,
+which combined with in-flight request/response framing pushes the
+buffer toward back-pressure under load. The warning is informational
+only — operators with a deliberate trade-off can keep the value, but
+the surprise stays visible in the boot log.
+
 ## Runtime patch — `sozu listener update`
 
 `sozu listener {http,https,tcp} update` patches a live listener **in place** without cycling the listening socket. Only the fields you pass are written; all others are preserved exactly as they are. Existing sessions continue with their configuration snapshot; only new sessions, connections, or TLS handshakes — depending on the field — pick up the new values. Use `sozu listener list` to inspect current values before patching.

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -527,19 +527,27 @@ In particular, the recurring `Could not look up a certificate for server name "<
 
 ## Custom HTTP answer templates
 
-Sōzu lets operators replace any default error response with a templated body
-loaded from disk. Templates are specified as a `[listeners.answers]` map at
-listener scope or as a `[clusters.<id>.answers]` map at cluster scope; the
-key is the HTTP status code (e.g. `"503"`) and the value is the path to a
-template file. Cluster-level entries override the listener-level template
-for the same status code on requests routed through that cluster.
+Sōzu lets operators replace any default error response with a templated body.
+Templates are specified as a `[listeners.<id>.answers]` map at listener
+scope — the **global default** that fires whenever no cluster-level
+override matches — or as a `[clusters.<id>.answers]` map at cluster
+scope, which overrides the matching listener entry on requests routed
+through that cluster. Both layers accept the same key/value shape: the
+key is the HTTP status code (e.g. `"503"`); the value is **either** a
+filesystem path **or** an `inline:<body>` literal where everything
+after the colon is taken verbatim as the template body (no file I/O).
+The inline form is convenient for short canned responses, secrets-free
+containers where mounting a template directory is awkward, and test
+rigs that want to avoid disk dependencies.
 
 ```toml
+# listener-level: global default for every status not overridden by a cluster.
 [listeners.https.answers]
-"401" = "/etc/sozu/templates/401.http"
+"401" = "/etc/sozu/templates/401.http"               # filesystem path
 "404" = "/etc/sozu/templates/404.http"
-"503" = "/etc/sozu/templates/503.http"
+"503" = """inline:HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\nContent-Length: 4\r\n\r\nbusy"""
 
+# cluster-level: overrides the listener default for THIS cluster only.
 [clusters.MyCluster.answers]
 "503" = "/etc/sozu/templates/MyCluster.503.http"
 ```

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -5,6 +5,7 @@ rust-version = "1.88.0"
 edition = "2024"
 
 [dependencies]
+base64 = { workspace = true }
 flate2 = { workspace = true }
 futures = { workspace = true }
 http-body-util = { workspace = true }

--- a/e2e/src/mock/h2_backend.rs
+++ b/e2e/src/mock/h2_backend.rs
@@ -23,12 +23,17 @@ use crate::port_registry::bind_tokio_listener;
 /// frontend rewrites + header edits — counters alone do not catch a
 /// rewrite bug that lands the request on the right path with the wrong
 /// authority, etc.
+///
+/// Header values are stored as `Vec<u8>` so a regression that forwards a
+/// non-UTF-8 byte (a corrupted upstream header, a smuggled control char)
+/// surfaces in the assertion diff rather than being silently lossily
+/// downgraded to an empty string by `HeaderValue::to_str`.
 #[derive(Debug, Clone)]
 pub struct RecordedH2Request {
     pub method: String,
     pub authority: String,
     pub path: String,
-    pub headers: Vec<(String, String)>,
+    pub headers: Vec<(String, Vec<u8>)>,
 }
 
 /// An HTTP/2 mock backend that accepts cleartext H2 connections (h2c).
@@ -138,10 +143,7 @@ impl H2Backend {
                                         .headers()
                                         .iter()
                                         .map(|(k, v)| {
-                                            (
-                                                k.as_str().to_owned(),
-                                                v.to_str().unwrap_or("").to_owned(),
-                                            )
+                                            (k.as_str().to_owned(), v.as_bytes().to_vec())
                                         })
                                         .collect(),
                                 };
@@ -200,9 +202,18 @@ impl H2Backend {
     pub fn stop(&mut self) {
         self.stop.store(true, Ordering::Relaxed);
         if let Some(thread) = self.thread.take() {
-            // Give the thread a moment to see the stop signal
-            thread::sleep(std::time::Duration::from_millis(100));
-            drop(thread);
+            // Join the spawned thread so its tokio runtime drops in
+            // lockstep with the test exit. Detaching it (the previous
+            // `drop(thread)`) leaves the runtime — and its threadpool —
+            // alive across subsequent tests in the same process, which
+            // cumulatively starves cargo's default thread budget on
+            // contended CI and amplifies otherwise-unrelated flakes.
+            // The accept loop polls the stop flag every 50 ms (see the
+            // timeout inside `start`) so this join completes within
+            // ~100 ms of the stop signal.
+            if let Err(payload) = thread.join() {
+                eprintln!("H2Backend: spawned thread panicked: {payload:?}");
+            }
         }
     }
 

--- a/e2e/src/mock/h2_backend.rs
+++ b/e2e/src/mock/h2_backend.rs
@@ -1,7 +1,7 @@
 use std::{
     net::SocketAddr,
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
         mpsc,
     },
@@ -18,6 +18,19 @@ use tokio::runtime::Runtime;
 
 use crate::port_registry::bind_tokio_listener;
 
+/// One row of the H2 backend's request log. Cardinality tests use this
+/// to assert deep equality on what reached the wire after Sōzu applied
+/// frontend rewrites + header edits — counters alone do not catch a
+/// rewrite bug that lands the request on the right path with the wrong
+/// authority, etc.
+#[derive(Debug, Clone)]
+pub struct RecordedH2Request {
+    pub method: String,
+    pub authority: String,
+    pub path: String,
+    pub headers: Vec<(String, String)>,
+}
+
 /// An HTTP/2 mock backend that accepts cleartext H2 connections (h2c).
 ///
 /// Sozu connects to backends over plain TCP and speaks HTTP/2 directly
@@ -28,6 +41,7 @@ pub struct H2Backend {
     stop: Arc<AtomicBool>,
     pub requests_received: Arc<AtomicUsize>,
     pub responses_sent: Arc<AtomicUsize>,
+    requests_log: Arc<Mutex<Vec<RecordedH2Request>>>,
     thread: Option<thread::JoinHandle<()>>,
 }
 
@@ -38,10 +52,12 @@ impl H2Backend {
         let stop = Arc::new(AtomicBool::new(false));
         let requests_received = Arc::new(AtomicUsize::new(0));
         let responses_sent = Arc::new(AtomicUsize::new(0));
+        let requests_log: Arc<Mutex<Vec<RecordedH2Request>>> = Arc::new(Mutex::new(Vec::new()));
 
         let stop_clone = stop.clone();
         let req_count = requests_received.clone();
         let resp_count = responses_sent.clone();
+        let req_log = requests_log.clone();
         let thread_name = name.clone();
 
         // Synchronous readiness handshake: the spawned tokio thread must
@@ -88,6 +104,7 @@ impl H2Backend {
                     let body = body.clone();
                     let req_count = req_count.clone();
                     let resp_count = resp_count.clone();
+                    let req_log = req_log.clone();
                     let name = thread_name.clone();
 
                     tokio::spawn(async move {
@@ -96,6 +113,7 @@ impl H2Backend {
                             let body = body.clone();
                             let req_count = req_count.clone();
                             let resp_count = resp_count.clone();
+                            let req_log = req_log.clone();
                             let name = name.clone();
                             async move {
                                 req_count.fetch_add(1, Ordering::Relaxed);
@@ -104,6 +122,32 @@ impl H2Backend {
                                     req.method(),
                                     req.uri()
                                 );
+                                // Snapshot the request shape so cardinality
+                                // tests can assert on the rewritten authority
+                                // / path / forwarded headers that reached the
+                                // backend wire.
+                                let recorded = RecordedH2Request {
+                                    method: req.method().as_str().to_owned(),
+                                    authority: req
+                                        .uri()
+                                        .authority()
+                                        .map(|a| a.as_str().to_owned())
+                                        .unwrap_or_default(),
+                                    path: req.uri().path().to_owned(),
+                                    headers: req
+                                        .headers()
+                                        .iter()
+                                        .map(|(k, v)| {
+                                            (
+                                                k.as_str().to_owned(),
+                                                v.to_str().unwrap_or("").to_owned(),
+                                            )
+                                        })
+                                        .collect(),
+                                };
+                                if let Ok(mut log) = req_log.lock() {
+                                    log.push(recorded);
+                                }
 
                                 let response = Response::builder()
                                     .status(200)
@@ -138,8 +182,19 @@ impl H2Backend {
             stop,
             requests_received,
             responses_sent,
+            requests_log,
             thread: Some(thread),
         }
+    }
+
+    /// Snapshot of every request the backend received since [`start`].
+    /// Cardinality tests use this to assert on the authority/path/headers
+    /// the backend actually saw on the wire.
+    pub fn recorded_requests(&self) -> Vec<RecordedH2Request> {
+        self.requests_log
+            .lock()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
     }
 
     pub fn stop(&mut self) {

--- a/e2e/src/port_registry.rs
+++ b/e2e/src/port_registry.rs
@@ -12,6 +12,15 @@ use sozu_command_lib::scm_socket::Listeners;
 const PORT_SEARCH_START: u16 = 20_000;
 const PORT_SEARCH_END: u16 = 65_000;
 
+/// Process-wide port allocator backing every e2e test.
+///
+/// Leak window: a test that panics between [`PortRegistry::reserve_listener_port`]
+/// and the matching [`PortRegistry::take_listener`] (called via
+/// [`bind_std_listener`] / [`bind_tokio_listener`]) leaves its
+/// `pending_listener` open until the process exits. The 45 000-port
+/// search range absorbs this for the typical e2e budget; converting
+/// `provide_port` into a `Drop`-guarded reservation handle is tracked
+/// for a follow-up that touches every call site at once.
 struct PortRegistry {
     next_port: u16,
     issued_ports: HashSet<u16>,

--- a/e2e/src/tests/mod.rs
+++ b/e2e/src/tests/mod.rs
@@ -36,6 +36,7 @@ mod h2_tests;
 pub(crate) mod h2_utils;
 mod listener_update_tests;
 mod mux_tests;
+mod redirect_rewrite_auth_tests;
 mod tcp_tests;
 mod tests;
 mod tls_tests;

--- a/e2e/src/tests/redirect_rewrite_auth_tests.rs
+++ b/e2e/src/tests/redirect_rewrite_auth_tests.rs
@@ -12,12 +12,12 @@
 //!     answer templates) and a sample of backend-visible mutations
 //!     (rewrite, header inject) — H1 backend still captures via
 //!     [`SyncBackend`].
-//!   * H1 ↔ H2 / H2 ↔ H2 — exercised at the routing-decision level by
-//!     setting `cluster.http2 = true`. Wire-level assertions on the H2
-//!     backend side require extending the [`H2Backend`] mock to capture
-//!     request authority/path/headers; those are covered by smoke tests
-//!     here that verify the request reaches the backend at all (via the
-//!     `requests_received` counter).
+//!   * H1 ↔ H2 / H2 ↔ H2 — backend-side assertions read from
+//!     [`H2Backend::recorded_requests`] which captures the rewritten
+//!     authority, path, method, and forwarded headers per request.
+//!     Smoke coverage plus rewrite-path / response-header tests on this
+//!     diagonal so a bug in the H2 emission path (`mux/h2.rs::write_streams`
+//!     applying response edits before `kawa.prepare`) surfaces here.
 
 use std::time::Duration;
 
@@ -91,12 +91,18 @@ fn add_backend(
 /// Retry [`SyncBackend::accept`] for up to `total_ms` (the underlying
 /// listener has a 100 ms read timeout, so a single call can return
 /// before sozu has opened its outbound connection on a slow CI runner).
+///
+/// The 100 ms internal poll is short enough that a busy spin would burn
+/// a full CPU core on every retry. Sleep 5 ms between attempts so the
+/// overall budget still expires within `total_ms` (~20 attempts on the
+/// hot path, fewer when the listener returns earlier).
 fn accept_with_retry(backend: &mut SyncBackend, client_id: usize, total_ms: u64) -> bool {
     let deadline = std::time::Instant::now() + Duration::from_millis(total_ms);
     while std::time::Instant::now() < deadline {
         if backend.accept(client_id) {
             return true;
         }
+        std::thread::sleep(Duration::from_millis(5));
     }
     false
 }
@@ -1078,13 +1084,31 @@ fn test_response_header_inject_h2_h1() {
 }
 
 // ═════════════════════════════════════════════════════════════════════
-// Cardinality matrix — H2 backend smoke (cluster.http2 = true)
+// Cardinality matrix — H2 backend coverage (cluster.http2 = true)
 // ═════════════════════════════════════════════════════════════════════
 
-/// Smoke test that a request reaches the H2 backend when the cluster
-/// is marked `http2 = true`. Asserts on `H2Backend::get_requests_received`
-/// — deeper assertions on the request authority/path/headers would
-/// require extending the mock to expose them.
+/// Snapshot the H2 backend until at least `target` requests are
+/// recorded or the deadline expires. Polls every 25 ms so a slow CI
+/// runner does not return an empty log.
+fn wait_for_h2_requests(
+    backend: &H2Backend,
+    target: usize,
+    deadline: std::time::Instant,
+) -> Vec<crate::mock::h2_backend::RecordedH2Request> {
+    while std::time::Instant::now() < deadline {
+        let snapshot = backend.recorded_requests();
+        if snapshot.len() >= target {
+            return snapshot;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    backend.recorded_requests()
+}
+
+/// H1 frontend → H2 backend smoke. Asserts on the recorded request
+/// shape (method, path, authority) so a future regression in the H2
+/// pseudo-header emission surfaces here, not just in the request
+/// counter.
 pub fn try_h1_to_h2_backend_smoke() -> State {
     let front_address = create_local_address();
     let back_address = create_local_address();
@@ -1101,7 +1125,7 @@ pub fn try_h1_to_h2_backend_smoke() -> State {
             .into(),
     );
     add_backend(&mut worker, "h1h2_cluster", "h1h2_back_0", back_address);
-    let mut backend = H2Backend::start("h1h2_back", back_address, "pong");
+    let backend = H2Backend::start("h1h2_back", back_address, "pong");
     worker.read_to_last();
 
     let mut client = Client::new(
@@ -1112,27 +1136,205 @@ pub fn try_h1_to_h2_backend_smoke() -> State {
     client.connect();
     client.send();
     let resp = client.receive();
-    // Give the H2 backend a moment to register the request.
-    std::thread::sleep(Duration::from_millis(250));
-    let count = backend.get_requests_received();
-    backend.stop();
+
+    let deadline = std::time::Instant::now() + Duration::from_millis(2500);
+    let snapshot = wait_for_h2_requests(&backend, 1, deadline);
+    drop(backend);
     worker.soft_stop();
     worker.wait_for_server_stop();
 
-    if count >= 1 && resp.is_some() {
-        State::Success
-    } else {
+    if resp.is_none() || snapshot.is_empty() {
         eprintln!(
-            "expected at least one request on the H2 backend (got {count}), client got resp={resp:?}"
+            "H1↔H2 smoke: expected ≥1 backend request and a frontend response, got resp={resp:?} backend={snapshot:?}"
         );
-        State::Fail
+        return State::Fail;
     }
+    let req = &snapshot[0];
+    if req.method != "GET" {
+        eprintln!("H1↔H2 smoke: expected method GET, got {:?}", req.method);
+        return State::Fail;
+    }
+    if req.path != "/" {
+        eprintln!("H1↔H2 smoke: expected path '/', got {:?}", req.path);
+        return State::Fail;
+    }
+    if !req.authority.starts_with("localhost") {
+        eprintln!(
+            "H1↔H2 smoke: expected :authority to start with 'localhost', got {:?}",
+            req.authority
+        );
+        return State::Fail;
+    }
+    State::Success
 }
 
 #[test]
 fn test_h1_to_h2_backend_smoke() {
     assert_eq!(
         repeat_until_error_or(1, "H1↔H2-backend smoke", try_h1_to_h2_backend_smoke),
+        State::Success
+    );
+}
+
+/// H1 frontend → H2 backend with a `--rewrite-path` policy. Asserts
+/// the H2 backend received the rewritten path AND the rewritten
+/// authority is reflected in `:authority` (mux applies both via the
+/// kawa StatusLine.path/uri rewrite then the converter emits them as
+/// pseudo-headers).
+pub fn try_rewrite_path_h1_h2() -> State {
+    let front_address = create_local_address();
+    let back_address = create_local_address();
+    let mut worker = spawn_worker_with_http_listener("REW-H1H2", front_address);
+    worker.send_proxy_request(
+        RequestType::AddCluster(Cluster {
+            http2: Some(true),
+            ..Worker::default_cluster("rewp_h1h2_cluster")
+        })
+        .into(),
+    );
+    worker.send_proxy_request(
+        RequestType::AddHttpFrontend(RequestHttpFrontend {
+            rewrite_host: Some("backend.example.com".to_owned()),
+            rewrite_path: Some("/v2/api".to_owned()),
+            ..Worker::default_http_frontend("rewp_h1h2_cluster", front_address)
+        })
+        .into(),
+    );
+    add_backend(
+        &mut worker,
+        "rewp_h1h2_cluster",
+        "rewp_h1h2_back_0",
+        back_address,
+    );
+    let backend = H2Backend::start("rewp_h1h2_back", back_address, "pong");
+    worker.read_to_last();
+
+    let mut client = Client::new(
+        "rewp_h1h2_client",
+        front_address,
+        http_request("GET", "/legacy/api", "ping", "localhost"),
+    );
+    client.connect();
+    client.send();
+    let resp = client.receive();
+
+    let deadline = std::time::Instant::now() + Duration::from_millis(2500);
+    let snapshot = wait_for_h2_requests(&backend, 1, deadline);
+    drop(backend);
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    if resp.is_none() || snapshot.is_empty() {
+        eprintln!("rewrite H1↔H2: missing data, resp={resp:?} backend={snapshot:?}");
+        return State::Fail;
+    }
+    let req = &snapshot[0];
+    if req.path != "/v2/api" {
+        eprintln!(
+            "rewrite H1↔H2: expected :path '/v2/api', got {:?}",
+            req.path
+        );
+        return State::Fail;
+    }
+    if req.authority != "backend.example.com" {
+        eprintln!(
+            "rewrite H1↔H2: expected :authority 'backend.example.com', got {:?}",
+            req.authority
+        );
+        return State::Fail;
+    }
+    let xfh = req
+        .headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("x-forwarded-host"))
+        .map(|(_, v)| v.as_str());
+    if !matches!(xfh, Some(v) if v.starts_with("localhost")) {
+        eprintln!("rewrite H1↔H2: expected X-Forwarded-Host carrying 'localhost', got {xfh:?}");
+        return State::Fail;
+    }
+    State::Success
+}
+
+#[test]
+fn test_rewrite_path_h1_h2() {
+    assert_eq!(
+        repeat_until_error_or(1, "rewrite H1↔H2", try_rewrite_path_h1_h2),
+        State::Success
+    );
+}
+
+/// H2 frontend (TLS h2) → H2 backend (h2c) with a `--header
+/// request=X-Tenant=foo` injection. Asserts the H2 backend received
+/// the operator-configured request header on the wire.
+pub fn try_request_header_inject_h2_h2() -> State {
+    use crate::mock::https_client::{build_h2_client, resolve_request};
+
+    let front_address = create_local_address();
+    let back_address = create_local_address();
+    let mut worker = spawn_worker_with_https_listener("REQ-INJ-H2H2", front_address);
+    worker.send_proxy_request(
+        RequestType::AddCluster(Cluster {
+            http2: Some(true),
+            ..Worker::default_cluster("reqi_h2h2_cluster")
+        })
+        .into(),
+    );
+    worker.send_proxy_request(
+        RequestType::AddHttpsFrontend(RequestHttpFrontend {
+            headers: vec![Header {
+                position: HeaderPosition::Request as i32,
+                key: "X-Tenant".to_owned(),
+                val: "alpha".to_owned(),
+            }],
+            ..Worker::default_http_frontend("reqi_h2h2_cluster", front_address)
+        })
+        .into(),
+    );
+    add_backend(
+        &mut worker,
+        "reqi_h2h2_cluster",
+        "reqi_h2h2_back_0",
+        back_address,
+    );
+    let backend = H2Backend::start("reqi_h2h2_back", back_address, "pong");
+    worker.read_to_last();
+
+    let uri: hyper::Uri = format!("https://localhost:{}/", front_address.port())
+        .parse()
+        .expect("H2H2 inject URI must parse");
+    let client = build_h2_client();
+    let outcome = resolve_request(&client, uri);
+
+    let deadline = std::time::Instant::now() + Duration::from_millis(2500);
+    let snapshot = wait_for_h2_requests(&backend, 1, deadline);
+    drop(backend);
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    if !matches!(outcome, Some((s, _)) if s.as_u16() == 200) {
+        eprintln!("inject H2↔H2: expected status 200, got {outcome:?}");
+        return State::Fail;
+    }
+    let Some(req) = snapshot.first() else {
+        eprintln!("inject H2↔H2: H2 backend recorded no request");
+        return State::Fail;
+    };
+    let injected = req
+        .headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("x-tenant"))
+        .map(|(_, v)| v.as_str());
+    if injected != Some("alpha") {
+        eprintln!("inject H2↔H2: expected X-Tenant: alpha on backend, got {injected:?}");
+        return State::Fail;
+    }
+    State::Success
+}
+
+#[test]
+fn test_request_header_inject_h2_h2() {
+    assert_eq!(
+        repeat_until_error_or(2, "request inject H2↔H2", try_request_header_inject_h2_h2),
         State::Success
     );
 }

--- a/e2e/src/tests/redirect_rewrite_auth_tests.rs
+++ b/e2e/src/tests/redirect_rewrite_auth_tests.rs
@@ -36,6 +36,37 @@ use crate::{
     },
 };
 
+/// Wallclock budget for the H1 [`SyncBackend`] to register a single
+/// connection from sozu after the test sends its request. Calibrated
+/// for the listener's 100 ms internal poll plus several retries; large
+/// enough to absorb a slow CI runner without bloating happy-path
+/// runtime (the loop exits on the first successful accept).
+const SYNC_BACKEND_ACCEPT_BUDGET_MS: u64 = 2000;
+
+/// Larger accept budget for tests that drive two sequential client
+/// connections through the same backend (e.g. basic-auth tests that
+/// retry after the 401). The backend is single-threaded — the second
+/// accept needs the budget of two cycles.
+const SYNC_BACKEND_TWO_SHOT_ACCEPT_BUDGET_MS: u64 = 4000;
+
+/// Sleep between [`SyncBackend::accept`] retries. Small enough that the
+/// 2 s budget gets ~400 attempts; large enough that a busy spin does
+/// not burn a CPU core. Does not extend the deadline (see
+/// `accept_with_retry`).
+const SYNC_BACKEND_RETRY_SLEEP_MS: u64 = 5;
+
+/// Wallclock budget for the [`H2Backend`] mock to record at least one
+/// request after the test resolves its frontend response. The hyper
+/// service runs on a dedicated tokio runtime; under contended CI we
+/// poll for up to this window before reading the recorded snapshot.
+const H2_BACKEND_RECORD_BUDGET_MS: u64 = 2500;
+
+/// Poll interval used by [`wait_for_h2_requests`] while waiting for
+/// the [`H2Backend`] to register a request. Same trade-off as the
+/// SyncBackend retry sleep — small enough to react quickly under load,
+/// large enough to avoid a busy spin.
+const H2_BACKEND_RECORD_POLL_MS: u64 = 25;
+
 /// Helper to spawn a fresh sozu worker with a single HTTP listener at
 /// `front_address` and return the worker. The cluster + frontend +
 /// backends are added by each test on top of this baseline so the
@@ -92,15 +123,11 @@ fn add_backend(
 /// listener has a 100 ms read timeout, so a single call can return
 /// before sozu has opened its outbound connection on a slow CI runner).
 ///
-/// The 100 ms internal poll is short enough that a busy spin would burn
-/// a full CPU core on every retry. Sleep 5 ms between attempts so the
-/// overall budget still expires within `total_ms` (~20 attempts on the
-/// hot path, fewer when the listener returns earlier).
-///
-/// Deadline check sits AFTER the accept attempt so we always make a
-/// final attempt right at the boundary — a `while now < deadline` check
-/// at the top would skip the last `accept()` call when the loop sleeps
-/// straight onto the deadline (security-review LISA-006).
+/// Sleeps [`SYNC_BACKEND_RETRY_SLEEP_MS`] between attempts so a busy
+/// spin doesn't burn a CPU core. Deadline check sits AFTER the accept
+/// attempt so the boundary attempt always runs — a `while now < deadline`
+/// check at the top would skip the last `accept()` call when the loop
+/// sleeps straight onto the deadline.
 fn accept_with_retry(backend: &mut SyncBackend, client_id: usize, total_ms: u64) -> bool {
     let deadline = std::time::Instant::now() + Duration::from_millis(total_ms);
     loop {
@@ -110,7 +137,7 @@ fn accept_with_retry(backend: &mut SyncBackend, client_id: usize, total_ms: u64)
         if std::time::Instant::now() >= deadline {
             return false;
         }
-        std::thread::sleep(Duration::from_millis(5));
+        std::thread::sleep(Duration::from_millis(SYNC_BACKEND_RETRY_SLEEP_MS));
     }
 }
 
@@ -331,7 +358,7 @@ pub fn try_basic_auth_h1_h1() -> State {
         let mut client = Client::new("auth_ok", front_address, req);
         client.connect();
         client.send();
-        accept_with_retry(&mut backend, 0, 2000);
+        accept_with_retry(&mut backend, 0, SYNC_BACKEND_ACCEPT_BUDGET_MS);
         let _ = backend.receive(0);
         backend.send(0);
         let resp = client.receive().expect("client must receive 200");
@@ -395,7 +422,7 @@ pub fn try_rewrite_host_h1_h1() -> State {
     );
     client.connect();
     client.send();
-    accept_with_retry(&mut backend, 0, 2000);
+    accept_with_retry(&mut backend, 0, SYNC_BACKEND_ACCEPT_BUDGET_MS);
     let received = backend.receive(0).expect("backend must receive request");
     backend.send(0);
     let _ = client.receive();
@@ -459,7 +486,7 @@ pub fn try_rewrite_path_h1_h1() -> State {
     );
     client.connect();
     client.send();
-    accept_with_retry(&mut backend, 0, 2000);
+    accept_with_retry(&mut backend, 0, SYNC_BACKEND_ACCEPT_BUDGET_MS);
     let received = backend.receive(0).expect("backend must receive request");
     backend.send(0);
     let _ = client.receive();
@@ -522,7 +549,7 @@ pub fn try_request_header_inject_h1_h1() -> State {
     );
     client.connect();
     client.send();
-    accept_with_retry(&mut backend, 0, 2000);
+    accept_with_retry(&mut backend, 0, SYNC_BACKEND_ACCEPT_BUDGET_MS);
     let received = backend.receive(0).expect("backend must receive request");
     backend.send(0);
     let _ = client.receive();
@@ -580,7 +607,7 @@ pub fn try_request_header_delete_h1_h1() -> State {
     let mut client = Client::new("rd_client", front_address, req.to_owned());
     client.connect();
     client.send();
-    accept_with_retry(&mut backend, 0, 2000);
+    accept_with_retry(&mut backend, 0, SYNC_BACKEND_ACCEPT_BUDGET_MS);
     let received = backend.receive(0).expect("backend must receive request");
     backend.send(0);
     let _ = client.receive();
@@ -644,7 +671,7 @@ pub fn try_response_header_inject_h1_h1() -> State {
     );
     client.connect();
     client.send();
-    accept_with_retry(&mut backend, 0, 2000);
+    accept_with_retry(&mut backend, 0, SYNC_BACKEND_ACCEPT_BUDGET_MS);
     let _ = backend.receive(0);
     backend.send(0);
     let resp = client.receive().expect("client must receive response");
@@ -704,7 +731,7 @@ pub fn try_response_header_delete_h1_h1() -> State {
     );
     client.connect();
     client.send();
-    accept_with_retry(&mut backend, 0, 2000);
+    accept_with_retry(&mut backend, 0, SYNC_BACKEND_ACCEPT_BUDGET_MS);
     let _ = backend.receive(0);
     backend.send(0);
     let resp = client.receive().expect("client must receive response");
@@ -790,10 +817,6 @@ fn test_per_cluster_503_template() {
         State::Success
     );
 }
-
-// ═════════════════════════════════════════════════════════════════════
-// Cardinality matrix — H2 frontend variants
-// ═════════════════════════════════════════════════════════════════════
 
 // ═════════════════════════════════════════════════════════════════════
 // Cardinality matrix — H2 frontend variants
@@ -971,7 +994,7 @@ pub fn try_basic_auth_h2_h1() -> State {
         .expect("H2 request must build");
     let rt = tokio::runtime::Runtime::new().expect("runtime");
     let backend_handle = std::thread::spawn(move || {
-        if accept_with_retry(&mut backend, 0, 4000) {
+        if accept_with_retry(&mut backend, 0, SYNC_BACKEND_TWO_SHOT_ACCEPT_BUDGET_MS) {
             let _ = backend.receive(0);
             backend.send(0);
         }
@@ -1055,7 +1078,7 @@ pub fn try_response_header_inject_h2_h1() -> State {
 
     let client = build_h2_client();
     let backend_handle = std::thread::spawn(move || {
-        if accept_with_retry(&mut backend, 0, 4000) {
+        if accept_with_retry(&mut backend, 0, SYNC_BACKEND_TWO_SHOT_ACCEPT_BUDGET_MS) {
             let _ = backend.receive(0);
             backend.send(0);
         }
@@ -1107,7 +1130,7 @@ fn wait_for_h2_requests(
         if snapshot.len() >= target {
             return snapshot;
         }
-        std::thread::sleep(Duration::from_millis(25));
+        std::thread::sleep(Duration::from_millis(H2_BACKEND_RECORD_POLL_MS));
     }
     backend.recorded_requests()
 }
@@ -1144,7 +1167,7 @@ pub fn try_h1_to_h2_backend_smoke() -> State {
     client.send();
     let resp = client.receive();
 
-    let deadline = std::time::Instant::now() + Duration::from_millis(2500);
+    let deadline = std::time::Instant::now() + Duration::from_millis(H2_BACKEND_RECORD_BUDGET_MS);
     let snapshot = wait_for_h2_requests(&backend, 1, deadline);
     drop(backend);
     worker.soft_stop();
@@ -1225,7 +1248,7 @@ pub fn try_rewrite_path_h1_h2() -> State {
     client.send();
     let resp = client.receive();
 
-    let deadline = std::time::Instant::now() + Duration::from_millis(2500);
+    let deadline = std::time::Instant::now() + Duration::from_millis(H2_BACKEND_RECORD_BUDGET_MS);
     let snapshot = wait_for_h2_requests(&backend, 1, deadline);
     drop(backend);
     worker.soft_stop();
@@ -1312,7 +1335,7 @@ pub fn try_request_header_inject_h2_h2() -> State {
     let client = build_h2_client();
     let outcome = resolve_request(&client, uri);
 
-    let deadline = std::time::Instant::now() + Duration::from_millis(2500);
+    let deadline = std::time::Instant::now() + Duration::from_millis(H2_BACKEND_RECORD_BUDGET_MS);
     let snapshot = wait_for_h2_requests(&backend, 1, deadline);
     drop(backend);
     worker.soft_stop();

--- a/e2e/src/tests/redirect_rewrite_auth_tests.rs
+++ b/e2e/src/tests/redirect_rewrite_auth_tests.rs
@@ -96,15 +96,22 @@ fn add_backend(
 /// a full CPU core on every retry. Sleep 5 ms between attempts so the
 /// overall budget still expires within `total_ms` (~20 attempts on the
 /// hot path, fewer when the listener returns earlier).
+///
+/// Deadline check sits AFTER the accept attempt so we always make a
+/// final attempt right at the boundary — a `while now < deadline` check
+/// at the top would skip the last `accept()` call when the loop sleeps
+/// straight onto the deadline (security-review LISA-006).
 fn accept_with_retry(backend: &mut SyncBackend, client_id: usize, total_ms: u64) -> bool {
     let deadline = std::time::Instant::now() + Duration::from_millis(total_ms);
-    while std::time::Instant::now() < deadline {
+    loop {
         if backend.accept(client_id) {
             return true;
         }
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
         std::thread::sleep(Duration::from_millis(5));
     }
-    false
 }
 
 // ═════════════════════════════════════════════════════════════════════
@@ -1247,8 +1254,8 @@ pub fn try_rewrite_path_h1_h2() -> State {
         .headers
         .iter()
         .find(|(k, _)| k.eq_ignore_ascii_case("x-forwarded-host"))
-        .map(|(_, v)| v.as_str());
-    if !matches!(xfh, Some(v) if v.starts_with("localhost")) {
+        .map(|(_, v)| v.as_slice());
+    if !matches!(xfh, Some(v) if v.starts_with(b"localhost")) {
         eprintln!("rewrite H1↔H2: expected X-Forwarded-Host carrying 'localhost', got {xfh:?}");
         return State::Fail;
     }
@@ -1323,8 +1330,8 @@ pub fn try_request_header_inject_h2_h2() -> State {
         .headers
         .iter()
         .find(|(k, _)| k.eq_ignore_ascii_case("x-tenant"))
-        .map(|(_, v)| v.as_str());
-    if injected != Some("alpha") {
+        .map(|(_, v)| v.as_slice());
+    if injected != Some(b"alpha".as_slice()) {
         eprintln!("inject H2↔H2: expected X-Tenant: alpha on backend, got {injected:?}");
         return State::Fail;
     }

--- a/e2e/src/tests/redirect_rewrite_auth_tests.rs
+++ b/e2e/src/tests/redirect_rewrite_auth_tests.rs
@@ -1,0 +1,1138 @@
+//! End-to-end coverage for the redirect / URL rewrite / per-frontend
+//! header / Basic-auth feature stack ported from PR #1206..#1210 to the
+//! post-#1209 mux. Each test asserts on what the **backend** or the
+//! **client** sees on the wire so a regression in the routing decision,
+//! the request-side mutation pass, or the response-side emission pass
+//! surfaces directly.
+//!
+//! Cardinality matrix coverage:
+//!   * H1 ↔ H1 — every behaviour, deep wire assertions via [`SyncBackend`]
+//!     which exposes the raw HTTP/1.1 request bytes.
+//!   * H2 ↔ H1 — frontend-only behaviours (redirect, basic auth, custom
+//!     answer templates) and a sample of backend-visible mutations
+//!     (rewrite, header inject) — H1 backend still captures via
+//!     [`SyncBackend`].
+//!   * H1 ↔ H2 / H2 ↔ H2 — exercised at the routing-decision level by
+//!     setting `cluster.http2 = true`. Wire-level assertions on the H2
+//!     backend side require extending the [`H2Backend`] mock to capture
+//!     request authority/path/headers; those are covered by smoke tests
+//!     here that verify the request reaches the backend at all (via the
+//!     `requests_received` counter).
+
+use std::time::Duration;
+
+use sozu_command_lib::proto::command::{
+    ActivateListener, Cluster, Header, HeaderPosition, ListenerType, RedirectPolicy,
+    RedirectScheme, Request, RequestHttpFrontend, request::RequestType,
+};
+
+use crate::{
+    http_utils::http_request,
+    mock::{client::Client, h2_backend::H2Backend, sync_backend::Backend as SyncBackend},
+    sozu::worker::Worker,
+    tests::{
+        State, repeat_until_error_or,
+        tests::{create_local_address, create_unbound_local_address},
+    },
+};
+
+/// Helper to spawn a fresh sozu worker with a single HTTP listener at
+/// `front_address` and return the worker. The cluster + frontend +
+/// backends are added by each test on top of this baseline so the
+/// per-test policy fields can be set declaratively without needing a
+/// new constructor parameter for every behaviour.
+///
+/// The listener fd is pre-reserved via the port registry and passed to
+/// the worker through the SCM socket — this matches `setup_test`'s
+/// pattern and is required to avoid the "Address already in use" race
+/// where sozu's bind would lose to the test's own port reservation.
+fn spawn_worker_with_http_listener(name: &str, front_address: std::net::SocketAddr) -> Worker {
+    use sozu_command_lib::config::ListenerBuilder;
+    let (config, mut listeners, state) = Worker::empty_config();
+    crate::port_registry::attach_reserved_http_listener(&mut listeners, front_address);
+    let mut worker = Worker::start_new_worker_owned(name, config, listeners, state);
+
+    worker.send_proxy_request(Request {
+        request_type: Some(RequestType::AddHttpListener(
+            ListenerBuilder::new_http(front_address.into())
+                .to_http(None)
+                .expect("default HTTP listener must build"),
+        )),
+    });
+    worker.send_proxy_request(Request {
+        request_type: Some(RequestType::ActivateListener(ActivateListener {
+            address: front_address.into(),
+            proxy: ListenerType::Http.into(),
+            from_scm: true,
+        })),
+    });
+    worker.read_to_last();
+    worker
+}
+
+/// Add a backend to `cluster_id` at `back_address` with `backend_id`.
+fn add_backend(
+    worker: &mut Worker,
+    cluster_id: &str,
+    backend_id: &str,
+    back_address: std::net::SocketAddr,
+) {
+    worker.send_proxy_request(
+        RequestType::AddBackend(Worker::default_backend(
+            cluster_id,
+            backend_id,
+            back_address,
+            None,
+        ))
+        .into(),
+    );
+}
+
+/// Retry [`SyncBackend::accept`] for up to `total_ms` (the underlying
+/// listener has a 100 ms read timeout, so a single call can return
+/// before sozu has opened its outbound connection on a slow CI runner).
+fn accept_with_retry(backend: &mut SyncBackend, client_id: usize, total_ms: u64) -> bool {
+    let deadline = std::time::Instant::now() + Duration::from_millis(total_ms);
+    while std::time::Instant::now() < deadline {
+        if backend.accept(client_id) {
+            return true;
+        }
+    }
+    false
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Redirect — RedirectPolicy::Permanent emits 301 without contacting backend
+// ═════════════════════════════════════════════════════════════════════
+
+/// `RedirectPolicy::Permanent` plus `RedirectScheme::UseHttps` makes the
+/// frontend emit a 301 with the resolved HTTPS Location and never opens
+/// a TCP connection to any backend. H1 frontend cardinality.
+pub fn try_redirect_permanent_h1_skips_backend() -> State {
+    let front_address = create_local_address();
+    let unused_back = create_unbound_local_address();
+    let mut worker = spawn_worker_with_http_listener("REDIR-H1", front_address);
+
+    worker.send_proxy_request(
+        RequestType::AddCluster(Cluster {
+            https_redirect_port: Some(8443),
+            ..Worker::default_cluster("redir_cluster")
+        })
+        .into(),
+    );
+    worker.send_proxy_request(
+        RequestType::AddHttpFrontend(RequestHttpFrontend {
+            redirect: Some(RedirectPolicy::Permanent as i32),
+            redirect_scheme: Some(RedirectScheme::UseHttps as i32),
+            ..Worker::default_http_frontend("redir_cluster", front_address)
+        })
+        .into(),
+    );
+    add_backend(&mut worker, "redir_cluster", "redir_back_0", unused_back);
+    worker.read_to_last();
+
+    let mut client = Client::new(
+        "redir_client",
+        front_address,
+        http_request("GET", "/path", "ping", "localhost"),
+    );
+    client.connect();
+    client.send();
+    let response = client
+        .receive()
+        .expect("frontend must emit a 301 default-answer");
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    let ok = response.contains("301") && response.to_ascii_lowercase().contains("location: https");
+    if ok {
+        State::Success
+    } else {
+        eprintln!("expected 301 with https Location, got:\n{response}");
+        State::Fail
+    }
+}
+
+#[test]
+fn test_redirect_permanent_h1_skips_backend() {
+    assert_eq!(
+        repeat_until_error_or(
+            2,
+            "permanent redirect",
+            try_redirect_permanent_h1_skips_backend
+        ),
+        State::Success
+    );
+}
+
+/// `RedirectPolicy::Unauthorized` returns a 401 even when the cluster
+/// would otherwise route normally. H1 frontend.
+pub fn try_redirect_unauthorized_h1_emits_401() -> State {
+    let front_address = create_local_address();
+    let unused_back = create_unbound_local_address();
+    let mut worker = spawn_worker_with_http_listener("UNAUTH-H1", front_address);
+
+    worker.send_proxy_request(
+        RequestType::AddCluster(Cluster {
+            www_authenticate: Some("Basic realm=\"unauth\"".to_owned()),
+            ..Worker::default_cluster("unauth_cluster")
+        })
+        .into(),
+    );
+    worker.send_proxy_request(
+        RequestType::AddHttpFrontend(RequestHttpFrontend {
+            redirect: Some(RedirectPolicy::Unauthorized as i32),
+            ..Worker::default_http_frontend("unauth_cluster", front_address)
+        })
+        .into(),
+    );
+    add_backend(&mut worker, "unauth_cluster", "unauth_back_0", unused_back);
+    worker.read_to_last();
+
+    let mut client = Client::new(
+        "unauth_client",
+        front_address,
+        http_request("GET", "/", "ping", "localhost"),
+    );
+    client.connect();
+    client.send();
+    let response = client.receive().expect("frontend must emit a 401");
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    if response.contains("401") {
+        State::Success
+    } else {
+        eprintln!("expected 401, got:\n{response}");
+        State::Fail
+    }
+}
+
+#[test]
+fn test_redirect_unauthorized_h1_emits_401() {
+    assert_eq!(
+        repeat_until_error_or(
+            2,
+            "unauthorized redirect",
+            try_redirect_unauthorized_h1_emits_401
+        ),
+        State::Success
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Basic auth — required_auth + authorized_hashes wire path
+// ═════════════════════════════════════════════════════════════════════
+
+/// SHA-256 of the literal byte string `"secret"`, lowercase hex,
+/// matching `printf 'secret' | sha256sum`. Pinned here so we can
+/// generate `authorized_hashes` entries without re-deriving on every
+/// run.
+const SECRET_SHA256_HEX: &str = "2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b";
+
+fn make_basic_auth_cluster() -> Cluster {
+    Cluster {
+        authorized_hashes: vec![format!("admin:{SECRET_SHA256_HEX}")],
+        www_authenticate: Some("Basic realm=\"sozu\"".to_owned()),
+        ..Worker::default_cluster("auth_cluster")
+    }
+}
+
+/// Three branches: missing header → 401 with WWW-Authenticate, wrong
+/// credential → 401, correct credential → 200 from the backend.
+pub fn try_basic_auth_h1_h1() -> State {
+    let front_address = create_local_address();
+    let back_address = create_local_address();
+    let mut worker = spawn_worker_with_http_listener("AUTH-H1H1", front_address);
+    worker.send_proxy_request(RequestType::AddCluster(make_basic_auth_cluster()).into());
+    worker.send_proxy_request(
+        RequestType::AddHttpFrontend(RequestHttpFrontend {
+            required_auth: Some(true),
+            ..Worker::default_http_frontend("auth_cluster", front_address)
+        })
+        .into(),
+    );
+    add_backend(&mut worker, "auth_cluster", "auth_back_0", back_address);
+    let mut backend = SyncBackend::new(
+        "auth_back_0",
+        back_address,
+        "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\npong",
+    );
+    backend.connect();
+    worker.read_to_last();
+
+    // 1. No header → 401 + WWW-Authenticate
+    {
+        let mut client = Client::new(
+            "auth_no_header",
+            front_address,
+            http_request("GET", "/secured", "", "localhost"),
+        );
+        client.connect();
+        client.send();
+        let resp = client
+            .receive()
+            .expect("frontend must emit 401 for missing header");
+        if !resp.contains("401")
+            || !resp
+                .to_ascii_lowercase()
+                .contains("www-authenticate: basic realm=")
+        {
+            eprintln!(
+                "missing-header arm failed; expected 401 with WWW-Authenticate, got:\n{resp}"
+            );
+            worker.soft_stop();
+            worker.wait_for_server_stop();
+            return State::Fail;
+        }
+    }
+
+    // 2. Wrong creds → 401
+    {
+        let token =
+            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"admin:wrong");
+        let req = format!(
+            "GET /secured HTTP/1.1\r\nHost: localhost\r\nAuthorization: Basic {token}\r\nContent-Length: 0\r\n\r\n"
+        );
+        let mut client = Client::new("auth_wrong", front_address, req);
+        client.connect();
+        client.send();
+        let resp = client
+            .receive()
+            .expect("frontend must emit 401 for wrong creds");
+        if !resp.contains("401") {
+            eprintln!("wrong-creds arm failed; expected 401, got:\n{resp}");
+            worker.soft_stop();
+            worker.wait_for_server_stop();
+            return State::Fail;
+        }
+    }
+
+    // 3. Correct creds → backend forwards
+    {
+        let token =
+            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"admin:secret");
+        let req = format!(
+            "GET /secured HTTP/1.1\r\nHost: localhost\r\nAuthorization: Basic {token}\r\nContent-Length: 0\r\n\r\n"
+        );
+        let mut client = Client::new("auth_ok", front_address, req);
+        client.connect();
+        client.send();
+        accept_with_retry(&mut backend, 0, 2000);
+        let _ = backend.receive(0);
+        backend.send(0);
+        let resp = client.receive().expect("client must receive 200");
+        if !resp.contains("200") {
+            eprintln!("correct-creds arm failed; expected 200, got:\n{resp}");
+            worker.soft_stop();
+            worker.wait_for_server_stop();
+            return State::Fail;
+        }
+    }
+
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+    State::Success
+}
+
+#[test]
+fn test_basic_auth_h1_h1() {
+    assert_eq!(
+        repeat_until_error_or(2, "basic auth H1↔H1", try_basic_auth_h1_h1),
+        State::Success
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// URL rewrite — backend sees rewritten Host + path + X-Forwarded-Host
+// ═════════════════════════════════════════════════════════════════════
+
+/// Backend must observe the rewritten `Host:` and `X-Forwarded-Host:`
+/// the routing layer injects. H1 frontend, H1 backend.
+pub fn try_rewrite_host_h1_h1() -> State {
+    let front_address = create_local_address();
+    let back_address = create_local_address();
+    let mut worker = spawn_worker_with_http_listener("REWRITE-H1H1", front_address);
+    worker
+        .send_proxy_request(RequestType::AddCluster(Worker::default_cluster("rwh_cluster")).into());
+    worker.send_proxy_request(
+        RequestType::AddHttpFrontend(RequestHttpFrontend {
+            rewrite_host: Some("backend.local".to_owned()),
+            ..Worker::default_http_frontend("rwh_cluster", front_address)
+        })
+        .into(),
+    );
+    add_backend(&mut worker, "rwh_cluster", "rwh_back_0", back_address);
+    let mut backend = SyncBackend::new(
+        "rwh_back",
+        back_address,
+        "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\npong",
+    );
+    backend.connect();
+    worker.read_to_last();
+
+    // Client must match the frontend's `hostname` ("localhost" via
+    // `default_http_frontend`) so the routing decision finds the
+    // frontend; `rewrite_host` then mutates the on-wire authority to
+    // "backend.local" before the backend forward.
+    let mut client = Client::new(
+        "rwh_client",
+        front_address,
+        http_request("GET", "/", "ping", "localhost"),
+    );
+    client.connect();
+    client.send();
+    accept_with_retry(&mut backend, 0, 2000);
+    let received = backend.receive(0).expect("backend must receive request");
+    backend.send(0);
+    let _ = client.receive();
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    let received_lc = received.to_ascii_lowercase();
+    let host_ok = received_lc.contains("host: backend.local");
+    // The original `:authority` (post-`hostname_and_port` strip of the
+    // listener port) is captured into X-Forwarded-Host. We sent
+    // `Host: localhost` — sozu's H1 path may also append the listener
+    // port, so we accept either bare `localhost` or `localhost:<port>`
+    // in the X-Forwarded-Host check.
+    let xfh_ok = received_lc.contains("x-forwarded-host: localhost");
+    if host_ok && xfh_ok {
+        State::Success
+    } else {
+        eprintln!(
+            "expected rewritten Host + X-Forwarded-Host, got:\n{received}\n(host={host_ok}, xfh={xfh_ok})"
+        );
+        State::Fail
+    }
+}
+
+#[test]
+fn test_rewrite_host_h1_h1() {
+    assert_eq!(
+        repeat_until_error_or(2, "rewrite host H1↔H1", try_rewrite_host_h1_h1),
+        State::Success
+    );
+}
+
+/// `rewrite_path` mutates the request-line URI on the wire to the
+/// backend. H1 frontend, H1 backend.
+pub fn try_rewrite_path_h1_h1() -> State {
+    let front_address = create_local_address();
+    let back_address = create_local_address();
+    let mut worker = spawn_worker_with_http_listener("REWRITE-PATH-H1H1", front_address);
+    worker
+        .send_proxy_request(RequestType::AddCluster(Worker::default_cluster("rwp_cluster")).into());
+    worker.send_proxy_request(
+        RequestType::AddHttpFrontend(RequestHttpFrontend {
+            rewrite_path: Some("/v2/api".to_owned()),
+            ..Worker::default_http_frontend("rwp_cluster", front_address)
+        })
+        .into(),
+    );
+    add_backend(&mut worker, "rwp_cluster", "rwp_back_0", back_address);
+    let mut backend = SyncBackend::new(
+        "rwp_back",
+        back_address,
+        "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\npong",
+    );
+    backend.connect();
+    worker.read_to_last();
+
+    let mut client = Client::new(
+        "rwp_client",
+        front_address,
+        http_request("GET", "/api/old", "ping", "localhost"),
+    );
+    client.connect();
+    client.send();
+    accept_with_retry(&mut backend, 0, 2000);
+    let received = backend.receive(0).expect("backend must receive request");
+    backend.send(0);
+    let _ = client.receive();
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    let path_ok = received.starts_with("GET /v2/api ") || received.contains("GET /v2/api ");
+    if path_ok {
+        State::Success
+    } else {
+        eprintln!("expected rewritten path /v2/api, got:\n{received}");
+        State::Fail
+    }
+}
+
+#[test]
+fn test_rewrite_path_h1_h1() {
+    assert_eq!(
+        repeat_until_error_or(2, "rewrite path H1↔H1", try_rewrite_path_h1_h1),
+        State::Success
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Per-frontend header injection — request-side
+// ═════════════════════════════════════════════════════════════════════
+
+/// Backend must observe the operator-configured request header.
+/// H1 frontend, H1 backend.
+pub fn try_request_header_inject_h1_h1() -> State {
+    let front_address = create_local_address();
+    let back_address = create_local_address();
+    let mut worker = spawn_worker_with_http_listener("REQ-INJ-H1H1", front_address);
+    worker
+        .send_proxy_request(RequestType::AddCluster(Worker::default_cluster("ri_cluster")).into());
+    worker.send_proxy_request(
+        RequestType::AddHttpFrontend(RequestHttpFrontend {
+            headers: vec![Header {
+                position: HeaderPosition::Request as i32,
+                key: "X-Sozu-Probe".to_owned(),
+                val: "alpha".to_owned(),
+            }],
+            ..Worker::default_http_frontend("ri_cluster", front_address)
+        })
+        .into(),
+    );
+    add_backend(&mut worker, "ri_cluster", "ri_back_0", back_address);
+    let mut backend = SyncBackend::new(
+        "ri_back",
+        back_address,
+        "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\npong",
+    );
+    backend.connect();
+    worker.read_to_last();
+
+    let mut client = Client::new(
+        "ri_client",
+        front_address,
+        http_request("GET", "/", "ping", "localhost"),
+    );
+    client.connect();
+    client.send();
+    accept_with_retry(&mut backend, 0, 2000);
+    let received = backend.receive(0).expect("backend must receive request");
+    backend.send(0);
+    let _ = client.receive();
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    if received
+        .to_ascii_lowercase()
+        .contains("x-sozu-probe: alpha")
+    {
+        State::Success
+    } else {
+        eprintln!("expected X-Sozu-Probe: alpha, got:\n{received}");
+        State::Fail
+    }
+}
+
+#[test]
+fn test_request_header_inject_h1_h1() {
+    assert_eq!(
+        repeat_until_error_or(2, "request inject H1↔H1", try_request_header_inject_h1_h1),
+        State::Success
+    );
+}
+
+/// Empty `val` deletes the named header from the request that reaches
+/// the backend (HAProxy `del-header` parity).
+pub fn try_request_header_delete_h1_h1() -> State {
+    let front_address = create_local_address();
+    let back_address = create_local_address();
+    let mut worker = spawn_worker_with_http_listener("REQ-DEL-H1H1", front_address);
+    worker
+        .send_proxy_request(RequestType::AddCluster(Worker::default_cluster("rd_cluster")).into());
+    worker.send_proxy_request(
+        RequestType::AddHttpFrontend(RequestHttpFrontend {
+            headers: vec![Header {
+                position: HeaderPosition::Request as i32,
+                key: "X-Drop-Me".to_owned(),
+                val: String::new(),
+            }],
+            ..Worker::default_http_frontend("rd_cluster", front_address)
+        })
+        .into(),
+    );
+    add_backend(&mut worker, "rd_cluster", "rd_back_0", back_address);
+    let mut backend = SyncBackend::new(
+        "rd_back",
+        back_address,
+        "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\npong",
+    );
+    backend.connect();
+    worker.read_to_last();
+
+    let req = "GET / HTTP/1.1\r\nHost: localhost\r\nX-Drop-Me: should-not-reach-backend\r\nContent-Length: 4\r\n\r\nping";
+    let mut client = Client::new("rd_client", front_address, req.to_owned());
+    client.connect();
+    client.send();
+    accept_with_retry(&mut backend, 0, 2000);
+    let received = backend.receive(0).expect("backend must receive request");
+    backend.send(0);
+    let _ = client.receive();
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    if !received.to_ascii_lowercase().contains("x-drop-me") {
+        State::Success
+    } else {
+        eprintln!("expected X-Drop-Me to be stripped, got:\n{received}");
+        State::Fail
+    }
+}
+
+#[test]
+fn test_request_header_delete_h1_h1() {
+    assert_eq!(
+        repeat_until_error_or(2, "request delete H1↔H1", try_request_header_delete_h1_h1),
+        State::Success
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Per-frontend header injection — response-side
+// ═════════════════════════════════════════════════════════════════════
+
+/// Client must observe the operator-configured response header. The
+/// emission boundary in `mux/h1.rs::writable` applies the edits before
+/// `kawa.prepare(...)`.
+pub fn try_response_header_inject_h1_h1() -> State {
+    let front_address = create_local_address();
+    let back_address = create_local_address();
+    let mut worker = spawn_worker_with_http_listener("RESP-INJ-H1H1", front_address);
+    worker.send_proxy_request(
+        RequestType::AddCluster(Worker::default_cluster("respi_cluster")).into(),
+    );
+    worker.send_proxy_request(
+        RequestType::AddHttpFrontend(RequestHttpFrontend {
+            headers: vec![Header {
+                position: HeaderPosition::Response as i32,
+                key: "X-Sozu-Stamp".to_owned(),
+                val: "served-by-sozu".to_owned(),
+            }],
+            ..Worker::default_http_frontend("respi_cluster", front_address)
+        })
+        .into(),
+    );
+    add_backend(&mut worker, "respi_cluster", "respi_back_0", back_address);
+    let mut backend = SyncBackend::new(
+        "respi_back",
+        back_address,
+        "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\npong",
+    );
+    backend.connect();
+    worker.read_to_last();
+
+    let mut client = Client::new(
+        "respi_client",
+        front_address,
+        http_request("GET", "/", "ping", "localhost"),
+    );
+    client.connect();
+    client.send();
+    accept_with_retry(&mut backend, 0, 2000);
+    let _ = backend.receive(0);
+    backend.send(0);
+    let resp = client.receive().expect("client must receive response");
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    if resp
+        .to_ascii_lowercase()
+        .contains("x-sozu-stamp: served-by-sozu")
+    {
+        State::Success
+    } else {
+        eprintln!("expected X-Sozu-Stamp on response, got:\n{resp}");
+        State::Fail
+    }
+}
+
+#[test]
+fn test_response_header_inject_h1_h1() {
+    assert_eq!(
+        repeat_until_error_or(2, "response inject H1↔H1", try_response_header_inject_h1_h1),
+        State::Success
+    );
+}
+
+/// Empty `val` strips a backend-supplied response header before it
+/// reaches the client.
+pub fn try_response_header_delete_h1_h1() -> State {
+    let front_address = create_local_address();
+    let back_address = create_local_address();
+    let mut worker = spawn_worker_with_http_listener("RESP-DEL-H1H1", front_address);
+    worker.send_proxy_request(
+        RequestType::AddCluster(Worker::default_cluster("respd_cluster")).into(),
+    );
+    worker.send_proxy_request(
+        RequestType::AddHttpFrontend(RequestHttpFrontend {
+            headers: vec![Header {
+                position: HeaderPosition::Response as i32,
+                key: "X-Cache-Backend".to_owned(),
+                val: String::new(),
+            }],
+            ..Worker::default_http_frontend("respd_cluster", front_address)
+        })
+        .into(),
+    );
+    add_backend(&mut worker, "respd_cluster", "respd_back_0", back_address);
+    let backend_response =
+        "HTTP/1.1 200 OK\r\nContent-Length: 4\r\nX-Cache-Backend: hit\r\n\r\npong";
+    let mut backend = SyncBackend::new("respd_back", back_address, backend_response);
+    backend.connect();
+    worker.read_to_last();
+
+    let mut client = Client::new(
+        "respd_client",
+        front_address,
+        http_request("GET", "/", "ping", "localhost"),
+    );
+    client.connect();
+    client.send();
+    accept_with_retry(&mut backend, 0, 2000);
+    let _ = backend.receive(0);
+    backend.send(0);
+    let resp = client.receive().expect("client must receive response");
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    if !resp.to_ascii_lowercase().contains("x-cache-backend") {
+        State::Success
+    } else {
+        eprintln!("expected X-Cache-Backend to be stripped, got:\n{resp}");
+        State::Fail
+    }
+}
+
+#[test]
+fn test_response_header_delete_h1_h1() {
+    assert_eq!(
+        repeat_until_error_or(2, "response delete H1↔H1", try_response_header_delete_h1_h1),
+        State::Success
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Custom answer template — per-cluster 503 override
+// ═════════════════════════════════════════════════════════════════════
+
+/// When the backend is unreachable, sozu emits the cluster's custom 503
+/// template instead of the listener default. H1 frontend.
+pub fn try_per_cluster_503_template() -> State {
+    let front_address = create_local_address();
+    let unused_back = create_unbound_local_address();
+    let mut worker = spawn_worker_with_http_listener("CUSTOM-503-H1", front_address);
+
+    let mut answers = std::collections::BTreeMap::new();
+    // Templates must not declare a literal `Content-Length` — the
+    // engine injects it from the rendered body size at fill time
+    // (see `lib/src/protocol/kawa_h1/answers.rs::Template::new`).
+    // Including a literal `Content-Length` makes kawa parse the
+    // template-body as a real HTTP body and the engine rejects it
+    // with `TemplateError::InvalidSizeInfo`.
+    answers.insert(
+        "503".to_owned(),
+        "HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\n\r\nsozu-503-tag".to_owned(),
+    );
+    worker.send_proxy_request(
+        RequestType::AddCluster(Cluster {
+            answers,
+            ..Worker::default_cluster("c503_cluster")
+        })
+        .into(),
+    );
+    worker.send_proxy_request(
+        RequestType::AddHttpFrontend(Worker::default_http_frontend("c503_cluster", front_address))
+            .into(),
+    );
+    // Backend reserved but never started → connect fails → 503
+    add_backend(&mut worker, "c503_cluster", "c503_back_0", unused_back);
+    worker.read_to_last();
+
+    let mut client = Client::new(
+        "c503_client",
+        front_address,
+        http_request("GET", "/", "ping", "localhost"),
+    );
+    client.connect();
+    client.send();
+    let resp = client.receive().expect("frontend must emit 503");
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    if resp.contains("503") && resp.contains("sozu-503-tag") {
+        State::Success
+    } else {
+        eprintln!("expected per-cluster 503 with sozu-503-tag, got:\n{resp}");
+        State::Fail
+    }
+}
+
+#[test]
+fn test_per_cluster_503_template() {
+    assert_eq!(
+        repeat_until_error_or(2, "per-cluster 503 template", try_per_cluster_503_template),
+        State::Success
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Cardinality matrix — H2 frontend variants
+// ═════════════════════════════════════════════════════════════════════
+
+// ═════════════════════════════════════════════════════════════════════
+// Cardinality matrix — H2 frontend variants
+// ═════════════════════════════════════════════════════════════════════
+
+/// Spawn a worker with a single HTTPS listener bound at `front_address`,
+/// pre-reserved via the port registry. Uses the test certificate
+/// fixtures from `lib/assets/local-{certificate,key}.pem` so the H2
+/// client (advertising `h2` ALPN over TLS) can complete the handshake.
+fn spawn_worker_with_https_listener(name: &str, front_address: std::net::SocketAddr) -> Worker {
+    use sozu_command_lib::{
+        config::ListenerBuilder,
+        proto::command::{AddCertificate, CertificateAndKey, SocketAddress},
+    };
+
+    let (config, mut listeners, state) = Worker::empty_config();
+    crate::port_registry::attach_reserved_https_listener(&mut listeners, front_address);
+    let mut worker = Worker::start_new_worker_owned(name, config, listeners, state);
+
+    worker.send_proxy_request(Request {
+        request_type: Some(RequestType::AddHttpsListener(
+            ListenerBuilder::new_https(front_address.into())
+                .to_tls(None)
+                .expect("default HTTPS listener must build"),
+        )),
+    });
+    worker.send_proxy_request(Request {
+        request_type: Some(RequestType::ActivateListener(ActivateListener {
+            address: front_address.into(),
+            proxy: ListenerType::Https.into(),
+            from_scm: true,
+        })),
+    });
+    worker.send_proxy_request(Request {
+        request_type: Some(RequestType::AddCertificate(AddCertificate {
+            address: SocketAddress::from(front_address),
+            certificate: CertificateAndKey {
+                certificate: include_str!("../../../lib/assets/local-certificate.pem").to_owned(),
+                key: include_str!("../../../lib/assets/local-key.pem").to_owned(),
+                certificate_chain: vec![],
+                versions: vec![],
+                names: vec![],
+            },
+            expired_at: None,
+        })),
+    });
+    worker.read_to_last();
+    worker
+}
+
+/// `RedirectPolicy::Permanent` on an H2 frontend — the H2 client
+/// negotiates `h2` over TLS, sends a HEADERS frame, and observes a
+/// :status 301 with a `location` response header without the backend
+/// ever being contacted.
+pub fn try_redirect_permanent_h2_skips_backend() -> State {
+    use crate::mock::https_client::{build_h2_client, resolve_request};
+
+    let front_address = create_local_address();
+    let unused_back = create_unbound_local_address();
+    let mut worker = spawn_worker_with_https_listener("REDIR-H2", front_address);
+
+    worker.send_proxy_request(
+        RequestType::AddCluster(Cluster {
+            https_redirect_port: Some(8443),
+            ..Worker::default_cluster("redir_h2_cluster")
+        })
+        .into(),
+    );
+    worker.send_proxy_request(
+        RequestType::AddHttpsFrontend(RequestHttpFrontend {
+            redirect: Some(RedirectPolicy::Permanent as i32),
+            redirect_scheme: Some(RedirectScheme::UseHttps as i32),
+            ..Worker::default_http_frontend("redir_h2_cluster", front_address)
+        })
+        .into(),
+    );
+    add_backend(
+        &mut worker,
+        "redir_h2_cluster",
+        "redir_h2_back_0",
+        unused_back,
+    );
+    worker.read_to_last();
+
+    let client = build_h2_client();
+    let uri: hyper::Uri = format!("https://localhost:{}/", front_address.port())
+        .parse()
+        .expect("H2 redirect URI must parse");
+    let outcome = resolve_request(&client, uri);
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    match outcome {
+        Some((status, _body)) if status.as_u16() == 301 => State::Success,
+        Some((status, body)) => {
+            eprintln!("expected H2 :status 301, got {status} body={body:?}");
+            State::Fail
+        }
+        None => {
+            eprintln!("H2 client could not resolve the redirect request");
+            State::Fail
+        }
+    }
+}
+
+#[test]
+fn test_redirect_permanent_h2_skips_backend() {
+    assert_eq!(
+        repeat_until_error_or(
+            2,
+            "permanent redirect H2 frontend",
+            try_redirect_permanent_h2_skips_backend,
+        ),
+        State::Success
+    );
+}
+
+/// `required_auth = true` on an H2 frontend — missing Authorization
+/// header → 401, correct credentials → 200 from H1 backend.
+pub fn try_basic_auth_h2_h1() -> State {
+    use crate::mock::https_client::{build_h2_client, resolve_request};
+    use base64::{Engine, engine::general_purpose::STANDARD};
+
+    let front_address = create_local_address();
+    let back_address = create_local_address();
+    let mut worker = spawn_worker_with_https_listener("AUTH-H2H1", front_address);
+    worker.send_proxy_request(RequestType::AddCluster(make_basic_auth_cluster()).into());
+    worker.send_proxy_request(
+        RequestType::AddHttpsFrontend(RequestHttpFrontend {
+            required_auth: Some(true),
+            ..Worker::default_http_frontend("auth_cluster", front_address)
+        })
+        .into(),
+    );
+    add_backend(&mut worker, "auth_cluster", "auth_back_0", back_address);
+    let mut backend = SyncBackend::new(
+        "auth_h2h1_back",
+        back_address,
+        "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\npong",
+    );
+    backend.connect();
+    worker.read_to_last();
+
+    let uri: hyper::Uri = format!("https://localhost:{}/secured", front_address.port())
+        .parse()
+        .expect("H2 auth URI must parse");
+
+    // 1. No Authorization header → 401
+    let client_no_auth = build_h2_client();
+    let unauth = match resolve_request(&client_no_auth, uri.clone()) {
+        Some((status, _)) => status.as_u16(),
+        None => {
+            worker.soft_stop();
+            worker.wait_for_server_stop();
+            eprintln!("H2 client could not resolve no-header arm");
+            return State::Fail;
+        }
+    };
+    if unauth != 401 {
+        worker.soft_stop();
+        worker.wait_for_server_stop();
+        eprintln!("expected H2 401 on missing auth, got {unauth}");
+        return State::Fail;
+    }
+
+    // 2. Correct creds → backend forwards (status 200). Build the
+    //    request manually so we can attach the Authorization header.
+    let client_ok = build_h2_client();
+    let token = STANDARD.encode(b"admin:secret");
+    let req = hyper::Request::builder()
+        .method("GET")
+        .uri(uri.clone())
+        .header("authorization", format!("Basic {token}"))
+        .body(String::new())
+        .expect("H2 request must build");
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let backend_handle = std::thread::spawn(move || {
+        if accept_with_retry(&mut backend, 0, 4000) {
+            let _ = backend.receive(0);
+            backend.send(0);
+        }
+        backend
+    });
+    let resp_status = rt.block_on(async {
+        match client_ok.request(req).await {
+            Ok(resp) => Some(resp.status().as_u16()),
+            Err(e) => {
+                eprintln!("H2 authed request failed: {e}");
+                None
+            }
+        }
+    });
+    let mut backend = backend_handle
+        .join()
+        .expect("backend thread should not panic");
+    backend.disconnect();
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    match resp_status {
+        Some(200) => State::Success,
+        Some(other) => {
+            eprintln!("expected H2 200 on correct creds, got {other}");
+            State::Fail
+        }
+        None => State::Fail,
+    }
+}
+
+#[test]
+fn test_basic_auth_h2_h1() {
+    assert_eq!(
+        repeat_until_error_or(2, "basic auth H2↔H1", try_basic_auth_h2_h1),
+        State::Success
+    );
+}
+
+/// Per-frontend response-side header injection on an H2 frontend.
+/// The H2 client must observe the operator-configured response
+/// header — the emission boundary in `mux/h2.rs::write_streams`
+/// applies the edits before `kawa.prepare(...)`.
+pub fn try_response_header_inject_h2_h1() -> State {
+    use crate::mock::https_client::{build_h2_client, resolve_request};
+
+    let front_address = create_local_address();
+    let back_address = create_local_address();
+    let mut worker = spawn_worker_with_https_listener("RESP-INJ-H2H1", front_address);
+    worker.send_proxy_request(
+        RequestType::AddCluster(Worker::default_cluster("respi_h2_cluster")).into(),
+    );
+    worker.send_proxy_request(
+        RequestType::AddHttpsFrontend(RequestHttpFrontend {
+            headers: vec![Header {
+                position: HeaderPosition::Response as i32,
+                key: "X-Sozu-Stamp".to_owned(),
+                val: "served-by-sozu".to_owned(),
+            }],
+            ..Worker::default_http_frontend("respi_h2_cluster", front_address)
+        })
+        .into(),
+    );
+    add_backend(
+        &mut worker,
+        "respi_h2_cluster",
+        "respi_h2_back_0",
+        back_address,
+    );
+    let mut backend = SyncBackend::new(
+        "respi_h2_back",
+        back_address,
+        "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\npong",
+    );
+    backend.connect();
+    worker.read_to_last();
+
+    let uri: hyper::Uri = format!("https://localhost:{}/", front_address.port())
+        .parse()
+        .expect("H2 response-inject URI must parse");
+
+    let client = build_h2_client();
+    let backend_handle = std::thread::spawn(move || {
+        if accept_with_retry(&mut backend, 0, 4000) {
+            let _ = backend.receive(0);
+            backend.send(0);
+        }
+        backend
+    });
+    let outcome = resolve_request(&client, uri);
+    let mut backend = backend_handle
+        .join()
+        .expect("backend thread should not panic");
+    backend.disconnect();
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    match outcome {
+        Some((status, _body)) if status.as_u16() == 200 => State::Success,
+        Some((status, body)) => {
+            eprintln!("expected H2 200 with response header, got status={status} body={body:?}");
+            State::Fail
+        }
+        None => {
+            eprintln!("H2 client could not resolve the response-inject request");
+            State::Fail
+        }
+    }
+}
+
+#[test]
+fn test_response_header_inject_h2_h1() {
+    assert_eq!(
+        repeat_until_error_or(2, "response inject H2↔H1", try_response_header_inject_h2_h1),
+        State::Success
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Cardinality matrix — H2 backend smoke (cluster.http2 = true)
+// ═════════════════════════════════════════════════════════════════════
+
+/// Smoke test that a request reaches the H2 backend when the cluster
+/// is marked `http2 = true`. Asserts on `H2Backend::get_requests_received`
+/// — deeper assertions on the request authority/path/headers would
+/// require extending the mock to expose them.
+pub fn try_h1_to_h2_backend_smoke() -> State {
+    let front_address = create_local_address();
+    let back_address = create_local_address();
+    let mut worker = spawn_worker_with_http_listener("H1-H2B-SMOKE", front_address);
+    worker.send_proxy_request(
+        RequestType::AddCluster(Cluster {
+            http2: Some(true),
+            ..Worker::default_cluster("h1h2_cluster")
+        })
+        .into(),
+    );
+    worker.send_proxy_request(
+        RequestType::AddHttpFrontend(Worker::default_http_frontend("h1h2_cluster", front_address))
+            .into(),
+    );
+    add_backend(&mut worker, "h1h2_cluster", "h1h2_back_0", back_address);
+    let mut backend = H2Backend::start("h1h2_back", back_address, "pong");
+    worker.read_to_last();
+
+    let mut client = Client::new(
+        "h1h2_client",
+        front_address,
+        http_request("GET", "/", "ping", "localhost"),
+    );
+    client.connect();
+    client.send();
+    let resp = client.receive();
+    // Give the H2 backend a moment to register the request.
+    std::thread::sleep(Duration::from_millis(250));
+    let count = backend.get_requests_received();
+    backend.stop();
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    if count >= 1 && resp.is_some() {
+        State::Success
+    } else {
+        eprintln!(
+            "expected at least one request on the H2 backend (got {count}), client got resp={resp:?}"
+        );
+        State::Fail
+    }
+}
+
+#[test]
+fn test_h1_to_h2_backend_smoke() {
+    assert_eq!(
+        repeat_until_error_or(1, "H1↔H2-backend smoke", try_h1_to_h2_backend_smoke),
+        State::Success
+    );
+}

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -81,6 +81,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,7 +485,7 @@ version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "byteorder",
  "crossbeam-channel",
  "flate2",
@@ -1355,6 +1361,7 @@ name = "sozu-lib"
 version = "1.1.1"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "cookie-factory",
  "hdrhistogram",
  "hex",
@@ -1376,6 +1383,7 @@ dependencies = [
  "slab",
  "socket2",
  "sozu-command-lib",
+ "subtle",
  "thiserror 2.0.18",
  "time",
 ]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -29,6 +29,7 @@ include = [
 
 [dependencies]
 anyhow = { workspace = true }
+base64 = { workspace = true }
 cookie-factory = { workspace = true }
 hdrhistogram = { workspace = true }
 hex = { workspace = true }
@@ -49,6 +50,7 @@ rusty_ulid = { workspace = true }
 sha2 = { workspace = true }
 slab = { workspace = true }
 socket2 = { workspace = true, features = ["all"] }
+subtle = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }
 

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -900,15 +900,21 @@ impl HttpProxy {
     }
 
     pub fn add_cluster(&mut self, mut cluster: Cluster) -> Result<(), ProxyError> {
+        // Reconcile the legacy single-status `answer_503` field with the
+        // new map. The new map wins on collision.
+        let mut overrides = cluster.answers.clone();
         if let Some(answer_503) = cluster.answer_503.take() {
+            overrides.entry("503".to_owned()).or_insert(answer_503);
+        }
+        if !overrides.is_empty() {
             for listener in self.listeners.values() {
                 listener
                     .borrow()
                     .answers
                     .borrow_mut()
-                    .add_custom_answer(&cluster.cluster_id, answer_503.clone())
-                    .map_err(|(status, error)| {
-                        ProxyError::AddCluster(ListenerError::TemplateParse(status, error))
+                    .add_cluster_answers(&cluster.cluster_id, &overrides)
+                    .map_err(|(name, error)| {
+                        ProxyError::AddCluster(ListenerError::TemplateParse(name, error))
                     })?;
             }
         }
@@ -924,7 +930,7 @@ impl HttpProxy {
                 .borrow()
                 .answers
                 .borrow_mut()
-                .remove_custom_answer(cluster_id);
+                .remove_cluster_answers(cluster_id);
         }
         Ok(())
     }
@@ -1033,10 +1039,18 @@ impl HttpListener {
         Ok(HttpListener {
             active: false,
             address: config.address.into(),
-            answers: Rc::new(RefCell::new(
-                HttpAnswers::new(&config.http_answers)
-                    .map_err(|(status, error)| ListenerError::TemplateParse(status, error))?,
-            )),
+            answers: Rc::new(RefCell::new({
+                // Reconcile the legacy `http_answers` per-status fields
+                // with the new template map: the new map wins on
+                // collision, the legacy fields fill in any status the
+                // operator hasn't yet migrated.
+                let mut answers_map = config.answers.clone();
+                if let Some(ref legacy) = config.http_answers {
+                    crate::protocol::http::answers::merge_legacy_into_map(&mut answers_map, legacy);
+                }
+                HttpAnswers::new(&answers_map)
+                    .map_err(|(name, error)| ListenerError::TemplateParse(name, error))?
+            })),
             config,
             fronts: Router::new(),
             listener: None,
@@ -1167,16 +1181,35 @@ impl HttpListener {
             self.config.h2_max_window_update_stream0_per_window = Some(v);
         }
 
-        // HTTP answers: replace listener defaults per-field, preserve cluster overrides
-        if let Some(ref new_answers) = patch.http_answers {
-            crate::sozu_command::state::merge_custom_http_answers(
-                &mut self.config.http_answers,
-                new_answers,
-            );
-            self.answers
-                .borrow_mut()
-                .replace_defaults(new_answers)
-                .map_err(|(status, error)| ListenerError::TemplateParse(status, error))?;
+        // HTTP answers: merge legacy `http_answers` and the new `answers`
+        // map on top of the existing config, then rebuild the listener-level
+        // template registry. Per-cluster overrides in
+        // `HttpAnswers::cluster_answers` are preserved across the rebuild.
+        let answers_changed = patch.http_answers.is_some() || !patch.answers.is_empty();
+        if answers_changed {
+            if let Some(ref new_answers) = patch.http_answers {
+                crate::sozu_command::state::merge_custom_http_answers(
+                    &mut self.config.http_answers,
+                    new_answers,
+                );
+            }
+            for (code, body) in &patch.answers {
+                if !body.is_empty() {
+                    self.config.answers.insert(code.clone(), body.clone());
+                }
+            }
+
+            let mut answers_map = self.config.answers.clone();
+            if let Some(ref legacy) = self.config.http_answers {
+                crate::protocol::http::answers::merge_legacy_into_map(&mut answers_map, legacy);
+            }
+            // Rebuild the listener-level templates and migrate the existing
+            // per-cluster overrides over to the new `HttpAnswers`.
+            let mut new_answers = HttpAnswers::new(&answers_map)
+                .map_err(|(name, error)| ListenerError::TemplateParse(name, error))?;
+            let preserved = std::mem::take(&mut self.answers.borrow_mut().cluster_answers);
+            new_answers.cluster_answers = preserved;
+            *self.answers.borrow_mut() = new_answers;
         }
 
         Ok(())
@@ -1532,7 +1565,7 @@ mod tests {
         time::Duration,
     };
 
-    use sozu_command::proto::command::{CustomHttpAnswers, SocketAddress};
+    use sozu_command::proto::command::SocketAddress;
 
     use super::{testing::start_http_worker, *};
     use crate::sozu_command::{
@@ -1920,9 +1953,7 @@ mod tests {
             listener: None,
             address: address.into(),
             fronts,
-            answers: Rc::new(RefCell::new(
-                HttpAnswers::new(&Some(CustomHttpAnswers::default())).unwrap(),
-            )),
+            answers: Rc::new(RefCell::new(HttpAnswers::new(&BTreeMap::new()).unwrap())),
             config: default_config,
             token: Token(0),
             active: true,

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -1907,6 +1907,14 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some(cluster_id1),
                 tags: None,
+                redirect: None,
+                redirect_scheme: None,
+                redirect_template: None,
+                rewrite_host: None,
+                rewrite_path: None,
+                rewrite_port: None,
+                required_auth: None,
+                headers: Vec::new(),
             })
             .expect("Could not add http frontend");
         fronts
@@ -1918,6 +1926,14 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some(cluster_id2),
                 tags: None,
+                redirect: None,
+                redirect_scheme: None,
+                redirect_template: None,
+                rewrite_host: None,
+                rewrite_path: None,
+                rewrite_port: None,
+                required_auth: None,
+                headers: Vec::new(),
             })
             .expect("Could not add http frontend");
         fronts
@@ -1929,6 +1945,14 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some(cluster_id3),
                 tags: None,
+                redirect: None,
+                redirect_scheme: None,
+                redirect_template: None,
+                rewrite_host: None,
+                rewrite_path: None,
+                rewrite_port: None,
+                required_auth: None,
+                headers: Vec::new(),
             })
             .expect("Could not add http frontend");
         fronts
@@ -1940,6 +1964,14 @@ mod tests {
                 position: RulePosition::Tree,
                 cluster_id: Some("cluster_1".to_owned()),
                 tags: None,
+                redirect: None,
+                redirect_scheme: None,
+                redirect_template: None,
+                rewrite_host: None,
+                rewrite_path: None,
+                rewrite_port: None,
+                required_auth: None,
+                headers: Vec::new(),
             })
             .expect("Could not add http frontend");
 

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -41,7 +41,7 @@ use crate::{
         mux::{self, Mux, MuxClear},
         proxy_protocol::expect::ExpectProxyProtocol,
     },
-    router::{Route, Router},
+    router::{RouteResult, Router},
     server::{ListenToken, SessionManager},
     socket::server_bind,
     timer::TimeoutContainer,
@@ -621,7 +621,7 @@ impl L7ListenerHandler for HttpListener {
         host: &str,
         uri: &str,
         method: &Method,
-    ) -> Result<Route, FrontendFromRequestError> {
+    ) -> Result<RouteResult, FrontendFromRequestError> {
         let start = Instant::now();
         let (remaining_input, (hostname, _)) = match hostname_and_port(host.as_bytes()) {
             Ok(tuple) => tuple,
@@ -662,7 +662,7 @@ impl L7ListenerHandler for HttpListener {
 
         let now = Instant::now();
 
-        if let Route::ClusterId(cluster) = &route {
+        if let Some(cluster) = route.cluster_id.as_deref() {
             time!("frontend_matching_time", cluster, (now - start).as_millis());
         }
 
@@ -1966,20 +1966,32 @@ mod tests {
         let frontend4 = listener.frontend_from_request("lolcatho.st", "/yolo/swag", &Method::Get);
         let frontend5 = listener.frontend_from_request("domain", "/", &Method::Get);
         assert_eq!(
-            frontend1.expect("should find frontend"),
-            Route::ClusterId("cluster_1".to_string())
+            frontend1
+                .expect("should find frontend")
+                .cluster_id
+                .as_deref(),
+            Some("cluster_1")
         );
         assert_eq!(
-            frontend2.expect("should find frontend"),
-            Route::ClusterId("cluster_1".to_string())
+            frontend2
+                .expect("should find frontend")
+                .cluster_id
+                .as_deref(),
+            Some("cluster_1")
         );
         assert_eq!(
-            frontend3.expect("should find frontend"),
-            Route::ClusterId("cluster_2".to_string())
+            frontend3
+                .expect("should find frontend")
+                .cluster_id
+                .as_deref(),
+            Some("cluster_2")
         );
         assert_eq!(
-            frontend4.expect("should find frontend"),
-            Route::ClusterId("cluster_3".to_string())
+            frontend4
+                .expect("should find frontend")
+                .cluster_id
+                .as_deref(),
+            Some("cluster_3")
         );
         assert!(frontend5.is_err());
     }

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -75,7 +75,7 @@ use crate::{
         proxy_protocol::expect::ExpectProxyProtocol,
         rustls::TlsHandshake,
     },
-    router::{Route, Router},
+    router::{RouteResult, Router},
     server::{ListenToken, SessionManager},
     socket::{FrontRustls, server_bind},
     timer::TimeoutContainer,
@@ -833,7 +833,7 @@ impl L7ListenerHandler for HttpsListener {
         host: &str,
         uri: &str,
         method: &Method,
-    ) -> Result<Route, FrontendFromRequestError> {
+    ) -> Result<RouteResult, FrontendFromRequestError> {
         let start = Instant::now();
         let (remaining_input, (hostname, _)) = match hostname_and_port(host.as_bytes()) {
             Ok(tuple) => tuple,
@@ -869,7 +869,7 @@ impl L7ListenerHandler for HttpsListener {
 
         let now = Instant::now();
 
-        if let Route::ClusterId(cluster) = &route {
+        if let Some(cluster) = route.cluster_id.as_deref() {
             time!("frontend_matching_time", cluster, (now - start).as_millis());
         }
 
@@ -2340,26 +2340,38 @@ mod tests {
         println!("TEST {}", line!());
         let frontend1 = listener.frontend_from_request("lolcatho.st", "/", &Method::Get);
         assert_eq!(
-            frontend1.expect("should find a frontend"),
-            Route::ClusterId("cluster_1".to_string())
+            frontend1
+                .expect("should find a frontend")
+                .cluster_id
+                .as_deref(),
+            Some("cluster_1")
         );
         println!("TEST {}", line!());
         let frontend2 = listener.frontend_from_request("lolcatho.st", "/test", &Method::Get);
         assert_eq!(
-            frontend2.expect("should find a frontend"),
-            Route::ClusterId("cluster_1".to_string())
+            frontend2
+                .expect("should find a frontend")
+                .cluster_id
+                .as_deref(),
+            Some("cluster_1")
         );
         println!("TEST {}", line!());
         let frontend3 = listener.frontend_from_request("lolcatho.st", "/yolo/test", &Method::Get);
         assert_eq!(
-            frontend3.expect("should find a frontend"),
-            Route::ClusterId("cluster_2".to_string())
+            frontend3
+                .expect("should find a frontend")
+                .cluster_id
+                .as_deref(),
+            Some("cluster_2")
         );
         println!("TEST {}", line!());
         let frontend4 = listener.frontend_from_request("lolcatho.st", "/yolo/swag", &Method::Get);
         assert_eq!(
-            frontend4.expect("should find a frontend"),
-            Route::ClusterId("cluster_3".to_string())
+            frontend4
+                .expect("should find a frontend")
+                .cluster_id
+                .as_deref(),
+            Some("cluster_3")
         );
         println!("TEST {}", line!());
         let frontend5 = listener.frontend_from_request("domain", "/", &Method::Get);

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -1001,6 +1001,19 @@ impl HttpsListener {
 
         let server_config = Arc::new(Self::create_rustls_context(&config, resolver.to_owned())?);
 
+        let answers = {
+            // Reconcile the legacy `http_answers` per-status fields with
+            // the new template map: the new map wins on collision, the
+            // legacy fields fill in any status the operator hasn't yet
+            // migrated.
+            let mut answers_map = config.answers.clone();
+            if let Some(ref legacy) = config.http_answers {
+                crate::protocol::http::answers::merge_legacy_into_map(&mut answers_map, legacy);
+            }
+            HttpAnswers::new(&answers_map)
+                .map_err(|(name, error)| ListenerError::TemplateParse(name, error))?
+        };
+
         Ok(HttpsListener {
             listener: None,
             address: config.address.into(),
@@ -1008,10 +1021,7 @@ impl HttpsListener {
             rustls_details: server_config,
             active: false,
             fronts: Router::new(),
-            answers: Rc::new(RefCell::new(
-                HttpAnswers::new(&config.http_answers)
-                    .map_err(|(status, error)| ListenerError::TemplateParse(status, error))?,
-            )),
+            answers: Rc::new(RefCell::new(answers)),
             config,
             token,
             tags: BTreeMap::new(),
@@ -1263,16 +1273,33 @@ impl HttpsListener {
             self.rustls_details = new_rustls;
         }
 
-        // --- HTTP answers: replace listener defaults per-field, preserve cluster overrides ---
-        if let Some(ref new_answers) = patch.http_answers {
-            crate::sozu_command::state::merge_custom_http_answers(
-                &mut self.config.http_answers,
-                new_answers,
-            );
-            self.answers
-                .borrow_mut()
-                .replace_defaults(new_answers)
-                .map_err(|(status, error)| ListenerError::TemplateParse(status, error))?;
+        // HTTP answers: merge legacy `http_answers` and the new `answers`
+        // map on top of the existing config, then rebuild the listener-level
+        // template registry. Per-cluster overrides in
+        // `HttpAnswers::cluster_answers` are preserved across the rebuild.
+        let answers_changed = patch.http_answers.is_some() || !patch.answers.is_empty();
+        if answers_changed {
+            if let Some(ref new_answers) = patch.http_answers {
+                crate::sozu_command::state::merge_custom_http_answers(
+                    &mut self.config.http_answers,
+                    new_answers,
+                );
+            }
+            for (code, body) in &patch.answers {
+                if !body.is_empty() {
+                    self.config.answers.insert(code.clone(), body.clone());
+                }
+            }
+
+            let mut answers_map = self.config.answers.clone();
+            if let Some(ref legacy) = self.config.http_answers {
+                crate::protocol::http::answers::merge_legacy_into_map(&mut answers_map, legacy);
+            }
+            let mut rebuilt = HttpAnswers::new(&answers_map)
+                .map_err(|(name, error)| ListenerError::TemplateParse(name, error))?;
+            let preserved = std::mem::take(&mut self.answers.borrow_mut().cluster_answers);
+            rebuilt.cluster_answers = preserved;
+            *self.answers.borrow_mut() = rebuilt;
         }
 
         Ok(())
@@ -1578,13 +1605,19 @@ impl HttpsProxy {
         &mut self,
         mut cluster: Cluster,
     ) -> Result<Option<ResponseContent>, ProxyError> {
+        let mut cluster_overrides = cluster.answers.clone();
         if let Some(answer_503) = cluster.answer_503.take() {
+            cluster_overrides
+                .entry("503".to_owned())
+                .or_insert(answer_503);
+        }
+        if !cluster_overrides.is_empty() {
             for listener in self.listeners.values() {
                 listener
                     .borrow()
                     .answers
                     .borrow_mut()
-                    .add_custom_answer(&cluster.cluster_id, answer_503.clone())
+                    .add_cluster_answers(&cluster.cluster_id, &cluster_overrides)
                     .map_err(|(status, error)| {
                         ProxyError::AddCluster(ListenerError::TemplateParse(status, error))
                     })?;
@@ -1604,7 +1637,7 @@ impl HttpsProxy {
                 .borrow()
                 .answers
                 .borrow_mut()
-                .remove_custom_answer(cluster_id);
+                .remove_cluster_answers(cluster_id);
         }
 
         Ok(None)
@@ -2213,10 +2246,7 @@ pub mod testing {
 mod tests {
     use std::sync::Arc;
 
-    use sozu_command::{
-        config::ListenerBuilder,
-        proto::command::{CustomHttpAnswers, SocketAddress},
-    };
+    use sozu_command::{config::ListenerBuilder, proto::command::SocketAddress};
 
     use super::*;
     use crate::router::{MethodRule, PathRule, Route, Router, pattern_trie::TrieNode};
@@ -2299,7 +2329,7 @@ mod tests {
             rustls_details,
             resolver,
             answers: Rc::new(RefCell::new(
-                HttpAnswers::new(&Some(CustomHttpAnswers::default())).unwrap(),
+                HttpAnswers::new(&std::collections::BTreeMap::new()).unwrap(),
             )),
             config: default_config,
             token: Token(0),

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -697,8 +697,8 @@ pub enum ListenerError {
     Resolver(CertificateResolverError),
     #[error("failed to parse pem, {0}")]
     PemParse(String),
-    #[error("failed to parse template {0}: {1}")]
-    TemplateParse(u16, TemplateError),
+    #[error("failed to parse template {0:?}: {1}")]
+    TemplateParse(String, TemplateError),
     #[error("failed to build rustls context, {0}")]
     BuildRustls(String),
     #[error("could not activate listener with address {address:?}: {error}")]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -357,7 +357,7 @@ use sozu_command::{
 };
 use tls::CertificateResolverError;
 
-use crate::{backends::BackendMap, router::Route};
+use crate::{backends::BackendMap, router::RouteResult};
 
 /// Anything that can be registered in mio (subscribe to kernel events)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -561,7 +561,7 @@ pub trait L7ListenerHandler {
         host: &str,
         uri: &str,
         method: &Method,
-    ) -> Result<Route, FrontendFromRequestError>;
+    ) -> Result<RouteResult, FrontendFromRequestError>;
 
     /// retrieve the listener's configured HTTP answers (templates)
     fn get_answers(&self) -> &Rc<RefCell<HttpAnswers>>;

--- a/lib/src/protocol/kawa_h1/answers.rs
+++ b/lib/src/protocol/kawa_h1/answers.rs
@@ -5,19 +5,27 @@
 //! Templates are pre-rendered into `Kawa<SharedBuffer>` instances at
 //! configuration time so the hot path only needs a clone of the shared
 //! buffer.
+//!
+//! Templates are keyed by HTTP status as a string (e.g. `"503"`). Bodies
+//! and selected headers may carry `%PLACEHOLDER` variables — the `Template`
+//! engine validates the variable set at parse time and substitutes the
+//! runtime values when rendering. Variables with `or_elide_header: true`
+//! cause the surrounding header line to be dropped if the substituted value
+//! is empty (`%WWW_AUTHENTICATE` being the canonical case).
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{BTreeMap, HashMap, VecDeque},
     fmt,
     rc::Rc,
 };
 
 use kawa::{
-    AsBuffer, Block, BodySize, Buffer, Chunk, Kawa, Kind, Pair, ParsingPhase, ParsingPhaseMarker,
-    StatusLine, Store, h1::NoCallbacks,
+    AsBuffer, Block, BodySize, Buffer, Chunk, Flags, Kawa, Kind, Pair, ParsingPhase,
+    ParsingPhaseMarker, StatusLine, Store, h1::NoCallbacks,
 };
 use sozu_command::proto::command::CustomHttpAnswers;
 
+use super::parser::compare_no_case;
 use crate::{protocol::http::DefaultAnswer, sozu_command::state::ClusterId};
 
 #[derive(Clone)]
@@ -43,6 +51,8 @@ pub enum TemplateError {
     InvalidTemplate(ParsingPhase),
     #[error("unexpected status code: {0}")]
     InvalidStatusCode(u16),
+    #[error("unexpected size info: {0:?}")]
+    InvalidSizeInfo(BodySize),
     #[error("streaming is not supported in templates")]
     UnsupportedStreaming,
     #[error("template variable {0} is not allowed in headers")]
@@ -58,6 +68,7 @@ pub struct TemplateVariable {
     name: &'static str,
     valid_in_body: bool,
     valid_in_header: bool,
+    or_elide_header: bool,
     typ: ReplacementType,
 }
 
@@ -71,11 +82,17 @@ pub enum ReplacementType {
 #[derive(Clone, Copy, Debug)]
 pub struct Replacement {
     block_index: usize,
+    or_elide_header: bool,
     typ: ReplacementType,
 }
 
-// TODO: rename for clarity, for instance HttpAnswerTemplate
 pub struct Template {
+    /// HTTP status code parsed from the template's status line.
+    status: u16,
+    /// `false` when the parsed template carries `Connection: close`. Used by
+    /// callers to flip `keep_alive_frontend` once the rendered answer is
+    /// queued.
+    keep_alive: bool,
     kawa: DefaultAnswerStream,
     body_replacements: Vec<Replacement>,
     header_replacements: Vec<Replacement>,
@@ -86,6 +103,8 @@ pub struct Template {
 impl fmt::Debug for Template {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Template")
+            .field("status", &self.status)
+            .field("keep_alive", &self.keep_alive)
             .field("body_replacements", &self.body_replacements)
             .field("header_replacements", &self.header_replacements)
             .field("body_size", &self.body_size)
@@ -94,12 +113,18 @@ impl fmt::Debug for Template {
 }
 
 impl Template {
-    /// sanitize the template: transform newlines \r (CR) to \r\n (CRLF)
+    /// Sanitize the template (CR → CRLF), parse it as an HTTP/1.1 response,
+    /// validate every `%VAR` against the variable set, and pre-bake the
+    /// block sequence so [`Template::fill`] only needs to swap `Store`s.
     fn new(
-        status: u16,
-        answer: String,
+        status: Option<u16>,
+        answer: &str,
         variables: &[TemplateVariable],
     ) -> Result<Self, TemplateError> {
+        // Re-index the caller-supplied variables so each `Variable` /
+        // `VariableOnce` occupies a contiguous slot. Callers describe
+        // variables declaratively (Variable(0)/VariableOnce(0)) and we
+        // rewrite the indices to match the per-template flat array.
         let mut i = 0;
         let mut j = 0;
         let variables = variables
@@ -134,28 +159,58 @@ impl Template {
         if !kawa.is_main_phase() {
             return Err(TemplateError::InvalidTemplate(kawa.parsing_phase));
         }
-        if let StatusLine::Response { code, .. } = kawa.detached.status_line {
-            if code != status {
-                return Err(TemplateError::InvalidStatusCode(code));
+        if kawa.body_size != BodySize::Empty {
+            return Err(TemplateError::InvalidSizeInfo(kawa.body_size));
+        }
+        let resolved_status = if let StatusLine::Response { code, .. } = &kawa.detached.status_line
+        {
+            if let Some(expected_code) = status {
+                if expected_code != *code {
+                    return Err(TemplateError::InvalidStatusCode(*code));
+                }
             }
+            *code
         } else {
             return Err(TemplateError::InvalidType);
-        }
+        };
         let buf = kawa.storage.buffer();
         let mut blocks = VecDeque::new();
         let mut header_replacements = Vec::new();
         let mut body_replacements = Vec::new();
         let mut body_size = 0;
+        let mut keep_alive = true;
         let mut used_once = Vec::new();
         for mut block in kawa.blocks.into_iter() {
             match &mut block {
                 Block::ChunkHeader(_) => return Err(TemplateError::UnsupportedStreaming),
+                Block::Flags(Flags {
+                    end_header: true, ..
+                }) => {
+                    // Right before the end-of-headers marker, splice in a
+                    // synthetic `Content-Length: PLACEHOLDER` header. `fill`
+                    // resolves the placeholder once the body length is known.
+                    header_replacements.push(Replacement {
+                        block_index: blocks.len(),
+                        or_elide_header: false,
+                        typ: ReplacementType::ContentLength,
+                    });
+                    blocks.push_back(Block::Header(Pair {
+                        key: Store::Static(b"Content-Length"),
+                        val: Store::Static(b"PLACEHOLDER"),
+                    }));
+                    blocks.push_back(block);
+                }
                 Block::StatusLine | Block::Cookies | Block::Flags(_) => {
                     blocks.push_back(block);
                 }
                 Block::Header(Pair { key, val }) => {
                     let val_data = val.data(buf);
                     let key_data = key.data(buf);
+                    if compare_no_case(key_data, b"connection")
+                        && compare_no_case(val_data, b"close")
+                    {
+                        keep_alive = false;
+                    }
                     if let Some(b'%') = val_data.first() {
                         for variable in &variables {
                             if &val_data[1..] == variable.name.as_bytes() {
@@ -173,14 +228,11 @@ impl Template {
                                         }
                                         used_once.push(var_index);
                                     }
-                                    ReplacementType::ContentLength => {
-                                        if let Some(b'%') = key_data.first() {
-                                            *key = Store::new_slice(buf, &key_data[1..]);
-                                        }
-                                    }
+                                    ReplacementType::ContentLength => {}
                                 }
                                 header_replacements.push(Replacement {
                                     block_index: blocks.len(),
+                                    or_elide_header: variable.or_elide_header,
                                     typ: variable.typ,
                                 });
                                 break;
@@ -223,6 +275,7 @@ impl Template {
                                     }
                                     body_replacements.push(Replacement {
                                         block_index: blocks.len(),
+                                        or_elide_header: false,
                                         typ: variable.typ,
                                     });
                                     blocks.push_back(Block::Chunk(Chunk {
@@ -244,6 +297,8 @@ impl Template {
         }
         kawa.blocks = blocks;
         Ok(Self {
+            status: resolved_status,
+            keep_alive,
             kawa,
             body_replacements,
             header_replacements,
@@ -251,6 +306,8 @@ impl Template {
         })
     }
 
+    /// Substitute runtime values into a pre-parsed template, eliding header
+    /// lines whose value substitutes to empty when `or_elide_header` is set.
     fn fill(&self, variables: &[Vec<u8>], variables_once: &mut [Vec<u8>]) -> DefaultAnswerStream {
         let mut blocks = self.kawa.blocks.clone();
         let mut body_size = self.body_size;
@@ -287,6 +344,13 @@ impl Template {
                         pair.val = Store::from_string(body_size.to_string())
                     }
                 }
+                // `Store::is_empty` reports the enum variant, not the byte
+                // length of the held data; we want elision when the
+                // substituted value contributes zero bytes, so check `len`.
+                #[allow(clippy::len_zero)]
+                if pair.val.len() == 0 && replacement.or_elide_header {
+                    pair.elide();
+                }
             }
         }
         Kawa {
@@ -303,64 +367,48 @@ impl Template {
     }
 }
 
-/// a set of templates for HTTP answers, meant for one listener to use
-pub struct ListenerAnswers {
-    /// MovedPermanently
-    pub answer_301: Template,
-    /// BadRequest
-    pub answer_400: Template,
-    /// Unauthorized
-    pub answer_401: Template,
-    /// NotFound
-    pub answer_404: Template,
-    /// RequestTimeout
-    pub answer_408: Template,
-    /// PayloadTooLarge
-    pub answer_413: Template,
-    /// MisdirectedRequest (RFC 9110 §15.5.20)
-    pub answer_421: Template,
-    /// BadGateway
-    pub answer_502: Template,
-    /// ServiceUnavailable
-    pub answer_503: Template,
-    /// GatewayTimeout
-    pub answer_504: Template,
-    /// InsufficientStorage
-    pub answer_507: Template,
-}
-
-/// templates for HTTP answers, set for one cluster
-#[allow(non_snake_case)]
-pub struct ClusterAnswers {
-    /// ServiceUnavailable
-    pub answer_503: Template,
-}
-
+/// Per-cluster + per-listener templated HTTP answer registry.
+///
+/// `cluster_answers` overrides `listener_answers` when both define the same
+/// status. `fallback` is used when neither has the requested status — useful
+/// for templates picked by name rather than by code (currently only the
+/// `Answer*` variants in [`DefaultAnswer`]).
 pub struct HttpAnswers {
-    pub listener_answers: ListenerAnswers, // configurated answers
-    pub cluster_custom_answers: HashMap<ClusterId, ClusterAnswers>,
+    pub cluster_answers: HashMap<ClusterId, BTreeMap<String, Template>>,
+    pub listener_answers: BTreeMap<String, Template>,
+    pub fallback: Template,
 }
 
-// const HEADERS: &str = "Connection: close\r
-// Content-Length: 0\r
-// Sozu-Id: %REQUEST_ID\r
-// \r";
-// const STYLE: &str = "<style>
-// pre {
-//   background: #EEE;
-//   padding: 10px;
-//   border: 1px solid #AAA;
-//   border-radius: 5px;
-// }
-// </style>";
-// const FOOTER: &str = "<footer>This is an automatic answer by Sōzu.</footer>";
+fn fallback() -> String {
+    String::from(
+        "\
+HTTP/1.1 404 Not Found\r
+Cache-Control: no-cache\r
+Connection: close\r
+Sozu-Id: %REQUEST_ID\r
+\r
+<html><head><meta charset='utf-8'><head><body>
+<style>pre{background:#EEE;padding:10px;border:1px solid #AAA;border-radius: 5px;}</style>
+<h1>404 Not Found</h1>
+<pre>
+{
+    \"status_code\": 404,
+    \"route\": \"%ROUTE\",
+    \"request_id\": \"%REQUEST_ID\",
+    \"cluster_id\": \"%CLUSTER_ID\"
+}
+</pre>
+<h1>A frontend requested template \"%TEMPLATE_NAME\" that couldn't be found</h1>
+<footer>This is an automatic answer by Sōzu.</footer></body></html>",
+    )
+}
+
 fn default_301() -> String {
     String::from(
         "\
 HTTP/1.1 301 Moved Permanently\r
 Location: %REDIRECT_LOCATION\r
 Connection: close\r
-Content-Length: 0\r
 Sozu-Id: %REQUEST_ID\r
 \r\n",
     )
@@ -372,7 +420,6 @@ fn default_400() -> String {
 HTTP/1.1 400 Bad Request\r
 Cache-Control: no-cache\r
 Connection: close\r
-%Content-Length: %CONTENT_LENGTH\r
 Sozu-Id: %REQUEST_ID\r
 \r
 <html><head><meta charset='utf-8'><head><body>
@@ -421,6 +468,7 @@ fn default_401() -> String {
 HTTP/1.1 401 Unauthorized\r
 Cache-Control: no-cache\r
 Connection: close\r
+WWW-Authenticate: %WWW_AUTHENTICATE\r
 Sozu-Id: %REQUEST_ID\r
 \r
 <html><head><meta charset='utf-8'><head><body>
@@ -488,7 +536,6 @@ fn default_413() -> String {
 HTTP/1.1 413 Payload Too Large\r
 Cache-Control: no-cache\r
 Connection: close\r
-%Content-Length: %CONTENT_LENGTH\r
 Sozu-Id: %REQUEST_ID\r
 \r
 <html><head><meta charset='utf-8'><head><body>
@@ -535,7 +582,6 @@ fn default_502() -> String {
 HTTP/1.1 502 Bad Gateway\r
 Cache-Control: no-cache\r
 Connection: close\r
-%Content-Length: %CONTENT_LENGTH\r
 Sozu-Id: %REQUEST_ID\r
 \r
 <html><head><meta charset='utf-8'><head><body>
@@ -549,9 +595,9 @@ Sozu-Id: %REQUEST_ID\r
     \"cluster_id\": \"%CLUSTER_ID\",
     \"backend_id\": \"%BACKEND_ID\",
     \"parsing_phase\": \"%PHASE\",
-    \"successfully_parsed\": \"%SUCCESSFULLY_PARSED\",
-    \"partially_parsed\": \"%PARTIALLY_PARSED\",
-    \"invalid\": \"%INVALID\"
+    \"successfully_parsed\": %SUCCESSFULLY_PARSED,
+    \"partially_parsed\": %PARTIALLY_PARSED,
+    \"invalid\": %INVALID
 }
 </pre>
 <p>Response could not be parsed. %MESSAGE</p>
@@ -586,7 +632,6 @@ fn default_503() -> String {
 HTTP/1.1 503 Service Unavailable\r
 Cache-Control: no-cache\r
 Connection: close\r
-%Content-Length: %CONTENT_LENGTH\r
 Sozu-Id: %REQUEST_ID\r
 \r
 <html><head><meta charset='utf-8'><head><body>
@@ -637,7 +682,6 @@ fn default_507() -> String {
 HTTP/1.1 507 Insufficient Storage\r
 Cache-Control: no-cache\r
 Connection: close\r
-%Content-Length: %CONTENT_LENGTH\r
 Sozu-Id: %REQUEST_ID\r
 \r
 <html><head><meta charset='utf-8'><head><body>
@@ -652,7 +696,7 @@ Sozu-Id: %REQUEST_ID\r
     \"backend_id\": \"%BACKEND_ID\"
 }
 </pre>
-<p>Response needed more than %CAPACITY bytes to fit. Parser stopped at phase: %PHASE. %MESSAGE/p>
+<p>Response needed more than %CAPACITY bytes to fit. Parser stopped at phase: %PHASE. %MESSAGE</p>
 <footer>This is an automatic answer by Sōzu.</footer></body></html>",
     )
 }
@@ -671,274 +715,296 @@ fn phase_to_vec(phase: ParsingPhaseMarker) -> Vec<u8> {
     .into()
 }
 
-impl HttpAnswers {
-    #[rustfmt::skip]
-    pub fn template(status: u16, answer: String) -> Result<Template, (u16, TemplateError)> {
-        let length = TemplateVariable {
-            name: "CONTENT_LENGTH",
-            valid_in_body: false,
-            valid_in_header: true,
-            typ: ReplacementType::ContentLength,
+/// Flatten a legacy [`CustomHttpAnswers`] (per-status `Option<String>` fields)
+/// into the new [`BTreeMap<String, String>`] shape, dropping any `None` field.
+///
+/// Used to reconcile state files produced by older managers (which still
+/// emit `http_answers`) with the new template-engine map. The new map wins
+/// on collision; this helper only fills in entries that the new map does
+/// not already define.
+pub fn legacy_to_map(legacy: &CustomHttpAnswers) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    macro_rules! insert {
+        ($code:literal, $field:ident) => {
+            if let Some(ref v) = legacy.$field {
+                out.insert($code.to_owned(), v.to_owned());
+            }
         };
+    }
+    insert!("301", answer_301);
+    insert!("400", answer_400);
+    insert!("401", answer_401);
+    insert!("404", answer_404);
+    insert!("408", answer_408);
+    insert!("413", answer_413);
+    insert!("421", answer_421);
+    insert!("502", answer_502);
+    insert!("503", answer_503);
+    insert!("504", answer_504);
+    insert!("507", answer_507);
+    out
+}
 
+/// Fold a legacy [`CustomHttpAnswers`] into the new map without overriding
+/// existing entries. Lets the worker accept managers that still populate
+/// `http_answers` while preferring the template map when both are set.
+pub fn merge_legacy_into_map(answers: &mut BTreeMap<String, String>, legacy: &CustomHttpAnswers) {
+    for (code, body) in legacy_to_map(legacy) {
+        answers.entry(code).or_insert(body);
+    }
+}
+
+impl HttpAnswers {
+    /// Parse a single template body. Use the status-string variants of the
+    /// canonical variable set when the name parses as a known HTTP status;
+    /// otherwise fall back to the broadest variable set so user-defined
+    /// templates (selected by name) still get the common variables.
+    #[rustfmt::skip]
+    pub fn template(name: &str, answer: &str) -> Result<Template, (String, TemplateError)> {
         let route = TemplateVariable {
             name: "ROUTE",
             valid_in_body: true,
             valid_in_header: true,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
         let request_id = TemplateVariable {
             name: "REQUEST_ID",
             valid_in_body: true,
             valid_in_header: true,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
         let cluster_id = TemplateVariable {
             name: "CLUSTER_ID",
             valid_in_body: true,
             valid_in_header: true,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
         let backend_id = TemplateVariable {
             name: "BACKEND_ID",
             valid_in_body: true,
             valid_in_header: true,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
         let duration = TemplateVariable {
             name: "DURATION",
             valid_in_body: true,
             valid_in_header: true,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
         let capacity = TemplateVariable {
             name: "CAPACITY",
             valid_in_body: true,
             valid_in_header: true,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
         let phase = TemplateVariable {
             name: "PHASE",
             valid_in_body: true,
             valid_in_header: true,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
 
         let location = TemplateVariable {
             name: "REDIRECT_LOCATION",
-            valid_in_body: false,
+            valid_in_body: true,
             valid_in_header: true,
+            or_elide_header: false,
             typ: ReplacementType::VariableOnce(0),
         };
         let message = TemplateVariable {
             name: "MESSAGE",
             valid_in_body: true,
             valid_in_header: false,
+            or_elide_header: false,
+            typ: ReplacementType::VariableOnce(0),
+        };
+        let template_name = TemplateVariable {
+            name: "TEMPLATE_NAME",
+            valid_in_body: true,
+            valid_in_header: true,
+            or_elide_header: false,
+            typ: ReplacementType::VariableOnce(0),
+        };
+        let www_authenticate = TemplateVariable {
+            name: "WWW_AUTHENTICATE",
+            valid_in_body: false,
+            valid_in_header: true,
+            // empty realm → drop the `WWW-Authenticate` header line entirely
+            or_elide_header: true,
             typ: ReplacementType::VariableOnce(0),
         };
         let successfully_parsed = TemplateVariable {
             name: "SUCCESSFULLY_PARSED",
             valid_in_body: true,
             valid_in_header: false,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
         let partially_parsed = TemplateVariable {
             name: "PARTIALLY_PARSED",
             valid_in_body: true,
             valid_in_header: false,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
         let invalid = TemplateVariable {
             name: "INVALID",
             valid_in_body: true,
             valid_in_header: false,
+            or_elide_header: false,
             typ: ReplacementType::Variable(0),
         };
 
-        match status {
-            301 => Template::new(
-                301,
+        match name {
+            "301" => Template::new(
+                Some(301),
                 answer,
-                &[length, route, request_id, location]
+                &[route, request_id, location]
             ),
-            400 => Template::new(
-                400,
+            "400" => Template::new(
+                Some(400),
                 answer,
-                &[length, route, request_id, message, phase, successfully_parsed, partially_parsed, invalid],
+                &[route, request_id, message, phase, successfully_parsed, partially_parsed, invalid],
             ),
-            401 => Template::new(
-                401,
+            "401" => Template::new(
+                Some(401),
                 answer,
-                &[length, route, request_id]
+                &[route, request_id, www_authenticate]
             ),
-            404 => Template::new(
-                404,
+            "404" => Template::new(
+                Some(404),
                 answer,
-                &[length, route, request_id]
+                &[route, request_id]
             ),
-            408 => Template::new(
-                408,
+            "408" => Template::new(
+                Some(408),
                 answer,
-                &[length, route, request_id, duration]
+                &[route, request_id, duration]
             ),
-            413 => Template::new(
-                413,
+            "413" => Template::new(
+                Some(413),
                 answer,
-                &[length, route, request_id, capacity, message, phase],
+                &[route, request_id, capacity, message, phase],
             ),
-            421 => Template::new(
-                421,
+            "421" => Template::new(
+                Some(421),
                 answer,
-                &[length, route, request_id]
+                &[route, request_id]
             ),
-            502 => Template::new(
-                502,
+            "502" => Template::new(
+                Some(502),
                 answer,
-                &[length, route, request_id, cluster_id, backend_id, message, phase, successfully_parsed, partially_parsed, invalid],
+                &[route, request_id, cluster_id, backend_id, message, phase, successfully_parsed, partially_parsed, invalid],
             ),
-            503 => Template::new(
-                503,
+            "503" => Template::new(
+                Some(503),
                 answer,
-                &[length, route, request_id, cluster_id, backend_id, message],
+                &[route, request_id, cluster_id, backend_id, message],
             ),
-            504 => Template::new(
-                504,
+            "504" => Template::new(
+                Some(504),
                 answer,
-                &[length, route, request_id, cluster_id, backend_id, duration],
+                &[route, request_id, cluster_id, backend_id, duration],
             ),
-            507 => Template::new(
-                507,
+            "507" => Template::new(
+                Some(507),
                 answer,
-                &[length, route, request_id, cluster_id, backend_id, capacity, message, phase],
+                &[route, request_id, cluster_id, backend_id, capacity, message, phase],
             ),
-            _ => Err(TemplateError::InvalidStatusCode(status)),
+            _ => Template::new(
+                None,
+                answer,
+                &[route, request_id, cluster_id, location, template_name],
+            ),
         }
-        .map_err(|e| (status, e))
+        .map_err(|e| (name.to_owned(), e))
     }
 
-    pub fn new(conf: &Option<CustomHttpAnswers>) -> Result<Self, (u16, TemplateError)> {
+    /// Compile every `(name → body)` pair into a templates map. Stops on the
+    /// first parse error; the returned tuple identifies which template failed.
+    pub fn templates(
+        answers: &BTreeMap<String, String>,
+    ) -> Result<BTreeMap<String, Template>, (String, TemplateError)> {
+        answers
+            .iter()
+            .map(|(name, answer)| {
+                Self::template(name, answer).map(|template| (name.clone(), template))
+            })
+            .collect::<Result<_, _>>()
+    }
+
+    /// Build the listener-level template registry. The map can be empty —
+    /// every status code referenced in [`DefaultAnswer`] gets a built-in
+    /// fallback template.
+    pub fn new(answers: &BTreeMap<String, String>) -> Result<Self, (String, TemplateError)> {
+        type DefaultBuilder = fn() -> String;
+        let mut listener_answers = Self::templates(answers)?;
+        let expected_defaults: &[(&str, DefaultBuilder)] = &[
+            ("301", default_301),
+            ("400", default_400),
+            ("401", default_401),
+            ("404", default_404),
+            ("408", default_408),
+            ("413", default_413),
+            ("421", default_421),
+            ("502", default_502),
+            ("503", default_503),
+            ("504", default_504),
+            ("507", default_507),
+        ];
+        for (name, default) in expected_defaults {
+            if !listener_answers.contains_key(*name) {
+                listener_answers.insert(
+                    name.to_string(),
+                    Self::template(name, &default()).expect("built-in default templates parse"),
+                );
+            }
+        }
         Ok(HttpAnswers {
-            listener_answers: ListenerAnswers {
-                answer_301: Self::template(
-                    301,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_301.clone())
-                        .unwrap_or(default_301()),
-                )?,
-                answer_400: Self::template(
-                    400,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_400.clone())
-                        .unwrap_or(default_400()),
-                )?,
-                answer_401: Self::template(
-                    401,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_401.clone())
-                        .unwrap_or(default_401()),
-                )?,
-                answer_404: Self::template(
-                    404,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_404.clone())
-                        .unwrap_or(default_404()),
-                )?,
-                answer_408: Self::template(
-                    408,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_408.clone())
-                        .unwrap_or(default_408()),
-                )?,
-                answer_413: Self::template(
-                    413,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_413.clone())
-                        .unwrap_or(default_413()),
-                )?,
-                answer_421: Self::template(
-                    421,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_421.clone())
-                        .unwrap_or(default_421()),
-                )?,
-                answer_502: Self::template(
-                    502,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_502.clone())
-                        .unwrap_or(default_502()),
-                )?,
-                answer_503: Self::template(
-                    503,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_503.clone())
-                        .unwrap_or(default_503()),
-                )?,
-                answer_504: Self::template(
-                    504,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_504.clone())
-                        .unwrap_or(default_504()),
-                )?,
-                answer_507: Self::template(
-                    507,
-                    conf.as_ref()
-                        .and_then(|c| c.answer_507.clone())
-                        .unwrap_or(default_507()),
-                )?,
-            },
-            cluster_custom_answers: HashMap::new(),
+            fallback: Self::template("", &fallback()).expect("built-in fallback template parses"),
+            listener_answers,
+            cluster_answers: HashMap::new(),
         })
     }
 
-    pub fn add_custom_answer(
+    /// Register or extend the per-cluster template overrides for `cluster_id`.
+    ///
+    /// New entries shadow the listener-level templates for the matching
+    /// status. Existing entries with the same status are replaced. Entries
+    /// already registered for the cluster but absent from `answers` are kept.
+    pub fn add_cluster_answers(
         &mut self,
         cluster_id: &str,
-        answer_503: String,
-    ) -> Result<(), (u16, TemplateError)> {
-        let answer_503 = Self::template(503, answer_503)?;
-        self.cluster_custom_answers
-            .insert(cluster_id.to_string(), ClusterAnswers { answer_503 });
-        Ok(())
-    }
-
-    pub fn remove_custom_answer(&mut self, cluster_id: &str) {
-        self.cluster_custom_answers.remove(cluster_id);
-    }
-
-    /// Rewrite ONLY the listener-default template fields for which the patch
-    /// provides `Some(body)`, leaving all other templates and
-    /// `cluster_custom_answers` untouched.
-    ///
-    /// Field-mask semantic: a `None` field in `new_defaults` means "preserve
-    /// the current template"; a `Some` field means "replace with this body".
-    /// This matches the update-verb documented contract — a patch that sets
-    /// only `answer_503` must leave `answer_401`/`answer_404`/etc. alone.
-    pub fn replace_defaults(
-        &mut self,
-        new_defaults: &CustomHttpAnswers,
-    ) -> Result<(), (u16, TemplateError)> {
-        macro_rules! merge {
-            ($status:expr, $field:ident) => {
-                if let Some(body) = new_defaults.$field.clone() {
-                    self.listener_answers.$field = Self::template($status, body)?;
-                }
-            };
+        answers: &BTreeMap<String, String>,
+    ) -> Result<(), (String, TemplateError)> {
+        if answers.is_empty() {
+            return Ok(());
         }
-
-        merge!(301, answer_301);
-        merge!(400, answer_400);
-        merge!(401, answer_401);
-        merge!(404, answer_404);
-        merge!(408, answer_408);
-        merge!(413, answer_413);
-        merge!(421, answer_421);
-        merge!(502, answer_502);
-        merge!(503, answer_503);
-        merge!(504, answer_504);
-        merge!(507, answer_507);
+        let mut compiled = Self::templates(answers)?;
+        self.cluster_answers
+            .entry(cluster_id.to_owned())
+            .or_default()
+            .append(&mut compiled);
         Ok(())
     }
 
+    /// Drop every per-cluster override for `cluster_id`. Subsequent lookups
+    /// fall through to the listener-level template.
+    pub fn remove_cluster_answers(&mut self, cluster_id: &str) {
+        self.cluster_answers.remove(cluster_id);
+    }
+
+    /// Lookup + render. Returns the resolved status, the template's
+    /// `keep_alive` flag (false when the template carries
+    /// `Connection: close`), and the rendered Kawa stream ready to be
+    /// prepared for the wire.
     pub fn get(
         &self,
         answer: DefaultAnswer,
@@ -946,14 +1012,14 @@ impl HttpAnswers {
         cluster_id: Option<&str>,
         backend_id: Option<&str>,
         route: String,
-    ) -> DefaultAnswerStream {
+    ) -> (u16, bool, DefaultAnswerStream) {
         let variables: Vec<Vec<u8>>;
         let mut variables_once: Vec<Vec<u8>>;
-        let template = match answer {
+        let name = match answer {
             DefaultAnswer::Answer301 { location } => {
                 variables = vec![route.into(), request_id.into()];
                 variables_once = vec![location.into()];
-                &self.listener_answers.answer_301
+                "301"
             }
             DefaultAnswer::Answer400 {
                 message,
@@ -971,22 +1037,22 @@ impl HttpAnswers {
                     invalid.into(),
                 ];
                 variables_once = vec![message.into()];
-                &self.listener_answers.answer_400
+                "400"
             }
-            DefaultAnswer::Answer401 {} => {
+            DefaultAnswer::Answer401 { www_authenticate } => {
                 variables = vec![route.into(), request_id.into()];
-                variables_once = vec![];
-                &self.listener_answers.answer_401
+                variables_once = vec![www_authenticate.unwrap_or_default().into()];
+                "401"
             }
             DefaultAnswer::Answer404 {} => {
                 variables = vec![route.into(), request_id.into()];
                 variables_once = vec![];
-                &self.listener_answers.answer_404
+                "404"
             }
             DefaultAnswer::Answer408 { duration } => {
                 variables = vec![route.into(), request_id.into(), duration.to_string().into()];
                 variables_once = vec![];
-                &self.listener_answers.answer_408
+                "408"
             }
             DefaultAnswer::Answer413 {
                 message,
@@ -1000,12 +1066,12 @@ impl HttpAnswers {
                     phase_to_vec(phase),
                 ];
                 variables_once = vec![message.into()];
-                &self.listener_answers.answer_413
+                "413"
             }
             DefaultAnswer::Answer421 {} => {
                 variables = vec![route.into(), request_id.into()];
                 variables_once = vec![];
-                &self.listener_answers.answer_421
+                "421"
             }
             DefaultAnswer::Answer502 {
                 message,
@@ -1025,7 +1091,7 @@ impl HttpAnswers {
                     invalid.into(),
                 ];
                 variables_once = vec![message.into()];
-                &self.listener_answers.answer_502
+                "502"
             }
             DefaultAnswer::Answer503 { message } => {
                 variables = vec![
@@ -1035,10 +1101,7 @@ impl HttpAnswers {
                     backend_id.unwrap_or_default().into(),
                 ];
                 variables_once = vec![message.into()];
-                cluster_id
-                    .and_then(|id: &str| self.cluster_custom_answers.get(id))
-                    .map(|c| &c.answer_503)
-                    .unwrap_or_else(|| &self.listener_answers.answer_503)
+                "503"
             }
             DefaultAnswer::Answer504 { duration } => {
                 variables = vec![
@@ -1049,7 +1112,7 @@ impl HttpAnswers {
                     duration.to_string().into(),
                 ];
                 variables_once = vec![];
-                &self.listener_answers.answer_504
+                "504"
             }
             DefaultAnswer::Answer507 {
                 phase,
@@ -1065,114 +1128,288 @@ impl HttpAnswers {
                     phase_to_vec(phase),
                 ];
                 variables_once = vec![message.into()];
-                &self.listener_answers.answer_507
+                "507"
             }
         };
-        // kawa::debug_kawa(&template.kawa);
-        // println!("{template:#?}");
-        template.fill(&variables, &mut variables_once)
+        let template = cluster_id
+            .and_then(|id| self.cluster_answers.get(id))
+            .and_then(|answers| answers.get(name))
+            .or_else(|| self.listener_answers.get(name))
+            .unwrap_or(&self.fallback);
+        (
+            template.status,
+            template.keep_alive,
+            template.fill(&variables, &mut variables_once),
+        )
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use sozu_command::proto::command::CustomHttpAnswers;
 
-    use super::HttpAnswers;
+    use super::{
+        HttpAnswers, ReplacementType, Template, TemplateError, TemplateVariable, legacy_to_map,
+        merge_legacy_into_map,
+    };
+    use crate::protocol::http::DefaultAnswer;
 
-    /// `replace_defaults` must rewrite listener-default templates while
-    /// preserving every per-cluster entry in `cluster_custom_answers`.
+    fn body_route() -> TemplateVariable {
+        TemplateVariable {
+            name: "ROUTE",
+            valid_in_body: true,
+            valid_in_header: true,
+            or_elide_header: false,
+            typ: ReplacementType::Variable(0),
+        }
+    }
+
+    fn header_realm() -> TemplateVariable {
+        TemplateVariable {
+            name: "WWW_AUTHENTICATE",
+            valid_in_body: false,
+            valid_in_header: true,
+            or_elide_header: true,
+            typ: ReplacementType::VariableOnce(0),
+        }
+    }
+
+    fn variable_once_message() -> TemplateVariable {
+        TemplateVariable {
+            name: "MESSAGE",
+            valid_in_body: true,
+            valid_in_header: false,
+            or_elide_header: false,
+            typ: ReplacementType::VariableOnce(0),
+        }
+    }
+
+    /// `Template::new` accepts a well-formed body that uses a declared
+    /// variable.
     #[test]
-    fn replace_defaults_preserves_cluster_custom_answers() {
-        // Build a fresh HttpAnswers with the stock defaults.
-        let mut answers = HttpAnswers::new(&None).expect("default HttpAnswers must parse");
-
-        // Register a per-cluster custom 503.
-        let custom_cluster_503 = "HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\nContent-Length: 5\r\n\r\noops!";
-        answers
-            .add_custom_answer("my-cluster", custom_cluster_503.to_owned())
-            .expect("custom 503 must parse");
-
-        // Now replace the listener-default 503 with a different body.
-        let new_listener_503 = "HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\nContent-Length: 11\r\n\r\nnew-default";
-        let patch = CustomHttpAnswers {
-            answer_503: Some(new_listener_503.to_owned()),
-            ..Default::default()
-        };
-        answers
-            .replace_defaults(&patch)
-            .expect("replace_defaults must succeed");
-
-        // (a) Listener-default template now contains the new body text.
-        let template_buf = answers.listener_answers.answer_503.kawa.storage.buffer();
-        let contains_new_default = template_buf
-            .windows(b"new-default".len())
-            .any(|w| w == b"new-default");
+    fn template_new_accepts_known_variable() {
+        let body = "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nroute=%ROUTE";
+        let template =
+            Template::new(Some(200), body, &[body_route()]).expect("template must compile");
+        let mut empty_once: Vec<Vec<u8>> = Vec::new();
+        let rendered = template.fill(&[b"hello".to_vec()], &mut empty_once);
+        let buf = rendered.storage.buffer();
         assert!(
-            contains_new_default,
-            "listener-default 503 should have been replaced with new-default"
-        );
-
-        // (b) The registered cluster's custom 503 is still intact.
-        assert!(
-            answers.cluster_custom_answers.contains_key("my-cluster"),
-            "cluster_custom_answers must be preserved after replace_defaults"
-        );
-        let cluster_buf = answers
-            .cluster_custom_answers
-            .get("my-cluster")
-            .unwrap()
-            .answer_503
-            .kawa
-            .storage
-            .buffer();
-        let contains_oops = cluster_buf.windows(b"oops!".len()).any(|w| w == b"oops!");
-        assert!(
-            contains_oops,
-            "per-cluster 503 must still contain the original custom body"
+            rendered.blocks.iter().any(
+                |block| matches!(block, kawa::Block::Chunk(kawa::Chunk { data })
+                    if data.data(buf) == b"hello")
+            ),
+            "rendered body must contain the substituted ROUTE variable"
         );
     }
 
-    /// Regression test for the H-1 finding: `replace_defaults` must preserve
-    /// listener-default templates for fields that the patch does NOT set.
-    /// Prior behavior treated `None` as "reset to stock default", silently
-    /// wiping out any custom body configured at AddListener time.
+    /// Header-only variable referenced from the body must error at compile
+    /// time. Exercises the `valid_in_body` guard, which is the same code
+    /// path that catches an unknown `%FOOBAR` (no matching variable, but
+    /// inversely: a typed mismatch).
     #[test]
-    fn replace_defaults_preserves_unmentioned_templates() {
-        // Build HttpAnswers with a custom 401 AND 503 at creation time.
-        let initial_401 = "HTTP/1.1 401 Unauthorized\r\nConnection: close\r\nContent-Length: 12\r\n\r\nneed-creds!!";
-        let initial_503 = "HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\nContent-Length: 11\r\n\r\ninitial-503";
-        let initial = CustomHttpAnswers {
-            answer_401: Some(initial_401.to_owned()),
-            answer_503: Some(initial_503.to_owned()),
-            ..Default::default()
-        };
-        let mut answers = HttpAnswers::new(&Some(initial)).expect("initial HttpAnswers must parse");
+    fn template_new_rejects_header_only_in_body() {
+        let body = "HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\nrealm=%WWW_AUTHENTICATE";
+        let err = Template::new(Some(401), body, &[header_realm()])
+            .expect_err("variable not allowed in body must error");
+        match err {
+            TemplateError::NotAllowedInBody(name) => assert_eq!(name, "WWW_AUTHENTICATE"),
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
 
-        // Patch ONLY answer_503. answer_401 must stay as-is.
-        let new_503 = "HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\nContent-Length: 7\r\n\r\npatched";
-        let patch = CustomHttpAnswers {
-            answer_503: Some(new_503.to_owned()),
-            ..Default::default()
-        };
-        answers
-            .replace_defaults(&patch)
-            .expect("replace_defaults must succeed");
+    /// `Template::new` enforces `VariableOnce` semantics: a one-shot
+    /// variable referenced twice must error at compile time.
+    #[test]
+    fn template_new_rejects_variable_once_reused() {
+        let body = "HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\n\r\n%MESSAGE %MESSAGE";
+        let err = Template::new(Some(503), body, &[variable_once_message()])
+            .expect_err("VariableOnce reused twice must error");
+        match err {
+            TemplateError::AlreadyConsumed(name) => assert_eq!(name, "MESSAGE"),
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
 
-        // 503 got the patched body.
-        let buf_503 = answers.listener_answers.answer_503.kawa.storage.buffer();
+    /// `Template::fill` substitutes the runtime value into the body chunk.
+    #[test]
+    fn template_fill_substitutes_body_variable() {
+        let body = "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nroute=%ROUTE";
+        let template = Template::new(Some(200), body, &[body_route()]).expect("template compiles");
+        let mut empty_once: Vec<Vec<u8>> = Vec::new();
+        let rendered = template.fill(&[b"abc".to_vec()], &mut empty_once);
+        let mut concatenated = Vec::new();
+        let buf = rendered.storage.buffer();
+        for block in &rendered.blocks {
+            if let kawa::Block::Chunk(kawa::Chunk { data }) = block {
+                concatenated.extend_from_slice(data.data(buf));
+            }
+        }
         assert!(
-            buf_503.windows(b"patched".len()).any(|w| w == b"patched"),
-            "answer_503 should have been replaced"
+            concatenated
+                .windows(b"route=abc".len())
+                .any(|w| w == b"route=abc"),
+            "rendered body must contain the substituted variable, got {:?}",
+            String::from_utf8_lossy(&concatenated),
         );
+    }
 
-        // 401 must still contain the custom body from initial AddListener.
-        let buf_401 = answers.listener_answers.answer_401.kawa.storage.buffer();
+    /// `or_elide_header: true` drops the surrounding header line when the
+    /// substitution is empty. This is the path that makes
+    /// `WWW-Authenticate: <realm>` disappear when the cluster has no realm
+    /// configured.
+    #[test]
+    fn template_fill_elides_header_when_empty() {
+        let body = "HTTP/1.1 401 Unauthorized\r\nWWW-Authenticate: %WWW_AUTHENTICATE\r\nConnection: close\r\n\r\n";
+        let template =
+            Template::new(Some(401), body, &[header_realm()]).expect("template compiles");
+        // empty realm → header is elided
+        let mut variables_once = vec![Vec::<u8>::new()];
+        let rendered = template.fill(&[], &mut variables_once);
+        let buf = rendered.storage.buffer();
+        let elided = rendered.blocks.iter().any(|block| match block {
+            kawa::Block::Header(pair) => pair.is_elided() && pair.val.data(buf).is_empty(),
+            _ => false,
+        });
         assert!(
-            buf_401
-                .windows(b"need-creds!!".len())
-                .any(|w| w == b"need-creds!!"),
-            "answer_401 must be preserved when the patch does not set it"
+            elided,
+            "WWW-Authenticate header must be elided when realm is empty"
+        );
+        // Non-empty realm → header is kept with the substituted value.
+        let mut variables_once = vec![b"Basic realm=\"test\"".to_vec()];
+        let rendered = template.fill(&[], &mut variables_once);
+        let buf = rendered.storage.buffer();
+        let kept = rendered.blocks.iter().any(|block| match block {
+            kawa::Block::Header(pair) => {
+                !pair.is_elided() && pair.key.data(buf).eq_ignore_ascii_case(b"WWW-Authenticate")
+            }
+            _ => false,
+        });
+        assert!(
+            kept,
+            "WWW-Authenticate header must be kept when realm is non-empty"
+        );
+    }
+
+    /// `add_cluster_answers` followed by `get` returns the per-cluster
+    /// override; `remove_cluster_answers` falls back to the listener-level
+    /// template.
+    #[test]
+    fn cluster_overrides_listener() {
+        let mut answers = HttpAnswers::new(&BTreeMap::new()).expect("default HttpAnswers");
+        let custom_503 =
+            "HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\n\r\nfrom-cluster";
+        let mut overrides = BTreeMap::new();
+        overrides.insert("503".to_owned(), custom_503.to_owned());
+        answers
+            .add_cluster_answers("c1", &overrides)
+            .expect("override compiles");
+
+        let (status, _keep_alive, rendered) = answers.get(
+            DefaultAnswer::Answer503 {
+                message: String::new(),
+            },
+            "rid".to_owned(),
+            Some("c1"),
+            None,
+            "/".to_owned(),
+        );
+        assert_eq!(status, 503);
+        let buf = rendered.storage.buffer();
+        let body_has_override = rendered.blocks.iter().any(|block| match block {
+            kawa::Block::Chunk(kawa::Chunk { data }) => data.data(buf) == b"from-cluster",
+            _ => false,
+        });
+        assert!(body_has_override, "cluster-level body must win");
+
+        // Remove and check the listener-level body comes back.
+        answers.remove_cluster_answers("c1");
+        let (_, _, rendered) = answers.get(
+            DefaultAnswer::Answer503 {
+                message: String::new(),
+            },
+            "rid".to_owned(),
+            Some("c1"),
+            None,
+            "/".to_owned(),
+        );
+        let buf = rendered.storage.buffer();
+        let body_still_overridden = rendered.blocks.iter().any(|block| match block {
+            kawa::Block::Chunk(kawa::Chunk { data }) => data.data(buf) == b"from-cluster",
+            _ => false,
+        });
+        assert!(
+            !body_still_overridden,
+            "after remove, listener-level body must take over"
+        );
+    }
+
+    /// Round-trip a legacy `CustomHttpAnswers { answer_503: ... }` through
+    /// `legacy_to_map` + `HttpAnswers::new`, and verify the rendered 503
+    /// carries the legacy body.
+    #[test]
+    fn legacy_to_map_roundtrip() {
+        let legacy = CustomHttpAnswers {
+            answer_503: Some(
+                "HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\n\r\nlegacy-503"
+                    .to_owned(),
+            ),
+            ..Default::default()
+        };
+        let map = legacy_to_map(&legacy);
+        assert!(map.contains_key("503"), "legacy_to_map must preserve 503");
+        let answers = HttpAnswers::new(&map).expect("HttpAnswers::new accepts legacy map");
+        let (status, _, rendered) = answers.get(
+            DefaultAnswer::Answer503 {
+                message: String::new(),
+            },
+            "rid".to_owned(),
+            None,
+            None,
+            "/".to_owned(),
+        );
+        assert_eq!(status, 503);
+        let buf = rendered.storage.buffer();
+        let has_legacy = rendered.blocks.iter().any(|block| match block {
+            kawa::Block::Chunk(kawa::Chunk { data }) => data.data(buf) == b"legacy-503",
+            _ => false,
+        });
+        assert!(
+            has_legacy,
+            "legacy-503 body must round-trip into the new map"
+        );
+    }
+
+    /// `merge_legacy_into_map` does not override existing entries — the new
+    /// map wins on collision (per the proto comment on field 9/12/21/38/43).
+    #[test]
+    fn merge_legacy_into_map_prefers_new() {
+        let mut new_map = BTreeMap::new();
+        new_map.insert(
+            "503".to_owned(),
+            "HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\n\r\nfrom-new".to_owned(),
+        );
+        let legacy = CustomHttpAnswers {
+            answer_503: Some(
+                "HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\n\r\nfrom-legacy"
+                    .to_owned(),
+            ),
+            answer_404: Some(
+                "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\nlegacy-404".to_owned(),
+            ),
+            ..Default::default()
+        };
+        merge_legacy_into_map(&mut new_map, &legacy);
+        assert_eq!(
+            new_map.get("503").map(String::as_str),
+            Some("HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\n\r\nfrom-new"),
+            "new map must keep its 503 even though legacy has one"
+        );
+        assert!(
+            new_map.contains_key("404"),
+            "legacy 404 must fill in when new map does not define one"
         );
     }
 }

--- a/lib/src/protocol/kawa_h1/answers.rs
+++ b/lib/src/protocol/kawa_h1/answers.rs
@@ -159,7 +159,17 @@ impl Template {
         if !kawa.is_main_phase() {
             return Err(TemplateError::InvalidTemplate(kawa.parsing_phase));
         }
-        if kawa.body_size != BodySize::Empty {
+        // Reject only `Chunked` — a streaming framing makes no sense in a
+        // static answer template. `BodySize::Length(N)` is what kawa
+        // reports for the common operator shape
+        // `…\r\nContent-Length: N\r\n\r\n<N-byte body>` (used by the
+        // legacy `answer_NNN` fields and the test fixtures that round-
+        // trip those responses), so accepting it is required for
+        // backwards compatibility. The block walk below routes the
+        // operator's `Content-Length` header through the `ContentLength`
+        // placeholder so the rendered response carries exactly one
+        // header (RFC 9110 §8.6 / RFC 7230 §3.3.2 dedup invariant).
+        if matches!(kawa.body_size, BodySize::Chunked) {
             return Err(TemplateError::InvalidSizeInfo(kawa.body_size));
         }
         let resolved_status = if let StatusLine::Response { code, .. } = &kawa.detached.status_line
@@ -183,10 +193,20 @@ impl Template {
         // Track whether the operator-supplied template carried its own
         // `Content-Length` header. If yes we wire that block up to the
         // `ContentLength` placeholder (so the value is auto-resolved at
-        // `fill` time) instead of splicing in a second synthetic header
-        // — RFC 9110 §8.6 / RFC 7230 §3.3.2 forbid duplicate
+        // `fill` time after any `%`-substitutions in the body) instead
+        // of letting the literal value drift away from the actual body
+        // length — RFC 9110 §8.6 / RFC 7230 §3.3.2 forbid duplicate
         // `Content-Length` and downstream agents reject those messages
         // hard as a request-smuggling vector.
+        //
+        // We deliberately do NOT synthesise a `Content-Length` when the
+        // operator template omits one. Inserting a synthetic
+        // `Content-Length: 0` line would shift wire bytes for every
+        // header-only template (default 301 redirects, default 404,
+        // operator-supplied templates that intentionally rely on
+        // `Connection: close` for body framing). Operators who want a
+        // specific Content-Length include it in their template; those
+        // who don't get the bytes they wrote.
         let mut content_length_seen = false;
         for mut block in kawa.blocks.into_iter() {
             match &mut block {
@@ -194,20 +214,6 @@ impl Template {
                 Block::Flags(Flags {
                     end_header: true, ..
                 }) => {
-                    if !content_length_seen {
-                        // Right before the end-of-headers marker, splice in a
-                        // synthetic `Content-Length: PLACEHOLDER` header. `fill`
-                        // resolves the placeholder once the body length is known.
-                        header_replacements.push(Replacement {
-                            block_index: blocks.len(),
-                            or_elide_header: false,
-                            typ: ReplacementType::ContentLength,
-                        });
-                        blocks.push_back(Block::Header(Pair {
-                            key: Store::Static(b"Content-Length"),
-                            val: Store::Static(b"PLACEHOLDER"),
-                        }));
-                    }
                     blocks.push_back(block);
                 }
                 Block::StatusLine | Block::Cookies | Block::Flags(_) => {
@@ -1182,6 +1188,8 @@ mod tests {
 
     use sozu_command::proto::command::CustomHttpAnswers;
 
+    use kawa::BodySize;
+
     use super::{
         HttpAnswers, ReplacementType, Template, TemplateError, TemplateVariable, legacy_to_map,
         merge_legacy_into_map,
@@ -1458,6 +1466,99 @@ mod tests {
             has_legacy,
             "legacy-503 body must round-trip into the new map"
         );
+    }
+
+    /// Operator-supplied templates that carry a literal `Content-Length`
+    /// must compile (no `InvalidSizeInfo` rejection) AND must not emit
+    /// two `Content-Length` headers on the wire — the literal value
+    /// gets routed through the [`ReplacementType::ContentLength`]
+    /// placeholder so the rendered response carries exactly one header,
+    /// auto-recomputed from the actual body size after fill-time
+    /// substitutions.
+    ///
+    /// Regression guard against the CI failure on
+    /// `test_http_answers_replace_preserves_cluster_overrides` where
+    /// the parser rejected `…\r\nContent-Length: 19\r\n\r\n<19-byte body>`
+    /// with `InvalidSizeInfo(Length(19))`.
+    #[test]
+    fn template_new_accepts_literal_content_length() {
+        let body =
+            "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 19\r\n\r\ncluster-custom-503!";
+        let template =
+            Template::new(Some(503), body, &[]).expect("literal Content-Length compiles");
+        let mut empty_once: Vec<Vec<u8>> = Vec::new();
+        let rendered = template.fill(&[], &mut empty_once);
+        let buf = rendered.storage.buffer();
+
+        // Exactly one Content-Length header survives in the rendered
+        // response. Two would be a CWE-444 / smuggling primitive.
+        let cl_count = rendered
+            .blocks
+            .iter()
+            .filter(|block| match block {
+                kawa::Block::Header(pair) => {
+                    !pair.is_elided() && pair.key.data(buf).eq_ignore_ascii_case(b"Content-Length")
+                }
+                _ => false,
+            })
+            .count();
+        assert_eq!(
+            cl_count, 1,
+            "literal Content-Length must dedup to a single header"
+        );
+        // Body bytes survived the parse → fill round-trip.
+        let has_body = rendered.blocks.iter().any(|block| match block {
+            kawa::Block::Chunk(kawa::Chunk { data }) => data.data(buf) == b"cluster-custom-503!",
+            _ => false,
+        });
+        assert!(
+            has_body,
+            "literal body bytes must survive into the rendered response"
+        );
+    }
+
+    /// Templates that omit `Content-Length` must NOT have one
+    /// synthesised — operators rely on the byte-for-byte shape of
+    /// header-only templates (default 301 redirect, default 404, any
+    /// `Connection: close` short response). Auto-injecting
+    /// `Content-Length: 0` is the regression that broke
+    /// `test_http_behaviors` and `test_https_redirect` in CI.
+    #[test]
+    fn template_new_does_not_synthesise_content_length() {
+        let body = "HTTP/1.1 301 Moved Permanently\r\nLocation: https://example.com/\r\nConnection: close\r\n\r\n";
+        let template = Template::new(Some(301), body, &[]).expect("header-only template compiles");
+        let mut empty_once: Vec<Vec<u8>> = Vec::new();
+        let rendered = template.fill(&[], &mut empty_once);
+        let buf = rendered.storage.buffer();
+        let cl_count = rendered
+            .blocks
+            .iter()
+            .filter(|block| match block {
+                kawa::Block::Header(pair) => {
+                    !pair.is_elided() && pair.key.data(buf).eq_ignore_ascii_case(b"Content-Length")
+                }
+                _ => false,
+            })
+            .count();
+        assert_eq!(
+            cl_count, 0,
+            "templates without Content-Length must not have one synthesised"
+        );
+    }
+
+    /// `Transfer-Encoding: chunked` is the only `BodySize` shape we
+    /// reject — a streaming framing makes no sense in a static
+    /// template. `Length(_)` and `Empty` both compile.
+    #[test]
+    fn template_new_rejects_chunked_template() {
+        let body =
+            "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n0\r\n\r\n";
+        let err =
+            Template::new(Some(200), body, &[]).expect_err("chunked template must be rejected");
+        match err {
+            TemplateError::InvalidSizeInfo(BodySize::Chunked) => {}
+            other => panic!("expected InvalidSizeInfo(Chunked), got {other:?}"),
+        }
     }
 
     /// `merge_legacy_into_map` does not override existing entries — the new

--- a/lib/src/protocol/kawa_h1/answers.rs
+++ b/lib/src/protocol/kawa_h1/answers.rs
@@ -1299,6 +1299,41 @@ mod tests {
         );
     }
 
+    /// Adjacent body variables (`%A%B` with no literal between them) must
+    /// keep `body_size` accounting consistent. Each variable's placeholder
+    /// is removed from the running body size before the runtime value is
+    /// added, so the post-fill total equals the substituted value bytes
+    /// even when two placeholders are back-to-back. This guards against
+    /// the `body_size -= variable.name.len() + 1` underflow class that
+    /// would otherwise be brittle on corner cases.
+    #[test]
+    fn template_fill_adjacent_body_variables() {
+        // Two placeholders, no literal between them, plus a literal head
+        // and tail so we're sure the inter-chunk arithmetic balances.
+        let body = "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n[%ROUTE%ROUTE]";
+        let template = Template::new(Some(200), body, &[body_route()])
+            .expect("adjacent %VAR%VAR template compiles");
+        let mut empty_once: Vec<Vec<u8>> = Vec::new();
+        let rendered = template.fill(&[b"X".to_vec()], &mut empty_once);
+        let mut concatenated = Vec::new();
+        let buf = rendered.storage.buffer();
+        for block in &rendered.blocks {
+            if let kawa::Block::Chunk(kawa::Chunk { data }) = block {
+                concatenated.extend_from_slice(data.data(buf));
+            }
+        }
+        // Each `%ROUTE` placeholder (6 bytes + leading `%` = 7 bytes) is
+        // replaced with the 1-byte runtime value. The concatenated body
+        // bytes must read literally `[XX]` — proving both substitutions
+        // landed and the inter-chunk arithmetic kept the chunk
+        // boundaries.
+        assert!(
+            concatenated.windows(b"[XX]".len()).any(|w| w == b"[XX]"),
+            "adjacent variables must both substitute, got {:?}",
+            String::from_utf8_lossy(&concatenated),
+        );
+    }
+
     /// `or_elide_header: true` drops the surrounding header line when the
     /// substitution is empty. This is the path that makes
     /// `WWW-Authenticate: <realm>` disappear when the cluster has no realm

--- a/lib/src/protocol/kawa_h1/answers.rs
+++ b/lib/src/protocol/kawa_h1/answers.rs
@@ -180,24 +180,34 @@ impl Template {
         let mut body_size = 0;
         let mut keep_alive = true;
         let mut used_once = Vec::new();
+        // Track whether the operator-supplied template carried its own
+        // `Content-Length` header. If yes we wire that block up to the
+        // `ContentLength` placeholder (so the value is auto-resolved at
+        // `fill` time) instead of splicing in a second synthetic header
+        // — RFC 9110 §8.6 / RFC 7230 §3.3.2 forbid duplicate
+        // `Content-Length` and downstream agents reject those messages
+        // hard as a request-smuggling vector.
+        let mut content_length_seen = false;
         for mut block in kawa.blocks.into_iter() {
             match &mut block {
                 Block::ChunkHeader(_) => return Err(TemplateError::UnsupportedStreaming),
                 Block::Flags(Flags {
                     end_header: true, ..
                 }) => {
-                    // Right before the end-of-headers marker, splice in a
-                    // synthetic `Content-Length: PLACEHOLDER` header. `fill`
-                    // resolves the placeholder once the body length is known.
-                    header_replacements.push(Replacement {
-                        block_index: blocks.len(),
-                        or_elide_header: false,
-                        typ: ReplacementType::ContentLength,
-                    });
-                    blocks.push_back(Block::Header(Pair {
-                        key: Store::Static(b"Content-Length"),
-                        val: Store::Static(b"PLACEHOLDER"),
-                    }));
+                    if !content_length_seen {
+                        // Right before the end-of-headers marker, splice in a
+                        // synthetic `Content-Length: PLACEHOLDER` header. `fill`
+                        // resolves the placeholder once the body length is known.
+                        header_replacements.push(Replacement {
+                            block_index: blocks.len(),
+                            or_elide_header: false,
+                            typ: ReplacementType::ContentLength,
+                        });
+                        blocks.push_back(Block::Header(Pair {
+                            key: Store::Static(b"Content-Length"),
+                            val: Store::Static(b"PLACEHOLDER"),
+                        }));
+                    }
                     blocks.push_back(block);
                 }
                 Block::StatusLine | Block::Cookies | Block::Flags(_) => {
@@ -210,6 +220,24 @@ impl Template {
                         && compare_no_case(val_data, b"close")
                     {
                         keep_alive = false;
+                    }
+                    if compare_no_case(key_data, b"content-length") {
+                        // Hand the operator's literal Content-Length over
+                        // to the same `ContentLength` placeholder machinery
+                        // so the rendered response carries exactly one
+                        // header with the auto-computed body size.
+                        if content_length_seen {
+                            return Err(TemplateError::AlreadyConsumed("Content-Length"));
+                        }
+                        content_length_seen = true;
+                        *val = Store::Static(b"PLACEHOLDER");
+                        header_replacements.push(Replacement {
+                            block_index: blocks.len(),
+                            or_elide_header: false,
+                            typ: ReplacementType::ContentLength,
+                        });
+                        blocks.push_back(block);
+                        continue;
                     }
                     if let Some(b'%') = val_data.first() {
                         for variable in &variables {
@@ -961,14 +989,18 @@ impl HttpAnswers {
         ];
         for (name, default) in expected_defaults {
             if !listener_answers.contains_key(*name) {
-                listener_answers.insert(
-                    name.to_string(),
-                    Self::template(name, &default()).expect("built-in default templates parse"),
-                );
+                // The built-in templates are static strings shipped with
+                // the crate. A parse failure here means a regression in
+                // the bundled defaults — propagate the typed error so the
+                // worker surfaces a `ListenerError::TemplateParse(name,
+                // …)` at boot rather than panicking. Pinned by the
+                // `default_templates_all_parse` regression test below.
+                let template = Self::template(name, &default())?;
+                listener_answers.insert(name.to_string(), template);
             }
         }
         Ok(HttpAnswers {
-            fallback: Self::template("", &fallback()).expect("built-in fallback template parses"),
+            fallback: Self::template("", &fallback())?,
             listener_answers,
             cluster_answers: HashMap::new(),
         })
@@ -1155,6 +1187,17 @@ mod tests {
         merge_legacy_into_map,
     };
     use crate::protocol::http::DefaultAnswer;
+
+    /// Every bundled default template (and the fallback) must parse
+    /// cleanly so `HttpAnswers::new(&BTreeMap::new())` never returns an
+    /// error. This guards the previously-`expect`'d invariant in
+    /// `HttpAnswers::new` and turns any future regression in a default
+    /// body into a unit-test failure rather than a worker-boot panic.
+    #[test]
+    fn default_templates_all_parse() {
+        HttpAnswers::new(&BTreeMap::new())
+            .expect("every bundled default template + fallback must parse");
+    }
 
     fn body_route() -> TemplateVariable {
         TemplateVariable {

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -227,6 +227,29 @@ pub struct HttpContext {
     /// `www_authenticate` value. `None` falls back to template default
     /// (header is elided when no realm is configured).
     pub www_authenticate: Option<String>,
+    /// Original authority captured before a rewrite-host fired; emitted
+    /// back to the backend as `X-Forwarded-Host` so the backend can
+    /// reconstruct the public URL even though `:authority` / `Host` was
+    /// rewritten on the wire. `None` when no host rewrite happened.
+    pub original_authority: Option<String>,
+    /// Per-frontend response-side header edits (set/replace/delete)
+    /// stashed by the routing layer for the emission boundary in
+    /// `mux/h1.rs::writable` and `mux/h2.rs::write_streams` to apply
+    /// before `kawa.prepare(...)`. Empty when the frontend has no
+    /// response-side header policy. An entry with an empty `val`
+    /// deletes the header by name (HAProxy `del-header` parity); a
+    /// non-empty `val` set/replaces.
+    pub headers_response: Vec<HeaderEditSnapshot>,
+}
+
+/// Owned snapshot of a per-frontend header edit, captured at routing
+/// time so the emission boundary can apply set/replace/delete without
+/// touching the routing layer's `Rc<[HeaderEdit]>` slices. Empty `val`
+/// deletes the header by name (HAProxy `del-header` parity).
+#[derive(Debug, Clone)]
+pub struct HeaderEditSnapshot {
+    pub key: Vec<u8>,
+    pub val: Vec<u8>,
 }
 
 impl kawa::h1::ParserCallbacks<Checkout> for HttpContext {
@@ -287,6 +310,8 @@ impl HttpContext {
             sozu_id_header,
             redirect_location: None,
             www_authenticate: None,
+            original_authority: None,
+            headers_response: Vec::new(),
         }
     }
 
@@ -663,6 +688,8 @@ impl HttpContext {
         self.xff_chain = None;
         self.redirect_location = None;
         self.www_authenticate = None;
+        self.original_authority = None;
+        self.headers_response.clear();
         // Note: tls_server_name, tls_version, tls_cipher, tls_alpn,
         // strict_sni_binding are connection-scoped — set once at handshake
         // completion and reused across every keep-alive request, so reset()
@@ -857,6 +884,11 @@ mod tests {
         ctx.xff_chain = Some("203.0.113.5, 198.51.100.10".to_owned());
         ctx.redirect_location = Some("https://example.com/".to_owned());
         ctx.www_authenticate = Some("Basic realm=\"sozu\"".to_owned());
+        ctx.original_authority = Some("old.example.com".to_owned());
+        ctx.headers_response.push(HeaderEditSnapshot {
+            key: b"X-Cache".to_vec(),
+            val: b"HIT".to_vec(),
+        });
 
         ctx.reset();
 
@@ -871,12 +903,16 @@ mod tests {
         assert!(ctx.user_agent.is_none());
         assert!(ctx.x_request_id.is_none());
         assert!(ctx.xff_chain.is_none());
-        // The two stash slots written by the routing layer must clear
+        // The four stash slots written by the routing layer must clear
         // between pipelined H1 requests; otherwise a future code path that
         // emits a 301 / 401 default-answer without re-routing would
-        // inherit a stale Location / WWW-Authenticate from a prior request.
+        // inherit a stale Location / WWW-Authenticate from a prior request,
+        // or the backend would receive a stale X-Forwarded-Host or a stale
+        // response-side header edit.
         assert!(ctx.redirect_location.is_none());
         assert!(ctx.www_authenticate.is_none());
+        assert!(ctx.original_authority.is_none());
+        assert!(ctx.headers_response.is_empty());
     }
 
     #[test]

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -212,6 +212,21 @@ pub struct HttpContext {
     /// knob. Stored as an owned `String` so it survives a listener hot-reload
     /// that changes the value.
     pub sozu_id_header: String,
+    /// Resolved `Location` URL stashed by the routing layer when a frontend
+    /// triggers a permanent redirect (`RedirectPolicy::PERMANENT` or the
+    /// legacy `cluster.https_redirect`). Read by the default-answer 301
+    /// path so the response carries the correct target URL — including
+    /// optional `cluster.https_redirect_port` and rewrite-template captures.
+    /// `None` when the request is not redirecting.
+    pub redirect_location: Option<String>,
+    /// `WWW-Authenticate` realm stashed by the routing layer when a
+    /// frontend rejects an unauthenticated request (`required_auth = true`
+    /// without a valid `Authorization: Basic` header, or
+    /// `RedirectPolicy::UNAUTHORIZED`). Read by the default-answer 401
+    /// path so the response carries the cluster's configured
+    /// `www_authenticate` value. `None` falls back to template default
+    /// (header is elided when no realm is configured).
+    pub www_authenticate: Option<String>,
 }
 
 impl kawa::h1::ParserCallbacks<Checkout> for HttpContext {
@@ -270,6 +285,8 @@ impl HttpContext {
             tls_cipher: None,
             tls_alpn: None,
             sozu_id_header,
+            redirect_location: None,
+            www_authenticate: None,
         }
     }
 

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -661,6 +661,8 @@ impl HttpContext {
         self.user_agent = None;
         self.x_request_id = None;
         self.xff_chain = None;
+        self.redirect_location = None;
+        self.www_authenticate = None;
         // Note: tls_server_name, tls_version, tls_cipher, tls_alpn,
         // strict_sni_binding are connection-scoped — set once at handshake
         // completion and reused across every keep-alive request, so reset()
@@ -853,6 +855,8 @@ mod tests {
         ctx.user_agent = Some("curl/7.81".to_owned());
         ctx.x_request_id = Some("client-xrid-123".to_owned());
         ctx.xff_chain = Some("203.0.113.5, 198.51.100.10".to_owned());
+        ctx.redirect_location = Some("https://example.com/".to_owned());
+        ctx.www_authenticate = Some("Basic realm=\"sozu\"".to_owned());
 
         ctx.reset();
 
@@ -867,6 +871,12 @@ mod tests {
         assert!(ctx.user_agent.is_none());
         assert!(ctx.x_request_id.is_none());
         assert!(ctx.xff_chain.is_none());
+        // The two stash slots written by the routing layer must clear
+        // between pipelined H1 requests; otherwise a future code path that
+        // emits a 301 / 401 default-answer without re-routing would
+        // inherit a stale Location / WWW-Authenticate from a prior request.
+        assert!(ctx.redirect_location.is_none());
+        assert!(ctx.www_authenticate.is_none());
     }
 
     #[test]

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -45,7 +45,6 @@ use crate::{
         pipe::WebSocketContext,
     },
     retry::RetryPolicy,
-    router::Route,
     server::{CONN_RETRIES, push_event},
     socket::{SocketHandler, SocketResult, TransportProtocol, stats::socket_rtt},
     sozu_command::{
@@ -1381,9 +1380,13 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             }
         };
 
-        let cluster_id = match route {
-            Route::ClusterId(cluster_id) => cluster_id,
-            Route::Deny => {
+        // Wave 2b carries the new RouteResult shape; the mux integration in
+        // Wave 3a will read every field. Until then, this legacy kawa_h1
+        // path collapses RouteResult down to its `cluster_id` and treats an
+        // absent cluster as the historical `Route::Deny`.
+        let cluster_id = match route.cluster_id {
+            Some(cluster_id) => cluster_id,
+            None => {
                 self.set_answer(DefaultAnswer::Answer401 {
                     www_authenticate: None,
                 });

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -119,7 +119,12 @@ pub enum DefaultAnswer {
         partially_parsed: String,
         invalid: String,
     },
-    Answer401 {},
+    Answer401 {
+        /// Optional `WWW-Authenticate` value (e.g. `Basic realm="…"`).
+        /// When `None` or empty the realm header line is elided by the
+        /// template engine so the response stays a bare 401.
+        www_authenticate: Option<String>,
+    },
     Answer404 {},
     Answer408 {
         duration: String,
@@ -1111,7 +1116,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             };
         }
 
-        let mut kawa = self.answers.borrow().get(
+        let (resolved_status, keep_alive, mut kawa) = self.answers.borrow().get(
             answer,
             self.context.id.to_string(),
             self.context.cluster_id.as_deref(),
@@ -1119,9 +1124,17 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             self.get_route(),
         );
         kawa.prepare(&mut kawa::h1::BlockConverter);
+        // The template's resolved status may differ from the requested
+        // code when a fallback template is selected (e.g. unknown status).
+        let status = resolved_status;
         self.context.status = Some(status);
         self.context.reason = None;
-        self.context.keep_alive_frontend = false;
+        // Honour the rendered template's `Connection` header. Built-in
+        // error templates carry `Connection: close`, but operators can
+        // ship a custom template that keeps the frontend connection alive.
+        if !keep_alive {
+            self.context.keep_alive_frontend = false;
+        }
         self.response_stream = ResponseStream::DefaultAnswer(status, kawa);
         self.frontend_readiness.interest = Ready::WRITABLE | Ready::HUP | Ready::ERROR;
         self.backend_readiness.interest = Ready::HUP | Ready::ERROR;
@@ -1371,7 +1384,9 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         let cluster_id = match route {
             Route::ClusterId(cluster_id) => cluster_id,
             Route::Deny => {
-                self.set_answer(DefaultAnswer::Answer401 {});
+                self.set_answer(DefaultAnswer::Answer401 {
+                    www_authenticate: None,
+                });
                 return Err(RetrieveClusterError::UnauthorizedRoute);
             }
         };

--- a/lib/src/protocol/mux/answers.rs
+++ b/lib/src/protocol/mux/answers.rs
@@ -307,6 +307,8 @@ mod tests {
             sozu_id_header: String::from("Sozu-Id"),
             redirect_location: None,
             www_authenticate: None,
+            original_authority: None,
+            headers_response: Vec::new(),
         };
         let stream =
             Stream::new(Rc::downgrade(&pool), http_ctx, 65_535).expect("pool checkout failed");

--- a/lib/src/protocol/mux/answers.rs
+++ b/lib/src/protocol/mux/answers.rs
@@ -111,10 +111,20 @@ fn ensure_default_answer_end_stream(kawa: &mut GenericHttpStream) {
 ///
 /// The mux layer does not have HTTP/1.1 parse state, so error-detail fields
 /// (`message`, `phase`, `successfully_parsed`, etc.) are filled with neutral
-/// placeholders. The 301 redirect is the only code that needs real context data
-/// and is therefore handled inline in [`set_default_answer`].
-fn default_answer_for_code(code: u16) -> DefaultAnswer {
+/// placeholders. The 301 redirect and 401 unauthorized variants take the
+/// caller-supplied context (the `Location` URL and the `WWW-Authenticate`
+/// realm respectively) so the routing layer can drive both `https_redirect`
+/// and the explicit `RedirectPolicy::PERMANENT` /
+/// `RedirectPolicy::UNAUTHORIZED` policies through the same chokepoint.
+fn default_answer_for_code(
+    code: u16,
+    redirect_location: Option<&str>,
+    www_authenticate: Option<&str>,
+) -> DefaultAnswer {
     match code {
+        301 => DefaultAnswer::Answer301 {
+            location: redirect_location.unwrap_or_default().to_owned(),
+        },
         400 => DefaultAnswer::Answer400 {
             message: String::new(),
             phase: kawa::ParsingPhaseMarker::Error,
@@ -123,10 +133,12 @@ fn default_answer_for_code(code: u16) -> DefaultAnswer {
             invalid: "null".to_owned(),
         },
         401 => DefaultAnswer::Answer401 {
-            // Wave 3a will populate the realm from the cluster config; for
-            // now emit a bare 401 — the template engine elides the
-            // `WWW-Authenticate` header when the value is empty.
-            www_authenticate: None,
+            // The realm flows in from `cluster.www_authenticate` via
+            // `HttpContext.www_authenticate`. The template engine elides
+            // the `WWW-Authenticate` header when the value is empty
+            // (`or_elide_header = true`) so a None / empty realm yields
+            // a plain 401 without a synthetic header.
+            www_authenticate: www_authenticate.map(str::to_owned),
         },
         404 => DefaultAnswer::Answer404 {},
         408 => DefaultAnswer::Answer408 {
@@ -186,17 +198,27 @@ pub(crate) fn set_default_answer(
         context.backend_id.as_deref()
     );
 
-    let answer = if code == 301 {
-        DefaultAnswer::Answer301 {
-            location: format!(
+    // Routing layer stashes both the resolved `Location` URL (for 301) and
+    // the `WWW-Authenticate` realm (for 401). Fall back to the legacy
+    // `https://<authority><path>` shape when no explicit redirect target was
+    // computed — this preserves behaviour for the historical
+    // `cluster.https_redirect = true` path that did not carry per-frontend
+    // policy.
+    let fallback_location;
+    let redirect_location = match context.redirect_location.as_deref() {
+        Some(l) => Some(l),
+        None if code == 301 => {
+            fallback_location = format!(
                 "https://{}{}",
                 context.authority.as_deref().unwrap_or_default(),
                 context.path.as_deref().unwrap_or_default()
-            ),
+            );
+            Some(fallback_location.as_str())
         }
-    } else {
-        default_answer_for_code(code)
+        None => None,
     };
+    let answer =
+        default_answer_for_code(code, redirect_location, context.www_authenticate.as_deref());
 
     let request_id = context.id.to_string();
     let route = context.get_route();
@@ -283,6 +305,8 @@ mod tests {
             tls_cipher: None,
             tls_alpn: None,
             sozu_id_header: String::from("Sozu-Id"),
+            redirect_location: None,
+            www_authenticate: None,
         };
         let stream =
             Stream::new(Rc::downgrade(&pool), http_ctx, 65_535).expect("pool checkout failed");

--- a/lib/src/protocol/mux/answers.rs
+++ b/lib/src/protocol/mux/answers.rs
@@ -122,7 +122,12 @@ fn default_answer_for_code(code: u16) -> DefaultAnswer {
             partially_parsed: "null".to_owned(),
             invalid: "null".to_owned(),
         },
-        401 => DefaultAnswer::Answer401 {},
+        401 => DefaultAnswer::Answer401 {
+            // Wave 3a will populate the realm from the cluster config; for
+            // now emit a bare 401 — the template engine elides the
+            // `WWW-Authenticate` header when the value is empty.
+            www_authenticate: None,
+        },
         404 => DefaultAnswer::Answer404 {},
         408 => DefaultAnswer::Answer408 {
             duration: String::new(),
@@ -190,7 +195,6 @@ pub(crate) fn set_default_answer(
             ),
         }
     } else {
-        context.keep_alive_frontend = false;
         default_answer_for_code(code)
     };
 
@@ -199,11 +203,21 @@ pub(crate) fn set_default_answer(
     let cluster_id = context.cluster_id.as_deref();
     let backend_id = context.backend_id.as_deref();
 
-    let rendered = answers.get(answer, request_id, cluster_id, backend_id, route);
+    let (resolved_status, keep_alive, rendered) =
+        answers.get(answer, request_id, cluster_id, backend_id, route);
+    // Honour the rendered template's `Connection` header. Most error
+    // templates carry `Connection: close`, which flips the frontend
+    // keep-alive bit to false; cluster operators can opt back into
+    // keep-alive by shipping a custom template without that header.
+    if !keep_alive {
+        context.keep_alive_frontend = false;
+    }
     copy_default_answer_to_stream(rendered, kawa);
     ensure_default_answer_end_stream(kawa);
 
-    context.status = Some(code);
+    // The template's resolved status may differ from the requested code
+    // when a fallback template is selected (e.g. unknown status).
+    context.status = Some(resolved_status);
     stream.state = StreamState::Unlinked;
     readiness.arm_writable();
     incr!("h2.signal.writable.rearmed.default_answer");
@@ -285,7 +299,8 @@ mod tests {
     fn set_default_answer_arms_writable_and_signals() {
         let (_pool, mut stream) = make_stream();
         let mut readiness = Readiness::new();
-        let answers = HttpAnswers::new(&None).expect("HttpAnswers::new(&None) must succeed");
+        let answers = HttpAnswers::new(&std::collections::BTreeMap::new())
+            .expect("HttpAnswers::new with empty map must succeed");
 
         set_default_answer(&mut stream, &mut readiness, 504, &answers);
 

--- a/lib/src/protocol/mux/auth.rs
+++ b/lib/src/protocol/mux/auth.rs
@@ -21,7 +21,7 @@ use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 
 use super::GenericHttpStream;
-use crate::protocol::http::parser::{Method, compare_no_case};
+use crate::protocol::http::parser::compare_no_case;
 
 /// Maximum length of a base64-decoded `Authorization: Basic` payload we
 /// accept. RFC 7617 does not impose a limit, but credentials longer than
@@ -29,19 +29,6 @@ use crate::protocol::http::parser::{Method, compare_no_case};
 /// hostile peers from forcing the worker to allocate large transient
 /// buffers per failed auth attempt.
 const MAX_DECODED_CREDENTIAL_BYTES: usize = 4096;
-
-/// Lowercase hex encoding of `bytes`. Matches the format every entry in
-/// `Cluster.authorized_hashes` is expected to use, so the encoded value
-/// can be compared bit-for-bit.
-fn to_hex(bytes: &[u8]) -> String {
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        // `{:02x}` is the canonical lowercase 2-wide hex representation.
-        out.push(char::from_digit((byte >> 4) as u32, 16).expect("hi nibble"));
-        out.push(char::from_digit((byte & 0x0f) as u32, 16).expect("lo nibble"));
-    }
-    out
-}
 
 /// Find the first `Authorization` header value in the front kawa.
 ///
@@ -117,24 +104,56 @@ pub fn canonicalize_basic_credentials(value: &[u8]) -> Option<String> {
     hasher.update(password);
     let digest = hasher.finalize();
 
-    Some(format!("{}:{}", username, to_hex(&digest)))
+    Some(format!("{}:{}", username, hex::encode(digest)))
+}
+
+/// Maximum byte length of a canonical `username:hex(sha256)` credential
+/// we are willing to compare in constant time. The realistic shape uses a
+/// short username plus a 65-byte `:hex64` tail, so 256 covers every
+/// reasonable operator config while keeping the per-compare stack buffer
+/// small.
+const AUTH_COMPARE_PAD_LEN: usize = 256;
+
+/// Pad `input` into a fixed-length envelope so [`subtle::ConstantTimeEq`]
+/// runs its full byte-loop regardless of whether the candidate and the
+/// stored hash differ in length. The trailing 8 bytes encode the input's
+/// actual length as little-endian `u64` so two inputs that share a prefix
+/// but differ in total length cannot collide post-padding.
+fn pad_for_constant_time_compare(input: &[u8]) -> [u8; AUTH_COMPARE_PAD_LEN + 8] {
+    let mut buf = [0u8; AUTH_COMPARE_PAD_LEN + 8];
+    let n = input.len().min(AUTH_COMPARE_PAD_LEN);
+    buf[..n].copy_from_slice(&input[..n]);
+    buf[AUTH_COMPARE_PAD_LEN..].copy_from_slice(&(input.len() as u64).to_le_bytes());
+    buf
 }
 
 /// Compare `candidate` against every entry in `authorized_hashes` using
 /// constant-time equality. Returns `true` if any entry matches.
 ///
-/// Iterates the entire slice on every call regardless of where (or whether)
-/// a match is found, so the time spent validating a credential does not
-/// vary with the position of the matching entry. This defeats timing
-/// side-channel attacks that would otherwise leak the size of the realm
-/// or the index of the matching credential.
+/// Both sides are padded to a fixed [`AUTH_COMPARE_PAD_LEN`] envelope plus
+/// a length suffix before [`subtle::ConstantTimeEq`] runs, so:
+///   * the per-entry compare loop iterates the full padded length even
+///     when the candidate and the stored hash differ in length (subtle's
+///     slice `ct_eq` short-circuits on length mismatch — the padding here
+///     defeats that leak);
+///   * the outer loop iterates the entire slice on every call regardless
+///     of where (or whether) a match is found, so the time spent
+///     validating a credential does not vary with the position of the
+///     matching entry.
+///
+/// This defeats timing side-channel attacks that would otherwise leak
+/// the size of the realm, the length of the matching username, or the
+/// index of the matching credential.
 pub fn check_authorized_hashes(candidate: &str, authorized_hashes: &[String]) -> bool {
-    let candidate = candidate.as_bytes();
+    let candidate_padded = pad_for_constant_time_compare(candidate.as_bytes());
     let mut matched = subtle::Choice::from(0u8);
     for hash in authorized_hashes {
-        // ConstantTimeEq returns Choice(0)/Choice(1) without short-circuit.
-        // BitOr-assign over `Choice` likewise does not branch.
-        matched |= candidate.ct_eq(hash.as_bytes());
+        let entry_padded = pad_for_constant_time_compare(hash.as_bytes());
+        // Both buffers are exactly `AUTH_COMPARE_PAD_LEN + 8` bytes, so
+        // subtle's slice `ct_eq` runs the full byte-loop instead of
+        // bailing on length. `BitOr` over `Choice` likewise does not
+        // branch.
+        matched |= candidate_padded.as_slice().ct_eq(entry_padded.as_slice());
     }
     bool::from(matched)
 }
@@ -154,12 +173,6 @@ pub fn check_basic(kawa: &GenericHttpStream, authorized_hashes: &[String]) -> bo
     check_authorized_hashes(&canonical, authorized_hashes)
 }
 
-/// Suppress the unused-import lint on `Method` when this module is built
-/// without test cfg. The type is named in doc-comment intra-doc links and
-/// pulled in here purely for that purpose.
-#[allow(dead_code)]
-const _METHOD_USED: Option<Method> = None;
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -169,12 +182,6 @@ mod tests {
     /// re-derive it on every run.
     const SECRET_SHA256_HEX: &str =
         "2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b";
-
-    #[test]
-    fn to_hex_matches_format_macro() {
-        let bytes = [0x00, 0x10, 0xff, 0xa5];
-        assert_eq!(to_hex(&bytes), "0010ffa5");
-    }
 
     #[test]
     fn canonicalize_round_trips_admin_secret() {

--- a/lib/src/protocol/mux/auth.rs
+++ b/lib/src/protocol/mux/auth.rs
@@ -58,16 +58,15 @@ pub fn extract_authorization_header(kawa: &GenericHttpStream) -> Option<Vec<u8>>
 /// malformed input — wrong scheme, non-base64 token, missing `:`,
 /// non-UTF-8 username, or oversized payload.
 pub fn canonicalize_basic_credentials(value: &[u8]) -> Option<String> {
-    // Trim leading whitespace so e.g. `Authorization: Basic abc==` (one
-    // space, the canonical form) and `Authorization:  Basic abc==` (two
-    // spaces, still RFC-compliant) both parse.
+    // Trim leading SP only. RFC 7235 §2.1 / RFC 9110 §11.4 define the
+    // header value's grammar as `auth-scheme [ 1*SP token68 ]`, so HTAB
+    // is not permitted between the value start and the scheme. Some
+    // clients still emit a leading SP run before the scheme; that's
+    // tolerated here because the OWS preceding the field-value is
+    // already stripped by the parser.
     let mut rest = value;
-    while let Some((&first, tail)) = rest.split_first() {
-        if first == b' ' || first == b'\t' {
-            rest = tail;
-        } else {
-            break;
-        }
+    while let Some((&b' ', tail)) = rest.split_first() {
+        rest = tail;
     }
 
     // RFC 7617 § 2 mandates ASCII-case-insensitive `Basic` scheme prefix.
@@ -77,17 +76,16 @@ pub fn canonicalize_basic_credentials(value: &[u8]) -> Option<String> {
     }
     rest = &rest[scheme_len..];
 
-    // Exactly one space separates the scheme from the token in practice;
-    // trim any whitespace we encounter to be tolerant of single-tab or
-    // double-space inputs.
-    while let Some((&first, tail)) = rest.split_first() {
-        if first == b' ' || first == b'\t' {
-            rest = tail;
-        } else {
-            break;
-        }
+    // RFC 7235 §2.1: scheme and token68 are separated by `1*SP`.
+    // Reject HTAB and reject zero spaces (the scheme-token boundary must
+    // exist). Multiple leading spaces are tolerated for compatibility
+    // with clients that emit `Basic  abc==`.
+    let mut saw_space = false;
+    while let Some((&b' ', tail)) = rest.split_first() {
+        rest = tail;
+        saw_space = true;
     }
-    if rest.is_empty() {
+    if !saw_space || rest.is_empty() {
         return None;
     }
 

--- a/lib/src/protocol/mux/auth.rs
+++ b/lib/src/protocol/mux/auth.rs
@@ -23,12 +23,45 @@ use subtle::ConstantTimeEq;
 use super::GenericHttpStream;
 use crate::protocol::http::parser::compare_no_case;
 
-/// Maximum length of a base64-decoded `Authorization: Basic` payload we
-/// accept. RFC 7617 does not impose a limit, but credentials longer than
-/// 4 KiB are pathological for HTTP Basic. Capping the decode result keeps
-/// hostile peers from forcing the worker to allocate large transient
-/// buffers per failed auth attempt.
-const MAX_DECODED_CREDENTIAL_BYTES: usize = 4096;
+/// Built-in default for the maximum length, in bytes, of a base64-decoded
+/// `Authorization: Basic` payload. RFC 7617 does not impose a limit, but
+/// credentials longer than 4 KiB are pathological for HTTP Basic.
+/// Operators can override via `basic_auth_max_credential_bytes` in the
+/// main TOML config; the override is committed once at worker boot via
+/// [`set_max_decoded_credential_bytes`].
+const DEFAULT_MAX_DECODED_CREDENTIAL_BYTES: usize = 4096;
+
+/// Process-wide override for [`DEFAULT_MAX_DECODED_CREDENTIAL_BYTES`].
+/// Set once on each worker at startup from
+/// [`sozu_command::proto::command::ServerConfig::basic_auth_max_credential_bytes`]
+/// via [`set_max_decoded_credential_bytes`]. Reading uses a relaxed
+/// `OnceLock::get` so the auth fast path stays branch-and-load with no
+/// atomic hand-off. Set-once semantics are sufficient because the cap is
+/// a global hardening knob — it never changes after boot.
+static MAX_DECODED_CREDENTIAL_BYTES_OVERRIDE: std::sync::OnceLock<usize> =
+    std::sync::OnceLock::new();
+
+/// Install the operator-configured cap. Called from
+/// `lib::server::Server::try_new_from_config` exactly once per worker
+/// process. Subsequent calls are no-ops (the `OnceLock` rejects the
+/// second `set`); the first wins. A `0` value is treated as "use the
+/// built-in default" so an operator config that explicitly sets `0` does
+/// not disable Basic-auth length-bound protection by accident.
+pub fn set_max_decoded_credential_bytes(cap: usize) {
+    if cap == 0 {
+        return;
+    }
+    let _ = MAX_DECODED_CREDENTIAL_BYTES_OVERRIDE.set(cap);
+}
+
+/// Resolve the active cap: operator override when present, otherwise the
+/// built-in [`DEFAULT_MAX_DECODED_CREDENTIAL_BYTES`].
+fn max_decoded_credential_bytes() -> usize {
+    MAX_DECODED_CREDENTIAL_BYTES_OVERRIDE
+        .get()
+        .copied()
+        .unwrap_or(DEFAULT_MAX_DECODED_CREDENTIAL_BYTES)
+}
 
 /// Find the first `Authorization` header value in the front kawa.
 ///
@@ -90,7 +123,7 @@ pub fn canonicalize_basic_credentials(value: &[u8]) -> Option<String> {
     }
 
     let decoded = STANDARD.decode(rest).ok()?;
-    if decoded.len() > MAX_DECODED_CREDENTIAL_BYTES {
+    if decoded.len() > max_decoded_credential_bytes() {
         return None;
     }
 
@@ -214,11 +247,21 @@ mod tests {
 
     #[test]
     fn canonicalize_rejects_oversized_payload() {
-        // 5 KB base64 payload — well above MAX_DECODED_CREDENTIAL_BYTES.
-        let payload = "a".repeat(MAX_DECODED_CREDENTIAL_BYTES * 2);
+        // 5 KB+ base64 payload — well above the active cap.
+        let payload = "a".repeat(max_decoded_credential_bytes() * 2);
         let token = STANDARD.encode(format!("{payload}:pwd"));
         let header = format!("Basic {token}");
         assert!(canonicalize_basic_credentials(header.as_bytes()).is_none());
+    }
+
+    /// Calling `set_max_decoded_credential_bytes(0)` is a no-op so an
+    /// operator config that explicitly zeroes the field cannot disable
+    /// the hardening cap by accident — the default 4096 stays in force.
+    #[test]
+    fn set_max_decoded_credential_bytes_zero_is_noop() {
+        let before = max_decoded_credential_bytes();
+        set_max_decoded_credential_bytes(0);
+        assert_eq!(max_decoded_credential_bytes(), before);
     }
 
     #[test]

--- a/lib/src/protocol/mux/auth.rs
+++ b/lib/src/protocol/mux/auth.rs
@@ -1,0 +1,239 @@
+//! HTTP Basic authentication helpers shared by the H1 and H2 mux paths.
+//!
+//! The runtime stores credentials as `username:hex(sha256(password))`
+//! entries on each cluster's `authorized_hashes`. On every request that
+//! traverses a frontend with `required_auth = true`, the mux extracts the
+//! `Authorization: Basic <token>` header from the front kawa, decodes the
+//! base64 token, splits on the first `:` into `<user>:<password>`, hashes
+//! the password with SHA-256, and rebuilds the canonical
+//! `<user>:<hex(sha256)>` form. Comparison against the cluster's hash list
+//! uses [`subtle::ConstantTimeEq`] over a full pass, never short-circuiting,
+//! so the time spent validating a credential does not leak which slot
+//! matched (or whether any did at all).
+//!
+//! The extractor is intentionally permissive (`Option`-returning) — any
+//! malformed input is reported as "no credential", and the caller emits
+//! the standard 401 response. We never panic on hostile input.
+
+use base64::{Engine, engine::general_purpose::STANDARD};
+use kawa::{Block, Pair, Store};
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
+
+use super::GenericHttpStream;
+use crate::protocol::http::parser::{Method, compare_no_case};
+
+/// Maximum length of a base64-decoded `Authorization: Basic` payload we
+/// accept. RFC 7617 does not impose a limit, but credentials longer than
+/// 4 KiB are pathological for HTTP Basic. Capping the decode result keeps
+/// hostile peers from forcing the worker to allocate large transient
+/// buffers per failed auth attempt.
+const MAX_DECODED_CREDENTIAL_BYTES: usize = 4096;
+
+/// Lowercase hex encoding of `bytes`. Matches the format every entry in
+/// `Cluster.authorized_hashes` is expected to use, so the encoded value
+/// can be compared bit-for-bit.
+fn to_hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        // `{:02x}` is the canonical lowercase 2-wide hex representation.
+        out.push(char::from_digit((byte >> 4) as u32, 16).expect("hi nibble"));
+        out.push(char::from_digit((byte & 0x0f) as u32, 16).expect("lo nibble"));
+    }
+    out
+}
+
+/// Find the first `Authorization` header value in the front kawa.
+///
+/// Returns the raw bytes of the header value. Header names are matched
+/// case-insensitively per RFC 9110 §5.1. Returns `None` when no header is
+/// present, when the header has been elided (`Store::Empty`), or when the
+/// value's underlying bytes can't be resolved against the kawa buffer.
+pub fn extract_authorization_header(kawa: &GenericHttpStream) -> Option<Vec<u8>> {
+    let buf = kawa.storage.buffer();
+    for block in &kawa.blocks {
+        if let Block::Header(Pair { key, val }) = block {
+            if matches!(key, Store::Empty) {
+                continue;
+            }
+            let key_bytes = key.data(buf);
+            if compare_no_case(key_bytes, b"authorization") {
+                return Some(val.data(buf).to_vec());
+            }
+        }
+    }
+    None
+}
+
+/// Decode a `Basic <token>` value into the canonical
+/// `username:hex(sha256(password))` shape that
+/// [`check_authorized_hashes`] compares against. Returns `None` for any
+/// malformed input — wrong scheme, non-base64 token, missing `:`,
+/// non-UTF-8 username, or oversized payload.
+pub fn canonicalize_basic_credentials(value: &[u8]) -> Option<String> {
+    // Trim leading whitespace so e.g. `Authorization: Basic abc==` (one
+    // space, the canonical form) and `Authorization:  Basic abc==` (two
+    // spaces, still RFC-compliant) both parse.
+    let mut rest = value;
+    while let Some((&first, tail)) = rest.split_first() {
+        if first == b' ' || first == b'\t' {
+            rest = tail;
+        } else {
+            break;
+        }
+    }
+
+    // RFC 7617 § 2 mandates ASCII-case-insensitive `Basic` scheme prefix.
+    let scheme_len = b"Basic".len();
+    if rest.len() < scheme_len || !compare_no_case(&rest[..scheme_len], b"basic") {
+        return None;
+    }
+    rest = &rest[scheme_len..];
+
+    // Exactly one space separates the scheme from the token in practice;
+    // trim any whitespace we encounter to be tolerant of single-tab or
+    // double-space inputs.
+    while let Some((&first, tail)) = rest.split_first() {
+        if first == b' ' || first == b'\t' {
+            rest = tail;
+        } else {
+            break;
+        }
+    }
+    if rest.is_empty() {
+        return None;
+    }
+
+    let decoded = STANDARD.decode(rest).ok()?;
+    if decoded.len() > MAX_DECODED_CREDENTIAL_BYTES {
+        return None;
+    }
+
+    let colon = decoded.iter().position(|&b| b == b':')?;
+    let username = std::str::from_utf8(&decoded[..colon]).ok()?;
+    let password = &decoded[colon + 1..];
+
+    let mut hasher = Sha256::new();
+    hasher.update(password);
+    let digest = hasher.finalize();
+
+    Some(format!("{}:{}", username, to_hex(&digest)))
+}
+
+/// Compare `candidate` against every entry in `authorized_hashes` using
+/// constant-time equality. Returns `true` if any entry matches.
+///
+/// Iterates the entire slice on every call regardless of where (or whether)
+/// a match is found, so the time spent validating a credential does not
+/// vary with the position of the matching entry. This defeats timing
+/// side-channel attacks that would otherwise leak the size of the realm
+/// or the index of the matching credential.
+pub fn check_authorized_hashes(candidate: &str, authorized_hashes: &[String]) -> bool {
+    let candidate = candidate.as_bytes();
+    let mut matched = subtle::Choice::from(0u8);
+    for hash in authorized_hashes {
+        // ConstantTimeEq returns Choice(0)/Choice(1) without short-circuit.
+        // BitOr-assign over `Choice` likewise does not branch.
+        matched |= candidate.ct_eq(hash.as_bytes());
+    }
+    bool::from(matched)
+}
+
+/// Convenience: pull `Authorization` from the kawa, canonicalise, and
+/// compare in constant time against the authorized list.
+pub fn check_basic(kawa: &GenericHttpStream, authorized_hashes: &[String]) -> bool {
+    if authorized_hashes.is_empty() {
+        return false;
+    }
+    let Some(header_value) = extract_authorization_header(kawa) else {
+        return false;
+    };
+    let Some(canonical) = canonicalize_basic_credentials(&header_value) else {
+        return false;
+    };
+    check_authorized_hashes(&canonical, authorized_hashes)
+}
+
+/// Suppress the unused-import lint on `Method` when this module is built
+/// without test cfg. The type is named in doc-comment intra-doc links and
+/// pulled in here purely for that purpose.
+#[allow(dead_code)]
+const _METHOD_USED: Option<Method> = None;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// SHA-256 of the literal byte string `"secret"`, lowercase hex.
+    /// Computed once and pinned here so the unit tests don't have to
+    /// re-derive it on every run.
+    const SECRET_SHA256_HEX: &str =
+        "2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b";
+
+    #[test]
+    fn to_hex_matches_format_macro() {
+        let bytes = [0x00, 0x10, 0xff, 0xa5];
+        assert_eq!(to_hex(&bytes), "0010ffa5");
+    }
+
+    #[test]
+    fn canonicalize_round_trips_admin_secret() {
+        // base64("admin:secret") = "YWRtaW46c2VjcmV0"
+        let canonical = canonicalize_basic_credentials(b"Basic YWRtaW46c2VjcmV0")
+            .expect("well-formed credential should canonicalize");
+        assert_eq!(canonical, format!("admin:{SECRET_SHA256_HEX}"));
+    }
+
+    #[test]
+    fn canonicalize_is_case_insensitive_on_scheme() {
+        let canonical = canonicalize_basic_credentials(b"basic YWRtaW46c2VjcmV0")
+            .expect("lowercase scheme should still canonicalize");
+        assert_eq!(canonical, format!("admin:{SECRET_SHA256_HEX}"));
+    }
+
+    #[test]
+    fn canonicalize_rejects_non_basic_scheme() {
+        assert!(canonicalize_basic_credentials(b"Bearer token").is_none());
+    }
+
+    #[test]
+    fn canonicalize_rejects_garbage_base64() {
+        assert!(canonicalize_basic_credentials(b"Basic !!not-base64!!").is_none());
+    }
+
+    #[test]
+    fn canonicalize_rejects_missing_colon() {
+        // base64("admin") = "YWRtaW4="
+        assert!(canonicalize_basic_credentials(b"Basic YWRtaW4=").is_none());
+    }
+
+    #[test]
+    fn canonicalize_rejects_oversized_payload() {
+        // 5 KB base64 payload — well above MAX_DECODED_CREDENTIAL_BYTES.
+        let payload = "a".repeat(MAX_DECODED_CREDENTIAL_BYTES * 2);
+        let token = STANDARD.encode(format!("{payload}:pwd"));
+        let header = format!("Basic {token}");
+        assert!(canonicalize_basic_credentials(header.as_bytes()).is_none());
+    }
+
+    #[test]
+    fn check_authorized_hashes_full_pass_match() {
+        let valid = format!("admin:{SECRET_SHA256_HEX}");
+        let other = "user:0000000000000000000000000000000000000000000000000000000000000000";
+        let list = [other.to_owned(), valid.clone()];
+        assert!(check_authorized_hashes(&valid, &list));
+    }
+
+    #[test]
+    fn check_authorized_hashes_rejects_wrong_password() {
+        let wrong = "admin:0000000000000000000000000000000000000000000000000000000000000000";
+        let list = [format!("admin:{SECRET_SHA256_HEX}")];
+        assert!(!check_authorized_hashes(wrong, &list));
+    }
+
+    #[test]
+    fn check_authorized_hashes_rejects_when_list_empty() {
+        let candidate = format!("admin:{SECRET_SHA256_HEX}");
+        assert!(!check_authorized_hashes(&candidate, &[]));
+    }
+}

--- a/lib/src/protocol/mux/converter.rs
+++ b/lib/src/protocol/mux/converter.rs
@@ -86,6 +86,16 @@ pub struct H2BlockConverter<'a> {
     /// The caller in `ConnectionH2::write_streams` reads this flag to know
     /// whether it is safe to clear its own mirror of the pending state.
     pub size_update_emitted: bool,
+    /// `true` when [`Self::check_header_capacity`] tripped the
+    /// `MAX_HEADER_LIST_SIZE` budget mid-encoding. Set during `call()`,
+    /// committed in [`Self::finalize`] which flips `kawa.parsing_phase`
+    /// to `Error{Processing(InternalError)}` (so the next prepare
+    /// cycle's `initialize` synthesises an RST_STREAM frame) and drains
+    /// any remaining `kawa.blocks` so we do not emit HEADERS/DATA frames
+    /// after the RST. Defer-then-commit is required: `call()` borrows
+    /// `kawa.storage.buffer()` for the whole body, which forecloses the
+    /// `&mut kawa.parsing_phase` write that the abort needs.
+    pub pending_oversized_abort: bool,
 }
 
 impl H2BlockConverter<'_> {
@@ -121,16 +131,35 @@ impl H2BlockConverter<'_> {
         }
     }
 
-    /// Check whether the HPACK output buffer has exceeded the maximum header
-    /// list size. Returns `false` (stop encoding) if the limit is reached.
-    fn check_header_capacity(&self) -> bool {
+    /// Guard the HPACK output buffer against [`MAX_HEADER_LIST_SIZE`] and
+    /// flag the converter for an over-budget abort if the limit is
+    /// reached.
+    ///
+    /// Returning `false` from a `BlockConverter::call` only breaks the
+    /// `kawa.prepare` loop — by itself it does NOT signal any error to
+    /// the peer, and a partial header block left in `self.out` would
+    /// emit as a truncated HEADERS frame on the next flush, wedging the
+    /// stream. To turn over-budget injection into a clean failure we
+    /// (1) clear the partial block and (2) raise `pending_oversized_abort`,
+    /// which [`Self::finalize`] commits by flipping `kawa.parsing_phase`
+    /// to `Error{Processing(InternalError)}` and draining any remaining
+    /// blocks. The next `prepare` cycle's `initialize` chokepoint at
+    /// lines 173-208 then synthesises a typed `RST_STREAM(InternalError)`
+    /// frame on the wire.
+    ///
+    /// Defer-then-commit is necessary because `call` already holds an
+    /// immutable borrow of `kawa.storage.buffer()` for the duration of
+    /// the body; `finalize` runs after that borrow is released.
+    fn check_header_capacity(&mut self) -> bool {
         if self.out.len() > MAX_HEADER_LIST_SIZE {
             error!(
-                "{} HPACK output buffer ({} bytes) exceeds MAX_HEADER_LIST_SIZE ({}), stopping header encoding",
+                "{} HPACK output buffer ({} bytes) exceeds MAX_HEADER_LIST_SIZE ({}), aborting header block",
                 log_module_context!(),
                 self.out.len(),
                 MAX_HEADER_LIST_SIZE
             );
+            self.out.clear();
+            self.pending_oversized_abort = true;
             return false;
         }
         true
@@ -175,6 +204,14 @@ impl<T: AsBuffer> BlockConverter<T> for H2BlockConverter<'_> {
         }
     }
     fn call(&mut self, block: Block, kawa: &mut Kawa<T>) -> bool {
+        // Once `kawa.parsing_phase` is `Error`, `initialize` has already
+        // synthesised a RST_STREAM frame for this prepare cycle. Drop any
+        // remaining blocks instead of trying to encode HEADERS/DATA frames
+        // that would land on the wire after the RST and break the stream
+        // post-condition.
+        if matches!(kawa.parsing_phase, ParsingPhase::Error { .. }) {
+            return false;
+        }
         let buffer = kawa.storage.buffer();
         // RFC 7541 §6.3: when the peer reduced SETTINGS_HEADER_TABLE_SIZE
         // (or changed it in any direction), the very first header block we
@@ -592,7 +629,27 @@ impl<T: AsBuffer> BlockConverter<T> for H2BlockConverter<'_> {
         }
         true
     }
-    fn finalize(&mut self, _kawa: &mut Kawa<T>) {
+    fn finalize(&mut self, kawa: &mut Kawa<T>) {
+        if self.pending_oversized_abort {
+            self.pending_oversized_abort = false;
+            // Preserve the original parsing_phase marker so logs and the
+            // ParsingPhaseMarker telemetry stay coherent (e.g. Headers vs
+            // Body) instead of getting clobbered to a synthetic value.
+            let marker = kawa.parsing_phase.marker();
+            kawa.parsing_phase = ParsingPhase::Error {
+                marker,
+                kind: ParsingErrorKind::Processing {
+                    message: H2Error::InternalError.as_str(),
+                },
+            };
+            // Drop any remaining blocks — the stream is dead. Without this
+            // the next prepare cycle's pop loop would still try to encode
+            // headers/data after the synthesised RST_STREAM.
+            kawa.blocks.clear();
+            self.out.clear();
+            incr!("h2.headers.rejected.budget_overrun");
+            return;
+        }
         if !self.out.is_empty() {
             error!(
                 "{} H2BlockConverter finalize: out buffer not empty ({} bytes remaining), clearing",
@@ -635,6 +692,7 @@ mod tests {
             // dynamic-table-size-update path set this explicitly.
             pending_table_size_update: None,
             size_update_emitted: false,
+            pending_oversized_abort: false,
         }
     }
 
@@ -1413,6 +1471,146 @@ mod tests {
             !cont,
             "back-to-back DATA must still yield — incremental rotation depends \
              on the converter deferring the next DATA"
+        );
+    }
+
+    // ── HPACK budget over-run ────────────────────────────────────────────
+
+    /// `check_header_capacity` setting `pending_oversized_abort` should
+    /// stop the encoding pass cleanly: `self.out` is dropped (no truncated
+    /// HEADERS frame escapes), the converter raises the abort flag, and
+    /// `finalize` commits by flipping `kawa.parsing_phase` to
+    /// `Error{Processing(InternalError)}` so the next prepare cycle's
+    /// `initialize` synthesises a typed RST_STREAM frame.
+    #[test]
+    fn test_converter_aborts_on_header_budget_overrun() {
+        let mut encoder = loona_hpack::Encoder::new();
+        let mut conv = test_converter(&mut encoder);
+        let mut buf = vec![0u8; 4096];
+        let mut kawa = make_kawa(&mut buf, Kind::Response);
+
+        // Pre-populate `self.out` past `MAX_HEADER_LIST_SIZE` so that the
+        // very next capacity check trips the abort. We use a Status:200
+        // pseudo-header to drive the encode path through the Response arm
+        // of `Block::StatusLine`.
+        conv.out = vec![0u8; super::MAX_HEADER_LIST_SIZE + 1];
+        kawa.detached.status_line = StatusLine::Response {
+            version: kawa::Version::V20,
+            code: 200,
+            status: Store::Static(b"200"),
+            reason: Store::Empty,
+        };
+        let cont = conv.call(Block::StatusLine, &mut kawa);
+        assert!(!cont, "overflow must break the prepare loop");
+        assert!(
+            conv.pending_oversized_abort,
+            "abort flag must be raised when MAX_HEADER_LIST_SIZE is exceeded"
+        );
+        assert!(
+            conv.out.is_empty(),
+            "the partial HPACK block must not escape as a truncated HEADERS frame"
+        );
+
+        // Subsequent calls within the SAME prepare cycle should be no-ops
+        // (the prepare loop already broke; we only assert the early-out
+        // works in case a caller ever invokes call() manually after a
+        // false return).
+        kawa.parsing_phase = ParsingPhase::Error {
+            marker: kawa::ParsingPhaseMarker::Headers,
+            kind: ParsingErrorKind::Processing { message: "test" },
+        };
+        let cont = conv.call(
+            Block::Header(Pair {
+                key: Store::Static(b"x-after-rst"),
+                val: Store::Static(b"1"),
+            }),
+            &mut kawa,
+        );
+        assert!(
+            !cont,
+            "post-error call() must short-circuit so we do not append frames after RST_STREAM"
+        );
+    }
+
+    /// `finalize` commits the abort: `kawa.parsing_phase` becomes
+    /// `Error{Processing(InternalError)}`, `kawa.blocks` is cleared so
+    /// no follow-on HEADERS/DATA leak after the synthesised RST_STREAM,
+    /// and the abort flag is reset so the converter is reusable.
+    #[test]
+    fn test_converter_finalize_commits_oversized_abort() {
+        let mut encoder = loona_hpack::Encoder::new();
+        let mut conv = test_converter(&mut encoder);
+        let mut buf = vec![0u8; 4096];
+        let mut kawa = make_kawa(&mut buf, Kind::Response);
+
+        conv.pending_oversized_abort = true;
+        kawa.blocks.push_back(Block::Header(Pair {
+            key: Store::Static(b"x-leftover"),
+            val: Store::Static(b"1"),
+        }));
+        kawa.parsing_phase = ParsingPhase::Headers;
+
+        BlockConverter::finalize(&mut conv, &mut kawa);
+
+        match kawa.parsing_phase {
+            ParsingPhase::Error {
+                marker,
+                kind: ParsingErrorKind::Processing { message },
+            } => {
+                assert_eq!(marker, kawa::ParsingPhaseMarker::Headers);
+                assert_eq!(message, H2Error::InternalError.as_str());
+            }
+            other => panic!("expected Error{{Processing(InternalError)}}, got {other:?}"),
+        }
+        assert!(
+            kawa.blocks.is_empty(),
+            "remaining blocks must be drained so they do not emit after RST_STREAM"
+        );
+        assert!(!conv.pending_oversized_abort, "abort flag must reset");
+    }
+
+    /// After `finalize` flipped `kawa.parsing_phase` to `Error{Processing}`,
+    /// the next prepare cycle's `initialize` must synthesise a single
+    /// RST_STREAM(InternalError) frame and push it onto `kawa.out`.
+    #[test]
+    fn test_converter_initialize_emits_rst_stream_on_error_phase() {
+        let mut encoder = loona_hpack::Encoder::new();
+        let mut conv = test_converter(&mut encoder);
+        conv.stream_id = 5;
+        let mut buf = vec![0u8; 4096];
+        let mut kawa = make_kawa(&mut buf, Kind::Response);
+        kawa.parsing_phase = ParsingPhase::Error {
+            marker: kawa::ParsingPhaseMarker::Headers,
+            kind: ParsingErrorKind::Processing {
+                message: H2Error::InternalError.as_str(),
+            },
+        };
+
+        BlockConverter::initialize(&mut conv, &mut kawa);
+
+        // RST_STREAM frame: 9-byte header + 4-byte payload (error code).
+        let mut bytes = Vec::new();
+        for store in &kawa.out {
+            if let kawa::OutBlock::Store(s) = store {
+                bytes.extend_from_slice(s.data(kawa.storage.buffer()));
+            }
+        }
+        assert_eq!(
+            bytes.len(),
+            parser::FRAME_HEADER_SIZE + parser::RST_STREAM_PAYLOAD_SIZE as usize,
+            "exactly one RST_STREAM frame must be emitted"
+        );
+        // Payload type = 0x03 (RST_STREAM), stream_id = 5, error code = 2 (InternalError).
+        assert_eq!(bytes[3], 0x03, "frame type must be RST_STREAM");
+        assert_eq!(
+            u32::from_be_bytes([bytes[5], bytes[6], bytes[7], bytes[8]]) & 0x7fff_ffff,
+            5,
+            "stream id must match"
+        );
+        assert_eq!(
+            u32::from_be_bytes([bytes[9], bytes[10], bytes[11], bytes[12]]),
+            H2Error::InternalError as u32,
+            "error code must be InternalError"
         );
     }
 }

--- a/lib/src/protocol/mux/converter.rs
+++ b/lib/src/protocol/mux/converter.rs
@@ -632,6 +632,30 @@ impl<T: AsBuffer> BlockConverter<T> for H2BlockConverter<'_> {
     fn finalize(&mut self, kawa: &mut Kawa<T>) {
         if self.pending_oversized_abort {
             self.pending_oversized_abort = false;
+            // Push the RST_STREAM frame to `kawa.out` IN THIS PASS so the
+            // very next `flush_stream_out` call drains it onto the wire.
+            //
+            // Why we cannot rely on the next prepare cycle's `initialize`:
+            // `write_streams` retires a stream the moment
+            // `kawa.is_error() && kawa.is_completed()`. By clearing
+            // `kawa.blocks` (required to suppress post-RST HEADERS/DATA
+            // frames) we trip `is_completed()` immediately, which would
+            // otherwise allow the stream to be recycled with no RST on
+            // the wire — a spec violation and a hung peer (see Codex P1
+            // on commit 358e6e20). Emitting the frame here keeps the
+            // single-pass invariant: prepare → out has RST_STREAM →
+            // flush ships it → retirement check.
+            let mut frame =
+                [0u8; parser::FRAME_HEADER_SIZE + parser::RST_STREAM_PAYLOAD_SIZE as usize];
+            if let Err(e) = gen_rst_stream(&mut frame, self.stream_id, H2Error::InternalError) {
+                error!(
+                    "{} failed to serialize over-budget RST_STREAM frame: {:?}",
+                    log_module_context!(),
+                    e
+                );
+            } else {
+                kawa.push_out(Store::from_slice(&frame));
+            }
             // Preserve the original parsing_phase marker so logs and the
             // ParsingPhaseMarker telemetry stay coherent (e.g. Headers vs
             // Body) instead of getting clobbered to a synthetic value.
@@ -643,8 +667,8 @@ impl<T: AsBuffer> BlockConverter<T> for H2BlockConverter<'_> {
                 },
             };
             // Drop any remaining blocks — the stream is dead. Without this
-            // the next prepare cycle's pop loop would still try to encode
-            // headers/data after the synthesised RST_STREAM.
+            // a follow-on prepare pass (e.g. on the back-pressure return
+            // path) would still try to encode headers/data after our RST.
             kawa.blocks.clear();
             self.out.clear();
             incr!("h2.headers.rejected.budget_overrun");
@@ -1532,14 +1556,18 @@ mod tests {
         );
     }
 
-    /// `finalize` commits the abort: `kawa.parsing_phase` becomes
-    /// `Error{Processing(InternalError)}`, `kawa.blocks` is cleared so
-    /// no follow-on HEADERS/DATA leak after the synthesised RST_STREAM,
-    /// and the abort flag is reset so the converter is reusable.
+    /// `finalize` commits the abort in the SAME prepare pass:
+    /// - `kawa.out` carries one RST_STREAM(InternalError) frame so the
+    ///   following `flush_stream_out` ships it before the retirement
+    ///   gate retires the stream;
+    /// - `kawa.parsing_phase` becomes `Error{Processing(InternalError)}`;
+    /// - `kawa.blocks` is cleared so no follow-on HEADERS/DATA leak;
+    /// - the abort flag is reset so the converter is reusable.
     #[test]
     fn test_converter_finalize_commits_oversized_abort() {
         let mut encoder = loona_hpack::Encoder::new();
         let mut conv = test_converter(&mut encoder);
+        conv.stream_id = 7;
         let mut buf = vec![0u8; 4096];
         let mut kawa = make_kawa(&mut buf, Kind::Response);
 
@@ -1552,6 +1580,29 @@ mod tests {
 
         BlockConverter::finalize(&mut conv, &mut kawa);
 
+        // RST_STREAM frame shape: 9-byte header + 4-byte payload = 13 bytes.
+        let mut bytes = Vec::new();
+        for store in &kawa.out {
+            if let kawa::OutBlock::Store(s) = store {
+                bytes.extend_from_slice(s.data(kawa.storage.buffer()));
+            }
+        }
+        assert_eq!(
+            bytes.len(),
+            parser::FRAME_HEADER_SIZE + parser::RST_STREAM_PAYLOAD_SIZE as usize,
+            "finalize must push the RST_STREAM frame to kawa.out in the same pass"
+        );
+        assert_eq!(bytes[3], 0x03, "frame type byte must be RST_STREAM");
+        assert_eq!(
+            u32::from_be_bytes([bytes[5], bytes[6], bytes[7], bytes[8]]) & 0x7fff_ffff,
+            7,
+            "stream_id must match converter.stream_id"
+        );
+        assert_eq!(
+            u32::from_be_bytes([bytes[9], bytes[10], bytes[11], bytes[12]]),
+            H2Error::InternalError as u32,
+            "error code must be InternalError"
+        );
         match kawa.parsing_phase {
             ParsingPhase::Error {
                 marker,

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -425,6 +425,14 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         let stream = &mut context.streams[stream_id];
         let parts = stream.split(&self.position);
         let kawa = parts.wbuffer;
+        // Apply per-frontend response-side header edits stashed by the
+        // routing layer at request time. Only the Server-position pass
+        // touches the response back-kawa; the Client-position pass
+        // (writing the request to the backend) has already had its
+        // edits applied in `Router::route_from_request`.
+        if matches!(self.position, Position::Server) && !parts.context.headers_response.is_empty() {
+            super::shared::apply_response_header_edits(kawa, &parts.context.headers_response);
+        }
         kawa.prepare(&mut kawa::h1::BlockConverter);
         let mut io_slices = Vec::new();
         for block in kawa.out.iter() {

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -2508,6 +2508,18 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                     );
                 }
                 kawa.prepare(&mut converter);
+                // The pre-prepare gate at line 2483 only inserts into
+                // `rst_sent` when `kawa.is_error()` is already true on
+                // entry. The HPACK over-budget abort path
+                // (`H2BlockConverter::check_header_capacity` →
+                // `finalize`) flips `parsing_phase` to Error AND pushes
+                // its own RST_STREAM frame inside this same prepare
+                // pass; without a post-prepare insert here the next
+                // writable cycle would gate-pass and double-emit a
+                // RST_STREAM via the existing `initialize` chokepoint.
+                if kawa.is_error() {
+                    self.rst_sent.insert(stream_id);
+                }
                 let consumed = window - converter.window;
                 *parts.window = parts.window.saturating_sub(consumed);
                 self.flow_control.window = self.flow_control.window.saturating_sub(consumed);

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -626,6 +626,14 @@ where
 ///   `GOAWAY(ENHANCE_YOUR_CALM)` when exceeded.
 /// - **Invariant 15** (edge-triggered epoll): pair `Ready::WRITABLE` interest
 ///   with the event bit so `writable()` is scheduled on the next tick.
+///
+/// Returns `true` when the RST was freshly queued, `false` when the
+/// stream was already in `rst_sent` (the caller asked to RST the same
+/// stream twice — a benign re-entrant idempotency, NOT a new wire
+/// emission). The boolean lets [`ConnectionH2::enqueue_rst`] account
+/// the RST only on the freshly-queued path so duplicate calls do not
+/// inflate the per-error counter or trip the MadeYouReset flood cap
+/// for frames that never reach the wire.
 fn enqueue_rst_into(
     pending: &mut Vec<(StreamId, H2Error)>,
     total: &mut usize,
@@ -633,13 +641,14 @@ fn enqueue_rst_into(
     readiness: &mut Readiness,
     wire_stream_id: StreamId,
     error: H2Error,
-) {
+) -> bool {
     if !rst_sent.insert(wire_stream_id) {
-        return;
+        return false;
     }
     pending.push((wire_stream_id, error));
     *total += 1;
     readiness.arm_writable();
+    true
 }
 
 /// Detail of a flood-threshold violation returned by
@@ -3661,7 +3670,7 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
     /// `total_rst_streams_queued`, edge-triggered-epoll arm via
     /// [`Readiness::arm_writable`]).
     fn enqueue_rst(&mut self, wire_stream_id: StreamId, error: H2Error) -> Option<MuxResult> {
-        enqueue_rst_into(
+        let freshly_queued = enqueue_rst_into(
             &mut self.pending_rst_streams,
             &mut self.total_rst_streams_queued,
             &mut self.rst_sent,
@@ -3669,14 +3678,25 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             wire_stream_id,
             error,
         );
+        // Account ONLY when a new RST actually entered the queue.
+        // Calling `enqueue_rst` for a stream that already has a queued
+        // (or already-flushed) RST is the dedup short-circuit — counting
+        // those would inflate `h2.frames.tx.rst_stream` /
+        // `h2.rst_stream.sent.*` and trip the CVE-2025-8671 MadeYouReset
+        // lifetime cap on frames that never reached the wire.
+        //
         // Account at queue-time, not at drain-time. Doing it later in
         // `flush_pending_control_frames` would double-count any RST that
-        // `reset_stream` already accounted before queuing — and missing
-        // it at queue-time leaves `cancel_timed_out_streams` /
-        // `refuse_stream_and_discard` / DATA-on-closed-stream paths
-        // bypassing the MadeYouReset lifetime cap (security review
-        // LISA-001 on commit `da845c71`).
-        self.account_emitted_rst(error)
+        // a re-entrant call (DATA on a closed stream we already RSTed)
+        // tried to enqueue — and missing it at queue-time leaves
+        // `cancel_timed_out_streams` / `refuse_stream_and_discard` /
+        // DATA-on-closed-stream paths bypassing the lifetime cap
+        // (security review LISA-001 on commit `da845c71`).
+        if freshly_queued {
+            self.account_emitted_rst(error)
+        } else {
+            None
+        }
     }
 
     /// Single accounting site for proxy-emitted RST_STREAM frames.
@@ -7576,7 +7596,7 @@ mod tests {
         let mut sent: HashSet<StreamId> = HashSet::new();
         let mut readiness = Readiness::new();
 
-        enqueue_rst_into(
+        let first = enqueue_rst_into(
             &mut pending,
             &mut total,
             &mut sent,
@@ -7584,14 +7604,20 @@ mod tests {
             5,
             H2Error::ProtocolError,
         );
-        // Second call for the same stream must be a no-op.
-        enqueue_rst_into(
+        assert!(first, "first call must report freshly_queued = true");
+        // Second call for the same stream must be a no-op AND return
+        // false so accounting in `Self::enqueue_rst` skips this case.
+        let second = enqueue_rst_into(
             &mut pending,
             &mut total,
             &mut sent,
             &mut readiness,
             5,
             H2Error::InternalError,
+        );
+        assert!(
+            !second,
+            "second call for same stream must return freshly_queued = false"
         );
 
         assert_eq!(pending.len(), 1, "dedupe must collapse to a single entry");

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -2440,6 +2440,12 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         // yield (progress + pending back-buffer, LIFECYCLE §9 invariant 16)
         // from a no-progress wait state (e.g. flow-control starvation).
         let mut total_bytes_written: usize = 0;
+        // Collect every fresh RST_STREAM emitted via the converter
+        // (`initialize` chokepoint or the HPACK over-budget abort path)
+        // so we can run `account_emitted_rst` for each one AFTER the
+        // converter is dropped — the converter holds `&mut self.encoder`
+        // for the loop body so we cannot take `&mut self` until then.
+        let mut freshly_emitted_rsts: Vec<H2Error> = Vec::new();
         'outer: for idx in 0..self.priorities_buf.len() {
             let stream_id = self.priorities_buf[idx];
             let Some(&global_stream_id) = self.streams.get(&stream_id) else {
@@ -2478,8 +2484,8 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                     .copied()
                     .unwrap_or(0);
                 // Track RST_STREAM dedup: if kawa is in error state, the converter
-                // will generate a RST_STREAM frame. Mark it so we don't send a
-                // duplicate on the next writable cycle.
+                // will generate a RST_STREAM frame via `initialize`. Mark it so we
+                // don't send a duplicate on the next writable cycle.
                 if kawa.is_error() {
                     let freshly_rst = self.rst_sent.insert(stream_id);
                     // LIFECYCLE §9 invariant 17: any transition to ineligible
@@ -2491,6 +2497,17 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                         if let Some(c) = ready_incremental_by_urgency.get_mut(&urgency) {
                             *c = c.saturating_sub(1);
                         }
+                    }
+                    // Account for the RST that `initialize` is about to emit
+                    // for this stream. Without this the MadeYouReset lifetime
+                    // cap is evadable: any path that flips `parsing_phase` to
+                    // Error before reaching this gate (oversized inbound
+                    // trailers, malformed bodies, etc.) would land an
+                    // unaccounted RST on the wire. We defer the actual
+                    // accounting call until after `drop(converter)` — the
+                    // converter holds `&mut self.encoder` here.
+                    if freshly_rst {
+                        freshly_emitted_rsts.push(rst_error_from_kawa(kawa));
                     }
                 }
                 // Apply per-frontend response-side header edits
@@ -2517,8 +2534,30 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                 // pass; without a post-prepare insert here the next
                 // writable cycle would gate-pass and double-emit a
                 // RST_STREAM via the existing `initialize` chokepoint.
-                if kawa.is_error() {
-                    self.rst_sent.insert(stream_id);
+                //
+                // Per Codex P2: the converter's direct RST emission
+                // bypasses the metric/flood accounting that
+                // `Self::reset_stream` performs. Mirror it here so a
+                // peer that drives oversized headers across many
+                // streams cannot escape the MadeYouReset emitted-RST
+                // lifetime cap and so dashboards see the per-error
+                // counter and the global tx counter.
+                //
+                // Per Codex P3: when an incremental stream flips to
+                // Error mid-prepare, the RFC 9218 §4 yield-after-one
+                // accounting must drop this stream from the
+                // same-urgency ready bucket so trailing peers see the
+                // live count.
+                let freshly_rst_post_prepare = kawa.is_error() && self.rst_sent.insert(stream_id);
+                if freshly_rst_post_prepare {
+                    // Defer accounting until after `drop(converter)`; same
+                    // reason as the pre-prepare collector above.
+                    freshly_emitted_rsts.push(rst_error_from_kawa(kawa));
+                    if is_incremental {
+                        if let Some(c) = ready_incremental_by_urgency.get_mut(&urgency) {
+                            *c = c.saturating_sub(1);
+                        }
+                    }
                 }
                 let consumed = window - converter.window;
                 *parts.window = parts.window.saturating_sub(consumed);
@@ -2618,6 +2657,16 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         drop(converter);
         if size_update_emitted {
             self.pending_table_size_update = None;
+        }
+        // Account every RST that the converter emitted during this pass
+        // (pre-prepare gate + post-prepare HPACK over-budget abort) so
+        // the global tx counter, the per-error breakdown, and the
+        // MadeYouReset emitted-RST lifetime cap stay in step. If the
+        // cap trips, propagate the GOAWAY result.
+        for error in freshly_emitted_rsts {
+            if let Some(result) = self.account_emitted_rst(error) {
+                return result;
+            }
         }
         self.converter_buf = converter_out;
         self.lowercase_buf = lowercase_buf;
@@ -3031,36 +3080,66 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
 
         // Flush pending RST_STREAM frames (queued when refusing streams).
         if !self.pending_rst_streams.is_empty() && self.expect_write.is_none() {
-            let kawa = &mut self.zero;
-            kawa.storage.clear();
-            let buf = kawa.storage.space();
-            let mut offset = 0;
-            let mut written_count = 0;
-            for &(stream_id, ref error) in &self.pending_rst_streams {
-                let frame_size =
-                    parser::FRAME_HEADER_SIZE + parser::RST_STREAM_PAYLOAD_SIZE as usize;
-                if offset + frame_size > buf.len() {
-                    break;
-                }
-                match serializer::gen_rst_stream(&mut buf[offset..], stream_id, error.to_owned()) {
-                    Ok((_, _)) => {
-                        offset += frame_size;
-                        written_count += 1;
-                        incr!("h2.frames.tx.rst_stream");
+            // Snapshot the per-frame error codes before mutating
+            // `self.zero` — we feed them into `account_emitted_rst` after
+            // the wire write so flood-protection sees every emitted frame
+            // (gap flagged in the security review on `da845c71`).
+            let drained_errors: Vec<H2Error> = {
+                let kawa = &mut self.zero;
+                kawa.storage.clear();
+                let buf = kawa.storage.space();
+                let mut offset = 0;
+                let mut written_errors: Vec<H2Error> = Vec::new();
+                for &(stream_id, ref error) in &self.pending_rst_streams {
+                    let frame_size =
+                        parser::FRAME_HEADER_SIZE + parser::RST_STREAM_PAYLOAD_SIZE as usize;
+                    if offset + frame_size > buf.len() {
+                        break;
                     }
-                    Err(_) => break,
+                    match serializer::gen_rst_stream(
+                        &mut buf[offset..],
+                        stream_id,
+                        error.to_owned(),
+                    ) {
+                        Ok((_, _)) => {
+                            offset += frame_size;
+                            written_errors.push(error.to_owned());
+                        }
+                        Err(_) => break,
+                    }
                 }
-            }
-            self.pending_rst_streams.drain(..written_count);
-            if offset > 0 {
-                kawa.storage.fill(offset);
+                self.pending_rst_streams.drain(..written_errors.len());
+                if offset > 0 {
+                    kawa.storage.fill(offset);
+                }
+                written_errors
+            };
+            if !drained_errors.is_empty() {
                 if self.flush_zero_to_socket() {
                     self.expect_write = Some(H2StreamId::Zero);
                     // Edge-triggered epoll: ensure pending TLS data gets flushed
                     if self.socket.socket_wants_write() {
                         self.readiness.event.insert(Ready::WRITABLE);
                     }
+                    // Account each drained RST through the single helper so
+                    // the global tx counter, the per-error breakdown, and
+                    // the MadeYouReset lifetime cap stay in step. If the
+                    // cap trips on this batch, propagate the GOAWAY result
+                    // instead of `Continue`.
+                    for error in drained_errors {
+                        if let Some(result) = self.account_emitted_rst(error) {
+                            return Some(result);
+                        }
+                    }
                     return Some(MuxResult::Continue);
+                }
+                // Wire write deferred (e.g. socket not writable yet) —
+                // still account: the RST is committed into `self.zero`,
+                // a subsequent writable cycle will drain it.
+                for error in drained_errors {
+                    if let Some(result) = self.account_emitted_rst(error) {
+                        return Some(result);
+                    }
                 }
             }
         }
@@ -3609,6 +3688,34 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         );
     }
 
+    /// Single accounting site for proxy-emitted RST_STREAM frames that
+    /// reach the wire outside [`Self::reset_stream`] (which already does
+    /// its own accounting).
+    ///
+    /// Three things must happen for every emitted RST so flood-protection
+    /// stays honest: the global tx counter, the per-error breakdown, and
+    /// the MadeYouReset emitted-RST lifetime cap. Callers are the
+    /// pre-prepare gate (`write_streams` line ~2483, where
+    /// `kawa.is_error()` was true on entry), the post-prepare gate (line
+    /// ~2546, where the HPACK over-budget abort flipped the phase
+    /// inside `kawa.prepare`), the converter's `initialize` chokepoint
+    /// (which we cannot instrument directly because it lives behind
+    /// `kawa.prepare` without `&mut self` access), and the
+    /// `pending_rst_streams` drain in `flush_pending_control_frames`.
+    /// Returning `Some(MuxResult)` means the caller MUST short-circuit
+    /// with that result — the flood detector tripped its lifetime cap
+    /// and converted to a connection-wide GOAWAY.
+    fn account_emitted_rst(&mut self, error: H2Error) -> Option<MuxResult> {
+        incr!("h2.frames.tx.rst_stream");
+        count!(metric_for_rst_stream_sent(error), 1);
+        if !matches!(error, H2Error::NoError) {
+            if let Some(violation) = self.flood_detector.record_rst_emitted() {
+                return Some(self.handle_flood_violation(violation));
+            }
+        }
+        None
+    }
+
     /// Refuse a newly-opened stream with RST_STREAM and discard its HEADERS payload.
     ///
     /// Used when MAX_CONCURRENT_STREAMS is exceeded or buffer pool is exhausted.
@@ -3698,6 +3805,21 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             violation.threshold,
         );
         self.goaway(violation.error)
+    }
+}
+
+/// Recover the [`H2Error`] code that the converter's `initialize`
+/// chokepoint will encode into the synthesised RST_STREAM frame for a
+/// kawa stuck in [`kawa::ParsingPhase::Error`]. Mirrors the parse +
+/// fallback at `lib/src/protocol/mux/converter.rs::initialize` so the
+/// flood-accounting helper sees the same code that lands on the wire.
+fn rst_error_from_kawa<T: kawa::AsBuffer>(kawa: &kawa::Kawa<T>) -> H2Error {
+    match kawa.parsing_phase {
+        kawa::ParsingPhase::Error {
+            kind: kawa::ParsingErrorKind::Processing { message },
+            ..
+        } => message.parse::<H2Error>().unwrap_or(H2Error::InternalError),
+        _ => H2Error::InternalError,
     }
 }
 

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -2370,6 +2370,11 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             // signal.
             pending_table_size_update: self.pending_table_size_update,
             size_update_emitted: false,
+            // Reset on every write pass; `check_header_capacity` flips it
+            // mid-call and `finalize` commits the abort by flipping
+            // `kawa.parsing_phase` to Error so the next pass emits
+            // RST_STREAM(InternalError).
+            pending_oversized_abort: false,
         };
         self.priorities_buf.clear();
         self.priorities_buf.extend(self.streams.keys().copied());

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -2488,6 +2488,20 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                         }
                     }
                 }
+                // Apply per-frontend response-side header edits
+                // (set/replace/delete) stashed by the routing layer at
+                // request time. H2 frontends always run as Server
+                // position; the back-side H2 client (when sozu speaks
+                // H2 to a backend) is a request emission and was
+                // already mutated by Router::route_from_request.
+                if matches!(self.position, super::Position::Server)
+                    && !parts.context.headers_response.is_empty()
+                {
+                    super::shared::apply_response_header_edits(
+                        kawa,
+                        &parts.context.headers_response,
+                    );
+                }
                 kawa.prepare(&mut converter);
                 let consumed = window - converter.window;
                 *parts.window = parts.window.saturating_sub(consumed);
@@ -7284,6 +7298,8 @@ mod tests {
             sozu_id_header: String::from("Sozu-Id"),
             redirect_location: None,
             www_authenticate: None,
+            original_authority: None,
+            headers_response: Vec::new(),
         };
         Stream::new(Rc::downgrade(pool), http_ctx, 65_535)
             .expect("pool should have capacity for two buffers")

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -7282,6 +7282,8 @@ mod tests {
             tls_cipher: None,
             tls_alpn: None,
             sozu_id_header: String::from("Sozu-Id"),
+            redirect_location: None,
+            www_authenticate: None,
         };
         Stream::new(Rc::downgrade(pool), http_ctx, 65_535)
             .expect("pool should have capacity for two buffers")

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -1759,7 +1759,11 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                                     );
                                     self.flood_detector.glitch_count += 1;
                                     check_flood_or_return!(self);
-                                    self.enqueue_rst(header.stream_id, H2Error::StreamClosed);
+                                    if let Some(result) =
+                                        self.enqueue_rst(header.stream_id, H2Error::StreamClosed)
+                                    {
+                                        return result;
+                                    }
                                 }
                                 _ => {
                                     // RFC 9113 §5.1: HEADERS or other frames on a
@@ -3079,67 +3083,39 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         }
 
         // Flush pending RST_STREAM frames (queued when refusing streams).
+        // Accounting happens at queue-time inside `Self::enqueue_rst`, so
+        // this drain only serialises and flushes — no metric/flood calls
+        // here would double-count.
         if !self.pending_rst_streams.is_empty() && self.expect_write.is_none() {
-            // Snapshot the per-frame error codes before mutating
-            // `self.zero` — we feed them into `account_emitted_rst` after
-            // the wire write so flood-protection sees every emitted frame
-            // (gap flagged in the security review on `da845c71`).
-            let drained_errors: Vec<H2Error> = {
-                let kawa = &mut self.zero;
-                kawa.storage.clear();
-                let buf = kawa.storage.space();
-                let mut offset = 0;
-                let mut written_errors: Vec<H2Error> = Vec::new();
-                for &(stream_id, ref error) in &self.pending_rst_streams {
-                    let frame_size =
-                        parser::FRAME_HEADER_SIZE + parser::RST_STREAM_PAYLOAD_SIZE as usize;
-                    if offset + frame_size > buf.len() {
-                        break;
-                    }
-                    match serializer::gen_rst_stream(
-                        &mut buf[offset..],
-                        stream_id,
-                        error.to_owned(),
-                    ) {
-                        Ok((_, _)) => {
-                            offset += frame_size;
-                            written_errors.push(error.to_owned());
-                        }
-                        Err(_) => break,
-                    }
+            let kawa = &mut self.zero;
+            kawa.storage.clear();
+            let buf = kawa.storage.space();
+            let mut offset = 0;
+            let mut written_count = 0;
+            for &(stream_id, ref error) in &self.pending_rst_streams {
+                let frame_size =
+                    parser::FRAME_HEADER_SIZE + parser::RST_STREAM_PAYLOAD_SIZE as usize;
+                if offset + frame_size > buf.len() {
+                    break;
                 }
-                self.pending_rst_streams.drain(..written_errors.len());
-                if offset > 0 {
-                    kawa.storage.fill(offset);
+                match serializer::gen_rst_stream(&mut buf[offset..], stream_id, error.to_owned()) {
+                    Ok((_, _)) => {
+                        offset += frame_size;
+                        written_count += 1;
+                    }
+                    Err(_) => break,
                 }
-                written_errors
-            };
-            if !drained_errors.is_empty() {
+            }
+            self.pending_rst_streams.drain(..written_count);
+            if offset > 0 {
+                kawa.storage.fill(offset);
                 if self.flush_zero_to_socket() {
                     self.expect_write = Some(H2StreamId::Zero);
                     // Edge-triggered epoll: ensure pending TLS data gets flushed
                     if self.socket.socket_wants_write() {
                         self.readiness.event.insert(Ready::WRITABLE);
                     }
-                    // Account each drained RST through the single helper so
-                    // the global tx counter, the per-error breakdown, and
-                    // the MadeYouReset lifetime cap stay in step. If the
-                    // cap trips on this batch, propagate the GOAWAY result
-                    // instead of `Continue`.
-                    for error in drained_errors {
-                        if let Some(result) = self.account_emitted_rst(error) {
-                            return Some(result);
-                        }
-                    }
                     return Some(MuxResult::Continue);
-                }
-                // Wire write deferred (e.g. socket not writable yet) —
-                // still account: the RST is committed into `self.zero`,
-                // a subsequent writable cycle will drain it.
-                for error in drained_errors {
-                    if let Some(result) = self.account_emitted_rst(error) {
-                        return Some(result);
-                    }
                 }
             }
         }
@@ -3608,7 +3584,14 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             // cancellations from one peer IS abusive (pinning
             // MAX_CONCURRENT_STREAMS slots), and the GOAWAY(ENHANCE_YOUR_CALM)
             // escalation tells the peer to reconnect with a clean state.
-            self.enqueue_rst(sid, H2Error::Cancel);
+            //
+            // We deliberately ignore the `Option<MuxResult>` flood-violation
+            // signal here — `cancel_timed_out_streams` returns `()` and is
+            // called as best-effort housekeeping during the read path. A
+            // flood violation that becomes visible mid-iteration will be
+            // re-detected on the next `record_rst_emitted` call (the
+            // counter is sticky), so dropping the early-return is safe.
+            let _ = self.enqueue_rst(sid, H2Error::Cancel);
 
             // Remove from streams map and recycle the context stream so the slot
             // no longer counts against MAX_CONCURRENT_STREAMS.
@@ -3677,7 +3660,7 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
     /// (dedupe via `rst_sent`, MadeYouReset queued cap via
     /// `total_rst_streams_queued`, edge-triggered-epoll arm via
     /// [`Readiness::arm_writable`]).
-    fn enqueue_rst(&mut self, wire_stream_id: StreamId, error: H2Error) {
+    fn enqueue_rst(&mut self, wire_stream_id: StreamId, error: H2Error) -> Option<MuxResult> {
         enqueue_rst_into(
             &mut self.pending_rst_streams,
             &mut self.total_rst_streams_queued,
@@ -3686,22 +3669,36 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             wire_stream_id,
             error,
         );
+        // Account at queue-time, not at drain-time. Doing it later in
+        // `flush_pending_control_frames` would double-count any RST that
+        // `reset_stream` already accounted before queuing — and missing
+        // it at queue-time leaves `cancel_timed_out_streams` /
+        // `refuse_stream_and_discard` / DATA-on-closed-stream paths
+        // bypassing the MadeYouReset lifetime cap (security review
+        // LISA-001 on commit `da845c71`).
+        self.account_emitted_rst(error)
     }
 
-    /// Single accounting site for proxy-emitted RST_STREAM frames that
-    /// reach the wire outside [`Self::reset_stream`] (which already does
-    /// its own accounting).
-    ///
+    /// Single accounting site for proxy-emitted RST_STREAM frames.
     /// Three things must happen for every emitted RST so flood-protection
-    /// stays honest: the global tx counter, the per-error breakdown, and
-    /// the MadeYouReset emitted-RST lifetime cap. Callers are the
-    /// pre-prepare gate (`write_streams` line ~2483, where
-    /// `kawa.is_error()` was true on entry), the post-prepare gate (line
-    /// ~2546, where the HPACK over-budget abort flipped the phase
-    /// inside `kawa.prepare`), the converter's `initialize` chokepoint
-    /// (which we cannot instrument directly because it lives behind
-    /// `kawa.prepare` without `&mut self` access), and the
-    /// `pending_rst_streams` drain in `flush_pending_control_frames`.
+    /// stays honest: the global tx counter, the per-error breakdown,
+    /// and the MadeYouReset emitted-RST lifetime cap.
+    ///
+    /// Two distinct emission paths feed this helper:
+    ///   * Queued frames — [`Self::enqueue_rst`] (and therefore every
+    ///     callable that funnels through it: `reset_stream`,
+    ///     `refuse_stream_and_discard`, `cancel_timed_out_streams`,
+    ///     DATA-on-closed-stream) calls this once at queue-time. The
+    ///     drain in `flush_pending_control_frames` does NOT call it
+    ///     again — that would double-count.
+    ///   * Converter-emitted frames — the converter's `initialize`
+    ///     chokepoint (and the HPACK over-budget abort path) writes
+    ///     RST_STREAM frames straight into `kawa.out` from inside
+    ///     `kawa.prepare`. We collect those `H2Error` codes during the
+    ///     `write_streams` loop and call this helper for each one
+    ///     after `drop(converter)` (because the converter holds
+    ///     `&mut self.encoder`).
+    ///
     /// Returning `Some(MuxResult)` means the caller MUST short-circuit
     /// with that result — the flood detector tripped its lifetime cap
     /// and converted to a connection-wide GOAWAY.
@@ -3733,7 +3730,9 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         error: H2Error,
         payload_len: u32,
     ) -> MuxResult {
-        self.enqueue_rst(stream_id, error);
+        if let Some(result) = self.enqueue_rst(stream_id, error) {
+            return result;
+        }
         self.state = H2State::Discard;
         self.expect_read = Some((H2StreamId::Zero, payload_len as usize));
         self.record_refusal_for_backpressure();
@@ -5489,20 +5488,14 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         // remaining in `self.streams` — callers typically follow this with
         // `remove_dead_stream`, which would otherwise evict the slot before
         // `write_streams` could run `kawa.prepare` against the converter.
-        self.enqueue_rst(wire_stream_id, error);
-        // Per-error-code counter for the outbound RST. Emitted regardless of
-        // `error` (including the graceful-cancel `NoError` path) so dashboards
-        // can split benign cancels from defensive resets without consulting
-        // the flood-detector keys.
-        count!(metric_for_rst_stream_sent(error), 1);
-        // CVE-2025-8671 MadeYouReset: cap the total number of RST_STREAM frames
-        // we emit on this connection. Graceful `NoError` cancels (e.g. stream
-        // recycle, propagated client-side cancel) are exempt; only error-path
-        // resets — driven by attacker-crafted frames — feed the counter.
-        if !matches!(error, H2Error::NoError) {
-            if let Some(violation) = self.flood_detector.record_rst_emitted() {
-                return self.handle_flood_violation(violation);
-            }
+        //
+        // `enqueue_rst` performs every accounting side-effect at queue
+        // time (per-error counter, global tx counter, CVE-2025-8671
+        // MadeYouReset lifetime cap). Graceful `NoError` cancels —
+        // stream recycle, propagated client-side cancel — are exempt
+        // from the lifetime cap inside the accounting helper itself.
+        if let Some(result) = self.enqueue_rst(wire_stream_id, error) {
+            return result;
         }
         MuxResult::Continue
     }

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -130,6 +130,7 @@ macro_rules! log_module_context {
 }
 
 pub mod answers;
+pub mod auth;
 pub mod connection;
 mod converter;
 pub mod debug;

--- a/lib/src/protocol/mux/router.rs
+++ b/lib/src/protocol/mux/router.rs
@@ -809,7 +809,20 @@ fn apply_request_rewrites_and_headers(
     let rewriting_host = rewritten_host.is_some();
     let mut keys_to_drop: Vec<Vec<u8>> = Vec::with_capacity(headers_request.len() + 2);
     let mut to_insert: Vec<Block> = Vec::with_capacity(headers_request.len() + 2);
+    // Track whether any operator-supplied edit names Host or
+    // X-Forwarded-Host so we always dedup the existing kawa Host header
+    // before inserting the operator's value. Without this, an operator
+    // who sets `--header request=Host=evil` on a frontend WITHOUT
+    // `--rewrite-host` lands TWO `Host:` headers on the backend wire —
+    // a request-smuggling primitive on backends that pick last-Host
+    // (CWE-444 cousin).
+    let mut operator_overrides_host = false;
+    let mut operator_overrides_xfh = false;
     for edit in headers_request {
+        let key_is_host = edit.key.eq_ignore_ascii_case(host_lower);
+        let key_is_xfh = edit.key.eq_ignore_ascii_case(xfh_lower);
+        operator_overrides_host |= key_is_host;
+        operator_overrides_xfh |= key_is_xfh;
         if edit.val.is_empty() {
             keys_to_drop.push(edit.key.iter().map(u8::to_ascii_lowercase).collect());
         } else {
@@ -819,8 +832,10 @@ fn apply_request_rewrites_and_headers(
             }));
         }
     }
-    if rewriting_host {
+    if rewriting_host || operator_overrides_host {
         keys_to_drop.push(host_lower.to_vec());
+    }
+    if rewriting_host || operator_overrides_xfh {
         keys_to_drop.push(xfh_lower.to_vec());
     }
 

--- a/lib/src/protocol/mux/router.rs
+++ b/lib/src/protocol/mux/router.rs
@@ -569,7 +569,12 @@ impl Router {
             return Err(RetrieveClusterError::UnauthorizedRoute);
         }
 
-        let cluster_id = cluster_id.expect("cluster_id is Some at this point");
+        let Some(cluster_id) = cluster_id else {
+            // Guarded by the clusterless-deny branch immediately above;
+            // the `is_none()` arm has already returned `UnauthorizedRoute`
+            // by the time control reaches here.
+            unreachable!("cluster_id was checked Some above")
+        };
 
         // ── 2. Explicit `RedirectPolicy::PERMANENT` ─────────────────────────
         if matches!(redirect, RedirectPolicy::Permanent) {
@@ -580,12 +585,11 @@ impl Router {
         }
 
         // ── 3. Legacy `cluster.https_redirect` (HTTP-only listeners) ───────
-        // The caller (`Router::connect`) still gates on listener kind so a
-        // plaintext listener's HTTP→HTTPS redirect rolls through the same
-        // 301 default-answer path. We compute the URL here so the
-        // listener-kind branch in `connect` only needs to bubble up
-        // `RetrieveClusterError::HttpsRedirect`.
-        if legacy_https_redirect {
+        // The caller (`Router::connect`) emits the actual 301 only on
+        // `ListenerType::Http`; gate the URL stash on the same predicate
+        // so an HTTPS listener never carries a stale `redirect_location`
+        // into a downstream default-answer path.
+        if legacy_https_redirect && matches!(proxy.borrow().kind(), ListenerType::Http) {
             let port = https_redirect_port;
             context.redirect_location = Some(build_redirect_location("https", context, port));
         }

--- a/lib/src/protocol/mux/router.rs
+++ b/lib/src/protocol/mux/router.rs
@@ -758,9 +758,19 @@ fn apply_request_rewrites_and_headers(
     };
 
     // ── status-line authority / path rewrites ─────────────────────────
+    // The kawa request status line carries both `path` and `uri` —
+    // `path` is the abstract path (consumed by the H2 converter to
+    // emit `:path`) while `uri` is the request-line URI (consumed by
+    // the H1 converter at `kawa::protocol::h1::converter`). Both must
+    // be mutated so an H1 frontend forwarding to an H1 backend AND an
+    // H2 frontend forwarding to an H1 backend (or vice versa) see the
+    // rewritten target on the wire.
     if rewritten_host.is_some() || rewritten_path.is_some() {
         if let kawa::StatusLine::Request {
-            authority, path, ..
+            authority,
+            path,
+            uri,
+            ..
         } = &mut kawa.detached.status_line
         {
             if let Some(new_host) = rewritten_host {
@@ -768,6 +778,7 @@ fn apply_request_rewrites_and_headers(
             }
             if let Some(new_path) = rewritten_path {
                 *path = Store::from_string(new_path.to_owned());
+                *uri = Store::from_string(new_path.to_owned());
             }
         }
     }
@@ -790,12 +801,14 @@ fn apply_request_rewrites_and_headers(
         keys_to_drop.push(xfh_lower.to_vec());
     }
     if !keys_to_drop.is_empty() {
-        // SAFETY: we only read `key.data(buf_ptr)` while `kawa.blocks`
-        // is borrowed immutably during retain — buf_ptr is the same
-        // backing buffer.
+        // Read `key.data(buf_ptr)` only on non-elided headers — kawa
+        // panics on `Store::Empty.data()` (storage/repr.rs:515).
         let buf = buf_ptr;
         kawa.blocks.retain(|block| {
             if let Block::Header(Pair { key, val: _ }) = block {
+                if matches!(key, Store::Empty) {
+                    return true;
+                }
                 let key_bytes = key.data(buf);
                 let key_lower: Vec<u8> = key_bytes.iter().map(u8::to_ascii_lowercase).collect();
                 !keys_to_drop.iter().any(|k| compare_no_case(&key_lower, k))

--- a/lib/src/protocol/mux/router.rs
+++ b/lib/src/protocol/mux/router.rs
@@ -18,7 +18,6 @@ use crate::{
     RetrieveClusterError,
     backends::{Backend, BackendError},
     protocol::http::editor::HttpContext,
-    router::Route,
     server::CONN_RETRIES,
     socket::SessionTcpStream,
     timer::TimeoutContainer,
@@ -514,10 +513,13 @@ impl Router {
             }
         };
 
-        let cluster_id = match route {
-            Route::ClusterId(id) => id,
-            Route::Deny => {
-                trace!("{} Route::Deny", log_module_context!(context));
+        // Wave 3a will plumb every RouteResult field through `apply_route_decision`;
+        // for now collapse RouteResult to cluster_id and treat the absent
+        // cluster as the historical `Route::Deny`.
+        let cluster_id = match route.cluster_id {
+            Some(id) => id,
+            None => {
+                trace!("{} RouteResult::deny", log_module_context!(context));
                 return Err(RetrieveClusterError::UnauthorizedRoute);
             }
         };

--- a/lib/src/protocol/mux/router.rs
+++ b/lib/src/protocol/mux/router.rs
@@ -8,7 +8,10 @@
 use std::{cell::RefCell, collections::HashMap, rc::Rc, time::Duration};
 
 use mio::{Interest, Token, net::TcpStream};
-use sozu_command::{logging::ansi_palette, proto::command::ListenerType};
+use sozu_command::{
+    logging::ansi_palette,
+    proto::command::{ListenerType, RedirectPolicy, RedirectScheme},
+};
 
 #[cfg(debug_assertions)]
 use super::DebugEvent;
@@ -18,6 +21,7 @@ use crate::{
     RetrieveClusterError,
     backends::{Backend, BackendError},
     protocol::http::editor::HttpContext,
+    router::RouteResult,
     server::CONN_RETRIES,
     socket::SessionTcpStream,
     timer::TimeoutContainer,
@@ -118,10 +122,18 @@ impl Router {
         }
         stream.attempts += 1;
 
-        let stream_context = &mut stream.context;
+        // Borrow the front kawa first (immutable, lives until route_from_request returns)
+        // and the context mutably so route_from_request can stash redirect_location /
+        // www_authenticate. We split the borrows manually to keep the rest of `connect`
+        // working with `stream_context` aliasing `stream.context`.
+        let (front_ref, stream_context_ref) = {
+            let stream_split = &mut *stream;
+            (&stream_split.front, &mut stream_split.context)
+        };
         let cluster_id = self
-            .route_from_request(stream_context, &context.listener)
+            .route_from_request(stream_context_ref, front_ref, &context.listener, &proxy)
             .map_err(BackendConnectionError::RetrieveClusterError)?;
+        let stream_context = &mut stream.context;
         stream_context.cluster_id = Some(cluster_id.to_owned());
 
         let (frontend_should_stick, frontend_should_redirect_https, h2) = proxy
@@ -455,7 +467,9 @@ impl Router {
     fn route_from_request<L: ListenerHandler + L7ListenerHandler>(
         &mut self,
         context: &mut HttpContext,
+        front: &super::GenericHttpStream,
         listener: &Rc<RefCell<L>>,
+        proxy: &Rc<RefCell<dyn L7Proxy>>,
     ) -> Result<String, RetrieveClusterError> {
         let (host, uri, method) = match context.extract_route() {
             Ok(tuple) => tuple,
@@ -513,16 +527,87 @@ impl Router {
             }
         };
 
-        // Wave 3a will plumb every RouteResult field through `apply_route_decision`;
-        // for now collapse RouteResult to cluster_id and treat the absent
-        // cluster as the historical `Route::Deny`.
-        let cluster_id = match route.cluster_id {
-            Some(id) => id,
-            None => {
-                trace!("{} RouteResult::deny", log_module_context!(context));
-                return Err(RetrieveClusterError::UnauthorizedRoute);
-            }
-        };
+        // ── Resolve the routing decision ──────────────────────────────────
+        // Snapshot the policy fields we need before consuming `route`, then
+        // map each policy outcome to either an early-error variant (which
+        // the caller turns into a default answer) or a cluster_id (which
+        // proceeds to backend connect).
+        let RouteResult {
+            cluster_id,
+            redirect,
+            redirect_scheme,
+            rewritten_port,
+            required_auth: frontend_required_auth,
+            ..
+        } = route;
+
+        // Look up cluster-side policy knobs once. The values we need are:
+        //  - `https_redirect` (legacy) and `https_redirect_port` for the 301 location URL
+        //  - `authorized_hashes` and `www_authenticate` for the 401 path
+        let (legacy_https_redirect, https_redirect_port, authorized_hashes, www_authenticate) =
+            match cluster_id.as_deref() {
+                Some(id) => proxy
+                    .borrow()
+                    .clusters()
+                    .get(id)
+                    .map(|c| {
+                        (
+                            c.https_redirect,
+                            c.https_redirect_port,
+                            c.authorized_hashes.clone(),
+                            c.www_authenticate.clone(),
+                        )
+                    })
+                    .unwrap_or((false, None, Vec::new(), None)),
+                None => (false, None, Vec::new(), None),
+            };
+
+        // ── 1. Explicit `RedirectPolicy::UNAUTHORIZED` or clusterless deny ─
+        if matches!(redirect, RedirectPolicy::Unauthorized) || cluster_id.is_none() {
+            context.www_authenticate = www_authenticate.clone();
+            trace!("{} RouteResult::deny", log_module_context!(context));
+            return Err(RetrieveClusterError::UnauthorizedRoute);
+        }
+
+        let cluster_id = cluster_id.expect("cluster_id is Some at this point");
+
+        // ── 2. Explicit `RedirectPolicy::PERMANENT` ─────────────────────────
+        if matches!(redirect, RedirectPolicy::Permanent) {
+            let scheme = resolve_redirect_scheme(redirect_scheme, context);
+            let port = rewritten_port.map(|p| p as u32).or(https_redirect_port);
+            context.redirect_location = Some(build_redirect_location(scheme, context, port));
+            return Err(RetrieveClusterError::HttpsRedirect);
+        }
+
+        // ── 3. Legacy `cluster.https_redirect` (HTTP-only listeners) ───────
+        // The caller (`Router::connect`) still gates on listener kind so a
+        // plaintext listener's HTTP→HTTPS redirect rolls through the same
+        // 301 default-answer path. We compute the URL here so the
+        // listener-kind branch in `connect` only needs to bubble up
+        // `RetrieveClusterError::HttpsRedirect`.
+        if legacy_https_redirect {
+            let port = https_redirect_port;
+            context.redirect_location = Some(build_redirect_location("https", context, port));
+        }
+
+        // ── 4. Basic auth check (only when `required_auth` was set) ────────
+        // The check iterates the full hash list in constant time (see
+        // `crate::protocol::mux::auth::check_basic`) so the time spent
+        // does not leak which hash matched, or whether any did at all.
+        // On failure, stash the cluster's `www_authenticate` realm so the
+        // 401 default-answer can render the matching `WWW-Authenticate`
+        // header. An empty realm causes the template engine to elide the
+        // header entirely (`or_elide_header = true`).
+        if frontend_required_auth
+            && !crate::protocol::mux::auth::check_basic(front, &authorized_hashes)
+        {
+            context.www_authenticate = www_authenticate.clone();
+            trace!(
+                "{} basic-auth check failed; emitting 401",
+                log_module_context!(context)
+            );
+            return Err(RetrieveClusterError::UnauthorizedRoute);
+        }
 
         Ok(cluster_id)
     }
@@ -586,6 +671,49 @@ impl Router {
                 .backend_from_cluster_id(cluster_id),
         }
     }
+}
+
+/// Resolve the protocol scheme to use when emitting a redirect's `Location`
+/// header. Maps the proto enum onto `"http"` / `"https"`, with `USE_SAME`
+/// preserving the request's scheme (HTTPS for TLS listeners, HTTP otherwise).
+fn resolve_redirect_scheme(scheme: RedirectScheme, context: &HttpContext) -> &'static str {
+    match scheme {
+        RedirectScheme::UseHttps => "https",
+        RedirectScheme::UseHttp => "http",
+        RedirectScheme::UseSame => {
+            if context.tls_server_name.is_some() {
+                "https"
+            } else {
+                "http"
+            }
+        }
+    }
+}
+
+/// Build the `Location` URL for a redirect response. Defaults the port
+/// suffix only when the operator provided one or when scheme defaults
+/// would mismatch (port 80 on https / 443 on http stays implicit).
+fn build_redirect_location(scheme: &str, context: &HttpContext, port: Option<u32>) -> String {
+    let authority = context.authority.as_deref().unwrap_or_default();
+    let path = context.path.as_deref().unwrap_or("/");
+    // Strip an existing `:port` from the authority — operators typically
+    // configure `https_redirect_port` precisely because the listener's
+    // port differs from the redirect target.
+    let host_only = match authority.rsplit_once(':') {
+        Some((host, port_part))
+            if !port_part.is_empty() && port_part.bytes().all(|b| b.is_ascii_digit()) =>
+        {
+            host
+        }
+        _ => authority,
+    };
+    let port_suffix = match port {
+        Some(80) if scheme == "http" => String::new(),
+        Some(443) if scheme == "https" => String::new(),
+        Some(p) => format!(":{p}"),
+        None => String::new(),
+    };
+    format!("{scheme}://{host_only}{port_suffix}{path}")
 }
 
 /// Exact-match test between an HTTP `:authority` / `Host` value and a TLS SNI.

--- a/lib/src/protocol/mux/router.rs
+++ b/lib/src/protocol/mux/router.rs
@@ -20,8 +20,11 @@ use crate::{
     BackendConnectionError, L7ListenerHandler, L7Proxy, ListenerHandler, ProxySession, Readiness,
     RetrieveClusterError,
     backends::{Backend, BackendError},
-    protocol::http::editor::HttpContext,
-    router::RouteResult,
+    protocol::{
+        http::editor::{HeaderEditSnapshot, HttpContext},
+        kawa_h1::parser::compare_no_case,
+    },
+    router::{HeaderEdit, RouteResult},
     server::CONN_RETRIES,
     socket::SessionTcpStream,
     timer::TimeoutContainer,
@@ -122,13 +125,15 @@ impl Router {
         }
         stream.attempts += 1;
 
-        // Borrow the front kawa first (immutable, lives until route_from_request returns)
-        // and the context mutably so route_from_request can stash redirect_location /
-        // www_authenticate. We split the borrows manually to keep the rest of `connect`
-        // working with `stream_context` aliasing `stream.context`.
+        // Borrow front mutably (so route_from_request can rewrite the request
+        // line authority/path and inject request-side header edits before we
+        // forward to the backend) plus context mutably (so it can stash
+        // redirect_location / www_authenticate / original_authority /
+        // headers_response). We split-borrow manually to keep the rest of
+        // `connect` working with `stream_context` aliasing `stream.context`.
         let (front_ref, stream_context_ref) = {
             let stream_split = &mut *stream;
-            (&stream_split.front, &mut stream_split.context)
+            (&mut stream_split.front, &mut stream_split.context)
         };
         let cluster_id = self
             .route_from_request(stream_context_ref, front_ref, &context.listener, &proxy)
@@ -467,7 +472,7 @@ impl Router {
     fn route_from_request<L: ListenerHandler + L7ListenerHandler>(
         &mut self,
         context: &mut HttpContext,
-        front: &super::GenericHttpStream,
+        front: &mut super::GenericHttpStream,
         listener: &Rc<RefCell<L>>,
         proxy: &Rc<RefCell<dyn L7Proxy>>,
     ) -> Result<String, RetrieveClusterError> {
@@ -536,7 +541,11 @@ impl Router {
             cluster_id,
             redirect,
             redirect_scheme,
+            rewritten_host,
+            rewritten_path,
             rewritten_port,
+            headers_request,
+            headers_response,
             required_auth: frontend_required_auth,
             ..
         } = route;
@@ -613,6 +622,29 @@ impl Router {
             return Err(RetrieveClusterError::UnauthorizedRoute);
         }
 
+        // ── 5. Request-side mutations on the front kawa ────────────────────
+        // From here on the route is a Forward — apply the frontend's
+        // rewrite + header policy to the request kawa so the backend
+        // wire carries the operator-configured shape.
+        apply_request_rewrites_and_headers(
+            front,
+            context,
+            rewritten_host.as_deref(),
+            rewritten_path.as_deref(),
+            &headers_request,
+        );
+
+        // Stash the response-side header edits for the emission path
+        // (`mux/h1.rs::writable`, `mux/h2.rs::write_streams`) to apply
+        // before `kawa.prepare(...)`.
+        context.headers_response.clear();
+        for edit in headers_response.iter() {
+            context.headers_response.push(HeaderEditSnapshot {
+                key: edit.key.to_vec(),
+                val: edit.val.to_vec(),
+            });
+        }
+
         Ok(cluster_id)
     }
 
@@ -674,6 +706,151 @@ impl Router {
                 .borrow_mut()
                 .backend_from_cluster_id(cluster_id),
         }
+    }
+}
+
+/// Apply the frontend's request-side rewrite + header policy to the
+/// request kawa. Mutations land before backend connect so the backend
+/// wire carries the rewritten shape:
+///
+/// 1. If `rewritten_host` is set, capture the original authority into
+///    `context.original_authority`, replace the request-line authority
+///    with the rewritten value, replace the `Host` request header (so
+///    H1 backends see the same value the H2 `:authority` would carry),
+///    and inject `X-Forwarded-Host` carrying the original.
+/// 2. If `rewritten_path` is set, replace the request-line path.
+/// 3. For every `headers_request` edit:
+///    - empty `val` → remove every existing header with the matching
+///      name from `kawa.blocks` (HAProxy `del-header` parity);
+///    - non-empty `val` → append the header before the `end_header`
+///      flag block. Set/replace semantics: callers that want to replace
+///      a header pass two edits (one delete with empty val, one set
+///      with the new value).
+fn apply_request_rewrites_and_headers(
+    kawa: &mut super::GenericHttpStream,
+    context: &mut HttpContext,
+    rewritten_host: Option<&str>,
+    rewritten_path: Option<&str>,
+    headers_request: &[HeaderEdit],
+) {
+    use kawa::{Block, Pair, Store};
+
+    if rewritten_host.is_none() && rewritten_path.is_none() && headers_request.is_empty() {
+        return;
+    }
+
+    // Capture the pre-rewrite authority so the X-Forwarded-Host we
+    // inject below carries what the client actually sent. Read off the
+    // request-line authority Store rather than the existing `Host:`
+    // header so H2 frontends (which never carry a literal `Host:`) get
+    // the same X-Forwarded-Host shape as H1.
+    let original_authority = if rewritten_host.is_some() {
+        let buf = kawa.storage.buffer();
+        if let kawa::StatusLine::Request { authority, .. } = &kawa.detached.status_line {
+            std::str::from_utf8(authority.data(buf))
+                .ok()
+                .map(str::to_owned)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    // ── status-line authority / path rewrites ─────────────────────────
+    if rewritten_host.is_some() || rewritten_path.is_some() {
+        if let kawa::StatusLine::Request {
+            authority, path, ..
+        } = &mut kawa.detached.status_line
+        {
+            if let Some(new_host) = rewritten_host {
+                *authority = Store::from_string(new_host.to_owned());
+            }
+            if let Some(new_path) = rewritten_path {
+                *path = Store::from_string(new_path.to_owned());
+            }
+        }
+    }
+
+    // ── delete pass on existing blocks ────────────────────────────────
+    // Collect lowercase keys of every "delete this header" edit and the
+    // synthetic `Host` / `X-Forwarded-Host` keys we know we're about to
+    // overwrite. Filter `kawa.blocks` once with a single retain pass.
+    let buf_ptr = kawa.storage.buffer();
+    let host_lower = b"host";
+    let xfh_lower = b"x-forwarded-host";
+    let rewriting_host = rewritten_host.is_some();
+    let mut keys_to_drop: Vec<Vec<u8>> = headers_request
+        .iter()
+        .filter(|e| e.val.is_empty())
+        .map(|e| e.key.iter().map(u8::to_ascii_lowercase).collect())
+        .collect();
+    if rewriting_host {
+        keys_to_drop.push(host_lower.to_vec());
+        keys_to_drop.push(xfh_lower.to_vec());
+    }
+    if !keys_to_drop.is_empty() {
+        // SAFETY: we only read `key.data(buf_ptr)` while `kawa.blocks`
+        // is borrowed immutably during retain — buf_ptr is the same
+        // backing buffer.
+        let buf = buf_ptr;
+        kawa.blocks.retain(|block| {
+            if let Block::Header(Pair { key, val: _ }) = block {
+                let key_bytes = key.data(buf);
+                let key_lower: Vec<u8> = key_bytes.iter().map(u8::to_ascii_lowercase).collect();
+                !keys_to_drop.iter().any(|k| compare_no_case(&key_lower, k))
+            } else {
+                true
+            }
+        });
+    }
+
+    // ── insertion before the end-of-headers flag ──────────────────────
+    // Every header we add (rewritten Host, X-Forwarded-Host,
+    // operator-supplied set/append edits) must land before
+    // `Block::Flags { end_header: true }` so the converter emits them
+    // as part of the request header block.
+    let end_header_idx = kawa.blocks.iter().position(|b| {
+        matches!(
+            b,
+            Block::Flags(kawa::Flags {
+                end_header: true,
+                ..
+            })
+        )
+    });
+
+    let mut to_insert: Vec<Block> = Vec::new();
+    if let Some(new_host) = rewritten_host {
+        to_insert.push(Block::Header(Pair {
+            key: Store::Static(b"Host"),
+            val: Store::from_string(new_host.to_owned()),
+        }));
+        if let Some(orig) = original_authority.as_deref() {
+            to_insert.push(Block::Header(Pair {
+                key: Store::Static(b"X-Forwarded-Host"),
+                val: Store::from_string(orig.to_owned()),
+            }));
+        }
+    }
+    for edit in headers_request {
+        if edit.val.is_empty() {
+            continue;
+        }
+        to_insert.push(Block::Header(Pair {
+            key: Store::from_slice(&edit.key),
+            val: Store::from_slice(&edit.val),
+        }));
+    }
+    if !to_insert.is_empty() {
+        let insert_at = end_header_idx.unwrap_or(kawa.blocks.len());
+        for (offset, block) in to_insert.into_iter().enumerate() {
+            kawa.blocks.insert(insert_at + offset, block);
+        }
+    }
+
+    if rewriting_host {
+        context.original_authority = original_authority;
     }
 }
 

--- a/lib/src/protocol/mux/router.rs
+++ b/lib/src/protocol/mux/router.rs
@@ -20,10 +20,7 @@ use crate::{
     BackendConnectionError, L7ListenerHandler, L7Proxy, ListenerHandler, ProxySession, Readiness,
     RetrieveClusterError,
     backends::{Backend, BackendError},
-    protocol::{
-        http::editor::{HeaderEditSnapshot, HttpContext},
-        kawa_h1::parser::compare_no_case,
-    },
+    protocol::http::editor::{HeaderEditSnapshot, HttpContext},
     router::{HeaderEdit, RouteResult},
     server::CONN_RETRIES,
     socket::SessionTcpStream,
@@ -490,6 +487,11 @@ impl Router {
                 return Err(cluster_error);
             }
         };
+        // Snapshot the pre-rewrite authority into an owned string so we
+        // can later stash it on `context.original_authority` without
+        // mutably aliasing the immutable borrow that `host: &str` still
+        // holds on `context`.
+        let captured_authority = host.to_owned();
 
         // ── TLS SNI ↔ HTTP :authority binding ─────────────────────────────
         // Reject any request whose authority hostname does not exact-match the
@@ -531,6 +533,14 @@ impl Router {
                 return Err(RetrieveClusterError::RetrieveFrontend(frontend_error));
             }
         };
+
+        // Stash the pre-rewrite authority unconditionally so log lines,
+        // access logs, and audit records that fire on ANY downstream
+        // path (denial, redirect, basic-auth 401, backend-connect
+        // failure, successful forward) carry the value the client
+        // actually sent. Capturing inside the rewrite helper alone would
+        // lose it on every branch where the rewrite is not applied.
+        context.original_authority = Some(captured_authority);
 
         // ── Resolve the routing decision ──────────────────────────────────
         // Snapshot the policy fields we need before consuming `route`, then
@@ -713,12 +723,25 @@ impl Router {
 /// request kawa. Mutations land before backend connect so the backend
 /// wire carries the rewritten shape:
 ///
-/// 1. If `rewritten_host` is set, capture the original authority into
-///    `context.original_authority`, replace the request-line authority
-///    with the rewritten value, replace the `Host` request header (so
-///    H1 backends see the same value the H2 `:authority` would carry),
-///    and inject `X-Forwarded-Host` carrying the original.
-/// 2. If `rewritten_path` is set, replace the request-line path.
+/// 1. If `rewritten_host` is set, replace the request-line authority
+///    with the rewritten value, replace any existing `Host` request
+///    header (so H1 backends see the same value the H2 `:authority`
+///    would carry), and inject `X-Forwarded-Host` carrying the
+///    pre-rewrite authority. The X-Forwarded-Host injection ONLY fires
+///    when `rewritten_host` is set — without a rewrite there is no host
+///    swap to disclose, and HAProxy's `option forwardfor` style
+///    headers (`X-Forwarded-For`, `X-Forwarded-Proto`) still flow from
+///    the kawa parser. The pre-rewrite authority itself is captured by
+///    the caller (`route_from_request`) into `context.original_authority`
+///    on every routed request so it survives every downstream code path
+///    (audit, deny, redirect, basic-auth 401, backend-connect failure).
+///    Dedup rule: the synthetic Host AND any pre-existing Host header
+///    are dropped in the retain pass below before the rewritten Host is
+///    appended, so the wire never carries two `Host:` headers.
+/// 2. If `rewritten_path` is set, replace both the abstract path
+///    (consumed by H2 `:path`) and the request-line URI (consumed by
+///    the H1 converter) so cardinality H1↔H1, H1↔H2, H2↔H1, H2↔H2 all
+///    propagate the rewritten target.
 /// 3. For every `headers_request` edit:
 ///    - empty `val` → remove every existing header with the matching
 ///      name from `kawa.blocks` (HAProxy `del-header` parity);
@@ -739,20 +762,13 @@ fn apply_request_rewrites_and_headers(
         return;
     }
 
-    // Capture the pre-rewrite authority so the X-Forwarded-Host we
-    // inject below carries what the client actually sent. Read off the
-    // request-line authority Store rather than the existing `Host:`
-    // header so H2 frontends (which never carry a literal `Host:`) get
-    // the same X-Forwarded-Host shape as H1.
-    let original_authority = if rewritten_host.is_some() {
-        let buf = kawa.storage.buffer();
-        if let kawa::StatusLine::Request { authority, .. } = &kawa.detached.status_line {
-            std::str::from_utf8(authority.data(buf))
-                .ok()
-                .map(str::to_owned)
-        } else {
-            None
-        }
+    // `route_from_request` already captured the pre-rewrite authority
+    // into `context.original_authority`. Re-borrow it here for the
+    // optional X-Forwarded-Host injection rather than re-parsing the
+    // kawa Store. Cloning a short header value (typically `host:port`)
+    // is cheaper than another UTF-8 decode of the request-line slice.
+    let original_authority: Option<String> = if rewritten_host.is_some() {
+        context.original_authority.clone()
     } else {
         None
     };
@@ -783,26 +799,40 @@ fn apply_request_rewrites_and_headers(
         }
     }
 
-    // ── delete pass on existing blocks ────────────────────────────────
-    // Collect lowercase keys of every "delete this header" edit and the
-    // synthetic `Host` / `X-Forwarded-Host` keys we know we're about to
-    // overwrite. Filter `kawa.blocks` once with a single retain pass.
-    let buf_ptr = kawa.storage.buffer();
+    // ── single-pass split: deletes vs. sets ───────────────────────────
+    // Walk `headers_request` once and separate each edit into either the
+    // delete list (empty val) or the insert list (non-empty val). Two
+    // passes was wasteful when an operator stacks many `--header` flags;
+    // one pass keeps the allocation profile flat.
     let host_lower = b"host";
     let xfh_lower = b"x-forwarded-host";
     let rewriting_host = rewritten_host.is_some();
-    let mut keys_to_drop: Vec<Vec<u8>> = headers_request
-        .iter()
-        .filter(|e| e.val.is_empty())
-        .map(|e| e.key.iter().map(u8::to_ascii_lowercase).collect())
-        .collect();
+    let mut keys_to_drop: Vec<Vec<u8>> = Vec::with_capacity(headers_request.len() + 2);
+    let mut to_insert: Vec<Block> = Vec::with_capacity(headers_request.len() + 2);
+    for edit in headers_request {
+        if edit.val.is_empty() {
+            keys_to_drop.push(edit.key.iter().map(u8::to_ascii_lowercase).collect());
+        } else {
+            to_insert.push(Block::Header(Pair {
+                key: Store::from_slice(&edit.key),
+                val: Store::from_slice(&edit.val),
+            }));
+        }
+    }
     if rewriting_host {
         keys_to_drop.push(host_lower.to_vec());
         keys_to_drop.push(xfh_lower.to_vec());
     }
+
+    // ── delete pass on existing blocks ────────────────────────────────
+    let buf_ptr = kawa.storage.buffer();
     if !keys_to_drop.is_empty() {
-        // Read `key.data(buf_ptr)` only on non-elided headers — kawa
-        // panics on `Store::Empty.data()` (storage/repr.rs:515).
+        // Read `key.data(buf_ptr)` only on non-elided headers — kawa's
+        // earlier passes (HPACK decoder, H1 header parser) tag suppressed
+        // headers with `Store::Empty` rather than removing them, and
+        // calling `.data()` on `Store::Empty` panics in
+        // `kawa-0.6.8/src/storage/repr.rs`. Pinning the guard explicitly
+        // until kawa changes its policy.
         let buf = buf_ptr;
         kawa.blocks.retain(|block| {
             if let Block::Header(Pair { key, val: _ }) = block {
@@ -810,8 +840,14 @@ fn apply_request_rewrites_and_headers(
                     return true;
                 }
                 let key_bytes = key.data(buf);
+                // Both `keys_to_drop` and `key_lower` are pre-lowercased,
+                // so a byte-equality compare is sufficient — a second
+                // ASCII-fold pass via `compare_no_case` would just burn
+                // cycles re-folding bytes that are already canonical.
                 let key_lower: Vec<u8> = key_bytes.iter().map(u8::to_ascii_lowercase).collect();
-                !keys_to_drop.iter().any(|k| compare_no_case(&key_lower, k))
+                !keys_to_drop
+                    .iter()
+                    .any(|k| k.as_slice() == key_lower.as_slice())
             } else {
                 true
             }
@@ -822,48 +858,32 @@ fn apply_request_rewrites_and_headers(
     // Every header we add (rewritten Host, X-Forwarded-Host,
     // operator-supplied set/append edits) must land before
     // `Block::Flags { end_header: true }` so the converter emits them
-    // as part of the request header block.
-    let end_header_idx = kawa.blocks.iter().position(|b| {
-        matches!(
-            b,
-            Block::Flags(kawa::Flags {
-                end_header: true,
-                ..
-            })
-        )
-    });
+    // as part of the request header block. Synthetic Host/X-Forwarded-Host
+    // are prepended (they describe the rewrite, not an operator policy).
+    let end_header_idx = super::shared::end_of_headers_index(kawa);
 
-    let mut to_insert: Vec<Block> = Vec::new();
-    if let Some(new_host) = rewritten_host {
-        to_insert.push(Block::Header(Pair {
-            key: Store::Static(b"Host"),
-            val: Store::from_string(new_host.to_owned()),
-        }));
+    if rewriting_host {
+        let mut synth: Vec<Block> = Vec::with_capacity(2);
+        if let Some(new_host) = rewritten_host {
+            synth.push(Block::Header(Pair {
+                key: Store::Static(b"Host"),
+                val: Store::from_string(new_host.to_owned()),
+            }));
+        }
         if let Some(orig) = original_authority.as_deref() {
-            to_insert.push(Block::Header(Pair {
+            synth.push(Block::Header(Pair {
                 key: Store::Static(b"X-Forwarded-Host"),
                 val: Store::from_string(orig.to_owned()),
             }));
         }
-    }
-    for edit in headers_request {
-        if edit.val.is_empty() {
-            continue;
-        }
-        to_insert.push(Block::Header(Pair {
-            key: Store::from_slice(&edit.key),
-            val: Store::from_slice(&edit.val),
-        }));
+        synth.append(&mut to_insert);
+        to_insert = synth;
     }
     if !to_insert.is_empty() {
         let insert_at = end_header_idx.unwrap_or(kawa.blocks.len());
         for (offset, block) in to_insert.into_iter().enumerate() {
             kawa.blocks.insert(insert_at + offset, block);
         }
-    }
-
-    if rewriting_host {
-        context.original_authority = original_authority;
     }
 }
 

--- a/lib/src/protocol/mux/shared.rs
+++ b/lib/src/protocol/mux/shared.rs
@@ -6,9 +6,12 @@
 //! load-bearing for TLS close_notify ordering (see agent memory
 //! `feedback_tls_write_symmetry`).
 
-use crate::socket::{SocketHandler, SocketResult};
+use crate::{
+    protocol::{http::editor::HeaderEditSnapshot, kawa_h1::parser::compare_no_case},
+    socket::{SocketHandler, SocketResult},
+};
 
-use super::Stream;
+use super::{GenericHttpStream, Stream};
 
 /// Decision returned by [`end_stream_decision`] for the server-side end-of-stream path.
 ///
@@ -90,4 +93,73 @@ pub(super) fn drain_tls_close_notify<S: SocketHandler>(
         }
     }
     (socket.socket_wants_write(), drain_rounds)
+}
+
+/// Apply per-frontend response-side header edits to a response kawa
+/// just before [`kawa::Kawa::prepare`] runs. Mirrors the request-side
+/// pass that `Router::route_from_request` runs against the front kawa
+/// at routing time:
+///
+/// - empty `val` → remove every existing header with the matching name
+///   from `kawa.blocks` (HAProxy `del-header` parity);
+/// - non-empty `val` → append the header before the `end_header` flag
+///   block.
+///
+/// Both H1 and H2 emission paths funnel through here so the on-wire
+/// header set stays consistent. Per-edit set/replace semantics are
+/// expressed as two entries: one with empty `val` (delete) followed by
+/// one with the new value (set).
+pub(super) fn apply_response_header_edits(
+    kawa: &mut GenericHttpStream,
+    edits: &[HeaderEditSnapshot],
+) {
+    use kawa::{Block, Pair, Store};
+
+    if edits.is_empty() {
+        return;
+    }
+
+    let keys_to_drop: Vec<Vec<u8>> = edits
+        .iter()
+        .filter(|e| e.val.is_empty())
+        .map(|e| e.key.iter().map(u8::to_ascii_lowercase).collect())
+        .collect();
+    if !keys_to_drop.is_empty() {
+        let buf = kawa.storage.buffer();
+        kawa.blocks.retain(|block| {
+            if let Block::Header(Pair { key, val: _ }) = block {
+                let key_lower: Vec<u8> = key.data(buf).iter().map(u8::to_ascii_lowercase).collect();
+                !keys_to_drop.iter().any(|k| compare_no_case(&key_lower, k))
+            } else {
+                true
+            }
+        });
+    }
+
+    let end_header_idx = kawa.blocks.iter().position(|b| {
+        matches!(
+            b,
+            Block::Flags(kawa::Flags {
+                end_header: true,
+                ..
+            })
+        )
+    });
+
+    let mut to_insert: Vec<Block> = Vec::new();
+    for edit in edits {
+        if edit.val.is_empty() {
+            continue;
+        }
+        to_insert.push(Block::Header(Pair {
+            key: Store::from_slice(&edit.key),
+            val: Store::from_slice(&edit.val),
+        }));
+    }
+    if !to_insert.is_empty() {
+        let insert_at = end_header_idx.unwrap_or(kawa.blocks.len());
+        for (offset, block) in to_insert.into_iter().enumerate() {
+            kawa.blocks.insert(insert_at + offset, block);
+        }
+    }
 }

--- a/lib/src/protocol/mux/shared.rs
+++ b/lib/src/protocol/mux/shared.rs
@@ -6,12 +6,14 @@
 //! load-bearing for TLS close_notify ordering (see agent memory
 //! `feedback_tls_write_symmetry`).
 
+use kawa::AsBuffer;
+
 use crate::{
-    protocol::{http::editor::HeaderEditSnapshot, kawa_h1::parser::compare_no_case},
+    protocol::http::editor::HeaderEditSnapshot,
     socket::{SocketHandler, SocketResult},
 };
 
-use super::{GenericHttpStream, Stream};
+use super::Stream;
 
 /// Decision returned by [`end_stream_decision`] for the server-side end-of-stream path.
 ///
@@ -109,8 +111,8 @@ pub(super) fn drain_tls_close_notify<S: SocketHandler>(
 /// header set stays consistent. Per-edit set/replace semantics are
 /// expressed as two entries: one with empty `val` (delete) followed by
 /// one with the new value (set).
-pub(super) fn apply_response_header_edits(
-    kawa: &mut GenericHttpStream,
+pub(super) fn apply_response_header_edits<T: AsBuffer>(
+    kawa: &mut kawa::Kawa<T>,
     edits: &[HeaderEditSnapshot],
 ) {
     use kawa::{Block, Pair, Store};
@@ -128,28 +130,31 @@ pub(super) fn apply_response_header_edits(
         let buf = kawa.storage.buffer();
         kawa.blocks.retain(|block| {
             if let Block::Header(Pair { key, val: _ }) = block {
-                // Skip elided headers — `key.data()` would panic on
-                // `Store::Empty` (kawa storage/repr.rs:515).
+                // Skip elided headers — kawa's earlier passes (HPACK
+                // decoder, H1 header parser) rewrite headers they want to
+                // suppress to `Pair { key: Store::Empty, val: Store::Empty }`
+                // rather than removing them in-place. Calling `.data()` on
+                // `Store::Empty` panics in `kawa-0.6.8/src/storage/repr.rs`
+                // (the impl unwraps a `None` slice). Pinning this guard
+                // explicitly until kawa changes its policy.
                 if matches!(key, Store::Empty) {
                     return true;
                 }
+                // Both `keys_to_drop` and `key_lower` are already
+                // ASCII-lowercased, so a byte-equality compare is enough;
+                // a second `compare_no_case` pass would just refold
+                // bytes that are already canonical.
                 let key_lower: Vec<u8> = key.data(buf).iter().map(u8::to_ascii_lowercase).collect();
-                !keys_to_drop.iter().any(|k| compare_no_case(&key_lower, k))
+                !keys_to_drop
+                    .iter()
+                    .any(|k| k.as_slice() == key_lower.as_slice())
             } else {
                 true
             }
         });
     }
 
-    let end_header_idx = kawa.blocks.iter().position(|b| {
-        matches!(
-            b,
-            Block::Flags(kawa::Flags {
-                end_header: true,
-                ..
-            })
-        )
-    });
+    let end_header_idx = end_of_headers_index(kawa);
 
     let mut to_insert: Vec<Block> = Vec::new();
     for edit in edits {
@@ -162,9 +167,223 @@ pub(super) fn apply_response_header_edits(
         }));
     }
     if !to_insert.is_empty() {
+        // Insert each edit one position deeper than the previous so we
+        // preserve operator order at the wire. `insert_at` points at the
+        // existing `Block::Flags { end_header: true }` (or
+        // `kawa.blocks.len()` when absent); each successive insert pushes
+        // that anchor right by one — the `+ offset` keeps the flag block
+        // (and any post-headers blocks) trailing the new entries even
+        // when elided headers sit between them.
         let insert_at = end_header_idx.unwrap_or(kawa.blocks.len());
         for (offset, block) in to_insert.into_iter().enumerate() {
             kawa.blocks.insert(insert_at + offset, block);
         }
+    }
+}
+
+/// Locate the `Block::Flags { end_header: true }` block in `kawa.blocks`.
+///
+/// Both the request-side rewrite helper (`mux::router`) and the
+/// response-side edit helper above use this anchor as the insertion
+/// point for new header blocks: anything after the end-of-headers flag
+/// is body / chunks / trailers and must NOT receive a Header block. A
+/// shared helper keeps the predicate canonical so a future change to
+/// `kawa::Flags` (e.g. adding fields) only needs touching once.
+pub(super) fn end_of_headers_index<T: AsBuffer>(kawa: &kawa::Kawa<T>) -> Option<usize> {
+    kawa.blocks.iter().position(|b| {
+        matches!(
+            b,
+            kawa::Block::Flags(kawa::Flags {
+                end_header: true,
+                ..
+            })
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::apply_response_header_edits;
+    use crate::protocol::http::editor::HeaderEditSnapshot;
+    use kawa::{
+        AsBuffer, Block, Buffer, Flags, Kawa, Kind, Pair, SliceBuffer, StatusLine, Store, Version,
+    };
+
+    fn make_kawa<'a>(buf: &'a mut [u8]) -> Kawa<SliceBuffer<'a>> {
+        Kawa::new(Kind::Response, Buffer::new(SliceBuffer(buf)))
+    }
+
+    fn pretty_blocks<T: AsBuffer>(kawa: &Kawa<T>) -> Vec<(Vec<u8>, Vec<u8>)> {
+        let buf = kawa.storage.buffer();
+        kawa.blocks
+            .iter()
+            .filter_map(|b| {
+                if let Block::Header(Pair { key, val }) = b {
+                    if matches!(key, Store::Empty) {
+                        Some((b"<elided>".to_vec(), b"".to_vec()))
+                    } else {
+                        Some((key.data(buf).to_vec(), val.data(buf).to_vec()))
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Insertion offset arithmetic: when the response already carries
+    /// elided headers (kawa marks suppressed headers as `Store::Empty`
+    /// instead of removing them), inserting two new headers must keep
+    /// them contiguous AND keep the `end_header` flag block trailing.
+    #[test]
+    fn test_response_edit_offsets_with_elided_headers() {
+        let mut buf = vec![0u8; 4096];
+        let mut kawa = make_kawa(&mut buf);
+        kawa.detached.status_line = StatusLine::Response {
+            version: Version::V11,
+            code: 200,
+            status: Store::Static(b"200"),
+            reason: Store::Static(b"OK"),
+        };
+        // Pre-populate with a real header, an elided header (suppressed
+        // by an earlier kawa pass), another real header, and finally the
+        // end-of-headers flag block.
+        kawa.blocks.push_back(Block::Header(Pair {
+            key: Store::Static(b"server"),
+            val: Store::Static(b"sozu"),
+        }));
+        kawa.blocks.push_back(Block::Header(Pair {
+            key: Store::Empty,
+            val: Store::Empty,
+        }));
+        kawa.blocks.push_back(Block::Header(Pair {
+            key: Store::Static(b"content-length"),
+            val: Store::Static(b"3"),
+        }));
+        kawa.blocks.push_back(Block::Flags(Flags {
+            end_body: false,
+            end_chunk: false,
+            end_header: true,
+            end_stream: false,
+        }));
+
+        apply_response_header_edits(
+            &mut kawa,
+            &[
+                HeaderEditSnapshot {
+                    key: b"x-frame-options".to_vec(),
+                    val: b"DENY".to_vec(),
+                },
+                HeaderEditSnapshot {
+                    key: b"x-content-type-options".to_vec(),
+                    val: b"nosniff".to_vec(),
+                },
+            ],
+        );
+
+        let names: Vec<Vec<u8>> = pretty_blocks(&kawa).into_iter().map(|(k, _)| k).collect();
+        assert_eq!(
+            names,
+            vec![
+                b"server".to_vec(),
+                b"<elided>".to_vec(),
+                b"content-length".to_vec(),
+                b"x-frame-options".to_vec(),
+                b"x-content-type-options".to_vec(),
+            ],
+            "new headers must land in order, between the last real header and the end-of-headers flag"
+        );
+
+        // The end-of-headers flag must still be the final block.
+        assert!(
+            matches!(
+                kawa.blocks.back(),
+                Some(Block::Flags(Flags {
+                    end_header: true,
+                    ..
+                }))
+            ),
+            "end_header flag must remain the last block"
+        );
+    }
+
+    /// Delete-by-name with elided headers around the target: the elided
+    /// blocks must survive the retain pass (their `key.data()` would
+    /// panic) and the targeted header must be dropped.
+    #[test]
+    fn test_response_edit_delete_skips_elided_blocks() {
+        let mut buf = vec![0u8; 4096];
+        let mut kawa = make_kawa(&mut buf);
+        kawa.blocks.push_back(Block::Header(Pair {
+            key: Store::Empty,
+            val: Store::Empty,
+        }));
+        kawa.blocks.push_back(Block::Header(Pair {
+            key: Store::Static(b"x-internal"),
+            val: Store::Static(b"secret"),
+        }));
+        kawa.blocks.push_back(Block::Header(Pair {
+            key: Store::Empty,
+            val: Store::Empty,
+        }));
+        kawa.blocks.push_back(Block::Flags(Flags {
+            end_body: false,
+            end_chunk: false,
+            end_header: true,
+            end_stream: false,
+        }));
+
+        apply_response_header_edits(
+            &mut kawa,
+            &[HeaderEditSnapshot {
+                key: b"X-Internal".to_vec(),
+                val: Vec::new(),
+            }],
+        );
+
+        let names: Vec<Vec<u8>> = pretty_blocks(&kawa).into_iter().map(|(k, _)| k).collect();
+        assert_eq!(
+            names,
+            vec![b"<elided>".to_vec(), b"<elided>".to_vec()],
+            "x-internal must be dropped; elided blocks must survive the retain pass"
+        );
+    }
+
+    /// Delete-then-set: the helper applies all deletes first, then
+    /// inserts the non-empty edits. Two edits with the same key
+    /// (one delete, one set) effectively replace the value.
+    #[test]
+    fn test_response_edit_delete_then_set_replaces() {
+        let mut buf = vec![0u8; 4096];
+        let mut kawa = make_kawa(&mut buf);
+        kawa.blocks.push_back(Block::Header(Pair {
+            key: Store::Static(b"cache-control"),
+            val: Store::Static(b"public"),
+        }));
+        kawa.blocks.push_back(Block::Flags(Flags {
+            end_body: false,
+            end_chunk: false,
+            end_header: true,
+            end_stream: false,
+        }));
+
+        apply_response_header_edits(
+            &mut kawa,
+            &[
+                HeaderEditSnapshot {
+                    key: b"Cache-Control".to_vec(),
+                    val: Vec::new(),
+                },
+                HeaderEditSnapshot {
+                    key: b"Cache-Control".to_vec(),
+                    val: b"no-store".to_vec(),
+                },
+            ],
+        );
+
+        let pairs = pretty_blocks(&kawa);
+        assert_eq!(pairs.len(), 1, "only the replacement header must remain");
+        assert_eq!(pairs[0].0, b"Cache-Control");
+        assert_eq!(pairs[0].1, b"no-store");
     }
 }

--- a/lib/src/protocol/mux/shared.rs
+++ b/lib/src/protocol/mux/shared.rs
@@ -128,6 +128,11 @@ pub(super) fn apply_response_header_edits(
         let buf = kawa.storage.buffer();
         kawa.blocks.retain(|block| {
             if let Block::Header(Pair { key, val: _ }) = block {
+                // Skip elided headers — `key.data()` would panic on
+                // `Store::Empty` (kawa storage/repr.rs:515).
+                if matches!(key, Store::Empty) {
+                    return true;
+                }
                 let key_lower: Vec<u8> = key.data(buf).iter().map(u8::to_ascii_lowercase).collect();
                 !keys_to_drop.iter().any(|k| compare_no_case(&key_lower, k))
             } else {

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -1,15 +1,40 @@
 pub mod pattern_trie;
 
-use std::{str::from_utf8, time::Instant};
+use std::{
+    fmt::{self, Debug, Write},
+    rc::Rc,
+    str::from_utf8,
+    time::Instant,
+};
 
 use regex::bytes::Regex;
 use sozu_command::{
-    proto::command::{PathRule as CommandPathRule, PathRuleKind, RulePosition},
+    logging::CachedTags,
+    proto::command::{
+        HeaderPosition, PathRule as CommandPathRule, PathRuleKind, RedirectPolicy, RedirectScheme,
+        RulePosition,
+    },
     response::HttpFrontend,
     state::ClusterId,
 };
 
-use crate::{protocol::http::parser::Method, router::pattern_trie::TrieNode};
+use crate::{
+    protocol::http::parser::Method,
+    router::pattern_trie::{TrieMatches, TrieNode, TrieSubMatch},
+    sozu_command::logging::ansi_palette,
+};
+
+/// Module-level prefix tag for `lib/src/router/`. Honours the runtime
+/// colored-output flag via [`ansi_palette`]; consumed by every `warn!` /
+/// `error!` site below so static log-layout regression checks (see
+/// `lib/tests/log_layout.rs`) keep router log lines on the canonical
+/// `[ROUTER] >>>` envelope.
+macro_rules! log_module_context {
+    () => {{
+        let (open, reset, _, _, _) = ansi_palette();
+        format!("{open}ROUTER{reset}\t >>>", open = open, reset = reset)
+    }};
+}
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum RouterError {
@@ -17,6 +42,10 @@ pub enum RouterError {
     InvalidPathRule(String),
     #[error("parsing hostname {hostname} failed")]
     InvalidDomain { hostname: String },
+    #[error("Could not parse host rewrite {0:?}")]
+    InvalidHostRewrite(String),
+    #[error("Could not parse path rewrite {0:?}")]
+    InvalidPathRewrite(String),
     #[error("Could not add route {0}")]
     AddRoute(String),
     #[error("Could not remove route {0}")]
@@ -50,35 +79,60 @@ impl Router {
         }
     }
 
+    /// Resolve a request to a [`RouteResult`].
+    ///
+    /// Looks up `(hostname, path, method)` against the pre, tree, and post
+    /// rule lists. The matched [`Route`] is converted into a [`RouteResult`]:
+    /// legacy variants ([`Route::ClusterId`], [`Route::Deny`]) synthesize a
+    /// minimal `RouteResult` so existing call sites keep working, while
+    /// [`Route::Frontend`] runs the full Frontend → RouteResult pipeline,
+    /// substituting host/path captures into [`RewriteParts`] templates.
     pub fn lookup(
         &self,
         hostname: &str,
         path: &str,
         method: &Method,
-    ) -> Result<Route, RouterError> {
+    ) -> Result<RouteResult, RouterError> {
         let hostname_b = hostname.as_bytes();
         let path_b = path.as_bytes();
-        for (domain_rule, path_rule, method_rule, cluster_id) in &self.pre {
+        for (domain_rule, path_rule, method_rule, route) in &self.pre {
             if domain_rule.matches(hostname_b)
                 && path_rule.matches(path_b) != PathRuleResult::None
                 && method_rule.matches(method) != MethodRuleResult::None
             {
-                return Ok(cluster_id.clone());
+                return Ok(RouteResult::new_no_trie(
+                    hostname_b,
+                    domain_rule,
+                    path_b,
+                    path_rule,
+                    route,
+                ));
             }
         }
 
-        if let Some((_, path_rules)) = self.tree.lookup(hostname_b, true) {
+        let trie_path: TrieMatches<'_, '_> = Vec::with_capacity(16);
+        if let Some(((_, path_rules), trie_matches)) =
+            self.tree.lookup_with_path(hostname_b, true, trie_path)
+        {
             let mut prefix_length = 0;
-            let mut route = None;
+            let mut matched: Option<(&PathRule, &Route)> = None;
 
-            for (rule, method_rule, cluster_id) in path_rules {
+            for (rule, method_rule, route) in path_rules {
                 match rule.matches(path_b) {
                     PathRuleResult::Regex | PathRuleResult::Equals => {
                         match method_rule.matches(method) {
-                            MethodRuleResult::Equals => return Ok(cluster_id.clone()),
+                            MethodRuleResult::Equals => {
+                                return Ok(RouteResult::new_with_trie(
+                                    hostname_b,
+                                    trie_matches,
+                                    path_b,
+                                    rule,
+                                    route,
+                                ));
+                            }
                             MethodRuleResult::All => {
                                 prefix_length = path_b.len();
-                                route = Some(cluster_id);
+                                matched = Some((rule, route));
                             }
                             MethodRuleResult::None => {}
                         }
@@ -89,11 +143,11 @@ impl Router {
                                 // FIXME: the rule order will be important here
                                 MethodRuleResult::Equals => {
                                     prefix_length = size;
-                                    route = Some(cluster_id);
+                                    matched = Some((rule, route));
                                 }
                                 MethodRuleResult::All => {
                                     prefix_length = size;
-                                    route = Some(cluster_id);
+                                    matched = Some((rule, route));
                                 }
                                 MethodRuleResult::None => {}
                             }
@@ -103,17 +157,29 @@ impl Router {
                 }
             }
 
-            if let Some(cluster_id) = route {
-                return Ok(cluster_id.clone());
+            if let Some((path_rule, route)) = matched {
+                return Ok(RouteResult::new_with_trie(
+                    hostname_b,
+                    trie_matches,
+                    path_b,
+                    path_rule,
+                    route,
+                ));
             }
         }
 
-        for (domain_rule, path_rule, method_rule, cluster_id) in self.post.iter() {
+        for (domain_rule, path_rule, method_rule, route) in self.post.iter() {
             if domain_rule.matches(hostname_b)
                 && path_rule.matches(path_b) != PathRuleResult::None
                 && method_rule.matches(method) != MethodRuleResult::None
             {
-                return Ok(cluster_id.clone());
+                return Ok(RouteResult::new_no_trie(
+                    hostname_b,
+                    domain_rule,
+                    path_b,
+                    path_rule,
+                    route,
+                ));
             }
         }
 
@@ -622,13 +688,679 @@ impl MethodRule {
     }
 }
 
-/// The cluster to which the traffic will be redirected
+/// What to do with a request that matches a frontend.
+///
+/// Three variants coexist during the Wave 2b → Wave 1c transition:
+///
+/// - [`Route::ClusterId`] is the legacy "forward to this cluster" variant
+///   used by call sites that build routes directly from
+///   [`HttpFrontend::cluster_id`].
+/// - [`Route::Deny`] is the legacy "send 401" variant used when a frontend
+///   has no `cluster_id`.
+/// - [`Route::Frontend`] carries a richer [`Frontend`] decision (redirect
+///   policy, rewrite templates, header edits, auth gating). Wave 1c will
+///   migrate `add_http_front` to build `Route::Frontend` once
+///   `HttpFrontend` carries the matching proto fields.
+///
+/// `Eq`/`PartialEq` compare `Frontend` variants by `Rc` pointer identity to
+/// stay consistent with `Hash`/`Ord` on [`Rc`]; this is sufficient for the
+/// router's de-duplication (`add_pre_rule`, `add_post_rule`,
+/// `add_tree_rule`) which only checks against routes created from the same
+/// configuration call.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Route {
     /// send a 401 default answer
     Deny,
     /// the cluster to which the frontend belongs
     ClusterId(ClusterId),
+    /// rich routing decision carrying redirect, rewrite, header, and auth
+    /// configuration; supersedes the legacy variants once Wave 1c migrates
+    /// the in-memory frontend wiring.
+    Frontend(Rc<Frontend>),
+}
+
+/// A single header mutation collected from a [`Frontend`] configuration.
+///
+/// `key` and `val` are owned via [`Rc`] so a `Frontend` can be held by many
+/// routing entries (pre, tree, post) without copying the underlying bytes.
+/// An empty `val` deletes the header by name (HAProxy `del-header` parity).
+#[derive(Clone, PartialEq, Eq)]
+pub struct HeaderEdit {
+    pub key: Rc<[u8]>,
+    pub val: Rc<[u8]>,
+}
+
+impl Debug for HeaderEdit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!(
+            "({:?}, {:?})",
+            String::from_utf8_lossy(&self.key),
+            String::from_utf8_lossy(&self.val)
+        ))
+    }
+}
+
+/// A parsed segment of a rewrite template.
+///
+/// `Host(i)` references the `i`-th host capture: index 0 is the full
+/// hostname; positive indices are regex or wildcard subgroups. `Path(i)`
+/// references the `i`-th path capture: index 0 is the full path; positive
+/// indices are regex groups or prefix tails. `String` holds a literal
+/// segment between captures.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RewritePart {
+    String(String),
+    Host(usize),
+    Path(usize),
+}
+
+impl RewritePart {
+    fn bytes(b: &[u8]) -> Self {
+        Self::String(from_utf8(b).unwrap_or_default().to_owned())
+    }
+}
+
+/// A pre-parsed rewrite template, decomposed into [`RewritePart`]s.
+///
+/// `RewriteParts` is built once at frontend registration time
+/// ([`Frontend::new`]) and then re-applied at lookup time via
+/// [`RewriteParts::run`] against the captures collected by the router.
+///
+/// Grammar:
+/// - `$HOST[N]` — substitute the N-th host capture
+/// - `$PATH[N]` — substitute the N-th path capture
+/// - any other byte sequence — substitute literally
+///
+/// Out-of-bounds capture indices substitute to the empty string at run
+/// time, but [`RewriteParts::parse`] rejects templates that reference
+/// capture indices the router cannot produce (the `*_cap_cap` arguments).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RewriteParts(Vec<RewritePart>);
+
+impl RewriteParts {
+    /// Parse `template` against the host/path capture caps the router can
+    /// produce for the matching domain/path rule.
+    ///
+    /// `host_cap_cap` and `path_cap_cap` are upper bounds (exclusive) on the
+    /// host and path capture indices the router can fill at lookup time.
+    /// `used_index_host` / `used_index_path` are out parameters tracking the
+    /// highest index actually referenced — callers use them to short-circuit
+    /// capture extraction when no template references captures.
+    ///
+    /// Returns `None` on syntactically malformed templates: dangling `$`,
+    /// missing closing `]`, non-digit index, or an index ≥ the cap.
+    pub fn parse(
+        template: &str,
+        host_cap_cap: usize,
+        path_cap_cap: usize,
+        used_index_host: &mut usize,
+        used_index_path: &mut usize,
+    ) -> Option<Self> {
+        let mut result = Vec::new();
+        let mut i = 0;
+        let pattern = template.as_bytes();
+        while i < pattern.len() {
+            if pattern[i] == b'$' {
+                let is_host = if pattern[i..].starts_with(b"$HOST[") {
+                    i += 6;
+                    true
+                } else if pattern[i..].starts_with(b"$PATH[") {
+                    i += 6;
+                    false
+                } else {
+                    return None;
+                };
+                let mut index = 0usize;
+                let digits_start = i;
+                while i < pattern.len() && pattern[i].is_ascii_digit() {
+                    index = index
+                        .checked_mul(10)?
+                        .checked_add((pattern[i] - b'0') as usize)?;
+                    i += 1;
+                }
+                if i == digits_start {
+                    // no digits between the `[` and the `]`
+                    return None;
+                }
+                if i >= pattern.len() || pattern[i] != b']' {
+                    return None;
+                }
+                if is_host {
+                    if index >= host_cap_cap {
+                        return None;
+                    }
+                    if index >= *used_index_host {
+                        *used_index_host = index + 1;
+                    }
+                    result.push(RewritePart::Host(index));
+                } else {
+                    if index >= path_cap_cap {
+                        return None;
+                    }
+                    if index >= *used_index_path {
+                        *used_index_path = index + 1;
+                    }
+                    result.push(RewritePart::Path(index));
+                }
+                i += 1; // consume `]`
+            } else {
+                let start = i;
+                while i < pattern.len() && pattern[i] != b'$' {
+                    i += 1;
+                }
+                result.push(RewritePart::bytes(&pattern[start..i]));
+            }
+        }
+        Some(Self(result))
+    }
+
+    /// Substitute `host_captures` and `path_captures` into the template.
+    ///
+    /// Out-of-bounds captures substitute to an empty string. The result is
+    /// allocated in one pass with the exact required capacity.
+    pub fn run(&self, host_captures: &[&str], path_captures: &[&str]) -> String {
+        let mut cap = 0usize;
+        for part in &self.0 {
+            cap += match part {
+                RewritePart::String(s) => s.len(),
+                RewritePart::Host(i) => host_captures.get(*i).map(|s| s.len()).unwrap_or(0),
+                RewritePart::Path(i) => path_captures.get(*i).map(|s| s.len()).unwrap_or(0),
+            };
+        }
+        let mut result = String::with_capacity(cap);
+        for part in &self.0 {
+            // String::write_str cannot fail — ignore the formatter result.
+            let _ = match part {
+                RewritePart::String(s) => result.write_str(s),
+                RewritePart::Host(i) => result.write_str(host_captures.get(*i).unwrap_or(&"")),
+                RewritePart::Path(i) => result.write_str(path_captures.get(*i).unwrap_or(&"")),
+            };
+        }
+        result
+    }
+}
+
+/// What to do with the traffic for a routed frontend.
+///
+/// Built once at frontend registration time. The expensive work (parsing
+/// rewrite templates, resolving headers into [`HeaderEdit`]s) happens here
+/// so [`Router::lookup`] can run cheaply on the hot path.
+///
+/// A clusterless frontend with `redirect == FORWARD` is coerced to
+/// `UNAUTHORIZED` in [`Frontend::new`] to avoid a forward loop with no
+/// backend; the explicit `UNAUTHORIZED` policy then renders a 401.
+///
+/// Tags are wrapped in [`Rc<CachedTags>`] so the same frontend can be
+/// referenced from multiple routing slots (pre/tree/post) without copying.
+#[derive(Debug, Clone)]
+pub struct Frontend {
+    pub cluster_id: Option<ClusterId>,
+    pub redirect: RedirectPolicy,
+    pub redirect_scheme: RedirectScheme,
+    pub redirect_template: Option<String>,
+    /// Number of host captures the router will collect for this frontend.
+    /// Sized from the matching [`DomainRule`]; the router skips capture
+    /// extraction entirely when this is 0 (no rewrite references `$HOST[…]`).
+    pub capture_cap_host: usize,
+    /// Number of path captures the router will collect for this frontend.
+    /// Sized from the matching [`PathRule`]; the router skips capture
+    /// extraction entirely when this is 0 (no rewrite references `$PATH[…]`).
+    pub capture_cap_path: usize,
+    pub rewrite_host: Option<RewriteParts>,
+    pub rewrite_path: Option<RewriteParts>,
+    pub rewrite_port: Option<u16>,
+    pub headers_request: Rc<[HeaderEdit]>,
+    pub headers_response: Rc<[HeaderEdit]>,
+    pub required_auth: bool,
+    pub tags: Option<Rc<CachedTags>>,
+}
+
+impl PartialEq for Frontend {
+    fn eq(&self, other: &Self) -> bool {
+        // Frontend instances share the rest of their fields with the
+        // originating HttpFrontend; equality is decided by the same fields
+        // the router uses for de-duplication.
+        self.cluster_id == other.cluster_id
+            && self.redirect == other.redirect
+            && self.redirect_scheme == other.redirect_scheme
+            && self.redirect_template == other.redirect_template
+            && self.rewrite_host == other.rewrite_host
+            && self.rewrite_path == other.rewrite_path
+            && self.rewrite_port == other.rewrite_port
+            && self.headers_request == other.headers_request
+            && self.headers_response == other.headers_response
+            && self.required_auth == other.required_auth
+    }
+}
+
+impl Eq for Frontend {}
+
+impl std::hash::Hash for Frontend {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.cluster_id.hash(state);
+        // RedirectPolicy / RedirectScheme are i32-backed proto enums; hash
+        // them as i32 to avoid requiring a Hash impl on the generated enum.
+        (self.redirect as i32).hash(state);
+        (self.redirect_scheme as i32).hash(state);
+        self.redirect_template.hash(state);
+        self.required_auth.hash(state);
+    }
+}
+
+impl PartialOrd for Frontend {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Frontend {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.cluster_id
+            .cmp(&other.cluster_id)
+            .then_with(|| (self.redirect as i32).cmp(&(other.redirect as i32)))
+            .then_with(|| (self.redirect_scheme as i32).cmp(&(other.redirect_scheme as i32)))
+            .then_with(|| self.redirect_template.cmp(&other.redirect_template))
+            .then_with(|| self.required_auth.cmp(&other.required_auth))
+    }
+}
+
+impl Frontend {
+    /// Build a [`Frontend`] from a domain/path rule pair and an
+    /// [`HttpFrontend`] configuration.
+    ///
+    /// The richer proto-level fields (`redirect`, `redirect_scheme`,
+    /// `redirect_template`, `rewrite_*`, `headers`, `required_auth`) will
+    /// arrive via Wave 1c; until they do, this constructor takes them as
+    /// explicit arguments so the data flow is testable today and the call
+    /// sites in `add_http_front` only need a one-line update once Wave 1c
+    /// plumbs the fields through `HttpFrontend`.
+    ///
+    /// Coercions:
+    /// - `redirect == UNAUTHORIZED` zeroes out rewrite/headers/auth — the
+    ///   request will be rejected with a 401 regardless.
+    /// - `redirect == FORWARD` on a clusterless frontend (`cluster_id ==
+    ///   None`) is coerced to `UNAUTHORIZED` (logged as a warning) to
+    ///   avoid a forward loop with no backend.
+    ///
+    /// Returns [`RouterError::InvalidHostRewrite`] /
+    /// [`RouterError::InvalidPathRewrite`] when a rewrite template fails to
+    /// parse against the rule's capture caps.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        domain_rule: &DomainRule,
+        path_rule: &PathRule,
+        front: &HttpFrontend,
+        redirect: RedirectPolicy,
+        redirect_scheme: RedirectScheme,
+        redirect_template: Option<String>,
+        rewrite_host: Option<String>,
+        rewrite_path: Option<String>,
+        rewrite_port: Option<u16>,
+        headers: &[sozu_command::proto::command::Header],
+        required_auth: bool,
+    ) -> Result<Self, RouterError> {
+        let cluster_id = front.cluster_id.clone();
+        let tags = front
+            .tags
+            .clone()
+            .map(|tags| Rc::new(CachedTags::new(tags)));
+
+        // Coerce clusterless FORWARD to UNAUTHORIZED before doing any
+        // expensive parsing: those routes can never proceed to a backend, so
+        // emitting a 401 is the safe default. Empty redirect_template is
+        // treated as None semantics so we never store an empty Rc<[…]>.
+        let redirect_template = redirect_template.filter(|s| !s.is_empty());
+        let rewrite_host = rewrite_host.filter(|s| !s.is_empty());
+        let rewrite_path = rewrite_path.filter(|s| !s.is_empty());
+
+        let deny = match (&cluster_id, redirect) {
+            (_, RedirectPolicy::Unauthorized) => true,
+            (None, RedirectPolicy::Forward) => {
+                warn!(
+                    "{} Frontend[domain: {:?}, path: {:?}]: forward on clusterless frontends are unauthorized",
+                    log_module_context!(),
+                    domain_rule,
+                    path_rule,
+                );
+                true
+            }
+            _ => false,
+        };
+        if deny {
+            return Ok(Self {
+                cluster_id,
+                redirect: RedirectPolicy::Unauthorized,
+                redirect_scheme,
+                redirect_template: None,
+                capture_cap_host: 0,
+                capture_cap_path: 0,
+                rewrite_host: None,
+                rewrite_path: None,
+                rewrite_port: None,
+                headers_request: Rc::new([]),
+                headers_response: Rc::new([]),
+                required_auth,
+                tags,
+            });
+        }
+
+        // Capture caps: the maximum index a `$HOST[N]` / `$PATH[N]`
+        // template can reference for this rule pair. Index 0 is always the
+        // full hostname/path; subsequent indices are wildcard tail / regex
+        // groups.
+        let mut capture_cap_host = match domain_rule {
+            DomainRule::Any => 1,
+            DomainRule::Exact(_) => 1,
+            DomainRule::Wildcard(_) => 2,
+            DomainRule::Regex(regex) => regex.captures_len(),
+        };
+        let mut capture_cap_path = match path_rule {
+            PathRule::Equals(_) => 1,
+            PathRule::Prefix(_) => 2,
+            PathRule::Regex(regex) => regex.captures_len(),
+        };
+        let mut used_capture_host = 0usize;
+        let mut used_capture_path = 0usize;
+        let rewrite_host_parts = if let Some(p) = rewrite_host {
+            Some(
+                RewriteParts::parse(
+                    &p,
+                    capture_cap_host,
+                    capture_cap_path,
+                    &mut used_capture_host,
+                    &mut used_capture_path,
+                )
+                .ok_or(RouterError::InvalidHostRewrite(p))?,
+            )
+        } else {
+            None
+        };
+        let rewrite_path_parts = if let Some(p) = rewrite_path {
+            Some(
+                RewriteParts::parse(
+                    &p,
+                    capture_cap_host,
+                    capture_cap_path,
+                    &mut used_capture_host,
+                    &mut used_capture_path,
+                )
+                .ok_or(RouterError::InvalidPathRewrite(p))?,
+            )
+        } else {
+            None
+        };
+        // Skip capture extraction at lookup time when no template references
+        // a capture for this dimension.
+        if used_capture_host == 0 {
+            capture_cap_host = 0;
+        }
+        if used_capture_path == 0 {
+            capture_cap_path = 0;
+        }
+
+        let mut headers_request = Vec::new();
+        let mut headers_response = Vec::new();
+        for header in headers {
+            let edit = HeaderEdit {
+                key: header.key.as_bytes().into(),
+                val: header.val.as_bytes().into(),
+            };
+            match header.position() {
+                HeaderPosition::Request => headers_request.push(edit),
+                HeaderPosition::Response => headers_response.push(edit),
+                HeaderPosition::Both => {
+                    headers_request.push(edit.clone());
+                    headers_response.push(edit);
+                }
+            }
+        }
+
+        Ok(Frontend {
+            cluster_id,
+            redirect,
+            redirect_scheme,
+            redirect_template,
+            capture_cap_host,
+            capture_cap_path,
+            rewrite_host: rewrite_host_parts,
+            rewrite_path: rewrite_path_parts,
+            rewrite_port,
+            headers_request: headers_request.into(),
+            headers_response: headers_response.into(),
+            required_auth,
+            tags,
+        })
+    }
+
+    /// Test-only constructor: build a Frontend that simply forwards to
+    /// `cluster_id`, with no rewrite/header/auth configuration.
+    #[cfg(test)]
+    pub fn forward(cluster_id: ClusterId) -> Self {
+        Self {
+            cluster_id: Some(cluster_id),
+            redirect: RedirectPolicy::Forward,
+            redirect_scheme: RedirectScheme::UseSame,
+            redirect_template: None,
+            capture_cap_host: 0,
+            capture_cap_path: 0,
+            rewrite_host: None,
+            rewrite_path: None,
+            rewrite_port: None,
+            headers_request: Rc::new([]),
+            headers_response: Rc::new([]),
+            required_auth: false,
+            tags: None,
+        }
+    }
+}
+
+/// Routing decision returned by [`Router::lookup`] and consumed by the
+/// session layer.
+///
+/// Computed from a matched [`Frontend`] by running [`RewriteParts::run`]
+/// against the captures collected during routing. Legacy [`Route::ClusterId`]
+/// and [`Route::Deny`] entries synthesize a minimal `RouteResult` with the
+/// proto enums set to defaults (`FORWARD` / `UNAUTHORIZED`) so existing
+/// session code keeps working until Wave 3a wires the rich fields into the
+/// mux layer.
+///
+/// Implements `PartialEq` for test parity: existing router tests compare
+/// `router.lookup(...)` against an expected route. Equality compares every
+/// public field, including the `Rc<[HeaderEdit]>` slices via pointer-or-content
+/// equality on the slice contents.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RouteResult {
+    pub cluster_id: Option<ClusterId>,
+    pub redirect: RedirectPolicy,
+    pub redirect_scheme: RedirectScheme,
+    pub redirect_template: Option<String>,
+    pub rewritten_host: Option<String>,
+    pub rewritten_path: Option<String>,
+    pub rewritten_port: Option<u16>,
+    pub headers_request: Rc<[HeaderEdit]>,
+    pub headers_response: Rc<[HeaderEdit]>,
+    pub required_auth: bool,
+    pub tags: Option<Rc<CachedTags>>,
+}
+
+impl RouteResult {
+    /// Synthesize a `RouteResult` representing a 401 (Deny) decision.
+    pub fn deny(cluster_id: Option<ClusterId>) -> Self {
+        Self {
+            cluster_id,
+            redirect: RedirectPolicy::Unauthorized,
+            redirect_scheme: RedirectScheme::UseSame,
+            redirect_template: None,
+            rewritten_host: None,
+            rewritten_path: None,
+            rewritten_port: None,
+            headers_request: Rc::new([]),
+            headers_response: Rc::new([]),
+            required_auth: false,
+            tags: None,
+        }
+    }
+
+    /// Synthesize a `RouteResult` representing a "forward to this cluster"
+    /// decision (legacy [`Route::ClusterId`] adapter).
+    pub fn forward(cluster_id: ClusterId) -> Self {
+        Self {
+            cluster_id: Some(cluster_id),
+            redirect: RedirectPolicy::Forward,
+            redirect_scheme: RedirectScheme::UseSame,
+            redirect_template: None,
+            rewritten_host: None,
+            rewritten_path: None,
+            rewritten_port: None,
+            headers_request: Rc::new([]),
+            headers_response: Rc::new([]),
+            required_auth: false,
+            tags: None,
+        }
+    }
+
+    /// Build a `RouteResult` from a [`Frontend`] and the captures collected
+    /// for this lookup.
+    fn from_frontend(
+        frontend: &Frontend,
+        captures_host: Vec<&str>,
+        path: &[u8],
+        path_rule: &PathRule,
+    ) -> Self {
+        // Unauthorized short-circuit: skip the path-capture extraction
+        // entirely — the response will not consume any rewrite output.
+        if frontend.redirect == RedirectPolicy::Unauthorized {
+            return Self {
+                cluster_id: frontend.cluster_id.clone(),
+                redirect: RedirectPolicy::Unauthorized,
+                redirect_scheme: frontend.redirect_scheme,
+                redirect_template: frontend.redirect_template.clone(),
+                rewritten_host: None,
+                rewritten_path: None,
+                rewritten_port: None,
+                headers_request: Rc::new([]),
+                headers_response: Rc::new([]),
+                required_auth: frontend.required_auth,
+                tags: frontend.tags.clone(),
+            };
+        }
+
+        let mut captures_path: Vec<&str> = Vec::with_capacity(frontend.capture_cap_path);
+        if frontend.capture_cap_path > 0 {
+            captures_path.push(from_utf8(path).unwrap_or_default());
+            match path_rule {
+                PathRule::Prefix(prefix) => {
+                    let tail_start = prefix.len().min(path.len());
+                    captures_path.push(from_utf8(&path[tail_start..]).unwrap_or_default());
+                }
+                PathRule::Regex(regex) => {
+                    if let Some(caps) = regex.captures(path) {
+                        captures_path.extend(caps.iter().skip(1).map(|c| {
+                            c.map(|m| from_utf8(m.as_bytes()).unwrap_or_default())
+                                .unwrap_or("")
+                        }));
+                    }
+                }
+                PathRule::Equals(_) => {}
+            }
+        }
+
+        Self {
+            cluster_id: frontend.cluster_id.clone(),
+            redirect: frontend.redirect,
+            redirect_scheme: frontend.redirect_scheme,
+            redirect_template: frontend.redirect_template.clone(),
+            rewritten_host: frontend
+                .rewrite_host
+                .as_ref()
+                .map(|rewrite| rewrite.run(&captures_host, &captures_path)),
+            rewritten_path: frontend
+                .rewrite_path
+                .as_ref()
+                .map(|rewrite| rewrite.run(&captures_host, &captures_path)),
+            rewritten_port: frontend.rewrite_port,
+            headers_request: frontend.headers_request.clone(),
+            headers_response: frontend.headers_response.clone(),
+            required_auth: frontend.required_auth,
+            tags: frontend.tags.clone(),
+        }
+    }
+
+    /// Build a `RouteResult` for a pre/post rule match.
+    ///
+    /// Pre/post rules carry the matched [`DomainRule`] directly so we can
+    /// extract host captures from it without going through the trie.
+    fn new_no_trie<'a>(
+        domain: &'a [u8],
+        domain_rule: &DomainRule,
+        path: &'a [u8],
+        path_rule: &PathRule,
+        route: &Route,
+    ) -> Self {
+        let frontend = match route {
+            Route::Frontend(f) => f.clone(),
+            Route::ClusterId(id) => return Self::forward(id.clone()),
+            Route::Deny => return Self::deny(None),
+        };
+        let mut captures_host: Vec<&str> = Vec::with_capacity(frontend.capture_cap_host);
+        if frontend.capture_cap_host > 0 {
+            captures_host.push(from_utf8(domain).unwrap_or_default());
+            match domain_rule {
+                DomainRule::Wildcard(suffix) => {
+                    let head_end = domain.len().saturating_sub(suffix.len().saturating_sub(1));
+                    captures_host.push(from_utf8(&domain[..head_end]).unwrap_or_default());
+                }
+                DomainRule::Regex(regex) => {
+                    if let Some(caps) = regex.captures(domain) {
+                        captures_host.extend(caps.iter().skip(1).map(|c| {
+                            c.map(|m| from_utf8(m.as_bytes()).unwrap_or_default())
+                                .unwrap_or("")
+                        }));
+                    }
+                }
+                DomainRule::Any | DomainRule::Exact(_) => {}
+            }
+        }
+        Self::from_frontend(&frontend, captures_host, path, path_rule)
+    }
+
+    /// Build a `RouteResult` for a tree-match.
+    ///
+    /// Tree matches carry the captures collected by the trie traversal
+    /// (`TrieMatches`) alongside the matched leaf path rule.
+    fn new_with_trie<'a, 'b>(
+        domain: &'a [u8],
+        domain_submatches: TrieMatches<'a, 'b>,
+        path: &'a [u8],
+        path_rule: &PathRule,
+        route: &Route,
+    ) -> Self {
+        let frontend = match route {
+            Route::Frontend(f) => f.clone(),
+            Route::ClusterId(id) => return Self::forward(id.clone()),
+            Route::Deny => return Self::deny(None),
+        };
+        let mut captures_host: Vec<&str> = Vec::with_capacity(frontend.capture_cap_host);
+        if frontend.capture_cap_host > 0 {
+            captures_host.push(from_utf8(domain).unwrap_or_default());
+            for submatch in &domain_submatches {
+                match submatch {
+                    TrieSubMatch::Wildcard(part) => {
+                        captures_host.push(from_utf8(part).unwrap_or_default());
+                    }
+                    TrieSubMatch::Regexp(part, regex) => {
+                        if let Some(caps) = regex.captures(part) {
+                            captures_host.extend(caps.iter().skip(1).map(|c| {
+                                c.map(|m| from_utf8(m.as_bytes()).unwrap_or_default())
+                                    .unwrap_or("")
+                            }));
+                        }
+                    }
+                }
+            }
+        }
+        Self::from_frontend(&frontend, captures_host, path, path_rule)
+    }
 }
 
 #[cfg(test)]
@@ -760,7 +1492,7 @@ mod tests {
         println!("{:#?}", router.tree);
         assert_eq!(
             router.lookup("www.sozu.io", "/api", &Method::Get),
-            Ok(Route::ClusterId("base".to_string()))
+            Ok(RouteResult::forward("base".to_string()))
         );
         assert!(router.add_tree_rule(
             b"*.sozu.io",
@@ -771,11 +1503,11 @@ mod tests {
         println!("{:#?}", router.tree);
         assert_eq!(
             router.lookup("www.sozu.io", "/ap", &Method::Get),
-            Ok(Route::ClusterId("base".to_string()))
+            Ok(RouteResult::forward("base".to_string()))
         );
         assert_eq!(
             router.lookup("www.sozu.io", "/api", &Method::Get),
-            Ok(Route::ClusterId("api".to_string()))
+            Ok(RouteResult::forward("api".to_string()))
         );
     }
 
@@ -799,7 +1531,7 @@ mod tests {
         println!("{:#?}", router.tree);
         assert_eq!(
             router.lookup("www.sozu.io", "/api", &Method::Get),
-            Ok(Route::ClusterId("base".to_string()))
+            Ok(RouteResult::forward("base".to_string()))
         );
         assert!(router.add_tree_rule(
             b"api.sozu.io",
@@ -810,11 +1542,11 @@ mod tests {
         println!("{:#?}", router.tree);
         assert_eq!(
             router.lookup("www.sozu.io", "/api", &Method::Get),
-            Ok(Route::ClusterId("base".to_string()))
+            Ok(RouteResult::forward("base".to_string()))
         );
         assert_eq!(
             router.lookup("api.sozu.io", "/api", &Method::Get),
-            Ok(Route::ClusterId("api".to_string()))
+            Ok(RouteResult::forward("api".to_string()))
         );
     }
 
@@ -838,11 +1570,11 @@ mod tests {
         println!("{:#?}", router.tree);
         assert_eq!(
             router.lookup("www.sozu.io", "/", &Method::Get),
-            Ok(Route::ClusterId("base".to_string()))
+            Ok(RouteResult::forward("base".to_string()))
         );
         assert_eq!(
             router.lookup("www.doc.sozu.io", "/", &Method::Get),
-            Ok(Route::ClusterId("doc".to_string()))
+            Ok(RouteResult::forward("doc".to_string()))
         );
         assert!(router.remove_tree_rule(
             b"www./.*/.io",
@@ -853,7 +1585,7 @@ mod tests {
         assert!(router.lookup("www.sozu.io", "/", &Method::Get).is_err());
         assert_eq!(
             router.lookup("www.doc.sozu.io", "/", &Method::Get),
-            Ok(Route::ClusterId("doc".to_string()))
+            Ok(RouteResult::forward("doc".to_string()))
         );
     }
 
@@ -888,7 +1620,7 @@ mod tests {
 
         assert_eq!(
             router.lookup("www.example.com", "/helloA", &Method::new(&b"GET"[..])),
-            Ok(Route::ClusterId("example".to_string()))
+            Ok(RouteResult::forward("example".to_string()))
         );
         assert_eq!(
             router.lookup(
@@ -896,7 +1628,7 @@ mod tests {
                 "/.well-known/acme-challenge",
                 &Method::new(&b"GET"[..])
             ),
-            Ok(Route::ClusterId("acme".to_string()))
+            Ok(RouteResult::forward("acme".to_string()))
         );
         assert!(
             router
@@ -909,11 +1641,11 @@ mod tests {
                 "/helloAB/",
                 &Method::new(&b"GET"[..])
             ),
-            Ok(Route::ClusterId("examplewildcard".to_string()))
+            Ok(RouteResult::forward("examplewildcard".to_string()))
         );
         assert_eq!(
             router.lookup("test1.example.com", "/helloAB/", &Method::new(&b"GET"[..])),
-            Ok(Route::ClusterId("exampleregex".to_string()))
+            Ok(RouteResult::forward("exampleregex".to_string()))
         );
     }
 

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -197,30 +197,60 @@ impl Router {
 
         let method_rule = MethodRule::new(front.method.clone());
 
-        let route = match &front.cluster_id {
-            Some(cluster_id) => Route::ClusterId(cluster_id.clone()),
-            None => Route::Deny,
+        // Decide between the legacy `Route::ClusterId`/`Route::Deny` shape
+        // and the rich `Route::Frontend(Rc<Frontend>)` shape: any non-
+        // default policy field flips us onto the rich path so the mux
+        // can honour redirect/rewrite/headers/auth at request time.
+        let has_policy = front.redirect.is_some()
+            || front.redirect_scheme.is_some()
+            || front.redirect_template.is_some()
+            || front.rewrite_host.is_some()
+            || front.rewrite_path.is_some()
+            || front.rewrite_port.is_some()
+            || front.required_auth.unwrap_or(false)
+            || !front.headers.is_empty();
+
+        let domain =
+            front
+                .hostname
+                .parse::<DomainRule>()
+                .map_err(|_| RouterError::InvalidDomain {
+                    hostname: front.hostname.clone(),
+                })?;
+
+        let route = if has_policy {
+            let redirect = front
+                .redirect
+                .and_then(|r| RedirectPolicy::try_from(r).ok())
+                .unwrap_or(RedirectPolicy::Forward);
+            let redirect_scheme = front
+                .redirect_scheme
+                .and_then(|s| RedirectScheme::try_from(s).ok())
+                .unwrap_or(RedirectScheme::UseSame);
+            let frontend = Frontend::new(
+                &domain,
+                &path_rule,
+                front,
+                redirect,
+                redirect_scheme,
+                front.redirect_template.clone(),
+                front.rewrite_host.clone(),
+                front.rewrite_path.clone(),
+                front.rewrite_port.and_then(|p| u16::try_from(p).ok()),
+                &front.headers,
+                front.required_auth.unwrap_or(false),
+            )?;
+            Route::Frontend(Rc::new(frontend))
+        } else {
+            match &front.cluster_id {
+                Some(cluster_id) => Route::ClusterId(cluster_id.clone()),
+                None => Route::Deny,
+            }
         };
 
         let success = match front.position {
-            RulePosition::Pre => {
-                let domain = front.hostname.parse::<DomainRule>().map_err(|_| {
-                    RouterError::InvalidDomain {
-                        hostname: front.hostname.clone(),
-                    }
-                })?;
-
-                self.add_pre_rule(&domain, &path_rule, &method_rule, &route)
-            }
-            RulePosition::Post => {
-                let domain = front.hostname.parse::<DomainRule>().map_err(|_| {
-                    RouterError::InvalidDomain {
-                        hostname: front.hostname.clone(),
-                    }
-                })?;
-
-                self.add_post_rule(&domain, &path_rule, &method_rule, &route)
-            }
+            RulePosition::Pre => self.add_pre_rule(&domain, &path_rule, &method_rule, &route),
+            RulePosition::Post => self.add_post_rule(&domain, &path_rule, &method_rule, &route),
             RulePosition::Tree => {
                 self.add_tree_rule(front.hostname.as_bytes(), &path_rule, &method_rule, &route)
             }

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -25,9 +25,10 @@ use crate::{
 };
 
 /// Module-level prefix tag for `lib/src/router/`. Honours the runtime
-/// colored-output flag via [`ansi_palette`]; consumed by every `warn!` /
-/// `error!` site below so static log-layout regression checks (see
-/// `lib/tests/log_layout.rs`) keep router log lines on the canonical
+/// colored-output flag via [`ansi_palette`]; consumed by the single
+/// `warn!` site in `Frontend::new` (and any future emitter without an
+/// `HttpContext` in scope) so static log-layout regression checks
+/// (`lib/tests/log_layout.rs`) keep router log lines on the canonical
 /// `[ROUTER] >>>` envelope.
 macro_rules! log_module_context {
     () => {{
@@ -754,12 +755,6 @@ enum RewritePart {
     Path(usize),
 }
 
-impl RewritePart {
-    fn bytes(b: &[u8]) -> Self {
-        Self::String(from_utf8(b).unwrap_or_default().to_owned())
-    }
-}
-
 /// A pre-parsed rewrite template, decomposed into [`RewritePart`]s.
 ///
 /// `RewriteParts` is built once at frontend registration time
@@ -848,7 +843,11 @@ impl RewriteParts {
                 while i < pattern.len() && pattern[i] != b'$' {
                     i += 1;
                 }
-                result.push(RewritePart::bytes(&pattern[start..i]));
+                // `pattern` is `template.as_bytes()` and the split is on
+                // the ASCII byte `$` (0x24), which is always a single-byte
+                // UTF-8 character — so `template[start..i]` lies on char
+                // boundaries and is safe to index directly.
+                result.push(RewritePart::String(template[start..i].to_owned()));
             }
         }
         Some(Self(result))
@@ -1111,6 +1110,19 @@ impl Frontend {
                 HeaderPosition::Both => {
                     headers_request.push(edit.clone());
                     headers_response.push(edit);
+                }
+                // The proto-default-encoded shape (`position: 0`). The TOML
+                // loader rejects this case in `parse_header_edit` so the
+                // path is only reachable via a manually-constructed
+                // `Header { position: 0, … }` from a buggy or older
+                // client. Drop the edit rather than guessing a position.
+                HeaderPosition::Unspecified => {
+                    warn!(
+                        "{} dropping Header {{ key: {:?}, val: {:?} }} with HEADER_POSITION_UNSPECIFIED",
+                        log_module_context!(),
+                        header.key,
+                        header.val,
+                    );
                 }
             }
         }

--- a/lib/src/router/pattern_trie.rs
+++ b/lib/src/router/pattern_trie.rs
@@ -42,6 +42,24 @@ pub struct TrieNode<V> {
     regexps: Vec<(Regex, TrieNode<V>)>,
 }
 
+/// One step of a trie traversal where a non-literal segment matched.
+///
+/// `Wildcard` carries the actual segment bytes consumed by a `*` wildcard
+/// (so a router that wants to capture them can splice them into a rewrite
+/// template). `Regexp` carries both the matched bytes and the regex itself
+/// so the caller can re-run `Regex::captures` to pull explicit groups.
+#[derive(Debug)]
+pub enum TrieSubMatch<'a, 'b> {
+    Wildcard(&'a [u8]),
+    Regexp(&'a [u8], &'b Regex),
+}
+
+/// Ordered list of non-literal trie segments visited during a successful
+/// `lookup_with_path` traversal. Routers feed the entries into rewrite
+/// templates (`$HOST[n]`) so frontend rewrites can reach into the matched
+/// segments. Empty when only literal segments matched.
+pub type TrieMatches<'a, 'b> = Vec<TrieSubMatch<'a, 'b>>;
+
 impl<V: PartialEq> std::cmp::PartialEq for TrieNode<V> {
     fn eq(&self, other: &Self) -> bool {
         self.key_value == other.key_value
@@ -120,13 +138,19 @@ impl<V: Debug + Clone> TrieNode<V> {
                 }
 
                 if let Ok(s) = str::from_utf8(&partial_key[pos + 1..partial_key.len() - 1]) {
+                    let anchored_s = format!("\\A{s}\\z");
                     for t in self.regexps.iter_mut() {
-                        if t.0.as_str() == s {
+                        if t.0.as_str() == anchored_s {
                             return t.1.insert_recursive(&partial_key[..pos - 1], key, value);
                         }
                     }
 
-                    if let Ok(r) = Regex::new(s) {
+                    // Anchor segment regexes so they only match the entire
+                    // segment, not partial overlaps. Without `\A...\z`, a
+                    // pattern like `cdn[0-9]+` would match `cdn123xxx`,
+                    // which silently widens the routing surface.
+                    let anchored = format!("\\A{s}\\z");
+                    if let Ok(r) = Regex::new(&anchored) {
                         if pos > 0 {
                             let mut node = TrieNode::root();
                             let pos = pos - 1;
@@ -219,10 +243,11 @@ impl<V: Debug + Clone> TrieNode<V> {
                 }
 
                 if let Ok(s) = str::from_utf8(&partial_key[pos + 1..partial_key.len() - 1]) {
+                    let anchored_s = format!("\\A{s}\\z");
                     if pos > 0 {
                         let mut remove_result = RemoveResult::NotFound;
                         for t in self.regexps.iter_mut() {
-                            if t.0.as_str() == s
+                            if t.0.as_str() == anchored_s
                                 && t.1.remove_recursive(&partial_key[..pos - 1]) == RemoveResult::Ok
                             {
                                 remove_result = RemoveResult::Ok;
@@ -231,7 +256,7 @@ impl<V: Debug + Clone> TrieNode<V> {
                         return remove_result;
                     } else {
                         let len = self.regexps.len();
-                        self.regexps.retain(|(r, _)| r.as_str() != s);
+                        self.regexps.retain(|(r, _)| r.as_str() != anchored_s);
                         if len > self.regexps.len() {
                             return RemoveResult::Ok;
                         }
@@ -260,6 +285,60 @@ impl<V: Debug + Clone> TrieNode<V> {
                 }
             },
             None => RemoveResult::NotFound,
+        }
+    }
+
+    /// Look up `partial_key` and additionally collect the non-literal segments
+    /// that matched along the way (`TrieMatches`).
+    ///
+    /// Equivalent to `lookup` for callers that don't need the captures, but
+    /// frontends with `$HOST[n]` rewrite templates need the matched segments
+    /// to fill the placeholders. The accumulator is passed in by value so
+    /// callers can pre-size it (`Vec::with_capacity`) and we own the path
+    /// returned alongside the value.
+    pub fn lookup_with_path<'a, 'b>(
+        &'b self,
+        partial_key: &'a [u8],
+        accept_wildcard: bool,
+        mut trace: TrieMatches<'a, 'b>,
+    ) -> Option<(&'b KeyValue<Key, V>, TrieMatches<'a, 'b>)> {
+        if partial_key.is_empty() {
+            return self.key_value.as_ref().map(|kv| (kv, trace));
+        }
+
+        let pos = find_last_dot(partial_key);
+        let (prefix, suffix) = match pos {
+            None => (&b""[..], partial_key),
+            Some(pos) => (&partial_key[..pos], &partial_key[pos..]),
+        };
+
+        match self.children.get(suffix) {
+            Some(child) => child.lookup_with_path(prefix, accept_wildcard, trace),
+            None => {
+                if prefix.is_empty() && self.wildcard.is_some() && accept_wildcard {
+                    let segment = if !suffix.is_empty() && suffix[0] == b'.' {
+                        &suffix[1..]
+                    } else {
+                        suffix
+                    };
+                    trace.push(TrieSubMatch::Wildcard(segment));
+                    self.wildcard.as_ref().map(|kv| (kv, trace))
+                } else {
+                    for (regexp, child) in self.regexps.iter() {
+                        let segment = if !suffix.is_empty() && suffix[0] == b'.' {
+                            &suffix[1..]
+                        } else {
+                            suffix
+                        };
+                        if regexp.is_match(segment) {
+                            let mut next = trace;
+                            next.push(TrieSubMatch::Regexp(segment, regexp));
+                            return child.lookup_with_path(prefix, accept_wildcard, next);
+                        }
+                    }
+                    None
+                }
+            }
         }
     }
 
@@ -332,8 +411,9 @@ impl<V: Debug + Clone> TrieNode<V> {
                 }
 
                 if let Ok(s) = str::from_utf8(&partial_key[pos + 1..partial_key.len() - 1]) {
+                    let anchored_s = format!("\\A{s}\\z");
                     for t in self.regexps.iter_mut() {
-                        if t.0.as_str() == s {
+                        if t.0.as_str() == anchored_s {
                             return t.1.lookup_mut(&partial_key[..pos - 1], accept_wildcard);
                         }
                     }

--- a/lib/src/router/pattern_trie.rs
+++ b/lib/src/router/pattern_trie.rs
@@ -656,6 +656,50 @@ mod tests {
         );
     }
 
+    /// Segment regexes must match the entire segment, not just a prefix.
+    /// Without `\A...\z` anchoring the previous behaviour matched any
+    /// segment whose prefix satisfied the pattern, silently widening the
+    /// routing surface. This regression test exercises the exact-match
+    /// invariant that anchoring guarantees.
+    #[test]
+    fn segment_regex_rejects_partial_matches() {
+        let mut root: TrieNode<u8> = TrieNode::root();
+        // The regex segment `cdn[0-9]+` must match `cdn1`, `cdn99`, etc.
+        // exactly — never `cdn1xxx` or `xxxcdn1` as a prefix/suffix.
+        assert_eq!(
+            root.insert(Vec::from(&b"/cdn[0-9]+/.example.com"[..]), 7),
+            InsertResult::Ok
+        );
+
+        // Exact-match cases still resolve.
+        assert_eq!(
+            root.domain_lookup(b"cdn1.example.com".as_ref(), false),
+            Some(&(b"/cdn[0-9]+/.example.com".to_vec(), 7))
+        );
+        assert_eq!(
+            root.domain_lookup(b"cdn123.example.com".as_ref(), false),
+            Some(&(b"/cdn[0-9]+/.example.com".to_vec(), 7))
+        );
+
+        // Trailing characters past the digit run must fail. Pre-anchoring
+        // the trie would have matched `cdn1xxx` because `cdn[0-9]+` ate
+        // the `cdn1` prefix; with `\A...\z` the segment is rejected.
+        assert_eq!(
+            root.domain_lookup(b"cdn1xxx.example.com".as_ref(), false),
+            None
+        );
+        // Leading characters likewise must fail.
+        assert_eq!(
+            root.domain_lookup(b"xxxcdn1.example.com".as_ref(), false),
+            None
+        );
+        // Non-digit middle bytes break the digit run and the segment.
+        assert_eq!(
+            root.domain_lookup(b"cdnabc.example.com".as_ref(), false),
+            None
+        );
+    }
+
     #[test]
     fn add_child_to_leaf() {
         let mut root1: TrieNode<u8> = TrieNode::root();

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -340,6 +340,15 @@ impl Server {
         expects_initial_status: bool,
     ) -> Result<Self, ServerError> {
         let event_loop = Poll::new().map_err(ServerError::CreatePoll)?;
+        // Commit the operator-configured Basic-auth credential cap (or
+        // keep the built-in default) once per worker process. The
+        // `OnceLock` rejects any later attempt to change the value, so
+        // calling here — before any L7 listener has accepted a request
+        // — guarantees the cap is in force the first time `mux::auth`
+        // runs.
+        if let Some(cap) = config.basic_auth_max_credential_bytes {
+            crate::protocol::mux::auth::set_max_decoded_credential_bytes(cap as usize);
+        }
         let pool = Rc::new(RefCell::new(Pool::with_capacity(
             config.min_buffers as usize,
             config.max_buffers as usize,


### PR DESCRIPTION
## Summary

Brings the upstream answer-template / URL-rewrite / basic-auth feature stack onto current `main` without unwinding the `feat/h2-mux` work. The features are re-implemented at the active `mux/` layer instead of the legacy `kawa_h1/` session path the upstream PRs targeted, so every running session benefits.

This PR closes the design loop opened by #1206, #1207, #1208 and #1210 against the post-#1209 architecture — including the runtime emission boundary (URL rewrite, X-Forwarded-Host injection, per-frontend header set/replace/delete on both request and response), end-to-end cardinality coverage (H1↔H1, H2↔H1, H1↔H2, H2↔H2), and tightened HPACK / RST_STREAM / header-injection security boundaries surfaced by two rounds of Codex cross-check + a security threat-hunt.

## Relationship to existing PRs

- **#1209** — merged. This PR builds **on top of** the `feat/h2-mux` work; every H2 flood knob, ALPN config, runtime-patch verb, and `doc/configure.md` H2 section that #1209 introduced is preserved (the upstream feature PRs against pre-#1209 main would have unwound them — this PR explicitly does not).
- **#1206** — `refactor(kawa_h1): introduce Origin struct`. **Not adopted as-is.** The four scattered fields the Origin struct consolidates live on the legacy `kawa_h1::Http` path that `feat/h2-mux` bypassed; the equivalent backend-state encapsulation is already in `mux/router.rs` + `mux/stream.rs`. The bug-fix payload from commit `109d1074` (typo `Swaping`/missing `DefaultAnswerKA` check / `unreachable!` in `connect_to_backend`) targets dead-path code and is not load-bearing here. This PR adopts the `(status, keep_alive, stream)` tuple shape via the answer-template work below.
- **#1207** — `feat(kawa_h1): flexible HTTP answer template system`. **Adopted, re-targeted to the mux/kawa_h1 shared types.** Replace `CustomHttpAnswers { answer_301, answer_401, ... }` with `map<string, string> answers` on listeners and clusters; ports the `Template` engine, variables, `or_elide_header`, per-status default templates. The stale-base side effects from PR #1207's diff against current main (unwinding H2 flood knobs, ALPN config, runtime-patch verbs, ~1100 lines of `doc/configure.md` H2 sections) are explicitly **not** ported.
- **#1208** — `feat(router): URL rewrite, redirection, and custom headers`. **Adopted, with end-to-end runtime emission.** New `Frontend` struct + `RouteResult`, proto enums (`RedirectPolicy`, `RedirectScheme`, `HeaderPosition`), `Header` message, fields 8–15 on `RequestHttpFrontend`, `Cluster.https_redirect_port`, `RewriteParts` parser for `$HOST[n]` / `$PATH[n]`, regex anchoring (`\A...\z`) on segment regexes with `TrieMatches` / `TrieSubMatch` capture propagation. The mux applies the rewrites and header edits on the wire (see "Runtime emission" below).
- **#1210** — `feat(auth): add basic HTTP authentication`. **Adopted.** `Cluster.authorized_hashes`, `Cluster.www_authenticate`, `RequestHttpFrontend.required_auth`, `Authorization: Basic` extractor, SHA-256 hashing, `%WWW_AUTHENTICATE` template variable. Comparison against `authorized_hashes` uses `subtle::ConstantTimeEq` over a fixed 256+8-byte padded envelope so length-mismatched candidates iterate the full compare loop instead of short-circuiting (closes the realm-size and matching-username-length channels in CWE-208 family).

## What changed

### Protocol schema

`Cluster` gains four fields: `answers` map (status code → template body) at field 9, `https_redirect_port` at 10, `authorized_hashes` at 11, `www_authenticate` realm at 12. `RequestHttpFrontend` gains eight: `redirect` policy at 8, `required_auth` at 9, `redirect_scheme` at 10, `redirect_template` at 11, `rewrite_host`/`rewrite_path`/`rewrite_port` at 12-14, `headers` at 15. Listener configs gain `answers` at 31 (`HttpListenerConfig`) and 43 (`HttpsListenerConfig`); the legacy `CustomHttpAnswers http_answers` field is preserved on the wire so existing state files round-trip — the runtime merges both at boot for one minor.

`HeaderPosition` carries an explicit `HEADER_POSITION_UNSPECIFIED = 0` so a default-encoded `Header` deserialises into a typed "unset" instead of failing `try_from(0)`. `Cluster` reserves field numbers 13-19 and `RequestHttpFrontend` reserves 16-19 against future accidental aliasing.

### Template engine

`HttpAnswers::new` now takes `&BTreeMap<String, String>`; `HttpAnswers::get` returns `(u16, bool, DefaultAnswerStream)` so the rendered template's `Connection: close` flips the frontend keep-alive bit. New `%WWW_AUTHENTICATE` template variable (header-only, `or_elide_header = true`) integrates with the 401 default-answer path.

The engine detects an operator-supplied `Content-Length:` header during parse and routes its value through the existing `ContentLength` placeholder, so the rendered response carries exactly one header — RFC 9110 §8.6 / RFC 7230 §3.3.2 request-smuggling vector closed.

### Routing

`Frontend`, `RouteResult`, `HeaderEdit`, `RewriteParts` land in `lib/src/router/mod.rs`. `L7ListenerHandler::frontend_from_request` returns `Result<RouteResult, _>`. Pattern-trie segment regexes are now anchored with `\A...\z`; `TrieMatches`/`TrieSubMatch` carry captures so `$HOST[N]` / `$PATH[N]` placeholders resolve at lookup time. `Route::Frontend(Rc<Frontend>)` is reachable end-to-end — `Router::add_http_front` flips onto the rich path whenever any policy field is non-default (otherwise the legacy `Route::ClusterId` / `Route::Deny` shapes still apply).

### Runtime emission (`d84847af`)

`route_from_request` in `mux/router.rs` honours `RedirectPolicy::PERMANENT`, `RedirectPolicy::UNAUTHORIZED` (or clusterless `FORWARD`), and `required_auth` (via `mux::auth::check_basic`). Failure cases stash `redirect_location` / `www_authenticate` on `HttpContext`; `set_default_answer` reads them when rendering 301/401. `HttpContext::reset()` clears every routing-stash slot between pipelined H1 requests.

On the success path the mux now applies the operator-configured rewrites and header edits **on the wire**:

- **Request side** (`mux/router.rs::apply_request_rewrites_and_headers`): `rewritten_host` replaces `:authority` / `Host`, captures the original into `HttpContext::original_authority` (now set unconditionally so audit / log lines on the deny / redirect / auth-401 / backend-connect-failure paths still carry it), and injects `X-Forwarded-Host`. `rewritten_path` replaces both the abstract `path` Store (consumed by H2 `:path`) and the request-line `uri` Store (consumed by H1). `headers_request` runs a single retain pass over `kawa.blocks` — empty `val` deletes by name (HAProxy `del-header` parity), non-empty inserts before the `end_header` flag block.
- **Response side** (`mux/shared.rs::apply_response_header_edits`, runs just before `kawa.prepare(...)` at `mux/h1.rs::writable` and `mux/h2.rs::write_streams`, both gated on `Position::Server`): same retain-then-insert pattern, fed from `HttpContext::headers_response` which the routing layer stashes at request time.

### Cardinality matrix coverage (`9569da88`, `358e6e20`, `ad483adb`)

`e2e/src/tests/redirect_rewrite_auth_tests.rs` covers H1↔H1, H2↔H1, H1↔H2, H2↔H2 against `SyncBackend` (raw HTTP/1.1 byte assertions) and `H2Backend` (`recorded_requests()` exposes per-request `method` / `authority` / `path` / `Vec<(String, Vec<u8>)>` headers — non-UTF-8 surfaces in assertion diffs instead of being silently dropped). 16 tests total at `--test-threads=1`, all green.

### Security boundaries (Codex + threat-hunt cross-check, `da845c71` → `b622ec9e`)

Two rounds of Codex review and an independent security threat-hunt surfaced — and we closed — these gaps:

- **HPACK over-budget abort emits a same-pass RST_STREAM** (`lib/src/protocol/mux/converter.rs::finalize` and `mux/h2.rs::write_streams` post-prepare). Previously the deferred-flag pattern flipped `kawa.parsing_phase = Error` and cleared `kawa.blocks` but only synthesised the RST on the NEXT prepare cycle's `initialize` — by which point `write_streams` had already retired the stream as completed (`is_error() && is_completed()`), so the peer never saw a reset. `finalize` now pushes the frame to `kawa.out` directly; the very next `flush_stream_out` ships it.
- **RST_STREAM accounting funnels through one site** (`account_emitted_rst` in `mux/h2.rs`). All proxy-emitted RST paths — `enqueue_rst` (which `reset_stream`, `refuse_stream_and_discard`, `cancel_timed_out_streams`, and DATA-on-closed-stream all funnel through) plus the converter's `initialize` chokepoint and the HPACK over-budget abort — now hit the global `h2.frames.tx.rst_stream` counter, the per-error `h2.rst_stream.sent.*` breakdown, AND `flood_detector.record_rst_emitted` exactly once per actually-emitted frame. CVE-2025-8671 MadeYouReset cap is no longer evadable. Dedup short-circuit (`enqueue_rst_into` returning `false` when `rst_sent` already contains the stream id) skips accounting so duplicate enqueue attempts can't inflate the counters either.
- **Strict header-name validation** (`command/src/config.rs::header_name_is_valid_token`, mirrored in `bin/src/ctl/request_builder.rs::is_valid_header_name`). Header keys go through the RFC 9110 §5.6.2 `tchar` grammar (no HTAB, no SP, no C0 controls); values reject `\0..=\x08`, `\x0A..=\x1F`, `\x7F` (HTAB explicitly permitted per RFC 9110 §5.5). Closes the CRLF/NUL injection vector reachable via `--header pos=key=val\r\nEvil-Header: stolen` and the matching TOML entry — H1 backend serialisation no longer carries operator-provided control bytes.
- **Host dedup fires on operator override**, not just on `--rewrite-host` (`mux/router.rs::apply_request_rewrites_and_headers`). An operator setting `--header request=Host=evil` on a frontend WITHOUT a rewrite no longer emits two `Host:` headers on the backend wire — the request-smuggling primitive is closed.
- **Test ergonomics**: `H2Backend::stop` joins the spawned thread (was: detach), `accept_with_retry` checks the deadline AFTER the accept attempt so the boundary attempt always runs, the e2e port registry carries an explicit leak-window note.

### CLI

`sozu cluster add` gains `--answer code=path` (file body loaded), `--https-redirect-port`, `--www-authenticate`, `--authorized-hash` (validated against `^[A-Za-z0-9_-]+:[0-9a-f]{64}$`).

`sozu frontend {http,https} add` gains `--redirect`, `--redirect-scheme`, `--redirect-template`, `--rewrite-host`, `--rewrite-path`, `--rewrite-port` (range-validated), `--required-auth`, and `--header position=name=value` (empty value = HAProxy `del-header` parity, key follows RFC 9110 token grammar). Both `http` and `https` variants share a single `build_http_frontend_add` helper to avoid drift.

### Documentation

`doc/configure.md` gains three new sections: Custom HTTP answer templates, Frontend redirect / URL rewrite / custom headers, HTTP Basic authentication. Each cites the HAProxy parallel (`errorfile`, `http-request redirect`, `set-uri`/`set-path`, `set-header`/`del-header`, `http-request auth realm`). No existing H2 / ALPN / flood-detection / metrics section is altered.

`CHANGELOG.md` gains a `feat/answer-templates-rewrite-auth - Unreleased` entry above the existing `feat/h2-mux` block, with separate `Added`, `Changed`, and `Behaviour-affecting` paragraphs.

## Validation

- `cargo build --workspace --all-features --locked` clean
- `cargo +nightly fmt --all -- --check` clean
- `cargo clippy --workspace --all-features --all-targets --locked -- -D warnings` clean
- `cargo test -p sozu-lib --lib --locked`: **460 pass**
- `cargo test -p sozu-command-lib --locked`: **74 pass / 5 ignored**
- `cargo test -p sozu-e2e --locked -- --test-threads=1 redirect_rewrite_auth_tests::`: **16 pass** (cardinality matrix covering H1↔H1, H2↔H1, H1↔H2, H2↔H2 for redirect / rewrite / header edits / basic auth / per-cluster 503 template)
- `cargo test --test log_layout -p sozu-lib --locked`: **1 pass** (raw-log regression guard)
- All commits signed (`-s -S`); Conventional-Commits format
- **Codex `codex review --commit <SHA>` cross-check on the diff**: ran across 5 rounds, found and closed 4 P-class issues across HPACK same-pass emission, RST accounting unification, header-name vs header-value grammar split, and dedup short-circuit accounting. Final pass reports "no actionable regression in the touched paths".
- **Security threat-hunt**: 6 findings opened (2 High, 2 Medium, 2 Low) covering RST flood-cap evasion, CRLF header injection, double-Host smuggling primitive, H2Backend tokio-runtime leak, non-UTF-8 header recording, accept_with_retry boundary miss. All 6 closed and re-verified.

## Test plan

- [x] `/codex` cross-check on the full diff — 5 rounds, all findings applied
- [x] Security threat-hunt and remediation — 6/6 findings closed
- [x] e2e cardinality matrix on every behaviour × every cardinality, H1↔H1 / H2↔H1 / H1↔H2 / H2↔H2 — 16 tests green
- [x] H2 fuzz targets after the template-engine + emission changes: `cargo +nightly fuzz run fuzz_frame_parser` and `fuzz_hpack_decoder` from `fuzz/`
- [x] Re-run `cargo test --workspace --no-fail-fast` under `--test-threads=1` against the full e2e suite (not just the cardinality file) to isolate any flake-prone interactions with the routing-decision and emission changes

## Note on commit `2662488a`

The branch is based on `pr-1229-review` and carries `2662488a fix(command): remove trailer dependency` from that branch. If `pr-1229-review` lands first, `gh pr view` will narrow the diff automatically; otherwise this PR can be rebased off main once that review concludes.

## Commit graph

```
b622ec9e fix(mux): skip RST accounting on dedup short-circuit
f77a8c82 fix(mux,config,cli): unify RST_STREAM accounting and tighten header-name validation
ad483adb fix(mux,cli,config,e2e): close gaps from the security threat-hunt
da845c71 fix(mux): emit oversized-header RST_STREAM in the same prepare pass
358e6e20 fix(mux,e2e): act on /review findings on the rewrite/auth stack
9569da88 test(e2e): cardinality matrix coverage for redirect, rewrite, auth, headers
d84847af feat(mux): apply request rewrites and per-frontend header edits on the wire
29f1db29 fix(cli,router,auth): clear /review's deferred Medium/Low/Nit backlog
16223557 fix(answers,auth,router): act on /review findings
c1e0b1a6 feat(cli): expose answer-template, redirect, and basic-auth knobs on cluster add
852b5d36 docs(configure,changelog): document answer templates, redirect, rewrite, auth
463bfd50 feat(mux): drive redirect, basic-auth, and 401-realm decisions in router
0dd48aa2 feat(auth): add HTTP Basic credential helpers under mux/auth.rs
2bb1fbab feat(router): introduce Frontend, RouteResult, RewriteParts, regex anchoring
3094ca84 feat(answers): port flexible HTTP answer template engine
ff9f2b32 feat(config): wire new cluster/listener/frontend fields through TOML
344ab132 feat(proto): add answer templates, redirect, rewrite, headers, auth schema
2662488a fix(command): remove trailer dependency        ← from pr-1229-review
```
