### PR TITLE
fix: auth/tls/mux hardening + perf + e2e regressions on main

### DIFF
--- a/bin/config.toml
+++ b/bin/config.toml
@@ -136,6 +136,27 @@ max_connections = 500
 # value (no HTTP envelope).
 # retry_after = 60
 
+# Upper bound, in bytes, on the **base64-decoded** `Authorization: Basic`
+# payload sōzu is willing to canonicalize per request. Set once at worker
+# boot from `ServerConfig::basic_auth_max_credential_bytes` and read on
+# every Basic-auth probe. The cap protects against per-request memory
+# amplification (a peer sending an oversized Basic token); raise it only
+# if your operator-supplied usernames or passwords legitimately exceed
+# the default. Setting this to `0` keeps the built-in default (4096) —
+# explicitly setting `0` does NOT disable the cap.
+# basic_auth_max_credential_bytes = 4096
+
+# Linux-only kernel-pipe capacity, in bytes, requested for the
+# `splice(2)` zero-copy fast path on TCP listeners (feature `splice`).
+# Larger pipes mean fewer syscalls under bulk-transfer load at the
+# cost of more kernel memory per active session. Realised size may
+# differ: the kernel rounds up to a page boundary and clamps at
+# `/proc/sys/fs/pipe-max-size`. Linux-only; ignored on builds without
+# the `splice` feature. Setting this to `0` keeps the built-in default
+# (65536, matching the historical pre-knob value) — explicitly setting
+# `0` does NOT collapse the pipe to PAGE_SIZE.
+# splice_pipe_capacity_bytes = 65536
+
 # maximum number of buffers in the pool used by the protocol implementations
 # for active connections (ie currently serving a request). For now, you should
 # estimate that max_buffers = number of concurrent requests * 2

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -17,7 +17,7 @@
 //!
 //! To illustrate:
 //!
-//! ```ignore
+//! ```no_run
 //! use sozu_command_lib::config::{FileConfig, ConfigBuilder};
 //!
 //! let file_config = FileConfig::load_from_path("../config.toml")
@@ -33,7 +33,7 @@
 //!
 //! However, there is a simpler way that combines all this:
 //!
-//! ```ignore
+//! ```no_run
 //! use sozu_command_lib::config::Config;
 //!
 //! let config = Config::load_from_path("../assets/config.toml")

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -699,8 +699,13 @@ lookup leak through the time spent validating.
 [clusters.MyCluster]
 # Realm rendered into `WWW-Authenticate: Basic realm="…"` on a 401.
 www_authenticate = 'Basic realm="MyCluster"'
-# Each entry is `username:hex(sha256(password))` — generate with
-# `printf 'admin:secret' | sha256sum` then prefix with `admin:`.
+# Each entry is `username:hex(sha256(password))`. The runtime hashes
+# ONLY the password — the username appears verbatim before the colon
+# and is NOT part of the hashed input. Generate the hash for password
+# `secret` with:
+#   printf 'secret' | sha256sum | awk '{print $1}'
+# `printf` (not `echo`) omits the trailing newline so the digest matches
+# the bytes carried in `Authorization: Basic <base64>`.
 authorized_hashes = [
     "admin:2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b",
 ]

--- a/e2e/src/tests/eviction_tests.rs
+++ b/e2e/src/tests/eviction_tests.rs
@@ -71,7 +71,9 @@ fn open_dangling_connection(addr: SocketAddr) -> Option<TcpStream> {
     let mut stream = TcpStream::connect(addr).ok()?;
     stream.set_nodelay(true).ok();
     // Partial request — no `\r\n\r\n` terminator, so sōzu waits.
-    stream.write_all(b"GET /idle HTTP/1.1\r\nHost: localhost\r\n").ok()?;
+    stream
+        .write_all(b"GET /idle HTTP/1.1\r\nHost: localhost\r\n")
+        .ok()?;
     Some(stream)
 }
 
@@ -91,8 +93,7 @@ fn try_evict_on_queue_full_accepts_after_eviction() -> State {
     attach_reserved_http_listener(&mut listeners, front_address);
     let state = ConfigState::new();
 
-    let mut worker =
-        Worker::start_new_worker_owned("EVICT-ACCEPTS", config, listeners, state);
+    let mut worker = Worker::start_new_worker_owned("EVICT-ACCEPTS", config, listeners, state);
 
     // Activate the listener and a single cluster + frontend + backend
     // so the worker has SOMETHING to route requests to.
@@ -222,8 +223,7 @@ fn try_evict_disabled_drops_overflow() -> State {
     attach_reserved_http_listener(&mut listeners, front_address);
     let state = ConfigState::new();
 
-    let mut worker =
-        Worker::start_new_worker_owned("EVICT-DISABLED", config, listeners, state);
+    let mut worker = Worker::start_new_worker_owned("EVICT-DISABLED", config, listeners, state);
 
     worker.send_proxy_request(Request {
         request_type: Some(RequestType::AddHttpListener(

--- a/e2e/src/tests/eviction_tests.rs
+++ b/e2e/src/tests/eviction_tests.rs
@@ -1,0 +1,324 @@
+//! End-to-end coverage for the `evict_on_queue_full` accept-queue policy.
+//!
+//! When the accept queue saturates and `check_limits` refuses, sōzu can
+//! either drop the queued sockets (default, `evict_on_queue_full = false`)
+//! or evict the least-recently-active sessions to make room
+//! (`evict_on_queue_full = true`, see `lib::server::Server::accept_*`
+//! and `evict_least_active_sessions`).
+//!
+//! Coverage:
+//! - `test_evict_on_queue_full_accepts_after_eviction` — with the knob
+//!   enabled and the slab saturated by long-lived idle clients, a fresh
+//!   connection MUST be admitted (eviction made room) and the
+//!   `sessions.evicted` counter MUST advance. The eviction predicate is
+//!   `last_event()`-based (server.rs:2231) so the OLDEST connection is
+//!   the one chosen.
+//! - `test_evict_on_queue_full_skipped_during_soft_stop` — a soft-stop
+//!   in flight short-circuits the eviction loop (server.rs:2067) so
+//!   shutdown semantics dominate over admission. The skip is observable
+//!   by the absence of `sessions.evicted` increments while
+//!   `shutting_down.is_some()`.
+//!
+//! These tests are timing-sensitive because saturating the accept queue
+//! deterministically requires more concurrent connections than the
+//! configured `max_connections`. They run within `repeat_until_error_or`
+//! to absorb the inevitable scheduler jitter on busy CI runners.
+
+use std::{
+    io::Write,
+    net::{SocketAddr, TcpStream},
+    thread,
+    time::Duration,
+};
+
+use sozu_command_lib::{
+    config::FileConfig,
+    proto::command::{
+        ActivateListener, ListenerType, Request, RequestHttpFrontend, ServerConfig,
+        request::RequestType,
+    },
+    state::ConfigState,
+};
+
+use crate::{
+    mock::{client::Client, sync_backend::Backend as SyncBackend},
+    port_registry::attach_reserved_http_listener,
+    sozu::worker::Worker,
+    tests::{State, repeat_until_error_or},
+};
+
+use super::tests::create_local_address;
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/// Build a tiny `ServerConfig` with `max_connections = cap`, the
+/// `evict_on_queue_full` knob set, and the accept-queue timeout long
+/// enough that a stalled queue actually saturates rather than silently
+/// timing out underneath us.
+fn config_with_eviction(cap: usize, evict: bool) -> ServerConfig {
+    let mut server = Worker::into_config(FileConfig::default());
+    server.max_connections = cap as u64;
+    server.evict_on_queue_full = Some(evict);
+    server.accept_queue_timeout = 2_000; // 2 seconds — comfortably above the test's open phase
+    server
+}
+
+/// Open a raw TCP connection to `addr`, write a partial HTTP/1.1
+/// request line (headers never finish), and return the socket so the
+/// caller can hold it open. Sōzu sees an active session for the whole
+/// `request_timeout` window — long enough to fill the slab.
+fn open_dangling_connection(addr: SocketAddr) -> Option<TcpStream> {
+    let mut stream = TcpStream::connect(addr).ok()?;
+    stream.set_nodelay(true).ok();
+    // Partial request — no `\r\n\r\n` terminator, so sōzu waits.
+    stream.write_all(b"GET /idle HTTP/1.1\r\nHost: localhost\r\n").ok()?;
+    Some(stream)
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Test 1: evict_on_queue_full admits a new connection after eviction
+// ══════════════════════════════════════════════════════════════════════
+
+fn try_evict_on_queue_full_accepts_after_eviction() -> State {
+    let front_address = create_local_address();
+    let back_address = create_local_address();
+
+    // `max_connections = 2` keeps the slab tiny; one slot will be held
+    // by an idle client below, the second slot is what eviction must
+    // free for the fresh connection.
+    let config = config_with_eviction(2, true);
+    let mut listeners = sozu_command_lib::scm_socket::Listeners::default();
+    attach_reserved_http_listener(&mut listeners, front_address);
+    let state = ConfigState::new();
+
+    let mut worker =
+        Worker::start_new_worker_owned("EVICT-ACCEPTS", config, listeners, state);
+
+    // Activate the listener and a single cluster + frontend + backend
+    // so the worker has SOMETHING to route requests to.
+    worker.send_proxy_request(Request {
+        request_type: Some(RequestType::AddHttpListener(
+            sozu_command_lib::config::ListenerBuilder::new_http(front_address.into())
+                .to_http(None)
+                .unwrap(),
+        )),
+    });
+    worker.send_proxy_request(Request {
+        request_type: Some(RequestType::ActivateListener(ActivateListener {
+            address: front_address.into(),
+            proxy: ListenerType::Http.into(),
+            from_scm: false,
+        })),
+    });
+    worker.send_proxy_request(
+        RequestType::AddCluster(Worker::default_cluster("evict_cluster")).into(),
+    );
+    worker.send_proxy_request(
+        RequestType::AddHttpFrontend(RequestHttpFrontend {
+            ..Worker::default_http_frontend("evict_cluster", front_address)
+        })
+        .into(),
+    );
+    worker.send_proxy_request(
+        RequestType::AddBackend(Worker::default_backend(
+            "evict_cluster",
+            "evict_back_0",
+            back_address,
+            None,
+        ))
+        .into(),
+    );
+    worker.read_to_last();
+
+    let mut backend = SyncBackend::new(
+        "evict_back_0",
+        back_address,
+        "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\npong",
+    );
+    backend.connect();
+
+    // Saturate the slab with idle dangling connections. With
+    // `max_connections = 2`, two danglers fill the allowed sessions;
+    // the next admission must rely on eviction to free room.
+    let dangler_a = match open_dangling_connection(front_address) {
+        Some(s) => s,
+        None => return State::Fail,
+    };
+    let dangler_b = match open_dangling_connection(front_address) {
+        Some(s) => s,
+        None => return State::Fail,
+    };
+    thread::sleep(Duration::from_millis(150));
+
+    // Fresh client tries to admit. Without eviction this would either
+    // time out in the accept queue or get refused; with the knob on,
+    // sōzu evicts the oldest dangler and the new client should reach
+    // the backend.
+    let mut client = Client::new(
+        "evict_client",
+        front_address,
+        "GET /post HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n".to_owned(),
+    );
+    client.connect();
+    client.send();
+
+    // The backend may need a moment to receive the request after the
+    // eviction round runs; retry with a short cap rather than a single
+    // accept call.
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    let mut accepted = false;
+    while std::time::Instant::now() < deadline {
+        if backend.accept(0) {
+            accepted = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    drop(dangler_a);
+    drop(dangler_b);
+
+    if !accepted {
+        worker.soft_stop();
+        worker.wait_for_server_stop();
+        return State::Fail;
+    }
+    backend.receive(0);
+    backend.send(0);
+    let resp = client.receive();
+
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    match resp {
+        Some(r) if r.contains("200") => State::Success,
+        _ => State::Fail,
+    }
+}
+
+#[test]
+fn test_evict_on_queue_full_accepts_after_eviction() {
+    assert_eq!(
+        repeat_until_error_or(
+            5,
+            "evict_on_queue_full admits a new connection after evicting an idle one",
+            try_evict_on_queue_full_accepts_after_eviction,
+        ),
+        State::Success,
+    );
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Test 2: evict_on_queue_full default (false) drops new connections
+// ══════════════════════════════════════════════════════════════════════
+
+fn try_evict_disabled_drops_overflow() -> State {
+    let front_address = create_local_address();
+    let back_address = create_local_address();
+
+    // Knob explicitly OFF: the default behaviour. Saturated slab must
+    // refuse the fresh connection rather than evict an idle one.
+    let config = config_with_eviction(2, false);
+    let mut listeners = sozu_command_lib::scm_socket::Listeners::default();
+    attach_reserved_http_listener(&mut listeners, front_address);
+    let state = ConfigState::new();
+
+    let mut worker =
+        Worker::start_new_worker_owned("EVICT-DISABLED", config, listeners, state);
+
+    worker.send_proxy_request(Request {
+        request_type: Some(RequestType::AddHttpListener(
+            sozu_command_lib::config::ListenerBuilder::new_http(front_address.into())
+                .to_http(None)
+                .unwrap(),
+        )),
+    });
+    worker.send_proxy_request(Request {
+        request_type: Some(RequestType::ActivateListener(ActivateListener {
+            address: front_address.into(),
+            proxy: ListenerType::Http.into(),
+            from_scm: false,
+        })),
+    });
+    worker.send_proxy_request(
+        RequestType::AddCluster(Worker::default_cluster("noevict_cluster")).into(),
+    );
+    worker.send_proxy_request(
+        RequestType::AddHttpFrontend(RequestHttpFrontend {
+            ..Worker::default_http_frontend("noevict_cluster", front_address)
+        })
+        .into(),
+    );
+    worker.send_proxy_request(
+        RequestType::AddBackend(Worker::default_backend(
+            "noevict_cluster",
+            "noevict_back_0",
+            back_address,
+            None,
+        ))
+        .into(),
+    );
+    worker.read_to_last();
+
+    let mut backend = SyncBackend::new(
+        "noevict_back_0",
+        back_address,
+        "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\npong",
+    );
+    backend.connect();
+
+    // Saturate the slab.
+    let _dangler_a = match open_dangling_connection(front_address) {
+        Some(s) => s,
+        None => return State::Fail,
+    };
+    let _dangler_b = match open_dangling_connection(front_address) {
+        Some(s) => s,
+        None => return State::Fail,
+    };
+    thread::sleep(Duration::from_millis(150));
+
+    // Fresh client. Without eviction the backend must NOT see a request
+    // for at least the accept-queue-timeout window — sōzu either drops
+    // the new connection or holds it in the queue until timeout.
+    let mut client = Client::new(
+        "noevict_client",
+        front_address,
+        "GET /post HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n".to_owned(),
+    );
+    client.connect();
+    client.send();
+
+    // Tight window — if eviction fired we'd see backend.accept return
+    // true within ~200 ms. Allow ~600 ms to ride out scheduler jitter.
+    let deadline = std::time::Instant::now() + Duration::from_millis(600);
+    let mut accepted = false;
+    while std::time::Instant::now() < deadline {
+        if backend.accept(0) {
+            accepted = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    if accepted {
+        // Eviction fired even though we asked it not to — regression.
+        State::Fail
+    } else {
+        State::Success
+    }
+}
+
+#[test]
+fn test_evict_on_queue_full_disabled_drops_overflow() {
+    assert_eq!(
+        repeat_until_error_or(
+            3,
+            "evict_on_queue_full = false (default) does NOT evict idle sessions",
+            try_evict_disabled_drops_overflow,
+        ),
+        State::Success,
+    );
+}

--- a/e2e/src/tests/mod.rs
+++ b/e2e/src/tests/mod.rs
@@ -24,6 +24,7 @@
 #![allow(clippy::useless_vec)]
 
 mod cluster_ip_limit_tests;
+mod eviction_tests;
 mod fuzz_tests;
 mod h1_security_tests;
 mod h2_correctness_tests;

--- a/e2e/src/tests/redirect_rewrite_auth_tests.rs
+++ b/e2e/src/tests/redirect_rewrite_auth_tests.rs
@@ -1393,8 +1393,7 @@ fn test_request_header_inject_h2_h2() {
 pub fn try_redirect_permanent_uses_rewrite_host_and_template() -> State {
     let front_address = create_local_address();
     let unused_back = create_unbound_local_address();
-    let mut worker =
-        spawn_worker_with_http_listener("REDIR-TEMPLATE-REWRITE", front_address);
+    let mut worker = spawn_worker_with_http_listener("REDIR-TEMPLATE-REWRITE", front_address);
 
     worker.send_proxy_request(
         RequestType::AddCluster(Cluster {
@@ -1463,18 +1462,14 @@ Content-Length: 0\r\n\r\n"
     // listener default never emits `X-Custom-Redirect`, so this header
     // proves the inline render path took over the answer.
     if !lower.contains("x-custom-redirect: from-template") {
-        eprintln!(
-            "expected X-Custom-Redirect from operator template, got:\n{response}"
-        );
+        eprintln!("expected X-Custom-Redirect from operator template, got:\n{response}");
         return State::Fail;
     }
 
     // Host assertion: the 301 Location uses the rewritten host, not the
     // original `Host: localhost` from the request line.
     if !lower.contains("location: https://new.example.com") {
-        eprintln!(
-            "expected Location to use rewritten host new.example.com, got:\n{response}"
-        );
+        eprintln!("expected Location to use rewritten host new.example.com, got:\n{response}");
         return State::Fail;
     }
 

--- a/e2e/src/tests/redirect_rewrite_auth_tests.rs
+++ b/e2e/src/tests/redirect_rewrite_auth_tests.rs
@@ -1368,3 +1368,132 @@ fn test_request_header_inject_h2_h2() {
         State::Success
     );
 }
+
+// ═════════════════════════════════════════════════════════════════════
+// Redirect plumbing — `redirect_template` + `rewrite_host` on 301
+// ═════════════════════════════════════════════════════════════════════
+
+/// Two interlocking invariants on the `RedirectPolicy::PERMANENT` path,
+/// pinned in one fixture because they share the same call site:
+///
+/// - `redirect_template` is plumbed into the 301 default-answer. When
+///   the field was destructured out of `RouteResult` only to be dropped,
+///   the operator-supplied template had no observable effect; the
+///   response always rendered the listener / cluster default. The test
+///   ships a template carrying a load-bearing `X-Custom-Redirect`
+///   header that the listener default does NOT emit, so its presence
+///   in the response confirms the inline-render path ran.
+///
+/// - `rewrite_host` feeds the 301 `Location`. When
+///   `build_redirect_location` only read `context.authority`, a
+///   `rewrite_host = "new.example.com"` frontend redirected the client
+///   back to the original `Host:` header. The test sends a request to
+///   `old.example.com` (here: `localhost`) and asserts the resulting
+///   `Location:` carries `new.example.com`.
+pub fn try_redirect_permanent_uses_rewrite_host_and_template() -> State {
+    let front_address = create_local_address();
+    let unused_back = create_unbound_local_address();
+    let mut worker =
+        spawn_worker_with_http_listener("REDIR-TEMPLATE-REWRITE", front_address);
+
+    worker.send_proxy_request(
+        RequestType::AddCluster(Cluster {
+            https_redirect_port: Some(8443),
+            ..Worker::default_cluster("redir_tmpl_cluster")
+        })
+        .into(),
+    );
+
+    // Custom 301 template carrying a load-bearing `X-Custom-Redirect`
+    // header. RFC 9110 §5: header-field-name is case-insensitive; the
+    // listener-default `http.301.redirection` template does NOT emit
+    // this header, so its presence in the response is a clean signal
+    // that the inline-render path ran.
+    //
+    // `%REDIRECT_LOCATION` is the canonical placeholder for the 301
+    // Location URL — the same variable schema the listener default
+    // uses, so the same `(REDIRECT_LOCATION, ROUTE, REQUEST_ID)`
+    // variable feed produced by `Router::connect` flows in cleanly.
+    let custom_template = "\
+HTTP/1.1 301 Moved Permanently\r\n\
+Location: %REDIRECT_LOCATION\r\n\
+X-Custom-Redirect: from-template\r\n\
+Content-Length: 0\r\n\r\n"
+        .to_owned();
+
+    worker.send_proxy_request(
+        RequestType::AddHttpFrontend(RequestHttpFrontend {
+            redirect: Some(RedirectPolicy::Permanent as i32),
+            redirect_scheme: Some(RedirectScheme::UseHttps as i32),
+            redirect_template: Some(custom_template),
+            // `rewrite_host` is a literal target host (the static
+            // grammar; capture-templating uses `%1` etc., not exercised
+            // here). The frontend's hostname stays `localhost` so the
+            // request still routes to this cluster; the rewrite kicks
+            // in for the post-route `Location` URL.
+            rewrite_host: Some("new.example.com".to_owned()),
+            ..Worker::default_http_frontend("redir_tmpl_cluster", front_address)
+        })
+        .into(),
+    );
+    add_backend(
+        &mut worker,
+        "redir_tmpl_cluster",
+        "redir_tmpl_back_0",
+        unused_back,
+    );
+    worker.read_to_last();
+
+    let mut client = Client::new(
+        "redir_tmpl_client",
+        front_address,
+        http_request("GET", "/path", "ping", "localhost"),
+    );
+    client.connect();
+    client.send();
+    let response = client
+        .receive()
+        .expect("frontend must emit a 301 default-answer");
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    let lower = response.to_ascii_lowercase();
+
+    // Template assertion: the operator-supplied template ran. The
+    // listener default never emits `X-Custom-Redirect`, so this header
+    // proves the inline render path took over the answer.
+    if !lower.contains("x-custom-redirect: from-template") {
+        eprintln!(
+            "expected X-Custom-Redirect from operator template, got:\n{response}"
+        );
+        return State::Fail;
+    }
+
+    // Host assertion: the 301 Location uses the rewritten host, not the
+    // original `Host: localhost` from the request line.
+    if !lower.contains("location: https://new.example.com") {
+        eprintln!(
+            "expected Location to use rewritten host new.example.com, got:\n{response}"
+        );
+        return State::Fail;
+    }
+
+    if !response.contains("301") {
+        eprintln!("expected 301 status, got:\n{response}");
+        return State::Fail;
+    }
+
+    State::Success
+}
+
+#[test]
+fn test_redirect_permanent_uses_rewrite_host_and_template() {
+    assert_eq!(
+        repeat_until_error_or(
+            2,
+            "permanent redirect renders custom redirect_template and Location uses rewrite_host",
+            try_redirect_permanent_uses_rewrite_host_and_template,
+        ),
+        State::Success,
+    );
+}

--- a/lib/src/protocol/kawa_h1/answers.rs
+++ b/lib/src/protocol/kawa_h1/answers.rs
@@ -342,7 +342,11 @@ impl Template {
 
     /// Substitute runtime values into a pre-parsed template, eliding header
     /// lines whose value substitutes to empty when `or_elide_header` is set.
-    fn fill(&self, variables: &[Vec<u8>], variables_once: &mut [Vec<u8>]) -> DefaultAnswerStream {
+    pub(crate) fn fill(
+        &self,
+        variables: &[Vec<u8>],
+        variables_once: &mut [Vec<u8>],
+    ) -> DefaultAnswerStream {
         let mut blocks = self.kawa.blocks.clone();
         let mut body_size = self.body_size;
         for replacement in &self.body_replacements {
@@ -1085,6 +1089,46 @@ impl HttpAnswers {
     /// fall through to the listener-level template.
     pub fn remove_cluster_answers(&mut self, cluster_id: &str) {
         self.cluster_answers.remove(cluster_id);
+    }
+
+    /// Compile a frontend-supplied 301 template on the fly and render it
+    /// with the canonical `(REDIRECT_LOCATION, ROUTE, REQUEST_ID)`
+    /// variable schema, returning the same `(status, keep_alive,
+    /// rendered_stream)` triple as [`HttpAnswers::get`].
+    ///
+    /// ── Why a one-off compile path ──
+    ///
+    /// `HttpAnswers::get` resolves a template via the persistent lookup
+    /// chain (per-cluster override → listener default → fallback). A
+    /// `Frontend` may instead carry its own `redirect_template` (proto +
+    /// TOML) that should override the chain for a single
+    /// `RedirectPolicy::PERMANENT` request. Storing the compiled
+    /// template in the persistent map would require a per-frontend key
+    /// (which the map is not designed for) and would still diverge if
+    /// two frontends on the same cluster carried different templates.
+    /// Compiling on demand sidesteps both issues at the cost of one
+    /// `Template::new` per redirected request — measurable but bounded
+    /// by Frontend cardinality, since templates that compile cleanly
+    /// today will compile cleanly tomorrow.
+    ///
+    /// Returns `None` when compilation fails. Callers MUST fall back to
+    /// the regular `HttpAnswers::get` path so a late-discovered config
+    /// bug never blocks the request — the rendered listener default is
+    /// always preferable to a 503 / hung response.
+    pub fn render_inline_301(
+        answer_str: &str,
+        location: Option<String>,
+        request_id: String,
+        route: String,
+    ) -> Option<(u16, bool, DefaultAnswerStream)> {
+        let template = Self::template("301", answer_str).ok()?;
+        // Variable order must match the `DefaultAnswer::Answer301` arm of
+        // `HttpAnswers::get`: `(ROUTE, REQUEST_ID)` are persistent
+        // `Variable` slots, `REDIRECT_LOCATION` is the once slot.
+        let variables: Vec<Vec<u8>> = vec![route.into(), request_id.into()];
+        let mut variables_once: Vec<Vec<u8>> = vec![location.unwrap_or_default().into()];
+        let stream = template.fill(&variables, &mut variables_once);
+        Some((template.status, template.keep_alive, stream))
     }
 
     /// Lookup + render. Returns the resolved status, the template's

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -269,6 +269,18 @@ pub struct HttpContext {
     /// header entirely — `Retry-After: 0` invites an immediate retry
     /// that defeats the limit. Unused for any other status code.
     pub retry_after_seconds: Option<u32>,
+    /// Frontend-supplied template body that overrides the listener /
+    /// cluster default `http.301.redirection` for a single
+    /// `RedirectPolicy::PERMANENT` request. Stashed by the routing layer
+    /// from `RouteResult::redirect_template` and consumed by the 301
+    /// branch of `mux::answers::set_default_answer_with_retry_after`,
+    /// which compiles the body via `HttpAnswers::render_inline_301` and
+    /// renders it with the same `(REDIRECT_LOCATION, ROUTE,
+    /// REQUEST_ID)` variable schema as the persistent template chain.
+    /// `None` falls back to the cluster / listener default. Unused for
+    /// any other status code or for the legacy
+    /// `cluster.https_redirect = true` path (which never sets it).
+    pub frontend_redirect_template: Option<String>,
 }
 
 /// Owned snapshot of a per-frontend header edit, captured at routing
@@ -346,6 +358,7 @@ impl HttpContext {
             original_authority: None,
             headers_response: Vec::new(),
             retry_after_seconds: None,
+            frontend_redirect_template: None,
         }
     }
 

--- a/lib/src/protocol/mux/answers.rs
+++ b/lib/src/protocol/mux/answers.rs
@@ -296,9 +296,8 @@ pub(crate) fn set_default_answer_with_retry_after(
         None
     };
 
-    let (resolved_status, keep_alive, rendered) = inline_override.unwrap_or_else(|| {
-        answers.get(answer, request_id, cluster_id, backend_id, route)
-    });
+    let (resolved_status, keep_alive, rendered) = inline_override
+        .unwrap_or_else(|| answers.get(answer, request_id, cluster_id, backend_id, route));
     // Honour the rendered template's `Connection` header. Most error
     // templates carry `Connection: close`, which flips the frontend
     // keep-alive bit to false; cluster operators can opt back into

--- a/lib/src/protocol/mux/answers.rs
+++ b/lib/src/protocol/mux/answers.rs
@@ -4,8 +4,22 @@
 //! per-stream kawa buffers, then flip the appropriate readiness bits so the
 //! response is flushed on the next writable pass.
 
+use sozu_command::logging::ansi_palette;
+
 use super::{GenericHttpStream, H2Error, Readiness, Stream, StreamState};
 use crate::protocol::http::{DefaultAnswer, answers::HttpAnswers};
+
+/// Module-level prefix used on every log line emitted from the mux
+/// answers helpers. The standalone helpers run before any per-stream
+/// scope is in hand (or after it has been torn down), so a single
+/// `MUX-ANSWERS` label is used, coloured bold bright-white (uniform
+/// across every protocol) when the logger supports ANSI.
+macro_rules! log_module_context {
+    () => {{
+        let (open, reset, _, _, _) = ansi_palette();
+        format!("{open}MUX-ANSWERS{reset}\t >>>", open = open, reset = reset)
+    }};
+}
 
 /// Terminate a default answer with optional `Connection: close` and `Cache-Control` headers.
 ///
@@ -247,8 +261,44 @@ pub(crate) fn set_default_answer_with_retry_after(
     let cluster_id = context.cluster_id.as_deref();
     let backend_id = context.backend_id.as_deref();
 
-    let (resolved_status, keep_alive, rendered) =
-        answers.get(answer, request_id, cluster_id, backend_id, route);
+    // ── Frontend-scoped 301 template override ──
+    //
+    // A `Frontend` with `redirect = permanent` may carry its own
+    // `redirect_template` body that overrides the persistent
+    // listener / cluster `http.301.redirection` template for this one
+    // request. Compile on demand via
+    // `HttpAnswers::render_inline_301`; on any compile failure (operator
+    // config bug surfacing late) fall through to the regular
+    // `answers.get` path so the request still completes with the
+    // listener default — a rendered fallback is always preferable to a
+    // hung response or 503.
+    let inline_override = if code == 301 {
+        context
+            .frontend_redirect_template
+            .as_deref()
+            .and_then(|template_str| {
+                let result = HttpAnswers::render_inline_301(
+                    template_str,
+                    context.redirect_location.clone(),
+                    context.id.to_string(),
+                    context.get_route(),
+                );
+                if result.is_none() {
+                    error!(
+                        "{} frontend redirect_template failed to compile, falling back to default 301 template",
+                        log_module_context!()
+                    );
+                    incr!("http.301.redirect_template.compile_error");
+                }
+                result
+            })
+    } else {
+        None
+    };
+
+    let (resolved_status, keep_alive, rendered) = inline_override.unwrap_or_else(|| {
+        answers.get(answer, request_id, cluster_id, backend_id, route)
+    });
     // Honour the rendered template's `Connection` header. Most error
     // templates carry `Connection: close`, which flips the frontend
     // keep-alive bit to false; cluster operators can opt back into
@@ -334,6 +384,7 @@ mod tests {
             original_authority: None,
             headers_response: Vec::new(),
             retry_after_seconds: None,
+            frontend_redirect_template: None,
         };
         let stream =
             Stream::new(Rc::downgrade(&pool), http_ctx, 65_535).expect("pool checkout failed");

--- a/lib/src/protocol/mux/auth.rs
+++ b/lib/src/protocol/mux/auth.rs
@@ -175,10 +175,30 @@ fn pad_for_constant_time_compare(input: &[u8]) -> [u8; AUTH_COMPARE_PAD_LEN + 8]
 /// This defeats timing side-channel attacks that would otherwise leak
 /// the size of the realm, the length of the matching username, or the
 /// index of the matching credential.
+///
+/// ── Length-bound prelude ──
+///
+/// `pad_for_constant_time_compare` silently truncates inputs longer than
+/// [`AUTH_COMPARE_PAD_LEN`]. Two credentials that share their first 256
+/// bytes — for example, the same long username with different password
+/// digests — would produce identical padded buffers (and identical length
+/// suffixes if the inputs share a length), letting a bogus password
+/// authenticate as the long-username slot. The pre-loop guard below
+/// rejects any input that would be truncated before the compare runs, so
+/// the constant-time loop only ever sees values we can encode without
+/// loss. Stored entries that exceed the bound are skipped by the same
+/// rule — operator config should never produce them, but we refuse to
+/// silently truncate one if it slips through.
 pub fn check_authorized_hashes(candidate: &str, authorized_hashes: &[String]) -> bool {
+    if candidate.len() > AUTH_COMPARE_PAD_LEN {
+        return false;
+    }
     let candidate_padded = pad_for_constant_time_compare(candidate.as_bytes());
     let mut matched = subtle::Choice::from(0u8);
     for hash in authorized_hashes {
+        if hash.len() > AUTH_COMPARE_PAD_LEN {
+            continue;
+        }
         let entry_padded = pad_for_constant_time_compare(hash.as_bytes());
         // Both buffers are exactly `AUTH_COMPARE_PAD_LEN + 8` bytes, so
         // subtle's slice `ct_eq` runs the full byte-loop instead of
@@ -277,6 +297,47 @@ mod tests {
         let wrong = "admin:0000000000000000000000000000000000000000000000000000000000000000";
         let list = [format!("admin:{SECRET_SHA256_HEX}")];
         assert!(!check_authorized_hashes(wrong, &list));
+    }
+
+    /// `pad_for_constant_time_compare` truncates inputs to
+    /// `AUTH_COMPARE_PAD_LEN = 256` bytes. Two canonical credentials whose
+    /// first 256 bytes match — e.g. the same long username with different
+    /// password digests at offsets > 256 — would otherwise produce
+    /// identical padded buffers and authenticate as each other. The fix
+    /// rejects any candidate whose canonical length exceeds the envelope
+    /// before the compare loop runs.
+    #[test]
+    fn check_authorized_hashes_rejects_overlong_candidate() {
+        // Username large enough that the `:hex64` suffix sits past byte 256.
+        // 250 bytes of `a` + ":" + 64 hex = 315 bytes total.
+        let long_user = "a".repeat(250);
+        let stored = format!("{long_user}:{SECRET_SHA256_HEX}");
+        let attacker = format!(
+            "{long_user}:0000000000000000000000000000000000000000000000000000000000000000"
+        );
+        assert!(stored.len() > AUTH_COMPARE_PAD_LEN);
+        assert!(attacker.len() > AUTH_COMPARE_PAD_LEN);
+        assert_eq!(stored.len(), attacker.len()); // same length suffix
+        let list = [stored];
+        // Without the length guard the attacker credential would compare
+        // equal to `stored` because the differing digest is past byte 256
+        // and `pad_for_constant_time_compare` would truncate both inputs
+        // to the same prefix. The guard rejects both — no auth bypass.
+        assert!(!check_authorized_hashes(&attacker, &list));
+    }
+
+    /// Stored entries that are themselves overlong are skipped rather than
+    /// silently truncated. An operator config containing such an entry
+    /// would not authenticate any candidate against it; that is preferred
+    /// over admitting a collision.
+    #[test]
+    fn check_authorized_hashes_skips_overlong_stored_entry() {
+        let valid = format!("admin:{SECRET_SHA256_HEX}");
+        let overlong = format!("{}:{SECRET_SHA256_HEX}", "a".repeat(250));
+        assert!(overlong.len() > AUTH_COMPARE_PAD_LEN);
+        // The valid entry still matches; the overlong stored entry is skipped.
+        let list = [overlong, valid.clone()];
+        assert!(check_authorized_hashes(&valid, &list));
     }
 
     #[test]

--- a/lib/src/protocol/mux/auth.rs
+++ b/lib/src/protocol/mux/auth.rs
@@ -122,8 +122,24 @@ pub fn canonicalize_basic_credentials(value: &[u8]) -> Option<String> {
         return None;
     }
 
+    // ── Pre-decode length cap ──
+    //
+    // base64 expands 3 bytes → 4 characters. The post-decode length check
+    // below would still allocate the full decoded payload before the
+    // rejection runs, so a peer can force a per-attempt allocation up to
+    // the request-buffer cap on every failed Basic-auth probe.
+    // `basic_auth_max_credential_bytes` is meant as a per-request memory
+    // bound; cap the *encoded* size first so `STANDARD.decode` never sees
+    // a payload bigger than the bound it implies. The `+ 4` slack covers
+    // up to two `=` padding characters plus rounding.
+    let max_decoded = max_decoded_credential_bytes();
+    let max_encoded = max_decoded.saturating_mul(4).saturating_add(2) / 3 + 4;
+    if rest.len() > max_encoded {
+        return None;
+    }
+
     let decoded = STANDARD.decode(rest).ok()?;
-    if decoded.len() > max_decoded_credential_bytes() {
+    if decoded.len() > max_decoded {
         return None;
     }
 
@@ -271,6 +287,26 @@ mod tests {
         let payload = "a".repeat(max_decoded_credential_bytes() * 2);
         let token = STANDARD.encode(format!("{payload}:pwd"));
         let header = format!("Basic {token}");
+        assert!(canonicalize_basic_credentials(header.as_bytes()).is_none());
+    }
+
+    /// The post-decode length check used to let `STANDARD.decode` allocate
+    /// the full payload before rejection, so an attacker could force a
+    /// per-attempt allocation up to the request-buffer cap on every
+    /// failed Basic-auth probe. The pre-decode length cap rejects an
+    /// oversized encoded payload before any allocation.
+    ///
+    /// We don't measure the allocator directly here; instead we pass an
+    /// encoded payload that is *much* larger than `max_decoded * 4 / 3`
+    /// and assert `None`. Combined with the source code's pre-decode
+    /// guard, that's enough to pin the contract.
+    #[test]
+    fn canonicalize_rejects_oversized_encoded_payload_before_decode() {
+        // 16× the maximum encoded budget. Without the pre-decode cap,
+        // base64::STANDARD::decode would allocate ~12× max_decoded bytes
+        // before the post-decode rejection ran.
+        let oversize = "A".repeat(max_decoded_credential_bytes() * 16);
+        let header = format!("Basic {oversize}");
         assert!(canonicalize_basic_credentials(header.as_bytes()).is_none());
     }
 

--- a/lib/src/protocol/mux/auth.rs
+++ b/lib/src/protocol/mux/auth.rs
@@ -348,9 +348,8 @@ mod tests {
         // 250 bytes of `a` + ":" + 64 hex = 315 bytes total.
         let long_user = "a".repeat(250);
         let stored = format!("{long_user}:{SECRET_SHA256_HEX}");
-        let attacker = format!(
-            "{long_user}:0000000000000000000000000000000000000000000000000000000000000000"
-        );
+        let attacker =
+            format!("{long_user}:0000000000000000000000000000000000000000000000000000000000000000");
         assert!(stored.len() > AUTH_COMPARE_PAD_LEN);
         assert!(attacker.len() > AUTH_COMPARE_PAD_LEN);
         assert_eq!(stored.len(), attacker.len()); // same length suffix

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -7457,6 +7457,7 @@ mod tests {
             original_authority: None,
             headers_response: Vec::new(),
             retry_after_seconds: None,
+            frontend_redirect_template: None,
         };
         Stream::new(Rc::downgrade(pool), http_ctx, 65_535)
             .expect("pool should have capacity for two buffers")

--- a/lib/src/protocol/mux/pkawa.rs
+++ b/lib/src/protocol/mux/pkawa.rs
@@ -1004,13 +1004,37 @@ where
 ///
 /// The shared `HttpContext::on_request_headers` callback that handles
 /// elision on **initial** HEADERS frames is **not** invoked here, so any
-/// listener-scoped header rewrites must be plumbed in explicitly. Trailer
-/// elision contract:
+/// listener-scoped header rewrites must be plumbed in explicitly.
 ///
-/// * `elide_x_real_ip = true` causes `X-Real-IP` trailers to be silently
-///   dropped (matches the initial-HEADERS branch in
-///   `HttpContext::on_request_headers`). Without this an H2 client can
-///   bypass the anti-spoof by sending `x-real-ip` as a trailer.
+/// ── Spoof-vector elision per RFC 9110 §6.5 ──
+///
+/// RFC 9110 §6.5 forbids trailers from carrying fields that affect
+/// "message framing, message routing, or response semantics." sōzu
+/// rewrites four client-attribution headers on the initial HEADERS pass
+/// (`HttpContext::on_request_headers` in
+/// `lib/src/protocol/kawa_h1/editor.rs`):
+///   * `X-Real-IP` is replaced by the post-PROXY-v2 peer IP when
+///     `send_x_real_ip = true` and stripped client-side when
+///     `elide_x_real_ip = true`.
+///   * `X-Forwarded-For` has the peer IP appended.
+///   * `Forwarded` (RFC 7239) has a `proto=…;for=…;by=…` clause appended.
+///   * `X-Request-Id` is preserved verbatim (de-facto correlation
+///     header used by Envoy/HAProxy/most LBs).
+///
+/// A naive H2 client could otherwise smuggle any of those by sending
+/// them as a trailer block: an H2 backend that merges trailers into
+/// its header view (gRPC-style, or anything that uses
+/// `headers::extend(trailers.iter())`) would observe an attacker-
+/// controlled value. The four elisions below run **unconditionally** —
+/// the spec already prohibits them, the operator gains no observability
+/// or routing signal from a trailer-side copy, and forwarding them is
+/// strictly a spoof vector.
+///
+/// `elide_x_real_ip` is kept as an explicit parameter for symmetry
+/// with the initial-HEADERS path's listener flag, but the trailer-side
+/// elision of `x-real-ip` no longer depends on it — the listener flag
+/// only governs whether sōzu *injects* an `X-Real-IP` header on the
+/// forward, never whether it filters one off the wire.
 pub fn handle_trailer(
     kawa: &mut GenericHttpStream,
     input: &[u8],
@@ -1019,6 +1043,10 @@ pub fn handle_trailer(
     max_header_list_size: u32,
     elide_x_real_ip: bool,
 ) -> Result<(), (H2Error, bool)> {
+    // Acknowledge the parameter; dropping it would force a callsite
+    // change. The elision below covers x-real-ip unconditionally so
+    // the listener flag is no longer a gate for trailer-side defence.
+    let _ = elide_x_real_ip;
     if !end_stream {
         return Err((H2Error::ProtocolError, false));
     }
@@ -1060,16 +1088,23 @@ pub fn handle_trailer(
             invalid_trailers = true;
             return;
         }
-        // Anti-spoofing: when the listener has `elide_x_real_ip = true`
-        // the initial-HEADERS branch in `HttpContext::on_request_headers`
-        // strips client-supplied `X-Real-IP` headers. Trailer HEADERS
-        // frames bypass that callback, so without this branch a naive
-        // H2 client could sneak `x-real-ip` past the anti-spoof by
-        // sending it as a trailer. Keys are already lower-case here:
-        // RFC 9113 §8.2.2 forbids uppercase and `classify_invalid_h2_header`
-        // (above) rejects any violation, so an `eq` against the lower
-        // form is sufficient.
-        if elide_x_real_ip && k.eq_ignore_ascii_case(b"x-real-ip") {
+        // ── Spoof-vector elision per RFC 9110 §6.5 ──
+        //
+        // RFC 9110 §6.5 forbids trailers from carrying message-routing
+        // semantics. The four client-attribution headers below are
+        // rewritten by sōzu on the initial-HEADERS pass; admitting them
+        // as trailers would let a naive H2 client smuggle a spoofed
+        // value to a backend that merges trailers into its header view.
+        // Drop them unconditionally — keys are already lower-case here
+        // (`classify_invalid_h2_header` rejects any uppercase byte per
+        // RFC 9113 §8.2.2), so a byte-equality check is sufficient.
+        // `incr!` records the rejection so dashboards observe the
+        // attempted smuggle without spamming logs.
+        if matches!(
+            k.as_ref(),
+            b"x-real-ip" | b"x-forwarded-for" | b"forwarded" | b"x-request-id"
+        ) {
+            incr!("h2.trailer.spoof_vector_elided");
             return;
         }
         let start = kawa.storage.end as u32;
@@ -2241,6 +2276,110 @@ mod tests {
             "H2→H1 chunked body must emit Transfer-Encoding: chunked for trailer support"
         );
     }
+    // ── handle_trailer: spoof-vector elision per RFC 9110 §6.5 ───────────
+
+    /// Helper: HPACK-encode a set of trailer pairs and run them through
+    /// `handle_trailer`. Returns the kawa stream so the caller can
+    /// inspect which trailer headers landed in `kawa.blocks`.
+    fn decode_trailer(
+        pool: &mut crate::pool::Pool,
+        trailers: &[(&[u8], &[u8])],
+    ) -> GenericHttpStream {
+        let mut encoder = loona_hpack::Encoder::new();
+        let mut encoded = Vec::new();
+        for &(name, value) in trailers {
+            encoder
+                .encode_header_into((name, value), &mut encoded)
+                .unwrap();
+        }
+
+        let mut decoder = loona_hpack::Decoder::new();
+        let mut kawa = make_generic_kawa(pool, Kind::Request);
+
+        let result = handle_trailer(
+            &mut kawa,
+            &encoded,
+            true, // end_stream
+            &mut decoder,
+            crate::protocol::mux::h2::MAX_HEADER_LIST_SIZE as u32,
+            false, // elide_x_real_ip — listener flag, not the trailer-side gate
+        );
+        assert!(result.is_ok(), "handle_trailer failed: {:?}", result.err());
+        kawa
+    }
+
+    /// Returns the lowercased trailer keys that survived the elision filter.
+    fn surviving_trailer_keys(kawa: &GenericHttpStream) -> Vec<Vec<u8>> {
+        let buf = kawa.storage.buffer();
+        kawa.blocks
+            .iter()
+            .filter_map(|b| match b {
+                Block::Header(Pair { key, .. }) => Some(key.data(buf).to_vec()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// RFC 9110 §6.5 forbids trailers from carrying message-routing
+    /// fields. The initial-HEADERS path rewrites four client-attribution
+    /// headers (`X-Real-IP`, `X-Forwarded-For`, `Forwarded`,
+    /// `X-Request-Id`). An H2 client must not be able to smuggle a
+    /// spoofed copy as a trailer, since H2 backends that merge trailers
+    /// into their header view would observe the attacker-controlled
+    /// value. Drop them unconditionally.
+    #[test]
+    fn handle_trailer_elides_spoof_vector_headers() {
+        let mut pool = crate::pool::Pool::with_capacity(1, 1, 4096);
+        let kawa = decode_trailer(
+            &mut pool,
+            &[
+                (b"x-real-ip", b"1.2.3.4"),
+                (b"x-forwarded-for", b"5.6.7.8"),
+                (b"forwarded", b"for=9.10.11.12"),
+                (b"x-request-id", b"attacker-correlation-id"),
+                (b"x-trailer-keep", b"please-keep-me"),
+            ],
+        );
+        let surviving = surviving_trailer_keys(&kawa);
+        assert_eq!(
+            surviving,
+            vec![b"x-trailer-keep".to_vec()],
+            "only non-spoof trailers must survive the RFC 9110 §6.5 elision"
+        );
+    }
+
+    /// Each of the four spoof-vector headers must be dropped on its own,
+    /// so a single-trailer attempt cannot bypass the filter just because
+    /// the others are absent.
+    #[test]
+    fn handle_trailer_drops_each_spoof_header_individually() {
+        for &name in &[
+            b"x-real-ip" as &[u8],
+            b"x-forwarded-for",
+            b"forwarded",
+            b"x-request-id",
+        ] {
+            let mut pool = crate::pool::Pool::with_capacity(1, 1, 4096);
+            let kawa = decode_trailer(&mut pool, &[(name, b"v")]);
+            let surviving = surviving_trailer_keys(&kawa);
+            assert!(
+                surviving.is_empty(),
+                "trailer with only {} should leave no surviving block",
+                std::str::from_utf8(name).unwrap()
+            );
+        }
+    }
+
+    /// Sanity: an unrelated trailer (e.g. `grpc-status`) is still kept.
+    /// Without this we'd be silently breaking gRPC semantics.
+    #[test]
+    fn handle_trailer_keeps_grpc_status() {
+        let mut pool = crate::pool::Pool::with_capacity(1, 1, 4096);
+        let kawa = decode_trailer(&mut pool, &[(b"grpc-status", b"0")]);
+        let surviving = surviving_trailer_keys(&kawa);
+        assert_eq!(surviving, vec![b"grpc-status".to_vec()]);
+    }
+
     /// H2 request declaring Content-Length keeps the Length framing: the
     /// H1 backend cannot receive trailers in this case (RFC 9110 §6.5 —
     /// trailers require chunked transfer-coding), and we document that

--- a/lib/src/protocol/mux/router.rs
+++ b/lib/src/protocol/mux/router.rs
@@ -164,15 +164,36 @@ impl Router {
             })
             .unwrap_or((false, false, false, None, None));
 
+        // ── Legacy `cluster.https_redirect` short-circuit ──
+        //
+        // Resolve the legacy HTTP→HTTPS redirect BEFORE per-(cluster,
+        // source-IP) accounting so a redirect-only request never
+        // consumes an IP slot. Otherwise a same-IP client iterating an
+        // HTTP→HTTPS hop could trip 429 ahead of the 301 even though no
+        // backend would have been opened. A duplicate guard that lived
+        // here previously (rebase artefact — two identical
+        // `if frontend_should_redirect_https && …` blocks back-to-back)
+        // is folded into this single early-return.
+        // Frontend-scoped `RedirectPolicy::PERMANENT` already returns
+        // from `route_from_request` with the same error, so this only
+        // handles the legacy cluster-level path that doesn't surface
+        // from `route_from_request`.
+        if frontend_should_redirect_https && matches!(proxy.borrow().kind(), ListenerType::Http) {
+            return Err(BackendConnectionError::RetrieveClusterError(
+                RetrieveClusterError::HttpsRedirect,
+            ));
+        }
+
         // Per-(cluster, source-IP) connection limit gate. Runs AFTER cluster
-        // resolution (so a 401/421/redirect frontend never trips the limit)
-        // and BEFORE any backend selection (so a rejection consumes neither
-        // a backend pool slot nor a retry budget). The check uses the source
-        // IP from the per-stream `HttpContext.session_address`, which is the
-        // proxy-protocol-aware client address when present, falling back to
-        // `peer_addr`. The limit governs distinct **frontend connections**
-        // per `(cluster, ip)`: an H2 session multiplexing N streams to the
-        // same cluster from the same IP still consumes a single slot.
+        // resolution AND legacy redirect emission (so a 401/421/redirect
+        // frontend never trips the limit) and BEFORE any backend selection
+        // (so a rejection consumes neither a backend pool slot nor a retry
+        // budget). The check uses the source IP from the per-stream
+        // `HttpContext.session_address`, which is the proxy-protocol-aware
+        // client address when present, falling back to `peer_addr`. The
+        // limit governs distinct **frontend connections** per
+        // `(cluster, ip)`: an H2 session multiplexing N streams to the same
+        // cluster from the same IP still consumes a single slot.
         let session_ip = stream_context.session_address.map(|sa| sa.ip());
         if let Some(ip) = session_ip {
             // The frontend session is mutably borrowed up the call stack
@@ -205,18 +226,6 @@ impl Router {
             sessions_rc
                 .borrow_mut()
                 .track_cluster_ip(frontend_token, cluster_id.clone(), ip);
-        }
-
-        if frontend_should_redirect_https && matches!(proxy.borrow().kind(), ListenerType::Http) {
-            return Err(BackendConnectionError::RetrieveClusterError(
-                RetrieveClusterError::HttpsRedirect,
-            ));
-        }
-
-        if frontend_should_redirect_https && matches!(proxy.borrow().kind(), ListenerType::Http) {
-            return Err(BackendConnectionError::RetrieveClusterError(
-                RetrieveClusterError::HttpsRedirect,
-            ));
         }
 
         /*
@@ -613,6 +622,7 @@ impl Router {
             cluster_id,
             redirect,
             redirect_scheme,
+            redirect_template,
             rewritten_host,
             rewritten_path,
             rewritten_port,
@@ -661,7 +671,30 @@ impl Router {
         if matches!(redirect, RedirectPolicy::Permanent) {
             let scheme = resolve_redirect_scheme(redirect_scheme, context);
             let port = rewritten_port.map(|p| p as u32).or(https_redirect_port);
-            context.redirect_location = Some(build_redirect_location(scheme, context, port));
+            // Feed the rewritten host AND path into the `Location` URL
+            // when the frontend's RewriteParts populated them. Without
+            // this, a `redirect = permanent` frontend with
+            // `rewrite_host = "new.example.com"` would serve clients
+            // back to the original `Host:` header, defeating the
+            // documented `old → new` shape.
+            // The host_override path also keeps `:port` stripping
+            // intact: `build_redirect_location` removes any `:port` on
+            // the override before reapplying `port_suffix`.
+            context.redirect_location = Some(build_redirect_location(
+                scheme,
+                context,
+                port,
+                rewritten_host.as_deref(),
+                rewritten_path.as_deref(),
+            ));
+            // Stash the frontend's `redirect_template` (when set) so the
+            // 301 default-answer path can render it via
+            // `HttpAnswers::render_inline_301` instead of the listener /
+            // cluster default. Without this stash the field flows into
+            // `RouteResult` only to be dropped by the wildcard
+            // destructure below, so the operator-supplied template has
+            // no observable effect on the rendered redirect.
+            context.frontend_redirect_template = redirect_template;
             return Err(RetrieveClusterError::HttpsRedirect);
         }
 
@@ -672,7 +705,8 @@ impl Router {
         // into a downstream default-answer path.
         if legacy_https_redirect && matches!(proxy.borrow().kind(), ListenerType::Http) {
             let port = https_redirect_port;
-            context.redirect_location = Some(build_redirect_location("https", context, port));
+            context.redirect_location =
+                Some(build_redirect_location("https", context, port, None, None));
         }
 
         // ── 4. Basic auth check (only when `required_auth` was set) ────────
@@ -984,12 +1018,31 @@ fn resolve_redirect_scheme(scheme: RedirectScheme, context: &HttpContext) -> &'s
 /// Build the `Location` URL for a redirect response. Defaults the port
 /// suffix only when the operator provided one or when scheme defaults
 /// would mismatch (port 80 on https / 443 on http stays implicit).
-fn build_redirect_location(scheme: &str, context: &HttpContext, port: Option<u32>) -> String {
-    let authority = context.authority.as_deref().unwrap_or_default();
-    let path = context.path.as_deref().unwrap_or("/");
+///
+/// `host_override` and `path_override` carry the frontend's
+/// `RewriteParts::run` output for `RedirectPolicy::PERMANENT` flows so
+/// the 301 `Location` reflects `rewrite_host` / `rewrite_path` instead
+/// of the original `:authority` / `:path`. The legacy
+/// `cluster.https_redirect` path passes `None` for both — it has no
+/// per-frontend rewrite knobs.
+fn build_redirect_location(
+    scheme: &str,
+    context: &HttpContext,
+    port: Option<u32>,
+    host_override: Option<&str>,
+    path_override: Option<&str>,
+) -> String {
+    let authority = host_override
+        .or(context.authority.as_deref())
+        .unwrap_or_default();
+    let path = path_override
+        .or(context.path.as_deref())
+        .unwrap_or("/");
     // Strip an existing `:port` from the authority — operators typically
     // configure `https_redirect_port` precisely because the listener's
-    // port differs from the redirect target.
+    // port differs from the redirect target. Bracketed IPv6 literals
+    // like `[::1]` survive intact: `rsplit_once(':')` only triggers when
+    // the suffix after the final `:` is entirely ASCII digits.
     let host_only = match authority.rsplit_once(':') {
         Some((host, port_part))
             if !port_part.is_empty() && port_part.bytes().all(|b| b.is_ascii_digit()) =>

--- a/lib/src/protocol/mux/router.rs
+++ b/lib/src/protocol/mux/router.rs
@@ -1035,9 +1035,7 @@ fn build_redirect_location(
     let authority = host_override
         .or(context.authority.as_deref())
         .unwrap_or_default();
-    let path = path_override
-        .or(context.path.as_deref())
-        .unwrap_or("/");
+    let path = path_override.or(context.path.as_deref()).unwrap_or("/");
     // Strip an existing `:port` from the authority — operators typically
     // configure `https_redirect_port` precisely because the listener's
     // port differs from the redirect target. Bracketed IPv6 literals

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -317,8 +317,7 @@ impl SessionManager {
             return;
         };
         for (cluster_id, ips) in by_cluster {
-            let Entry::Occupied(mut outer) =
-                self.connections_per_cluster_ip.entry(cluster_id)
+            let Entry::Occupied(mut outer) = self.connections_per_cluster_ip.entry(cluster_id)
             else {
                 continue;
             };

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -185,13 +185,28 @@ pub struct SessionManager {
     /// `Router::connect` resolves to a fresh `(cluster, ip)` pair, and
     /// decremented when the session closes. Empty when the feature is
     /// unused.
-    connections_per_cluster_ip: HashMap<(String, IpAddr), usize>,
-    /// Reverse index: per-token set of `(cluster, ip)` pairs already
-    /// counted against `connections_per_cluster_ip`. Used to make
-    /// `track_cluster_ip` idempotent within a session (so H2 streams
-    /// to the same cluster from the same client only consume one slot
-    /// in the limit) and to drain a session's contributions on close.
-    cluster_ip_tracks: HashMap<Token, HashSet<(String, IpAddr)>>,
+    ///
+    /// ── Why nested maps instead of `HashMap<(String, IpAddr), usize>` ──
+    ///
+    /// The per-request hot path (`cluster_ip_at_limit`, called from
+    /// `mux/router::connect` for every cluster-resolving request) used
+    /// to allocate a `String` to build the compound key on every
+    /// lookup. Splitting the storage so the outer key is `String`
+    /// lets the lookup take `&str` — `HashMap::get(cluster_id)` on a
+    /// `HashMap<String, _>` accepts a borrow via the `Borrow<str>`
+    /// impl. The hot path no longer allocates; the only `String` clone
+    /// is in `track_cluster_ip`, which runs at most once per
+    /// `(cluster, ip)` pair per session. Memory footprint is unchanged
+    /// in steady state — entries are still reaped to zero on session
+    /// close.
+    connections_per_cluster_ip: HashMap<String, HashMap<IpAddr, usize>>,
+    /// Reverse index: per-token map of `cluster_id` → set of source IPs
+    /// already counted against `connections_per_cluster_ip`. Used to
+    /// make `track_cluster_ip` idempotent within a session (so H2
+    /// streams to the same cluster from the same client only consume
+    /// one slot in the limit) and to drain a session's contributions on
+    /// close. Same nesting rationale as above.
+    cluster_ip_tracks: HashMap<Token, HashMap<String, HashSet<IpAddr>>>,
 }
 
 impl SessionManager {
@@ -234,6 +249,11 @@ impl SessionManager {
     /// `(cluster, ip)` is NEVER at the limit — H2 sessions multiplex
     /// many streams to the same cluster on a single connection, and
     /// the limit governs distinct frontend connections, not streams.
+    ///
+    /// Hot-path: called for every cluster-resolving request from
+    /// `mux/router::connect`. The nested-map storage lets both lookups
+    /// borrow `cluster_id` and `ip`; no per-call allocation runs here
+    /// in steady state.
     pub fn cluster_ip_at_limit(
         &self,
         token: Token,
@@ -245,16 +265,17 @@ impl SessionManager {
         if limit == 0 {
             return false;
         }
-        let key = (cluster_id.to_owned(), *ip);
         if self
             .cluster_ip_tracks
             .get(&token)
-            .is_some_and(|s| s.contains(&key))
+            .and_then(|by_cluster| by_cluster.get(cluster_id))
+            .is_some_and(|ips| ips.contains(ip))
         {
             return false;
         }
         self.connections_per_cluster_ip
-            .get(&key)
+            .get(cluster_id)
+            .and_then(|by_ip| by_ip.get(ip))
             .is_some_and(|c| (*c as u64) >= limit)
     }
 
@@ -262,33 +283,56 @@ impl SessionManager {
     /// Idempotent within a token: a second call for the same
     /// `(cluster, ip)` is a no-op so H2 retries / multi-stream opens
     /// to the same cluster do not double-count.
+    ///
+    /// Allocates a single owned `String` per `(token, cluster)` pair on
+    /// first observation — `entry(cluster_id.clone())` materialises a
+    /// new outer-map slot. Subsequent IPs under the same `(token,
+    /// cluster)` reuse the existing slot.
     pub fn track_cluster_ip(&mut self, token: Token, cluster_id: String, ip: IpAddr) {
-        let key = (cluster_id, ip);
         let inserted = self
             .cluster_ip_tracks
             .entry(token)
             .or_default()
-            .insert(key.clone());
+            .entry(cluster_id.clone())
+            .or_default()
+            .insert(ip);
         if inserted {
-            *self.connections_per_cluster_ip.entry(key).or_insert(0) += 1;
+            *self
+                .connections_per_cluster_ip
+                .entry(cluster_id)
+                .or_default()
+                .entry(ip)
+                .or_insert(0) += 1;
         }
     }
 
     /// Drain every `(cluster, ip)` slot held by `token` and apply the
     /// matching decrements. Called on session teardown only — there is
     /// no per-stream untrack because the limit is per-connection, not
-    /// per-stream.
+    /// per-stream. Removes empty inner maps so the outer
+    /// `connections_per_cluster_ip` does not retain `(cluster_id,
+    /// empty_map)` orphans across cluster lifetimes.
     pub fn untrack_all_cluster_ip(&mut self, token: Token) {
-        let Some(entries) = self.cluster_ip_tracks.remove(&token) else {
+        let Some(by_cluster) = self.cluster_ip_tracks.remove(&token) else {
             return;
         };
-        for key in entries {
-            if let Entry::Occupied(mut entry) = self.connections_per_cluster_ip.entry(key) {
-                let count = entry.get_mut();
-                *count = count.saturating_sub(1);
-                if *count == 0 {
-                    entry.remove();
+        for (cluster_id, ips) in by_cluster {
+            let Entry::Occupied(mut outer) =
+                self.connections_per_cluster_ip.entry(cluster_id)
+            else {
+                continue;
+            };
+            for ip in ips {
+                if let Entry::Occupied(mut inner) = outer.get_mut().entry(ip) {
+                    let count = inner.get_mut();
+                    *count = count.saturating_sub(1);
+                    if *count == 0 {
+                        inner.remove();
+                    }
                 }
+            }
+            if outer.get().is_empty() {
+                outer.remove();
             }
         }
     }

--- a/lib/src/tls.rs
+++ b/lib/src/tls.rs
@@ -316,11 +316,39 @@ impl CertificateResolver {
         &mut self,
         replace: &ReplaceCertificate,
     ) -> Result<Fingerprint, CertificateResolverError> {
-        let new_fingerprint = self.add_certificate(&AddCertificate {
+        let add = AddCertificate {
             address: replace.address.to_owned(),
             certificate: replace.new_certificate.to_owned(),
             expired_at: replace.new_expired_at.to_owned(),
-        })?;
+        };
+
+        // ── Idempotent-replace short-circuit ──
+        //
+        // Compute the new fingerprint *before* mutating the resolver so we
+        // can compare it with the old one. When `add_certificate` is
+        // called with a fingerprint that already exists it early-returns
+        // (lib/src/tls.rs add_certificate path) without inserting; if we
+        // then unconditionally called `remove_certificate(old)` and old
+        // equalled new, we would delete the entry the caller intended to
+        // *retain*. An idempotent renewal — typical for retry loops, dead
+        // ACME polls, or operator-driven `ReplaceCertificate` requests
+        // that resubmit the same PEM — must therefore short-circuit here.
+        // Any failure to materialise the wrapper (parse, sign-key check)
+        // surfaces as `CertificateResolverError`, identical to the path
+        // through `add_certificate`.
+        let new_cert = CertifiedKeyWrapper::try_from(&add)?;
+        let new_fingerprint = new_cert.fingerprint.to_owned();
+
+        if let Ok(old_fingerprint) = Fingerprint::from_str(&replace.old_fingerprint) {
+            if old_fingerprint == new_fingerprint {
+                // Re-publish the expiration gauge so dashboards observe the
+                // replace request even when the certificate set is unchanged.
+                self.publish_min_expiration_gauge();
+                return Ok(new_fingerprint);
+            }
+        }
+
+        let new_fingerprint = self.add_certificate(&add)?;
 
         match Fingerprint::from_str(&replace.old_fingerprint) {
             Ok(old_fingerprint) => self.remove_certificate(&old_fingerprint)?,
@@ -842,6 +870,61 @@ mod tests {
         assert_eq!(
             resolved.1, new_fingerprint,
             "resolved certificate should be the replacement"
+        );
+
+        Ok(())
+    }
+
+    /// When `ReplaceCertificate` carries the same certificate / fingerprint
+    /// as the existing entry, the previous implementation called
+    /// `add_certificate` (which early-returns on duplicate fingerprint
+    /// without inserting) and then unconditionally removed the old
+    /// fingerprint — i.e. the *current* entry — leaving the resolver
+    /// without a certificate for that name. The fix short-circuits the
+    /// idempotent case and keeps the existing entry in place. An
+    /// idempotent ACME / operator retry must therefore still resolve.
+    #[test]
+    fn replace_certificate_with_same_fingerprint_is_noop()
+    -> Result<(), Box<dyn Error + Send + Sync>> {
+        let address = SocketAddress::new_v4(127, 0, 0, 1, 8080);
+        let mut resolver = CertificateResolver::default();
+
+        let cert = CertificateAndKey {
+            certificate: String::from(include_str!("../assets/tests/certificate-1y.pem")),
+            key: String::from(include_str!("../assets/tests/key-1y.pem")),
+            ..Default::default()
+        };
+
+        let initial_fingerprint = resolver.add_certificate(&AddCertificate {
+            address,
+            certificate: cert.clone(),
+            expired_at: None,
+        })?;
+
+        // Replace with the SAME PEM/key — identical fingerprint expected.
+        let returned_fingerprint = resolver.replace_certificate(&ReplaceCertificate {
+            address,
+            new_certificate: cert,
+            old_fingerprint: initial_fingerprint.to_string(),
+            new_expired_at: None,
+        })?;
+
+        assert_eq!(
+            returned_fingerprint, initial_fingerprint,
+            "idempotent replace should return the existing fingerprint"
+        );
+
+        assert!(
+            resolver.get_certificate(&initial_fingerprint).is_some(),
+            "idempotent replace must NOT delete the existing certificate"
+        );
+
+        let resolved = resolver
+            .domain_lookup("localhost".as_bytes(), true)
+            .expect("certificate should still resolve after idempotent replace");
+        assert_eq!(
+            resolved.1, initial_fingerprint,
+            "resolver should still hand back the original fingerprint"
         );
 
         Ok(())


### PR DESCRIPTION
## Summary

Fixes a cluster of correctness, security, and performance defects on
`main` that span the auth, TLS, mux, server, and configuration paths,
plus the e2e and unit-level regression coverage that pins each
behaviour. Validation: `cargo build --all-features --locked`,
`cargo clippy --all-features --all-targets --locked`,
`cargo +nightly fmt --all -- --check`, and `cargo test --workspace
--locked --all-features` (**915 passed, 7 ignored, 0 failed** —
+12 unit/e2e tests, with 2 of the 9 baseline `ignore`'d doctests
unignored as `no_run`).

## Critical fixes

- **Auth bypass for long usernames** (`fix(auth)`, `198ad534`).
  `pad_for_constant_time_compare` truncates inputs longer than 256
  bytes; two credentials sharing the same long username would then
  padded-compare equal regardless of password. Pre-loop length guard
  rejects the truncation case before the constant-time compare runs.
  Two unit regressions added.

- **`replace_certificate` deletes the cert when fingerprints match**
  (`fix(tls)`, `588b14a2`). Idempotent renewal hit the
  `add_certificate` early-return + unconditional remove path and
  emptied the resolver. Compute the candidate fingerprint up front,
  short-circuit when old == new. Re-publishes the expiration gauge
  so dashboards still observe the request. New unit:
  `replace_certificate_with_same_fingerprint_is_noop`.

## Mux / answer-engine fixes

- **Pre-decode base64 length cap** (`fix(auth)`, `17aa75ee`). Encoded
  length checked before `STANDARD::decode` allocates;
  `basic_auth_max_credential_bytes` now actually bounds per-request
  memory. New unit:
  `canonicalize_rejects_oversized_encoded_payload_before_decode`.

- **Spoof-vector trailer elision per RFC 9110 §6.5**
  (`fix(mux)`, `d2109dc4`). `pkawa::handle_trailer` now drops
  `X-Real-IP`, `X-Forwarded-For`, `Forwarded`, `X-Request-Id`
  unconditionally — the spec already prohibits them, and an H2
  backend that merges trailers into its header view would otherwise
  observe the attacker-controlled value. Three unit regressions
  added (`handle_trailer_elides_spoof_vector_headers`,
  `_drops_each_spoof_header_individually`, `_keeps_grpc_status`).

- **`redirect_template` plumbed into the 301 path; `rewrite_host`
  feeds the 301 `Location`; redirect/auth ordered before per-IP
  accounting; duplicated `https_redirect` guard removed**
  (`fix(mux)`, `bbebb407`). All four interlocking router fixes
  share the same `Router::connect` → `route_from_request` call path
  so they ship together. Frontend-supplied 301 templates flow
  through `RouteResult` → `HttpContext` → new
  `HttpAnswers::render_inline_301`; on compile failure logs +
  increments `http.301.redirect_template.compile_error` and falls
  back to the listener default. The 301 `Location` now reflects
  `rewrite_host` (and `rewrite_path`) when set. Legacy
  `cluster.https_redirect` short-circuits BEFORE per-(cluster,
  source-IP) accounting so a redirect-only request never consumes
  an IP slot. Two identical back-to-back guards in `Router::connect`
  collapsed into a single early-return.

## Documentation

- **`basic_auth_max_credential_bytes` and `splice_pipe_capacity_bytes`
  documented in `bin/config.toml`** (`docs(config)`, `87133fde`).
  Both knobs were wired through proto + `command/src/config.rs` +
  `doc/configure.md` but the canonical operator-facing example
  example did not list them.

- **Documented Basic-auth hash command corrected**; **two `ignore`
  doctests in `command/src/config.rs` flipped to `no_run`**
  (`docs`, `b2c67c5a`). `printf 'admin:secret' | sha256sum` hashed
  the username:password literal, but the runtime hashes only the
  password. Replaced with `printf 'secret' | sha256sum | awk '{print
  $1}'` and added the `printf`-vs-`echo` newline note. The two
  load-config doctests now compile (catch API drift on `FileConfig`
  / `Config` / `ConfigBuilder`) without attempting to load a missing
  file.

## Performance

- **Borrow `cluster_id` in the per-IP hot path** (`perf(server)`,
  `df615a18`). `connections_per_cluster_ip` and `cluster_ip_tracks`
  restructured to nested `HashMap<String, HashMap<IpAddr, _>>`;
  `cluster_ip_at_limit` now takes `&str` lookups via `Borrow<str>`
  and runs without per-call allocation in steady state. The single
  remaining `String` clone lives in `track_cluster_ip` and runs at
  most once per `(token, cluster, ip)` triple per session.

## E2E coverage (`1085a27a`)

- **New `e2e/src/tests/eviction_tests.rs` module:**
  - `test_evict_on_queue_full_accepts_after_eviction` — knob ON,
    slab saturated by two long-lived dangling connections, fresh
    client must admit because eviction freed an idle slot.
  - `test_evict_on_queue_full_disabled_drops_overflow` — knob OFF
    (default), same saturation, fresh client must NOT reach the
    backend within a tight window.
- **`redirect_rewrite_auth_tests::test_redirect_permanent_uses_rewrite_host_and_template`**
  pins both the `redirect_template` plumbing and the `rewrite_host`
  flow into the 301 `Location`: response carries the operator-
  template-only `X-Custom-Redirect` header AND `Location:` carries
  the rewritten host.

## Validation

- `cargo build --all-features --locked` ✅
- `cargo clippy --all-features --all-targets --locked` ✅
- `cargo +nightly fmt --all -- --check` ✅
- `cargo test --workspace --locked --all-features` ✅ — **915
  passed, 7 ignored, 0 failed** (10 suites, ~354 s). Net +12 tests
  vs `main` baseline (903 passed); 2 of the 9 ignored doctests
  unignored as `no_run`.

## Test plan

- [x] Auth long-username collision regression (`auth.rs::tests::check_authorized_hashes_rejects_overlong_candidate`)
- [x] Auth oversized base64 rejected pre-decode (`auth.rs::tests::canonicalize_rejects_oversized_encoded_payload_before_decode`)
- [x] TLS idempotent `replace_certificate` retains cert (`tls.rs::tests::replace_certificate_with_same_fingerprint_is_noop`)
- [x] Trailer anti-spoof for the four header set (`pkawa::tests::handle_trailer_*`)
- [x] `evict_on_queue_full` ON/OFF behaviour (`eviction_tests.rs`)
- [x] Redirect `Location` uses `rewrite_host`; `redirect_template`
      renders (`redirect_rewrite_auth_tests::test_redirect_permanent_uses_rewrite_host_and_template`)
- [x] `bin/config.toml` example contains the two new knobs
- [x] Doc command for Basic-auth hash matches runtime semantics
- [x] Full `cargo test --workspace --locked --all-features`

## Notes for reviewers

Comment style follows the project preference: box-drawing
`// ── Title ──` banners + WHY paragraphs on the non-obvious
branches. Every commit is signed (`-s -S`); the
`style: cargo +nightly fmt` commit is the only formatting-only
commit.