### PR TITLE
docs(getting-started): document NixOS package install

### DIFF
--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -29,6 +29,36 @@ Build the sozu executable and command line:
 > The `--locked` flag tells cargo to stick to dependency versions as specified in `Cargo.lock`
 > and thus prevent dependency breaks.
 
+### Run on NixOS
+
+Sōzu is packaged in [nixpkgs][nx]; the latest release is in the
+`nixos-unstable` channel.
+
+Try it without installing:
+
+```bash
+nix-shell -p sozu --run "sozu --version"
+```
+
+Install it into your user profile:
+
+```bash
+nix profile install nixpkgs#sozu
+```
+
+Or add it to a NixOS system configuration:
+
+```nix
+environment.systemPackages = [ pkgs.sozu ];
+```
+
+> The upstream derivation is currently marked `broken` on non-`x86_64`
+> platforms. Run Sōzu on an x86_64 NixOS host or build from source.
+>
+> The derivation does not ship a `services.sozu` NixOS module. To run
+> Sōzu as a daemon, write a `systemd.services.sozu` unit pointing at your
+> `config.toml`; see the [configuration reference](./configure.md).
+
 ### Cargo features
 
 The Cargo features published by the workspace tune behaviour and select the
@@ -128,3 +158,4 @@ cd bin && cargo build --release --locked --no-default-features --features fips
 
 [ru]: https://rustup.rs
 [cr]: https://crates.io/
+[nx]: https://search.nixos.org/packages?channel=unstable&query=sozu


### PR DESCRIPTION
## Summary

Add a `### Run on NixOS` section to `doc/getting_started.md` covering the three idiomatic install/run paths via the upstream `nixpkgs` package, plus two caveats that prevent foot-guns. Closes #1033.

The original 2023 thread on #1033 (between @Keksoj and @gaelreyrol) agreed on a "Run on NixOS" subsection in `getting_started.md`; no PR ever landed. This is that PR.

### What ships

- New `### Run on NixOS` H3 sibling under `## Setting up Sōzu`, between `### Build from source` and `### Cargo features`.
- Three install/run paths:
  - `nix-shell -p sozu --run "sozu --version"` (ephemeral try-out)
  - `nix profile install nixpkgs#sozu` (user profile, flakes / new CLI)
  - `environment.systemPackages = [ pkgs.sozu ];` (NixOS system config)
- Two caveats as `>` blockquotes (matching the file's existing tone):
  - The upstream derivation is currently marked `broken` on non-`x86_64` platforms (`std::arch::x86_64` import in `lib/`), so non-x86_64 NixOS users must build from source.
  - `nixpkgs` ships no `services.sozu` NixOS module; running Sōzu as a daemon requires a hand-written `systemd.services.sozu` unit, with readers pointed at `doc/configure.md` for the config-file shape.
- New `[nx]` footnote pointing at `search.nixos.org/packages?channel=unstable&query=sozu` so the live version stays the source of truth instead of pinning a number that ages out.

### Why these decisions

- **No version pin** in the doc. `search.nixos.org` is the live truth; pinning `1.1.1` (current at the time of writing) ages out the next time nixpkgs bumps the package.
- **No `services.sozu` recipe** included. There is no upstream NixOS module, and writing a full systemd unit here would create a second source of truth versus `os-build/`. The doc points at the existing config reference and lets the user wire up systemd themselves.
- **No `CHANGELOG.md` entry.** Per repo conventions in `CLAUDE.md`, the changelog covers user-visible behavior — config keys, metrics, CLI flags. A doc-only addition is not user-visible behavior.
- **No `doc/README.md` update.** The new H3 is anchor-reachable (`getting_started.md#run-on-nixos`); the existing index entry for `Getting started` already covers it, and no other H3 in the file is indexed there.
- **H3 depth (not H2 as the 2023 issue suggested).** `### Run on NixOS` matches `### Install` and `### Build from source`, both H3s under `## Setting up Sōzu`.

### Verified upstream state (at time of writing)

- nixpkgs derivation: `pkgs/by-name/so/sozu/package.nix` on `NixOS/nixpkgs@master`, version `1.1.1` (bumped 2025-11-07 in nixpkgs PR [#459099](https://github.com/NixOS/nixpkgs/pull/459099)).
- Channel: published in `nixos-unstable` (verified via `search.nixos.org` index `nixos-46-unstable-…`).
- `broken = !stdenv.hostPlatform.isx86_64` is still in the upstream derivation, comment cites `error[E0432]: unresolved import std::arch::x86_64`.
- No `services.sozu` module exists anywhere under `nixos/modules/` in `nixpkgs`.

### Protocol / security impact

None. Documentation only.

### Test plan

- [x] `grep -n '^###' doc/getting_started.md` lists four H3s under `## Setting up Sōzu` (Install, Build from source, Run on NixOS, Cargo features).
- [x] `grep -n '\[nx\]' doc/getting_started.md` shows the inline reference and the bottom-of-file footnote.
- [x] Codex (`gpt-5.5`, codex-cli 0.128.0) review on the diff: no actionable correctness issue.
- [x] No code changed → no `cargo build`/`clippy`/`fmt`/`test` needed.

cc CODEOWNERS @FlorentinDUBOIS @Wonshtrum @llenotre