### PR TITLE
fix(router): prevent panic in DomainRule::Wildcard::matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 See milestone [`v1.1.0`](https://github.com/sozu-proxy/sozu/projects/3?card_filter_query=milestone%3Av1.1.0)
 
+### Security
+
+- **Worker panic on short hostnames vs `Wildcard` rules ([#1223](https://github.com/sozu-proxy/sozu/issues/1223))**: `DomainRule::Wildcard::matches` in `lib/src/router/mod.rs` computed `hostname.len() - s.len() + 1` unconditionally, panicking with `attempt to subtract with overflow` in debug builds when the incoming hostname was shorter than the configured wildcard pattern (CWE-191 → CWE-754, remote-reachable DoS). In release builds the wrap is masked by the `&&` short-circuit on `ends_with(suffix)`, so the false-positive in §1 of the issue was rare; debug builds always panicked. The arm now uses `<[u8]>::strip_suffix` and validates the leftmost prefix on the returned slice — there is no length arithmetic to underflow, and short hostnames return `false` without panic. Boundary case `hostname == suffix` (empty leftmost label, e.g. `.foo.example.com` against `*.foo.example.com`) is now rejected as an invalid DNS label per RFC 1035 §3.1. Reachable from H1 (`HttpListener::frontend_from_request`, `lib/src/http.rs:658`), H2 (single-byte `:authority`, `lib/src/https.rs:865`), and operator-driven `Router::has_hostname` introspection. Affected versions: all releases including `sozu-lib` 1.1.1 and earlier (bug introduced in `a9dd46e9`, 2019-06-04). Regression tests `match_domain_rule_wildcard_short_hostname_does_not_panic` and `router_lookup_wildcard_pre_rule_short_hostname_does_not_panic` in `lib/src/router/mod.rs`.
+
 ## feat/answer-templates-rewrite-auth - Unreleased
 
 Brings the upstream answer-template / URL-rewrite / basic-auth feature stack

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -497,6 +497,11 @@ impl Router {
 pub enum DomainRule {
     Any,
     Exact(String),
+    /// Matches when `hostname` ends with `s[1..]` (the wildcard pattern with
+    /// the leading `*` stripped) and the remaining leftmost prefix is
+    /// non-empty and contains no `.`. Comparison is byte-exact and
+    /// case-sensitive; no IDN/punycode normalisation is performed here.
+    /// Stored with the leading `*`.
     Wildcard(String),
     Regex(Regex),
 }
@@ -559,9 +564,10 @@ impl DomainRule {
         match self {
             DomainRule::Any => true,
             DomainRule::Wildcard(s) => {
-                let len_without_suffix = hostname.len() - s.len() + 1;
-                hostname.ends_with(&s.as_bytes()[1..])
-                    && !&hostname[..len_without_suffix].contains(&b'.')
+                let suffix = &s.as_bytes()[1..];
+                hostname
+                    .strip_suffix(suffix)
+                    .is_some_and(|prefix| !prefix.is_empty() && !prefix.contains(&b'.'))
             }
             DomainRule::Exact(s) => s.as_bytes() == hostname,
             DomainRule::Regex(r) => {
@@ -1492,6 +1498,59 @@ mod tests {
                 .parse::<DomainRule>()
                 .unwrap()
                 .matches("cdn10.exampleAcom".as_bytes())
+        );
+    }
+
+    #[test]
+    fn match_domain_rule_wildcard_short_hostname_does_not_panic() {
+        let rule = DomainRule::Wildcard("*.foo.example.com".to_string());
+
+        // Regression for issue #1223: an empty hostname must not panic and must not match.
+        assert!(!rule.matches(b""));
+
+        // Hostname strictly shorter than the suffix must not panic and must not match.
+        assert!(!rule.matches(b"a.b"));
+        assert!(!rule.matches(b"x"));
+
+        // Boundary: hostname equal to the suffix (s without the leading '*') has an empty
+        // leftmost label. RFC 1035 §3.1 forbids empty labels, so reject.
+        assert!(!rule.matches(b".foo.example.com"));
+
+        // Multi-label leftmost prefix (existing intent — single-label only).
+        assert!(!rule.matches(b"y.x.foo.example.com"));
+
+        // Single-label leftmost prefix — must still match (this is the happy case the
+        // pre-existing match_domain_rule already covers, repeated here for symmetry).
+        assert!(rule.matches(b"x.foo.example.com"));
+    }
+
+    #[test]
+    fn router_lookup_wildcard_pre_rule_short_hostname_does_not_panic() {
+        let mut router = Router::new();
+
+        // Wildcard in a pre-rule routes through DomainRule::Wildcard::matches
+        // (not the trie). This is the path that panicked on issue #1223.
+        assert!(router.add_pre_rule(
+            &"*.foo.example.com".parse::<DomainRule>().unwrap(),
+            &PathRule::Prefix("/".to_string()),
+            &MethodRule::new(Some("GET".to_string())),
+            &Route::ClusterId("wildcard".to_string()),
+        ));
+
+        let method = Method::new(&b"GET"[..]);
+
+        // Issue #1223: short hostnames must not panic Router::lookup.
+        assert!(router.lookup("", "/", &method).is_err());
+        assert!(router.lookup("x", "/", &method).is_err());
+        assert!(router.lookup("a.b", "/", &method).is_err());
+
+        // Boundary: hostname equal to the suffix has an empty leftmost label.
+        assert!(router.lookup(".foo.example.com", "/", &method).is_err());
+
+        // Happy case: single-label leftmost matches via the pre-rule path.
+        assert_eq!(
+            router.lookup("x.foo.example.com", "/", &method),
+            Ok(RouteResult::forward("wildcard".to_string()))
         );
     }
 


### PR DESCRIPTION
## Summary

`DomainRule::Wildcard::matches` in `lib/src/router/mod.rs` computed
`hostname.len() - s.len() + 1` unconditionally, underflowing `usize` and
panicking the HTTP worker thread with `attempt to subtract with overflow`
whenever the incoming hostname was shorter than the configured wildcard
pattern. An unauthenticated client can trigger this with a short `Host:`
header (H1) or a 1-byte `:authority` (H2). Debug builds always panic;
release builds wrap and are masked by the `&&` short-circuit on
`ends_with(suffix)`, so the false-positive in §1 of the issue is rare —
but the latent OOB slice would itself panic if `ends_with` ever returned
true on the wrapped value. CWE-191 → CWE-754, remote-reachable DoS.

Closes #1223.

## Fix

Replace the unguarded subtraction with `<[u8]>::strip_suffix` and
validate the leftmost-prefix invariants on the returned slice:

```rust
DomainRule::Wildcard(s) => {
    let suffix = &s.as_bytes()[1..];
    hostname
        .strip_suffix(suffix)
        .is_some_and(|prefix| !prefix.is_empty() && !prefix.contains(&b'.'))
}
```

There is no length arithmetic to underflow. `!prefix.is_empty()` enforces
"leftmost label must be non-empty" — the boundary `Host: .foo.example.com`
against `*.foo.example.com` is now rejected as an invalid DNS label per
RFC 1035 §3.1. `!prefix.contains(&b'.')` preserves single-label wildcard
semantics. A `///` doc-comment on `enum DomainRule::Wildcard` records the
implementation contract.

## Behavior changes

| Hostname vs `*.foo.example.com` | Before | After |
|---|---|---|
| `b""`, `b"x"`, `b"a.b"` | panic in debug, `false` in release (wrap masked by `&&` short-circuit on `ends_with`) | `false` |
| `b".foo.example.com"` | `true` (buggy: empty prefix slice) | `false` (empty leftmost label rejected) |
| `b"x.foo.example.com"` | `true` | `true` (unchanged) |
| `b"y.x.foo.example.com"` | `false` | `false` (unchanged) |

Production-realistic traffic semantics are unchanged. The only flip is
the boundary case `hostname == s[1..]`, which previously crashed (debug)
or accepted-via-empty-slice (release) an invalid DNS label.

## Reachability

- **H1**: `HttpListener::frontend_from_request` → `Router::lookup` → linear
  pre/post `DomainRule::matches`. `hostname_and_port` accepts an empty
  hostname via `take_while`, so a literal empty `Host:` reaches the bug.
- **H2**: `:authority` is rejected when empty by `pkawa.rs`, but a 1-byte
  authority still triggered the underflow against any wildcard of length
  ≥ 3.
- **Operator-driven**: `Router::has_hostname` (frontend-removal cleanup)
  shares the arm and benefits identically.

The trie path (`pattern_trie::lookup`) has its own `is_empty()` guard and
is not affected.

## Tests

Two new unit tests in `lib/src/router/mod.rs`:

- `match_domain_rule_wildcard_short_hostname_does_not_panic` exercises
  `DomainRule::matches` directly with `b""`, `b"x"`, `b"a.b"`, the
  boundary `b".foo.example.com"`, multi-label `b"y.x.foo.example.com"`,
  and the canonical happy case `b"x.foo.example.com"`. The first three
  would panic in debug builds on `main` today.
- `router_lookup_wildcard_pre_rule_short_hostname_does_not_panic`
  exercises the full `Router::lookup` integration with a `Wildcard`
  pre-rule. The pre-existing `match_router` test only puts `Wildcard`
  in `add_tree_rule` (which routes through `pattern_trie::lookup` and
  bypasses `DomainRule::Wildcard::matches`), so this new test closes
  the only path actually affected by #1223.

## Validation

- [x] `cargo build --all-features --locked`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --locked` — no issues
- [x] `cargo test -p sozu-lib --lib router::tests` — 20 passed (was 18; +2 new)
- [x] `cargo test --workspace --doc --locked` — 5 passed, 9 ignored
- [x] `cargo test --workspace --locked --lib --tests` — 862 passed, 6 suites

## Backport

The bug arm has been unchanged since `a9dd46e9` (2019-06-04, "implement
the new Router") — `git blame` on the modified region shows no functional
edits since introduction. All released `sozu-lib` versions (≤ 1.1.1) are
affected. The patch cherry-picks cleanly to a 1.1.x point release if
maintainers cut one.

## Out of scope (filed for separate follow-ups, not this PR)

- Tighten `FromStr for DomainRule` to reject `*foo` / `**` patterns
  (require `*.` prefix). The fixed `matches` arm already handles those
  patterns safely.
- Reject empty hostname at the H1 parser layer (`hostname_and_port`).
- Add a libfuzzer target over `Router::lookup` / `DomainRule::matches`.
- Enable `#![deny(clippy::arithmetic_side_effects)]` on the router module.

## Changelog

`### Security` entry under `[Unreleased]` describing the bug, fix,
behavior change, reachability, and affected versions.