### PR TITLE
feat(hsts): typed HSTS (RFC 6797) with listener default + per-frontend override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,9 +258,10 @@ upgrade. See `doc/upgrade/1.x-to-2.0.md` for the full migration guide.
   copies it into every binary tarball as `LICENSE-LGPL3` so AGPL §6 / LGPL §4
   obligations are satisfied without an external URL fetch.
 - **Typed HSTS (HTTP Strict Transport Security, RFC 6797) policy with
-  listener-default + per-frontend override**: a new `[hsts]` block under
-  `[https.listeners.default]` (listener default) or
-  `[clusters.<id>.frontends]` (per-frontend override) lets operators emit
+  listener-default + per-frontend override**: a new `[hsts]` block under an
+  HTTPS `[[listeners]]` entry (listener default) or
+  `[clusters.<cluster>.frontends.hsts]` (per-frontend override) lets operators
+  emit
   `Strict-Transport-Security: max-age=N[; includeSubDomains][; preload]` on
   every HTTPS response — backend-served, redirect 3xx, auth-deny 401, and
   proxy-generated 5xx alike. Knobs: `enabled` (required when the block is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,6 +257,35 @@ upgrade. See `doc/upgrade/1.x-to-2.0.md` for the full migration guide.
   GitHub source archive carries it in `command/`, and the release workflow
   copies it into every binary tarball as `LICENSE-LGPL3` so AGPL §6 / LGPL §4
   obligations are satisfied without an external URL fetch.
+- **Typed HSTS (HTTP Strict Transport Security, RFC 6797) policy with
+  listener-default + per-frontend override**: a new `[hsts]` block under
+  `[https.listeners.default]` (listener default) or
+  `[clusters.<id>.frontends]` (per-frontend override) lets operators emit
+  `Strict-Transport-Security: max-age=N[; includeSubDomains][; preload]` on
+  every HTTPS response — backend-served, redirect 3xx, auth-deny 401, and
+  proxy-generated 5xx alike. Knobs: `enabled` (required when the block is
+  present so partial-update semantics distinguish preserve / explicit-disable
+  / enable), `max_age` (defaults to `31_536_000` = 1 year, matches the HSTS
+  preload list minimum), `include_subdomains`, `preload`. Validation refuses
+  HSTS on plain-HTTP listeners (RFC 6797 §7.2 — at TOML config-load via
+  `ConfigError::HstsOnPlainHttp` and at the worker IPC entry via
+  `ProxyError::HstsOnPlainHttp`), allows `max_age = 0` silently as the §11.4
+  kill switch, and warns on sub-day `max_age` and on `preload = true` without
+  `include_subdomains` or with insufficient `max_age` (Chrome HSTS preload
+  list rules). Per-frontend `enabled = false` explicitly suppresses an
+  inherited listener default. Backend-supplied `Strict-Transport-Security`
+  headers pass through unchanged via the new `HeaderEditMode::SetIfAbsent`
+  semantics on `apply_response_header_edits` so RFC 6797 §6.1 single-header
+  expectations hold. Implementation: new `HstsConfig` proto message attached
+  to `HttpsListenerConfig` (tag 46), `UpdateHttpsListenerConfig` (tag 41),
+  and `RequestHttpFrontend` (tag 16); `Frontend::new` materialises a single
+  `HeaderEdit` with key `strict-transport-security`, value `render_hsts(cfg)`,
+  and mode `SetIfAbsent` into `headers_response` at routing-table-build time;
+  the `mux/router.rs` snapshot copy is hoisted above the redirect / auth-deny
+  early returns and gated on `context.protocol == Protocol::HTTPS` so
+  HTTPS-served default answers carry HSTS (RFC 6797 §8.1) while plaintext HTTP
+  listeners can never leak the header (defense in depth on top of config-load
+  validation).
 - **Per-cluster availability surface
   ([#892](https://github.com/sozu-proxy/sozu/issues/892))**: closes the
   long-standing observability gap in which a cluster losing every backend

--- a/bin/config.toml
+++ b/bin/config.toml
@@ -362,6 +362,11 @@ address = "0.0.0.0:8443"
 # max_age = 31536000
 # include_subdomains = true
 # preload = false
+# # Operator opt-in to override any backend-supplied
+# # `Strict-Transport-Security` header (instead of preserving it per
+# # RFC 6797 §6.1). Use when upstream backends emit a stale or weak
+# # HSTS policy that the operator wants to harden centrally.
+# force_replace_backend = false
 
 # Supported TLS versions. Possible values are "SSL_V2", "SSL_V3", "TLSv1", "TLS_V11", "TLS_V12", "TLS_V13".
 # Defaults to `["TLS_V12", "TLS_V13"]`. Besides, `rustls` tls provider only support "TLS_V12" and "TLS_V13" values.

--- a/bin/config.toml
+++ b/bin/config.toml
@@ -334,6 +334,35 @@ address = "0.0.0.0:8443"
 # `elide_x_real_ip`. Default: false.
 # send_x_real_ip = false
 
+# HSTS = HTTP Strict Transport Security (RFC 6797). Listener-level default
+# inherited by every HTTPS frontend on this listener that does not declare
+# its own `[hsts]` block. Per RFC 6797 §7.2 this section is only valid on
+# HTTPS listeners — sozu refuses HSTS on a plain-HTTP listener at config
+# load. Per-frontend overrides live under
+# `[clusters.<id>.frontends.hsts]`.
+#
+# `enabled` is REQUIRED whenever the block is present so partial-update
+# semantics can distinguish "preserve current" / "explicit disable" /
+# "enable" on hot-reconfig.
+#
+# When `enabled = true` and `max_age` is omitted, sozu substitutes
+# 31_536_000 seconds (1 year) — the HSTS preload list minimum.
+#
+# `max_age = 0` is the RFC 6797 §11.4 kill switch and instructs the UA to
+# stop treating the host as a Known HSTS Host. Allowed silently.
+#
+# `preload = true` is opt-in only; it appends `; preload` so the host can
+# be submitted to the Chrome HSTS preload list (https://hstspreload.org/).
+# Sozu warns at config load when `preload = true` is paired with
+# `include_subdomains != true` or with `max_age < 31_536_000` because the
+# preload list will reject the host.
+#
+# [hsts]
+# enabled = true
+# max_age = 31536000
+# include_subdomains = true
+# preload = false
+
 # Supported TLS versions. Possible values are "SSL_V2", "SSL_V3", "TLSv1", "TLS_V11", "TLS_V12", "TLS_V13".
 # Defaults to `["TLS_V12", "TLS_V13"]`. Besides, `rustls` tls provider only support "TLS_V12" and "TLS_V13" values.
 tls_versions = ["TLS_V12", "TLS_V13"]

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -670,7 +670,8 @@ pub enum HttpFrontendCmd {
         hsts_preload: bool,
         #[clap(
             long = "hsts-disabled",
-            help = "Explicitly disable HSTS on this frontend, suppressing any inherited listener-default HSTS. Mutually exclusive with --hsts-max-age / --hsts-include-subdomains / --hsts-preload."
+            conflicts_with_all = ["hsts_max_age", "hsts_include_subdomains", "hsts_preload", "hsts_force_replace_backend"],
+            help = "Explicitly disable HSTS on this frontend, suppressing any inherited listener-default HSTS. Mutually exclusive with --hsts-max-age / --hsts-include-subdomains / --hsts-preload / --hsts-force-replace-backend."
         )]
         hsts_disabled: bool,
         #[clap(

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -673,6 +673,11 @@ pub enum HttpFrontendCmd {
             help = "Explicitly disable HSTS on this frontend, suppressing any inherited listener-default HSTS. Mutually exclusive with --hsts-max-age / --hsts-include-subdomains / --hsts-preload."
         )]
         hsts_disabled: bool,
+        #[clap(
+            long = "hsts-force-replace-backend",
+            help = "Override any backend-supplied `Strict-Transport-Security` header with sozu's typed policy instead of preserving it (RFC 6797 §6.1 backend-wins is the default). Use when upstream backends emit a stale or weak HSTS policy that the operator wants to harden centrally. Implies HSTS enabled."
+        )]
+        hsts_force_replace_backend: bool,
     },
     #[clap(name = "remove")]
     Remove {

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -653,6 +653,26 @@ pub enum HttpFrontendCmd {
             help = "Header mutation, format: <position>=<name>=<value>. Position is 'request', 'response', or 'both'. Empty <value> deletes the header (HAProxy del-header parity). Repeatable. To replace a header, pass it twice: first with an empty value (deletes the existing one), then with the new value (sets it). The runtime applies all deletes before any sets."
         )]
         header: Vec<String>,
+        #[clap(
+            long = "hsts-max-age",
+            help = "HSTS (RFC 6797) `max-age` directive in seconds. Setting any of the --hsts-* flags enables HSTS on this frontend. Defaults to 31536000 (1 year, HSTS preload list minimum) when --hsts-max-age is omitted but another --hsts-* flag is set. `0` is the RFC 6797 §11.4 kill switch."
+        )]
+        hsts_max_age: Option<u32>,
+        #[clap(
+            long = "hsts-include-subdomains",
+            help = "Append `; includeSubDomains` to the rendered HSTS header. Implies HSTS enabled."
+        )]
+        hsts_include_subdomains: bool,
+        #[clap(
+            long = "hsts-preload",
+            help = "Append `; preload` to the rendered HSTS header (Chrome HSTS preload list — see https://hstspreload.org/). Implies HSTS enabled. Opt-in only; once submitted, removal from the preload list is slow and partial (RFC 6797 §14.2)."
+        )]
+        hsts_preload: bool,
+        #[clap(
+            long = "hsts-disabled",
+            help = "Explicitly disable HSTS on this frontend, suppressing any inherited listener-default HSTS. Mutually exclusive with --hsts-max-age / --hsts-include-subdomains / --hsts-preload."
+        )]
+        hsts_disabled: bool,
     },
     #[clap(name = "remove")]
     Remove {

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -1392,10 +1392,14 @@ fn build_http_frontend_add(cmd: HttpFrontendCmd) -> Result<RequestHttpFrontend, 
 /// Combine the four `--hsts-*` CLI flags into an `Option<HstsConfig>`.
 /// `None` = inherit listener default; `Some(HstsConfig { enabled: Some(false), .. })`
 /// = explicit disable (suppresses listener default); `Some(HstsConfig { enabled: Some(true), .. })`
-/// = explicit enable with the specified knobs (worker substitutes the default
-/// `max-age = 31_536_000` when omitted). `--hsts-disabled` mutually excludes
-/// the three enabling flags; the function returns a typed `CtlError::ArgsNeeded`
-/// rather than silently picking an interpretation.
+/// = explicit enable with the specified knobs (the helper substitutes the
+/// canonical `DEFAULT_HSTS_MAX_AGE = 31_536_000` here so the IPC payload
+/// is self-contained — the worker no longer needs to apply a default for
+/// CLI-built frontends; only the TOML loader path still substitutes there
+/// because `FileHstsConfig` carries the typed `Option<u32>` shape).
+/// `--hsts-disabled` mutually excludes the three enabling flags; the
+/// function returns a typed `CtlError::ArgsNeeded` rather than silently
+/// picking an interpretation.
 fn build_hsts_from_cli(
     max_age: Option<u32>,
     include_subdomains: bool,
@@ -1425,10 +1429,70 @@ fn build_hsts_from_cli(
     }
     Ok(Some(HstsConfig {
         enabled: Some(true),
-        max_age,
+        // Substitute the canonical default at CLI-build time so the
+        // resulting IPC payload renders end-to-end without the worker
+        // having to re-apply a default. Mirrors the TOML loader's
+        // substitution in `FileHstsConfig::to_proto`.
+        max_age: max_age.or(Some(sozu_command_lib::config::DEFAULT_HSTS_MAX_AGE)),
         include_subdomains: if include_subdomains { Some(true) } else { None },
         preload: if preload { Some(true) } else { None },
     }))
+}
+
+#[cfg(test)]
+mod hsts_cli_tests {
+    use super::*;
+    use sozu_command_lib::config::DEFAULT_HSTS_MAX_AGE;
+
+    #[test]
+    fn no_flags_returns_none() {
+        // No `--hsts-*` flags = inherit listener default.
+        assert!(matches!(
+            build_hsts_from_cli(None, false, false, false),
+            Ok(None)
+        ));
+    }
+
+    #[test]
+    fn disabled_only_returns_some_disabled() {
+        let out = build_hsts_from_cli(None, false, false, true)
+            .expect("should validate")
+            .expect("should be Some");
+        assert_eq!(out.enabled, Some(false));
+        assert_eq!(out.max_age, None);
+        assert_eq!(out.include_subdomains, None);
+        assert_eq!(out.preload, None);
+    }
+
+    #[test]
+    fn partial_enabling_substitutes_default_max_age() {
+        // Operator opted into HSTS via --hsts-include-subdomains alone;
+        // helper must substitute the canonical default so the worker
+        // does not see a `max_age = None` and silently no-op the render.
+        let out = build_hsts_from_cli(None, true, false, false)
+            .expect("should validate")
+            .expect("should be Some");
+        assert_eq!(out.enabled, Some(true));
+        assert_eq!(out.max_age, Some(DEFAULT_HSTS_MAX_AGE));
+        assert_eq!(out.include_subdomains, Some(true));
+    }
+
+    #[test]
+    fn explicit_max_age_kept() {
+        let out = build_hsts_from_cli(Some(63_072_000), true, true, false)
+            .expect("should validate")
+            .expect("should be Some");
+        assert_eq!(out.max_age, Some(63_072_000));
+        assert_eq!(out.preload, Some(true));
+    }
+
+    #[test]
+    fn disabled_with_enabling_flags_returns_args_needed() {
+        match build_hsts_from_cli(Some(31_536_000), false, false, true).unwrap_err() {
+            CtlError::ArgsNeeded(_, _) => {}
+            other => panic!("expected ArgsNeeded, got {other:?}"),
+        }
+    }
 }
 
 /// Reject NUL / CR / LF / other C0 controls in a header value. HTAB

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -1364,6 +1364,7 @@ fn build_http_frontend_add(cmd: HttpFrontendCmd) -> Result<RequestHttpFrontend, 
         rewrite_port,
         required_auth: if required_auth { Some(true) } else { None },
         headers: headers_proto,
+        hsts: None,
     })
 }
 

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -1236,6 +1236,7 @@ fn build_http_frontend_add(cmd: HttpFrontendCmd) -> Result<RequestHttpFrontend, 
         hsts_include_subdomains,
         hsts_preload,
         hsts_disabled,
+        hsts_force_replace_backend,
     } = cmd
     else {
         return Err(CtlError::ArgsNeeded(
@@ -1367,6 +1368,7 @@ fn build_http_frontend_add(cmd: HttpFrontendCmd) -> Result<RequestHttpFrontend, 
         hsts_include_subdomains,
         hsts_preload,
         hsts_disabled,
+        hsts_force_replace_backend,
     )?;
 
     Ok(RequestHttpFrontend {
@@ -1405,13 +1407,14 @@ fn build_hsts_from_cli(
     include_subdomains: bool,
     preload: bool,
     disabled: bool,
+    force_replace_backend: bool,
 ) -> Result<Option<sozu_command_lib::proto::command::HstsConfig>, CtlError> {
     use sozu_command_lib::proto::command::HstsConfig;
 
-    let any_enabling = max_age.is_some() || include_subdomains || preload;
+    let any_enabling = max_age.is_some() || include_subdomains || preload || force_replace_backend;
     if disabled && any_enabling {
         return Err(CtlError::ArgsNeeded(
-            "either --hsts-disabled OR (--hsts-max-age | --hsts-include-subdomains | --hsts-preload) — not both"
+            "either --hsts-disabled OR (--hsts-max-age | --hsts-include-subdomains | --hsts-preload | --hsts-force-replace-backend) — not both"
                 .to_owned(),
             "got --hsts-disabled together with one of the enabling flags".to_owned(),
         ));
@@ -1422,6 +1425,7 @@ fn build_hsts_from_cli(
             max_age: None,
             include_subdomains: None,
             preload: None,
+            force_replace_backend: None,
         }));
     }
     if !any_enabling {
@@ -1436,6 +1440,11 @@ fn build_hsts_from_cli(
         max_age: max_age.or(Some(sozu_command_lib::config::DEFAULT_HSTS_MAX_AGE)),
         include_subdomains: if include_subdomains { Some(true) } else { None },
         preload: if preload { Some(true) } else { None },
+        force_replace_backend: if force_replace_backend {
+            Some(true)
+        } else {
+            None
+        },
     }))
 }
 
@@ -1448,20 +1457,21 @@ mod hsts_cli_tests {
     fn no_flags_returns_none() {
         // No `--hsts-*` flags = inherit listener default.
         assert!(matches!(
-            build_hsts_from_cli(None, false, false, false),
+            build_hsts_from_cli(None, false, false, false, false),
             Ok(None)
         ));
     }
 
     #[test]
     fn disabled_only_returns_some_disabled() {
-        let out = build_hsts_from_cli(None, false, false, true)
+        let out = build_hsts_from_cli(None, false, false, true, false)
             .expect("should validate")
             .expect("should be Some");
         assert_eq!(out.enabled, Some(false));
         assert_eq!(out.max_age, None);
         assert_eq!(out.include_subdomains, None);
         assert_eq!(out.preload, None);
+        assert_eq!(out.force_replace_backend, None);
     }
 
     #[test]
@@ -1469,17 +1479,18 @@ mod hsts_cli_tests {
         // Operator opted into HSTS via --hsts-include-subdomains alone;
         // helper must substitute the canonical default so the worker
         // does not see a `max_age = None` and silently no-op the render.
-        let out = build_hsts_from_cli(None, true, false, false)
+        let out = build_hsts_from_cli(None, true, false, false, false)
             .expect("should validate")
             .expect("should be Some");
         assert_eq!(out.enabled, Some(true));
         assert_eq!(out.max_age, Some(DEFAULT_HSTS_MAX_AGE));
         assert_eq!(out.include_subdomains, Some(true));
+        assert_eq!(out.force_replace_backend, None);
     }
 
     #[test]
     fn explicit_max_age_kept() {
-        let out = build_hsts_from_cli(Some(63_072_000), true, true, false)
+        let out = build_hsts_from_cli(Some(63_072_000), true, true, false, false)
             .expect("should validate")
             .expect("should be Some");
         assert_eq!(out.max_age, Some(63_072_000));
@@ -1487,8 +1498,29 @@ mod hsts_cli_tests {
     }
 
     #[test]
+    fn force_replace_backend_alone_enables_with_default_max_age() {
+        // Setting --hsts-force-replace-backend on its own is also an
+        // enabling flag — operator wants override semantics; the
+        // canonical default max-age applies.
+        let out = build_hsts_from_cli(None, false, false, false, true)
+            .expect("should validate")
+            .expect("should be Some");
+        assert_eq!(out.enabled, Some(true));
+        assert_eq!(out.max_age, Some(DEFAULT_HSTS_MAX_AGE));
+        assert_eq!(out.force_replace_backend, Some(true));
+    }
+
+    #[test]
+    fn disabled_with_force_replace_returns_args_needed() {
+        match build_hsts_from_cli(None, false, false, true, true).unwrap_err() {
+            CtlError::ArgsNeeded(_, _) => {}
+            other => panic!("expected ArgsNeeded, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn disabled_with_enabling_flags_returns_args_needed() {
-        match build_hsts_from_cli(Some(31_536_000), false, false, true).unwrap_err() {
+        match build_hsts_from_cli(Some(31_536_000), false, false, true, false).unwrap_err() {
             CtlError::ArgsNeeded(_, _) => {}
             other => panic!("expected ArgsNeeded, got {other:?}"),
         }

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -1232,6 +1232,10 @@ fn build_http_frontend_add(cmd: HttpFrontendCmd) -> Result<RequestHttpFrontend, 
         rewrite_port,
         required_auth,
         header,
+        hsts_max_age,
+        hsts_include_subdomains,
+        hsts_preload,
+        hsts_disabled,
     } = cmd
     else {
         return Err(CtlError::ArgsNeeded(
@@ -1348,6 +1352,23 @@ fn build_http_frontend_add(cmd: HttpFrontendCmd) -> Result<RequestHttpFrontend, 
         });
     }
 
+    // Build the typed HSTS block from the four `--hsts-*` flags. Layering:
+    // - `--hsts-disabled` is mutually exclusive with the enabling flags;
+    //   if combined we error rather than silently picking one (operator
+    //   intent is ambiguous).
+    // - any of `--hsts-max-age`, `--hsts-include-subdomains`,
+    //   `--hsts-preload` flips the frontend into "explicit enable"; the
+    //   worker substitutes `DEFAULT_HSTS_MAX_AGE = 31_536_000` if
+    //   `--hsts-max-age` is omitted (matching the TOML semantics in
+    //   `command/src/config.rs::FileHstsConfig::to_proto`).
+    // - none of the flags = `None` = inherit listener default.
+    let hsts_proto = build_hsts_from_cli(
+        hsts_max_age,
+        hsts_include_subdomains,
+        hsts_preload,
+        hsts_disabled,
+    )?;
+
     Ok(RequestHttpFrontend {
         cluster_id: route.into(),
         address: address.into(),
@@ -1364,8 +1385,50 @@ fn build_http_frontend_add(cmd: HttpFrontendCmd) -> Result<RequestHttpFrontend, 
         rewrite_port,
         required_auth: if required_auth { Some(true) } else { None },
         headers: headers_proto,
-        hsts: None,
+        hsts: hsts_proto,
     })
+}
+
+/// Combine the four `--hsts-*` CLI flags into an `Option<HstsConfig>`.
+/// `None` = inherit listener default; `Some(HstsConfig { enabled: Some(false), .. })`
+/// = explicit disable (suppresses listener default); `Some(HstsConfig { enabled: Some(true), .. })`
+/// = explicit enable with the specified knobs (worker substitutes the default
+/// `max-age = 31_536_000` when omitted). `--hsts-disabled` mutually excludes
+/// the three enabling flags; the function returns a typed `CtlError::ArgsNeeded`
+/// rather than silently picking an interpretation.
+fn build_hsts_from_cli(
+    max_age: Option<u32>,
+    include_subdomains: bool,
+    preload: bool,
+    disabled: bool,
+) -> Result<Option<sozu_command_lib::proto::command::HstsConfig>, CtlError> {
+    use sozu_command_lib::proto::command::HstsConfig;
+
+    let any_enabling = max_age.is_some() || include_subdomains || preload;
+    if disabled && any_enabling {
+        return Err(CtlError::ArgsNeeded(
+            "either --hsts-disabled OR (--hsts-max-age | --hsts-include-subdomains | --hsts-preload) — not both"
+                .to_owned(),
+            "got --hsts-disabled together with one of the enabling flags".to_owned(),
+        ));
+    }
+    if disabled {
+        return Ok(Some(HstsConfig {
+            enabled: Some(false),
+            max_age: None,
+            include_subdomains: None,
+            preload: None,
+        }));
+    }
+    if !any_enabling {
+        return Ok(None);
+    }
+    Ok(Some(HstsConfig {
+        enabled: Some(true),
+        max_age,
+        include_subdomains: if include_subdomains { Some(true) } else { None },
+        preload: if preload { Some(true) } else { None },
+    }))
 }
 
 /// Reject NUL / CR / LF / other C0 controls in a header value. HTAB

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -317,6 +317,14 @@ message UpdateHttpsListenerConfig {
     // When true, a proxy-generated `X-Real-IP` header carrying the connection
     // peer IP is appended to every forwarded request. See HttpsListenerConfig.
     optional bool send_x_real_ip                    = 40;
+    // Listener-default HSTS policy (RFC 6797). Full-object replacement on
+    // partial update — when this field is `Some`, the supplied
+    // `HstsConfig` overwrites whatever the listener currently holds; when
+    // absent, the existing policy is preserved. Use
+    // `Some(HstsConfig { enabled: Some(false), .. })` to explicitly
+    // disable HSTS via partial update. Cites RFC 6797 §6.1 (single
+    // header) and §7.2 (HTTPS-only).
+    optional HstsConfig hsts                        = 41;
 }
 
 // Partial-update patch for a running TCP listener.
@@ -569,6 +577,13 @@ message HttpsListenerConfig {
     // to every forwarded request. Independently combinable with
     // `elide_x_real_ip`. Default: false.
     optional bool send_x_real_ip = 45 [default = false];
+    // Listener-default HSTS (HTTP Strict Transport Security, RFC 6797)
+    // policy. When set, every successful response on this listener gains
+    // a `Strict-Transport-Security` header derived from the materialised
+    // policy (RFC 6797 §6.1 single-header requirement, §7.2 HTTPS-only
+    // emission, §8.1 host scope, §11.4 max-age=0 kill-switch). A
+    // per-frontend `RequestHttpFrontend.hsts` overrides this default.
+    optional HstsConfig hsts = 46;
 }
 
 // details of an TCP listener
@@ -584,6 +599,41 @@ message TcpListenerConfig {
     required uint32 connect_timeout = 6 [default = 3];
     // wether the listener is actively listening on its socket
     required bool active = 7 [default = false];
+}
+
+// HSTS (HTTP Strict Transport Security, RFC 6797) policy attached to
+// an HTTPS listener default or per-frontend. The materialised
+// `Strict-Transport-Security: max-age=N[; includeSubDomains][; preload]`
+// header is injected on every successful HTTPS response (including
+// proxy-generated 3xx/401/5xx default answers). Per RFC 6797 §7.2 the
+// header MUST NOT be emitted on plaintext-HTTP responses; sozu rejects
+// HSTS configured on an HttpListenerConfig at config-load time and gates
+// the runtime injection on `context.protocol == Protocol::HTTPS`.
+//
+// Validation:
+// - `enabled = true` with `max_age = None` defaults `max_age` to
+//  31536000 seconds (1 year) at config-load.
+// - `max_age = 0` is the RFC 6797 §11.4 kill-switch and is allowed
+//  silently; `0 < max_age < 86400` warns.
+// - `preload = true` with `max_age < 31536000` or
+//  `include_subdomains != true` warns (Chrome HSTS preload list
+//  prerequisites at https://hstspreload.org/).
+// - `preload` is opt-in only; never default-true (RFC 6797 §14.2 —
+//  removal from the preload list is slow and partial).
+message HstsConfig {
+    // Whether HSTS is enabled for this scope. Required whenever the
+    // parent message includes an HstsConfig — the partial-update path
+    // treats `enabled = false` as the explicit-disable signal.
+    optional bool enabled = 1;
+    // Strict-Transport-Security `max-age` directive in seconds. When
+    // `enabled = true` and this is unset, sozu substitutes 31536000
+    // (1 year, HSTS preload list minimum) at config-load.
+    optional uint32 max_age = 2;
+    // Append `; includeSubDomains` to the rendered header.
+    optional bool include_subdomains = 3;
+    // Append `; preload` to the rendered header. Opt-in only — see
+    // RFC 6797 §14.2 and https://hstspreload.org/.
+    optional bool preload = 4;
 }
 
 // custom HTTP answers, useful for 404, 503 pages
@@ -737,6 +787,16 @@ message RequestHttpFrontend {
     // Header mutations applied to requests and/or responses passing through
     // this frontend. See `Header` for delete semantics.
     repeated Header headers = 15;
+    // Per-frontend HSTS (RFC 6797) override. When `Some`, this entire
+    // policy replaces the listener-default `HttpsListenerConfig.hsts`
+    // for matched requests; when absent, the listener default applies.
+    // Honours RFC 6797 §6.1 (single Strict-Transport-Security header on
+    // the response) and §8.1 (HSTS host scope tied to the receiving
+    // host). On HTTP-only frontends the value is rejected at config-load
+    // (RFC 6797 §7.2). The §11.4 `max-age=0` kill-switch is honoured
+    // verbatim so an operator can shadow a listener-wide HSTS for one
+    // hostname.
+    optional HstsConfig hsts = 16;
 }
 
 message RequestTcpFrontend {

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -634,6 +634,23 @@ message HstsConfig {
     // Append `; preload` to the rendered header. Opt-in only — see
     // RFC 6797 §14.2 and https://hstspreload.org/.
     optional bool preload = 4;
+    // Operator opt-in to override any backend-supplied
+    // `Strict-Transport-Security` header with sozu's typed policy.
+    //
+    // RFC 6797 §6.1 default behaviour is to PRESERVE a backend-emitted
+    // STS header when one is already present (sozu's HSTS edit uses
+    // `HeaderEditMode::SetIfAbsent`). That keeps the backend's intent
+    // intact for upstreams that ship their own HSTS policy.
+    //
+    // Set this to `true` for the harden-centrally case: backends behind
+    // sozu emit a stale or weak HSTS policy (e.g. legacy `max-age=300`)
+    // and the operator wants to enforce a stronger policy at the proxy
+    // edge unconditionally. The materialiser then uses
+    // `HeaderEditMode::Set` instead of `SetIfAbsent`, replacing every
+    // backend-supplied STS header with sozu's rendered value.
+    //
+    // Cite: https://datatracker.ietf.org/doc/html/rfc6797#section-6.1
+    optional bool force_replace_backend = 5;
 }
 
 // custom HTTP answers, useful for 404, 503 pages

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -63,12 +63,12 @@ use crate::{
     logging::AccessLogFormat,
     proto::command::{
         ActivateListener, AddBackend, AddCertificate, CertificateAndKey, Cluster,
-        CustomHttpAnswers, Header, HeaderPosition, HealthCheckConfig, HttpListenerConfig,
-        HttpsListenerConfig, ListenerType, LoadBalancingAlgorithms, LoadBalancingParams,
-        LoadMetric, MetricDetail, MetricsConfiguration, PathRule, ProtobufAccessLogFormat,
-        ProxyProtocolConfig, RedirectPolicy, RedirectScheme, Request, RequestHttpFrontend,
-        RequestTcpFrontend, RulePosition, ServerConfig, ServerMetricsConfig, SocketAddress,
-        TcpListenerConfig, TlsVersion, WorkerRequest, request::RequestType,
+        CustomHttpAnswers, Header, HeaderPosition, HealthCheckConfig, HstsConfig,
+        HttpListenerConfig, HttpsListenerConfig, ListenerType, LoadBalancingAlgorithms,
+        LoadBalancingParams, LoadMetric, MetricDetail, MetricsConfiguration, PathRule,
+        ProtobufAccessLogFormat, ProxyProtocolConfig, RedirectPolicy, RedirectScheme, Request,
+        RequestHttpFrontend, RequestTcpFrontend, RulePosition, ServerConfig, ServerMetricsConfig,
+        SocketAddress, TcpListenerConfig, TlsVersion, WorkerRequest, request::RequestType,
     },
 };
 
@@ -134,6 +134,14 @@ pub const DEFAULT_ZOMBIE_CHECK_INTERVAL: u32 = 1_800;
 
 /// timeout to accept connection events in the accept queue (60 seconds)
 pub const DEFAULT_ACCEPT_QUEUE_TIMEOUT: u32 = 60;
+
+/// Default `Strict-Transport-Security: max-age` value (1 year, 31_536_000
+/// seconds) substituted at config-load when an [hsts] block sets
+/// `enabled = true` but omits `max_age`. Matches the HSTS preload list
+/// minimum (https://hstspreload.org/) and the Caddy / Nginx community
+/// recommendation. Operators can override with any `u32`; `max_age = 0`
+/// is the RFC 6797 §11.4 kill switch and is allowed silently.
+pub const DEFAULT_HSTS_MAX_AGE: u32 = 31_536_000;
 
 /// whether to evict least-recently-active sessions when the accept queue is
 /// saturated (false). Defaults to false because during a DDoS the existing
@@ -328,6 +336,27 @@ pub enum ConfigError {
          (NUL / CR / LF / other C0) are forbidden in header keys and values"
     )]
     InvalidHeaderBytes { index: usize, field: &'static str },
+    /// An `[hsts]` block populated `max_age`, `include_subdomains`, or
+    /// `preload` but did not set `enabled`. The TOML representation requires
+    /// `enabled` to be present whenever the block is — that single field
+    /// disambiguates "preserve current" / "explicit disable" / "enable" on
+    /// hot-reconfig partial updates.
+    #[error("invalid HSTS config at {0}: `enabled` is required when an [hsts] block is present")]
+    HstsEnabledRequired(String),
+    /// An `[hsts]` block on an HTTP-only listener or frontend. RFC 6797
+    /// §7.2 forbids emitting `Strict-Transport-Security` over plaintext
+    /// HTTP; sozu rejects the configuration at load time so the
+    /// non-conformant policy never ships to a worker.
+    #[error(
+        "invalid HSTS config at {0}: HSTS is only valid on HTTPS listeners and frontends \
+         (RFC 6797 §7.2 forbids the header over plaintext HTTP)"
+    )]
+    HstsOnPlainHttp(String),
+    /// An `[hsts]` field carries an out-of-range or otherwise nonsensical
+    /// value (e.g. negative `max_age`, although `u32` rules that out at
+    /// type level — kept for forward compatibility with future fields).
+    #[error("invalid HSTS config at {scope}: {reason}")]
+    InvalidHstsConfig { scope: String, reason: String },
 }
 
 /// An HTTP, HTTPS or TCP listener as parsed from the `Listeners` section in the toml
@@ -470,6 +499,12 @@ pub struct ListenerBuilder {
     /// for backwards compatibility but are equivalent to a one-line entry
     /// in this map; new configs should prefer `[listeners.answers]`.
     pub answers: Option<BTreeMap<String, String>>,
+    /// Listener-default HSTS (RFC 6797) policy. When set, every HTTPS
+    /// frontend on this listener that does not declare its own `[hsts]`
+    /// block inherits this value. Per RFC 6797 §7.2 HSTS is rejected on
+    /// HTTP listeners at config-load time; this field is only meaningful
+    /// for HTTPS listeners. Defaults to `None` (no HSTS).
+    pub hsts: Option<FileHstsConfig>,
 }
 
 pub fn default_sticky_name() -> String {
@@ -552,6 +587,7 @@ impl ListenerBuilder {
             elide_x_real_ip: None,
             send_x_real_ip: None,
             answers: None,
+            hsts: None,
         }
     }
 
@@ -979,7 +1015,10 @@ impl ListenerBuilder {
             sozu_id_header: self.sozu_id_header.clone(),
             elide_x_real_ip: Some(self.elide_x_real_ip.unwrap_or(false)),
             send_x_real_ip: Some(self.send_x_real_ip.unwrap_or(false)),
-            hsts: None,
+            hsts: match self.hsts.as_ref() {
+                Some(h) => Some(h.to_proto("listener")?),
+                None => None,
+            },
         };
 
         Ok(https_listener_config)
@@ -1223,6 +1262,11 @@ pub struct FileClusterFrontendConfig {
     /// this frontend. See [`HeaderEditConfig`] for the empty-value-deletes
     /// semantics (HAProxy `del-header` parity).
     pub headers: Option<Vec<HeaderEditConfig>>,
+    /// Per-frontend HSTS (RFC 6797) policy. When set, overrides any
+    /// listener-default HSTS for this frontend. Set `enabled = false`
+    /// to suppress an inherited listener default. Per RFC 6797 §7.2,
+    /// HSTS is rejected on plain-HTTP frontends at config-load time.
+    pub hsts: Option<FileHstsConfig>,
 }
 
 /// A single header mutation as serialised under
@@ -1237,6 +1281,106 @@ pub struct HeaderEditConfig {
     pub position: String,
     pub key: String,
     pub value: String,
+}
+
+/// HSTS (HTTP Strict Transport Security, RFC 6797) policy as serialised
+/// under `[https.listeners.default.hsts]` (listener default) or
+/// `[clusters.<id>.frontends.hsts]` (per-frontend override).
+///
+/// `enabled` is REQUIRED whenever the block is present — its presence vs
+/// absence disambiguates "preserve current" / "explicit disable" / "enable"
+/// on hot-reconfig partial updates.
+///
+/// When `enabled = true` and `max_age` is omitted, sozu substitutes
+/// [`DEFAULT_HSTS_MAX_AGE`] (1 year) at config-load time.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FileHstsConfig {
+    /// REQUIRED. `true` enables HSTS for this scope; `false` suppresses
+    /// any inherited listener default (explicit-disable signal).
+    pub enabled: Option<bool>,
+    /// `Strict-Transport-Security: max-age=<seconds>`. Optional —
+    /// defaults to [`DEFAULT_HSTS_MAX_AGE`] when `enabled = true`.
+    /// `max_age = 0` is the RFC 6797 §11.4 kill switch and is allowed
+    /// silently; `0 < max_age < 86400` warns at config-load.
+    pub max_age: Option<u32>,
+    /// Append `; includeSubDomains` to the rendered header.
+    pub include_subdomains: Option<bool>,
+    /// Append `; preload` to the rendered header. Opt-in only — see RFC
+    /// 6797 §14.2 and <https://hstspreload.org/>.
+    pub preload: Option<bool>,
+}
+
+impl FileHstsConfig {
+    /// Validate and convert the file-level [`FileHstsConfig`] into the
+    /// proto [`HstsConfig`]. `scope` is a human-readable string (e.g.
+    /// "listener" or "frontend api/example.com") surfaced into errors
+    /// and warnings so the operator can pinpoint the offending block.
+    ///
+    /// Validation:
+    /// - `enabled` is required when any other field is set
+    ///   (`HstsEnabledRequired`); the parser returns the typed error so
+    ///   callers can fail fast.
+    /// - `enabled = true && max_age = None` substitutes
+    ///   [`DEFAULT_HSTS_MAX_AGE`].
+    /// - `0 < max_age < 86400` warns (likely misconfig — sub-day max-age
+    ///   is useful only for testing).
+    /// - `preload = true` with `max_age < DEFAULT_HSTS_MAX_AGE` or
+    ///   `include_subdomains != Some(true)` warns (the Chrome HSTS
+    ///   preload list will reject the host).
+    /// - `max_age = 0` is allowed silently (RFC 6797 §11.4 kill switch).
+    pub fn to_proto(&self, scope: &str) -> Result<HstsConfig, ConfigError> {
+        let enabled = match self.enabled {
+            Some(v) => v,
+            None => return Err(ConfigError::HstsEnabledRequired(scope.to_owned())),
+        };
+
+        let max_age = match (enabled, self.max_age) {
+            (true, None) => Some(DEFAULT_HSTS_MAX_AGE),
+            (_, m) => m,
+        };
+
+        if let Some(value) = max_age
+            && value > 0
+            && value < 86_400
+        {
+            warn!(
+                "HSTS max_age = {}s on {} is below 1 day — this is almost certainly a \
+                 misconfiguration. RFC 6797 §11.4 reserves max_age = 0 as the explicit kill \
+                 switch.",
+                value, scope
+            );
+        }
+
+        let include_subdomains = self.include_subdomains;
+        let preload = self.preload;
+
+        if matches!(preload, Some(true)) {
+            let max_age_value = max_age.unwrap_or(0);
+            if max_age_value < DEFAULT_HSTS_MAX_AGE {
+                warn!(
+                    "HSTS preload = true on {} with max_age = {}s; the Chrome HSTS preload \
+                     list requires max_age >= {} (https://hstspreload.org/).",
+                    scope, max_age_value, DEFAULT_HSTS_MAX_AGE
+                );
+            }
+            if include_subdomains != Some(true) {
+                warn!(
+                    "HSTS preload = true on {} without include_subdomains = true; the Chrome \
+                     HSTS preload list requires includeSubDomains \
+                     (https://hstspreload.org/).",
+                    scope
+                );
+            }
+        }
+
+        Ok(HstsConfig {
+            enabled: Some(enabled),
+            max_age,
+            include_subdomains,
+            preload,
+        })
+    }
 }
 
 impl FileClusterFrontendConfig {
@@ -1331,6 +1475,11 @@ impl FileClusterFrontendConfig {
             None => Vec::new(),
         };
 
+        let hsts = match self.hsts.as_ref() {
+            Some(h) => Some(h.to_proto(&format!("frontend {_cluster_id}/{hostname}"))?),
+            None => None,
+        };
+
         Ok(HttpFrontendConfig {
             address: self.address,
             hostname,
@@ -1350,6 +1499,7 @@ impl FileClusterFrontendConfig {
             rewrite_port: self.rewrite_port,
             required_auth: self.required_auth,
             headers,
+            hsts,
         })
     }
 }
@@ -1776,6 +1926,10 @@ pub struct HttpFrontendConfig {
     /// this frontend. Empty by default.
     #[serde(default)]
     pub headers: Vec<Header>,
+    /// Resolved per-frontend HSTS (RFC 6797) policy. `None` means inherit
+    /// the listener default at frontend-add time in the worker.
+    #[serde(default)]
+    pub hsts: Option<HstsConfig>,
 }
 
 impl HttpFrontendConfig {
@@ -1821,7 +1975,7 @@ impl HttpFrontendConfig {
                     rewrite_path: self.rewrite_path.clone(),
                     rewrite_port: self.rewrite_port,
                     headers: self.headers.clone(),
-                    hsts: None,
+                    hsts: self.hsts,
                 })
                 .into(),
             );
@@ -1844,7 +1998,7 @@ impl HttpFrontendConfig {
                     rewrite_path: self.rewrite_path.clone(),
                     rewrite_port: self.rewrite_port,
                     headers: self.headers.clone(),
-                    hsts: None,
+                    hsts: self.hsts,
                 })
                 .into(),
             );

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -3227,6 +3227,77 @@ mod tests {
     use super::*;
 
     #[test]
+    fn hsts_to_proto_enabled_substitutes_default_max_age() {
+        let cfg = FileHstsConfig {
+            enabled: Some(true),
+            max_age: None,
+            include_subdomains: None,
+            preload: None,
+        };
+        let proto = cfg.to_proto("test").expect("should validate");
+        assert_eq!(proto.enabled, Some(true));
+        assert_eq!(proto.max_age, Some(DEFAULT_HSTS_MAX_AGE));
+    }
+
+    #[test]
+    fn hsts_to_proto_explicit_max_age_kept() {
+        let cfg = FileHstsConfig {
+            enabled: Some(true),
+            max_age: Some(63_072_000),
+            include_subdomains: Some(true),
+            preload: Some(true),
+        };
+        let proto = cfg.to_proto("test").expect("should validate");
+        assert_eq!(proto.max_age, Some(63_072_000));
+        assert_eq!(proto.include_subdomains, Some(true));
+        assert_eq!(proto.preload, Some(true));
+    }
+
+    #[test]
+    fn hsts_to_proto_disabled_keeps_zero_intent() {
+        // `enabled = false` means "explicit disable" — the materialiser
+        // in `Frontend::new` won't append an edit, so the proto still
+        // round-trips with `enabled = Some(false)`.
+        let cfg = FileHstsConfig {
+            enabled: Some(false),
+            max_age: None,
+            include_subdomains: None,
+            preload: None,
+        };
+        let proto = cfg.to_proto("test").expect("should validate");
+        assert_eq!(proto.enabled, Some(false));
+    }
+
+    #[test]
+    fn hsts_to_proto_kill_switch_max_age_zero_allowed() {
+        // RFC 6797 §11.4: `max-age=0` instructs the UA to "cease
+        // regarding the host as a Known HSTS Host". Explicit operator
+        // intent — must NOT warn or fail.
+        let cfg = FileHstsConfig {
+            enabled: Some(true),
+            max_age: Some(0),
+            include_subdomains: None,
+            preload: None,
+        };
+        let proto = cfg.to_proto("test").expect("kill-switch must validate");
+        assert_eq!(proto.max_age, Some(0));
+    }
+
+    #[test]
+    fn hsts_to_proto_missing_enabled_errors() {
+        let cfg = FileHstsConfig {
+            enabled: None,
+            max_age: Some(31_536_000),
+            include_subdomains: None,
+            preload: None,
+        };
+        match cfg.to_proto("test").unwrap_err() {
+            ConfigError::HstsEnabledRequired(scope) => assert_eq!(scope, "test"),
+            other => panic!("expected HstsEnabledRequired, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn serialize() {
         let http = ListenerBuilder::new(
             SocketAddress::new_v4(127, 0, 0, 1, 8080),

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -1316,6 +1316,14 @@ pub struct FileHstsConfig {
     /// Append `; preload` to the rendered header. Opt-in only — see RFC
     /// 6797 §14.2 and <https://hstspreload.org/>.
     pub preload: Option<bool>,
+    /// Operator opt-in to override any backend-supplied
+    /// `Strict-Transport-Security` header. RFC 6797 §6.1 default
+    /// behaviour is to PRESERVE the backend's value (sozu's edit uses
+    /// `HeaderEditMode::SetIfAbsent`). Set this to `true` to harden a
+    /// stale or weak upstream HSTS policy centrally — the materialiser
+    /// then uses `HeaderEditMode::Set`, replacing any backend STS with
+    /// sozu's rendered value.
+    pub force_replace_backend: Option<bool>,
 }
 
 impl FileHstsConfig {
@@ -1386,6 +1394,7 @@ impl FileHstsConfig {
             max_age,
             include_subdomains,
             preload,
+            force_replace_backend: self.force_replace_backend,
         })
     }
 }
@@ -3254,6 +3263,7 @@ mod tests {
             max_age: None,
             include_subdomains: None,
             preload: None,
+            force_replace_backend: None,
         };
         let proto = cfg.to_proto("test").expect("should validate");
         assert_eq!(proto.enabled, Some(true));
@@ -3267,6 +3277,7 @@ mod tests {
             max_age: Some(63_072_000),
             include_subdomains: Some(true),
             preload: Some(true),
+            force_replace_backend: None,
         };
         let proto = cfg.to_proto("test").expect("should validate");
         assert_eq!(proto.max_age, Some(63_072_000));
@@ -3284,6 +3295,7 @@ mod tests {
             max_age: None,
             include_subdomains: None,
             preload: None,
+            force_replace_backend: None,
         };
         let proto = cfg.to_proto("test").expect("should validate");
         assert_eq!(proto.enabled, Some(false));
@@ -3299,6 +3311,7 @@ mod tests {
             max_age: Some(0),
             include_subdomains: None,
             preload: None,
+            force_replace_backend: None,
         };
         let proto = cfg.to_proto("test").expect("kill-switch must validate");
         assert_eq!(proto.max_age, Some(0));
@@ -3311,6 +3324,7 @@ mod tests {
             max_age: Some(31_536_000),
             include_subdomains: None,
             preload: None,
+            force_replace_backend: None,
         };
         match cfg.to_proto("test").unwrap_err() {
             ConfigError::HstsEnabledRequired(scope) => assert_eq!(scope, "test"),
@@ -3333,6 +3347,7 @@ mod tests {
             max_age: Some(31_536_000),
             include_subdomains: None,
             preload: None,
+            force_replace_backend: None,
         });
         match listener.to_http(None).unwrap_err() {
             ConfigError::HstsOnPlainHttp(scope) => assert!(
@@ -3375,6 +3390,7 @@ mod tests {
                 max_age: Some(31_536_000),
                 include_subdomains: None,
                 preload: None,
+                force_replace_backend: None,
             }),
         };
         match frontend.to_http_front("api").unwrap_err() {

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -979,6 +979,7 @@ impl ListenerBuilder {
             sozu_id_header: self.sozu_id_header.clone(),
             elide_x_real_ip: Some(self.elide_x_real_ip.unwrap_or(false)),
             send_x_real_ip: Some(self.send_x_real_ip.unwrap_or(false)),
+            hsts: None,
         };
 
         Ok(https_listener_config)
@@ -1820,6 +1821,7 @@ impl HttpFrontendConfig {
                     rewrite_path: self.rewrite_path.clone(),
                     rewrite_port: self.rewrite_port,
                     headers: self.headers.clone(),
+                    hsts: None,
                 })
                 .into(),
             );
@@ -1842,6 +1844,7 @@ impl HttpFrontendConfig {
                     rewrite_path: self.rewrite_path.clone(),
                     rewrite_port: self.rewrite_port,
                     headers: self.headers.clone(),
+                    hsts: None,
                 })
                 .into(),
             );

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -352,11 +352,6 @@ pub enum ConfigError {
          (RFC 6797 §7.2 forbids the header over plaintext HTTP)"
     )]
     HstsOnPlainHttp(String),
-    /// An `[hsts]` field carries an out-of-range or otherwise nonsensical
-    /// value (e.g. negative `max_age`, although `u32` rules that out at
-    /// type level — kept for forward compatibility with future fields).
-    #[error("invalid HSTS config at {scope}: {reason}")]
-    InvalidHstsConfig { scope: String, reason: String },
 }
 
 /// An HTTP, HTTPS or TCP listener as parsed from the `Listeners` section in the toml
@@ -805,6 +800,18 @@ impl ListenerBuilder {
                 expected: ListenerProtocol::Http,
                 found: self.protocol.to_owned(),
             });
+        }
+
+        // RFC 6797 §7.2: `Strict-Transport-Security` MUST NOT appear on
+        // plaintext-HTTP responses. Reject an `[hsts]` block on an HTTP
+        // listener at config-load — `HttpListenerConfig` has no `hsts`
+        // field, so silently dropping the operator's intent would be a
+        // worse failure mode than a typed error here.
+        if self.hsts.is_some() {
+            return Err(ConfigError::HstsOnPlainHttp(format!(
+                "HTTP listener {}",
+                self.address
+            )));
         }
 
         if let Some(config) = config {
@@ -1475,8 +1482,22 @@ impl FileClusterFrontendConfig {
             None => Vec::new(),
         };
 
+        // RFC 6797 §7.2: `Strict-Transport-Security` MUST NOT appear on
+        // plaintext-HTTP responses. A frontend without a key+certificate
+        // pair generates `RequestType::AddHttpFrontend` in
+        // `HttpFrontendConfig::generate_requests`, so HSTS configured
+        // there would silently target an HTTP frontend. Reject at
+        // config-load before the cert-presence branch can consume it.
+        let frontend_serves_https = key_opt.is_some() && certificate_opt.is_some();
         let hsts = match self.hsts.as_ref() {
-            Some(h) => Some(h.to_proto(&format!("frontend {_cluster_id}/{hostname}"))?),
+            Some(h) => {
+                if !frontend_serves_https {
+                    return Err(ConfigError::HstsOnPlainHttp(format!(
+                        "frontend {_cluster_id}/{hostname}"
+                    )));
+                }
+                Some(h.to_proto(&format!("frontend {_cluster_id}/{hostname}"))?)
+            }
             None => None,
         };
 
@@ -3294,6 +3315,76 @@ mod tests {
         match cfg.to_proto("test").unwrap_err() {
             ConfigError::HstsEnabledRequired(scope) => assert_eq!(scope, "test"),
             other => panic!("expected HstsEnabledRequired, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hsts_rejected_on_http_listener() {
+        // RFC 6797 §7.2: an [hsts] block on an HTTP listener must be
+        // rejected at TOML config-load — `HttpListenerConfig` carries no
+        // `hsts` field and silently dropping the operator's intent
+        // would be a worse failure mode than a typed error.
+        let mut listener = ListenerBuilder::new(
+            SocketAddress::new_v4(127, 0, 0, 1, 8080),
+            ListenerProtocol::Http,
+        );
+        listener.hsts = Some(FileHstsConfig {
+            enabled: Some(true),
+            max_age: Some(31_536_000),
+            include_subdomains: None,
+            preload: None,
+        });
+        match listener.to_http(None).unwrap_err() {
+            ConfigError::HstsOnPlainHttp(scope) => assert!(
+                scope.contains("HTTP listener"),
+                "expected scope to mention 'HTTP listener', got {scope:?}"
+            ),
+            other => panic!("expected HstsOnPlainHttp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hsts_rejected_on_http_frontend() {
+        // A `FileClusterFrontendConfig` without a key+certificate pair
+        // generates `RequestType::AddHttpFrontend` in
+        // `HttpFrontendConfig::generate_requests`. RFC 6797 §7.2 forbids
+        // HSTS on plaintext HTTP, so an `[hsts]` block on a cert-less
+        // (HTTP-bound) frontend must be rejected at TOML config-load.
+        let frontend = FileClusterFrontendConfig {
+            address: "127.0.0.1:8080".parse().unwrap(),
+            hostname: Some("example.com".to_owned()),
+            path: None,
+            path_type: None,
+            method: None,
+            certificate: None,
+            key: None,
+            certificate_chain: None,
+            tls_versions: vec![],
+            position: RulePosition::Tree,
+            tags: None,
+            redirect: None,
+            redirect_scheme: None,
+            redirect_template: None,
+            rewrite_host: None,
+            rewrite_path: None,
+            rewrite_port: None,
+            required_auth: None,
+            headers: None,
+            hsts: Some(FileHstsConfig {
+                enabled: Some(true),
+                max_age: Some(31_536_000),
+                include_subdomains: None,
+                preload: None,
+            }),
+        };
+        match frontend.to_http_front("api").unwrap_err() {
+            ConfigError::HstsOnPlainHttp(scope) => {
+                assert!(
+                    scope.contains("api") && scope.contains("example.com"),
+                    "expected scope to mention 'api' and 'example.com', got {scope:?}"
+                );
+            }
+            other => panic!("expected HstsOnPlainHttp, got {other:?}"),
         }
     }
 

--- a/command/src/request.rs
+++ b/command/src/request.rs
@@ -190,6 +190,7 @@ impl RequestHttpFrontend {
             rewrite_port: self.rewrite_port,
             required_auth: self.required_auth,
             headers: self.headers,
+            hsts: self.hsts,
         })
     }
 }

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -2,9 +2,9 @@ use std::{cmp::Ordering, collections::BTreeMap, fmt, net::SocketAddr};
 
 use crate::{
     proto::command::{
-        AddBackend, FilteredTimeSerie, Header, LoadBalancingParams, PathRule, PathRuleKind,
-        RequestHttpFrontend, RequestTcpFrontend, Response, ResponseContent, ResponseStatus,
-        RulePosition, RunState, WorkerResponse,
+        AddBackend, FilteredTimeSerie, Header, HstsConfig, LoadBalancingParams, PathRule,
+        PathRuleKind, RequestHttpFrontend, RequestTcpFrontend, Response, ResponseContent,
+        ResponseStatus, RulePosition, RunState, WorkerResponse,
     },
     state::ClusterId,
 };
@@ -68,6 +68,11 @@ pub struct HttpFrontend {
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub headers: Vec<Header>,
+    /// Resolved per-frontend HSTS (RFC 6797) policy. `None` means inherit
+    /// the listener default at frontend-add time in the worker.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hsts: Option<HstsConfig>,
 }
 
 impl From<HttpFrontend> for RequestHttpFrontend {
@@ -88,7 +93,7 @@ impl From<HttpFrontend> for RequestHttpFrontend {
             rewrite_port: val.rewrite_port,
             required_auth: val.required_auth,
             headers: val.headers,
-            hsts: None,
+            hsts: val.hsts,
         }
     }
 }

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -88,6 +88,7 @@ impl From<HttpFrontend> for RequestHttpFrontend {
             rewrite_port: val.rewrite_port,
             required_auth: val.required_auth,
             headers: val.headers,
+            hsts: None,
         }
     }
 }

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -341,7 +341,7 @@ sozu frontend https add \
 
 `UpdateHttpsListenerConfig.hsts` follows full-object replacement semantics: when present in the patch, the entire HSTS block replaces the listener's current value. `enabled` is REQUIRED whenever `hsts` is present (`ListenerError::HstsEnabledRequired` rejects an `enabled = None` block). Absent `hsts` field on the patch preserves the current value.
 
-**Inheritance refresh limitation.** Patching the listener-default HSTS updates `HttpsListenerConfig.hsts` for FUTURE frontend adds; existing frontends keep their materialised HSTS edit (the value that was the listener default at frontend-add time). To re-flow the new default onto an inheriting frontend, the operator must remove + re-add the frontend. A `warn!` log line and the `http.hsts.listener_default_patched` counter fire on every patch so the pending operator action is surfaced. Per-frontend explicit overrides are unaffected.
+**Inheriting frontends are refreshed automatically.** Patching the listener-default HSTS reflows the new policy onto every existing frontend that inherited from the listener (i.e. has no per-frontend `[hsts]` block at add time). `Router::refresh_inheriting_hsts` walks the routing trie, identifies inheriting entries via the `Frontend.inherits_listener_hsts` marker, and rebuilds their `headers_response` against the new value — stripping any prior `Strict-Transport-Security` entry and appending a freshly rendered one. Per-frontend explicit overrides (`inherits_listener_hsts == false`) are left untouched. The `http.hsts.listener_default_patched` counter fires once per patch and `http.hsts.frontend_refreshed` increments per refreshed frontend, so dashboards can correlate the rate of patches with the size of the affected fleet.
 
 ##### Metrics
 
@@ -350,7 +350,8 @@ sozu frontend https add \
 | `http.hsts.frontend_added`          | counter | A frontend is added with `hsts.enabled = true` and the HSTS edit is materialised in `headers_response`. |
 | `http.hsts.suppressed_plaintext`    | counter | An `AddHttpFrontend` IPC was rejected because it carried an enabled HSTS policy (RFC 6797 §7.2 defense in depth). |
 | `http.hsts.unrendered`              | counter | Defense-in-depth: a frontend reached `Frontend::new` with `hsts.enabled = true` but `render_hsts` returned `None` (max_age missing). The TOML loader and the CLI helper both substitute `DEFAULT_HSTS_MAX_AGE` so this counter only fires when a programmatic IPC sender ships an ill-formed `HstsConfig`. |
-| `http.hsts.listener_default_patched`| counter | A `UpdateHttpsListenerConfig.hsts` patch was applied. Pairs with a `warn!` reminding the operator to remove + re-add inheriting frontends so they pick up the new default. |
+| `http.hsts.listener_default_patched`| counter | A `UpdateHttpsListenerConfig.hsts` patch was applied. Fires once per patch. |
+| `http.hsts.frontend_refreshed`      | counter | An inheriting frontend was refreshed during a listener-default HSTS patch (one increment per refreshed entry). Sum across a patch interval = number of frontends touched by that patch. |
 
 #### Options specific to Rustls based HTTPS listeners
 

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -226,6 +226,41 @@ A `[hsts]` block under an HTTPS listener is the operator-default; per-frontend o
 
 Per RFC 6797 §7.2 the `Strict-Transport-Security` header MUST NOT appear on plaintext-HTTP responses. Sōzu enforces this in three layers: (1) TOML config-load rejects `[hsts]` on a plain-HTTP listener (`ConfigError::HstsOnPlainHttp`), (2) the worker IPC entry rejects `AddHttpFrontend` carrying an enabled HSTS (`ProxyError::HstsOnPlainHttp` and the `http.hsts.suppressed_plaintext` counter), and (3) the runtime per-stream snapshot copy is gated on `context.protocol == Protocol::HTTPS` so plaintext connections never apply HSTS edits even when one slips through.
 
+##### Is the `[hsts]` block required?
+
+**No** — it is optional everywhere. Omitting the block on every listener and every frontend is a fully valid configuration: no `Strict-Transport-Security` header is ever emitted.
+
+| Surface                                                       | Required? | Notes                                                                                                                       |
+|---------------------------------------------------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------|
+| `[hsts]` under a plain-HTTP listener / frontend               | **N/A**   | The field does not exist on the HTTP listener proto. Setting it on an HTTP frontend is rejected at config-load (RFC §7.2).  |
+| `[hsts]` under an HTTPS listener (operator default)           | Optional  | Omit the block and no listener-default HSTS is set. HTTPS frontends without their own block then carry no HSTS.             |
+| `[hsts]` under a per-frontend section                         | Optional  | Omit and the frontend inherits the listener default (or nothing if the listener has none).                                  |
+| `[hsts]` is **not** a cluster-level field                     | **N/A**   | HSTS lives on frontends (Caddy / Traefik shape), not on clusters.                                                           |
+| `UpdateHttpsListenerConfig.hsts` (hot-reconfig partial patch) | Optional  | Absent in the patch preserves the current listener HSTS value. Present = full-object replacement (see below).               |
+
+The only **conditional** required-field rule is inside the block itself: when the `[hsts]` block is present (TOML or partial-update patch), the `enabled` field must also be present. This disambiguates three otherwise-conflated semantics:
+
+| TOML / patch shape                          | Meaning                                                                                |
+|---------------------------------------------|----------------------------------------------------------------------------------------|
+| Block omitted                               | Inherit listener default (or no HSTS if the listener has none).                        |
+| `[hsts]` with `enabled = true`              | Explicitly enable HSTS at this scope. `max_age` defaults to `31_536_000` if omitted.   |
+| `[hsts]` with `enabled = false`             | Explicitly disable HSTS at this scope, suppressing any inherited listener default.     |
+| `[hsts]` without `enabled`                  | **Error** — `ConfigError::HstsEnabledRequired` (TOML) or `ListenerError::HstsEnabledRequired` (partial update). |
+
+A minimal HTTPS deployment with no HSTS is therefore just:
+
+```toml
+[[listeners]]
+protocol = "https"
+address  = "0.0.0.0:443"
+# no [hsts] block — fine
+
+[[clusters.api.frontends]]
+address  = "0.0.0.0:443"
+hostname = "api.example.com"
+# no [hsts] block — fine
+```
+
 ```toml
 # Listener-level default — every HTTPS frontend on this listener
 # inherits unless it declares its own [hsts] block.

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -347,6 +347,7 @@ sozu frontend https add \
 |-------------------------------------|---------|----------------------------------------------------------------------------------------------------|
 | `http.hsts.frontend_added`          | counter | A frontend is added with `hsts.enabled = true` and the HSTS edit is materialised in `headers_response`. |
 | `http.hsts.suppressed_plaintext`    | counter | An `AddHttpFrontend` IPC was rejected because it carried an enabled HSTS policy (RFC 6797 §7.2 defense in depth). |
+| `http.hsts.unrendered`              | counter | Defense-in-depth: a frontend reached `Frontend::new` with `hsts.enabled = true` but `render_hsts` returned `None` (max_age missing). The TOML loader and the CLI helper both substitute `DEFAULT_HSTS_MAX_AGE` so this counter only fires when a programmatic IPC sender ships an ill-formed `HstsConfig`. |
 
 #### Options specific to Rustls based HTTPS listeners
 

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -263,7 +263,12 @@ hostname = "api.example.com"
 
 ```toml
 # Listener-level default — every HTTPS frontend on this listener
-# inherits unless it declares its own [hsts] block.
+# inherits unless it declares its own [hsts] block. The `[hsts]`
+# table nests under the enclosing `[[listeners]]` entry.
+[[listeners]]
+protocol = "https"
+address  = "0.0.0.0:443"
+
 [hsts]
 # REQUIRED whenever the [hsts] block is present. `false` is the
 # explicit-disable signal on a partial-update; new TOML deployments

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -341,6 +341,8 @@ sozu frontend https add \
 
 `UpdateHttpsListenerConfig.hsts` follows full-object replacement semantics: when present in the patch, the entire HSTS block replaces the listener's current value. `enabled` is REQUIRED whenever `hsts` is present (`ListenerError::HstsEnabledRequired` rejects an `enabled = None` block). Absent `hsts` field on the patch preserves the current value.
 
+**Inheritance refresh limitation.** Patching the listener-default HSTS updates `HttpsListenerConfig.hsts` for FUTURE frontend adds; existing frontends keep their materialised HSTS edit (the value that was the listener default at frontend-add time). To re-flow the new default onto an inheriting frontend, the operator must remove + re-add the frontend. A `warn!` log line and the `http.hsts.listener_default_patched` counter fire on every patch so the pending operator action is surfaced. Per-frontend explicit overrides are unaffected.
+
 ##### Metrics
 
 | Metric                              | Kind    | Emitted when                                                                                       |
@@ -348,6 +350,7 @@ sozu frontend https add \
 | `http.hsts.frontend_added`          | counter | A frontend is added with `hsts.enabled = true` and the HSTS edit is materialised in `headers_response`. |
 | `http.hsts.suppressed_plaintext`    | counter | An `AddHttpFrontend` IPC was rejected because it carried an enabled HSTS policy (RFC 6797 §7.2 defense in depth). |
 | `http.hsts.unrendered`              | counter | Defense-in-depth: a frontend reached `Frontend::new` with `hsts.enabled = true` but `render_hsts` returned `None` (max_age missing). The TOML loader and the CLI helper both substitute `DEFAULT_HSTS_MAX_AGE` so this counter only fires when a programmatic IPC sender ships an ill-formed `HstsConfig`. |
+| `http.hsts.listener_default_patched`| counter | A `UpdateHttpsListenerConfig.hsts` patch was applied. Pairs with a `warn!` reminding the operator to remove + re-add inheriting frontends so they pick up the new default. |
 
 #### Options specific to Rustls based HTTPS listeners
 

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -218,6 +218,96 @@ sticky_name = "SOZUBALANCEID"
 tls_versions = ["TLS_V12", "TLS_V13"]
 ```
 
+#### HSTS — HTTP Strict Transport Security (RFC 6797)
+
+HSTS = HTTP Strict Transport Security ([RFC 6797](https://datatracker.ietf.org/doc/html/rfc6797)). When configured on an HTTPS listener or frontend, Sōzu emits the `Strict-Transport-Security` response header so conformant browsers refuse to talk to the host over plaintext HTTP for the configured `max-age` duration.
+
+A `[hsts]` block under an HTTPS listener is the operator-default; per-frontend overrides live under `[clusters.<id>.frontends.hsts]`. Per-frontend `enabled = true` overrides the listener default; per-frontend `enabled = false` explicitly suppresses an inherited listener default for that frontend.
+
+Per RFC 6797 §7.2 the `Strict-Transport-Security` header MUST NOT appear on plaintext-HTTP responses. Sōzu enforces this in three layers: (1) TOML config-load rejects `[hsts]` on a plain-HTTP listener (`ConfigError::HstsOnPlainHttp`), (2) the worker IPC entry rejects `AddHttpFrontend` carrying an enabled HSTS (`ProxyError::HstsOnPlainHttp` and the `http.hsts.suppressed_plaintext` counter), and (3) the runtime per-stream snapshot copy is gated on `context.protocol == Protocol::HTTPS` so plaintext connections never apply HSTS edits even when one slips through.
+
+```toml
+# Listener-level default — every HTTPS frontend on this listener
+# inherits unless it declares its own [hsts] block.
+[hsts]
+# REQUIRED whenever the [hsts] block is present. `false` is the
+# explicit-disable signal on a partial-update; new TOML deployments
+# will normally set `true`.
+enabled = true
+# `Strict-Transport-Security: max-age=<seconds>`. When omitted with
+# `enabled = true`, sozu substitutes 31_536_000 seconds (1 year — the
+# Chrome HSTS preload list minimum) at config-load.
+max_age = 31536000
+# Append `; includeSubDomains` to the rendered header.
+include_subdomains = true
+# Append `; preload` to the rendered header. Opt-in only — once
+# submitted to https://hstspreload.org/, removal is slow and partial
+# (RFC 6797 §14.2). NEVER default-true.
+preload = false
+```
+
+Per-frontend override or explicit disable:
+
+```toml
+[[clusters.api.frontends]]
+address  = "0.0.0.0:443"
+hostname = "api.example.com"
+
+# Override the listener default with a longer 2-year max-age and
+# opt the host into the preload list.
+[clusters.api.frontends.hsts]
+enabled            = true
+max_age            = 63072000
+include_subdomains = true
+preload            = true
+
+# Suppress the inherited listener default for a legacy frontend that
+# cannot commit to HSTS yet:
+[[clusters.legacy.frontends]]
+address  = "0.0.0.0:443"
+hostname = "legacy.example.com"
+
+[clusters.legacy.frontends.hsts]
+enabled = false
+```
+
+##### Validation matrix
+
+| Configuration                                                 | Outcome                                                                                                                                                  |
+|---------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `[hsts]` block without `enabled`                              | **Error** `HstsEnabledRequired` at config-load. `enabled` is the explicit-disambiguator between disable / enable on partial updates.                     |
+| `[hsts]` on a plain-HTTP listener or frontend                 | **Error** `HstsOnPlainHttp` at config-load (and `ProxyError::HstsOnPlainHttp` if it slipped through to the worker). RFC 6797 §7.2.                       |
+| `enabled = true`, `max_age` omitted                           | Substituted to `DEFAULT_HSTS_MAX_AGE = 31_536_000` (1 year). Matches the HSTS preload list minimum.                                                      |
+| `max_age = 0`                                                 | **Allowed silently** — RFC 6797 §11.4 kill switch. Conformant UAs stop treating the host as a Known HSTS Host.                                           |
+| `0 < max_age < 86_400`                                        | **Warning** at config-load (likely misconfiguration — sub-day HSTS only makes sense for testing).                                                        |
+| `preload = true` with `max_age < 31_536_000`                  | **Warning** at config-load. The Chrome HSTS preload list rejects hosts below the minimum.                                                                |
+| `preload = true` without `include_subdomains = true`          | **Warning** at config-load. Same preload-list rejection.                                                                                                 |
+| Backend emits its own `Strict-Transport-Security`             | Pass-through unchanged. Sōzu's HSTS edit uses `HeaderEditMode::SetIfAbsent` so a single header reaches the wire (RFC 6797 §6.1).                         |
+| HTTPS-served default answer (3xx redirect, 401, 503)          | Carries the HSTS header per RFC 6797 §8.1. The per-stream snapshot copy fires before the early returns in `mux/router.rs`, gated on `Protocol::HTTPS`.    |
+
+##### Runtime CLI surface
+
+```
+sozu frontend https add \
+  --address 0.0.0.0:443 \
+  --hostname api.example.com \
+  --hsts-max-age 31536000 \
+  --hsts-include-subdomains
+```
+
+`--hsts-disabled` is mutually exclusive with `--hsts-max-age` / `--hsts-include-subdomains` / `--hsts-preload`; combining them surfaces `CtlError::ArgsNeeded` rather than a silent pick.
+
+##### Hot-reconfig partial-update
+
+`UpdateHttpsListenerConfig.hsts` follows full-object replacement semantics: when present in the patch, the entire HSTS block replaces the listener's current value. `enabled` is REQUIRED whenever `hsts` is present (`ListenerError::HstsEnabledRequired` rejects an `enabled = None` block). Absent `hsts` field on the patch preserves the current value.
+
+##### Metrics
+
+| Metric                              | Kind    | Emitted when                                                                                       |
+|-------------------------------------|---------|----------------------------------------------------------------------------------------------------|
+| `http.hsts.frontend_added`          | counter | A frontend is added with `hsts.enabled = true` and the HSTS edit is materialised in `headers_response`. |
+| `http.hsts.suppressed_plaintext`    | counter | An `AddHttpFrontend` IPC was rejected because it carried an enabled HSTS policy (RFC 6797 §7.2 defense in depth). |
+
 #### Options specific to Rustls based HTTPS listeners
 
 ##### Cipher suites
@@ -984,6 +1074,62 @@ value    = ""                      # empty value DELETES the header by name
 HAProxy parallels: `http-request redirect` (permanent / scheme), `set-uri` and
 `set-path` (rewrite), `http-request set-header` and `http-request del-header`
 (custom headers).
+
+### HSTS for the HTTPS counterpart of an automatic redirect
+
+When an HTTP listener carries a `redirect_scheme = "use-https"` frontend
+that pushes traffic to an HTTPS counterpart, HSTS belongs on the **HTTPS**
+side, **never** on the redirect itself. RFC 6797 §7.2 forbids
+`Strict-Transport-Security` on plaintext-HTTP responses; conformant browsers
+ignore the header on plain-HTTP and Sōzu refuses the configuration at
+load time on HTTP listeners.
+
+The recommended pattern is two paired frontends with HSTS attached to
+the HTTPS one:
+
+```toml
+# Plain-HTTP frontend that pushes everything to HTTPS via 301.
+[[clusters.api.frontends]]
+address         = "0.0.0.0:80"
+hostname        = "api.example.com"
+redirect        = "permanent"     # 301 (or "permanent_redirect" for 308)
+redirect_scheme = "use-https"
+# NO [hsts] block here — Sōzu would reject it (RFC §7.2).
+
+# HTTPS counterpart that serves traffic and pins HSTS.
+[[clusters.api.frontends]]
+address  = "0.0.0.0:443"
+hostname = "api.example.com"
+
+[clusters.api.frontends.hsts]
+enabled            = true
+max_age            = 31536000     # 1 year — preload list minimum
+include_subdomains = true
+preload            = false        # opt-in only
+```
+
+For convenience, declare HSTS once at the listener default and let every
+HTTPS frontend inherit:
+
+```toml
+[[listeners]]
+protocol = "https"
+address  = "0.0.0.0:443"
+
+[hsts]
+enabled            = true
+max_age            = 31536000
+include_subdomains = true
+```
+
+Per-frontend `hsts.enabled = false` suppresses the inherited default for
+a single frontend that cannot commit to HSTS yet.
+
+The header is emitted on every successful HTTPS response, including
+proxy-generated 3xx redirects (e.g. `redirect_scheme = "use-https"` from
+an HTTPS frontend, or a `redirect = "permanent"` shape served on the
+HTTPS side), 401 auth-deny, and 502 / 503 / 504 default answers — RFC
+6797 §8.1 requires HSTS on every response code from the host.
 
 ## HTTP Basic authentication on a frontend
 

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -322,7 +322,7 @@ enabled = false
 | `0 < max_age < 86_400`                                        | **Warning** at config-load (likely misconfiguration — sub-day HSTS only makes sense for testing).                                                        |
 | `preload = true` with `max_age < 31_536_000`                  | **Warning** at config-load. The Chrome HSTS preload list rejects hosts below the minimum.                                                                |
 | `preload = true` without `include_subdomains = true`          | **Warning** at config-load. Same preload-list rejection.                                                                                                 |
-| Backend emits its own `Strict-Transport-Security`             | Pass-through unchanged. Sōzu's HSTS edit uses `HeaderEditMode::SetIfAbsent` so a single header reaches the wire (RFC 6797 §6.1).                         |
+| Backend emits its own `Strict-Transport-Security`             | Pass-through unchanged by default. Sōzu's HSTS edit uses `HeaderEditMode::SetIfAbsent` so a single header reaches the wire (RFC 6797 §6.1). Set `force_replace_backend = true` to override the backend value with sōzu's typed policy (`HeaderEditMode::Set` — delete-then-insert).  |
 | HTTPS-served default answer (3xx redirect, 401, 503)          | Carries the HSTS header per RFC 6797 §8.1. The per-stream snapshot copy fires before the early returns in `mux/router.rs`, gated on `Protocol::HTTPS`.    |
 
 ##### Runtime CLI surface

--- a/e2e/src/mock/https_client.rs
+++ b/e2e/src/mock/https_client.rs
@@ -121,6 +121,48 @@ pub fn resolve_request(client: &HttpsClient, uri: hyper::Uri) -> Option<(StatusC
     resolve_request_timeout(client, uri, Duration::from_secs(10))
 }
 
+/// Variant of [`resolve_request`] that also returns the response
+/// `HeaderMap`. Used by the HSTS e2e tests to assert on
+/// `Strict-Transport-Security` (and any other response-side header
+/// emitted by sozu) rather than relying on the body. Same 10 s
+/// timeout as [`resolve_request`]; the inner future does not follow
+/// redirects so 3xx default answers stay as-is for the assertion.
+pub fn resolve_request_with_headers(
+    client: &HttpsClient,
+    uri: hyper::Uri,
+) -> Option<(StatusCode, hyper::HeaderMap, String)> {
+    let rt = tokio::runtime::Runtime::new().expect("Could not create Runtime");
+    rt.block_on(async {
+        let fut = async {
+            let response = match client.get(uri).await {
+                Ok(response) => response,
+                Err(error) => {
+                    println!("Could not get response: {error}");
+                    return None;
+                }
+            };
+            let status = response.status();
+            let headers = response.headers().clone();
+            let body_bytes = match response.into_body().collect().await {
+                Ok(collected) => collected.to_bytes(),
+                Err(error) => {
+                    println!("Could not get body: {error}");
+                    return Some((status, headers, String::new()));
+                }
+            };
+            let body = String::from_utf8(body_bytes.to_vec()).unwrap_or_default();
+            Some((status, headers, body))
+        };
+        match tokio::time::timeout(Duration::from_secs(10), fut).await {
+            Ok(result) => result,
+            Err(_) => {
+                println!("resolve_request_with_headers timed out after 10s");
+                None
+            }
+        }
+    })
+}
+
 pub fn resolve_request_timeout(
     client: &HttpsClient,
     uri: hyper::Uri,

--- a/e2e/src/tests/hsts_tests.rs
+++ b/e2e/src/tests/hsts_tests.rs
@@ -125,15 +125,16 @@ fn test_hsts_on_http_frontend_rejected() {
 }
 
 // ═════════════════════════════════════════════════════════════════════
-// Explicit disable signal on HTTP — accepted, no §7.2 reject
+// Explicit disable signal on HTTP — also rejected
 // ═════════════════════════════════════════════════════════════════════
 
-/// `hsts.enabled = Some(false)` is the explicit-disable signal: it must
-/// NOT trip the §7.2 reject (the worker's predicate keys on
-/// `enabled == Some(true)`). Operators use this shape on plain-HTTP
-/// frontends to surface "we know HSTS is off here on purpose" in the
-/// configuration without semantic ambiguity.
-pub fn try_hsts_explicit_disable_on_http_accepted() -> State {
+/// `hsts.enabled = Some(false)` (the explicit-disable signal) on a
+/// plain-HTTP frontend is also rejected by `add_http_frontend`. There
+/// is no listener-default HSTS to inherit on an HTTP listener (the
+/// field doesn't exist on `HttpListenerConfig`), so the
+/// explicit-disable shape has nothing to suppress on this surface —
+/// carrying any `hsts` block here is treated as a misconfiguration.
+pub fn try_hsts_explicit_disable_on_http_rejected() -> State {
     let front_address = create_local_address();
     let _unused_back = create_unbound_local_address();
     let mut worker = spawn_worker_with_http_listener("HSTS-7.2-DISABLE", front_address);
@@ -155,16 +156,16 @@ pub fn try_hsts_explicit_disable_on_http_accepted() -> State {
     let resp = worker
         .read_proxy_response()
         .expect("worker must respond to AddHttpFrontend");
-    let accepted = resp.status == ResponseStatus::Ok as i32;
+    let rejected = resp.status == ResponseStatus::Failure as i32;
 
     worker.soft_stop();
     worker.wait_for_server_stop();
 
-    if accepted {
+    if rejected {
         State::Success
     } else {
         eprintln!(
-            "expected ResponseStatus::Ok for hsts.enabled = false on HTTP \
+            "expected ResponseStatus::Failure for hsts.enabled = false on HTTP \
              frontend, got status={} message={:?}",
             resp.status, resp.message
         );
@@ -173,12 +174,12 @@ pub fn try_hsts_explicit_disable_on_http_accepted() -> State {
 }
 
 #[test]
-fn test_hsts_explicit_disable_on_http_accepted() {
+fn test_hsts_explicit_disable_on_http_rejected() {
     assert_eq!(
         repeat_until_error_or(
             2,
-            "HSTS enabled = false on HTTP frontend accepted",
-            try_hsts_explicit_disable_on_http_accepted
+            "HSTS enabled = false on HTTP frontend rejected",
+            try_hsts_explicit_disable_on_http_rejected
         ),
         State::Success
     );

--- a/e2e/src/tests/hsts_tests.rs
+++ b/e2e/src/tests/hsts_tests.rs
@@ -1,0 +1,183 @@
+//! End-to-end coverage for the typed HSTS (RFC 6797) policy.
+//!
+//! Wire-level positive coverage (HTTPS frontend emits the
+//! `Strict-Transport-Security` header on backend-served responses,
+//! redirect-default answers, and 5xx default answers) is intentionally
+//! deferred — those tests need a full TLS stack (cert generation,
+//! `https_client::build_https_client`, `H2Backend`) and the per-test
+//! setup is heavier than the §7.2 reject path covered here. The
+//! unit tests in `lib/src/router/mod.rs::tests::render_hsts_*` and
+//! `lib/src/protocol/mux/shared.rs::tests` exercise the rendering and
+//! `apply_response_header_edits` SetIfAbsent paths exhaustively.
+//!
+//! What this module covers:
+//! - **§7.2 reject at the worker IPC entry point**: `AddHttpFrontend`
+//!   carrying `hsts.enabled = true` is rejected with `ResponseStatus::Failure`
+//!   (the `ProxyError::HstsOnPlainHttp` arm). Defense in depth on top of the
+//!   TOML config-load reject.
+//! - **`hsts.enabled = false` on plain HTTP is accepted**: the explicit
+//!   disable signal must NOT trip the §7.2 reject — it's the operator's
+//!   way of suppressing an inherited listener default.
+
+use sozu_command_lib::{
+    config::ListenerBuilder,
+    proto::command::{
+        ActivateListener, HstsConfig, ListenerType, Request, ResponseStatus, request::RequestType,
+    },
+};
+
+use crate::{
+    sozu::worker::Worker,
+    tests::{
+        State, repeat_until_error_or,
+        tests::{create_local_address, create_unbound_local_address},
+    },
+};
+
+/// Spawn a worker with a single plain-HTTP listener. Mirrors the helper
+/// in `redirect_rewrite_auth_tests.rs` so the §7.2 reject path can be
+/// exercised on the cheapest possible setup.
+fn spawn_worker_with_http_listener(name: &str, front_address: std::net::SocketAddr) -> Worker {
+    let (config, mut listeners, state) = Worker::empty_config();
+    crate::port_registry::attach_reserved_http_listener(&mut listeners, front_address);
+    let mut worker = Worker::start_new_worker_owned(name, config, listeners, state);
+
+    worker.send_proxy_request(Request {
+        request_type: Some(RequestType::AddHttpListener(
+            ListenerBuilder::new_http(front_address.into())
+                .to_http(None)
+                .expect("default HTTP listener must build"),
+        )),
+    });
+    worker.send_proxy_request(Request {
+        request_type: Some(RequestType::ActivateListener(ActivateListener {
+            address: front_address.into(),
+            proxy: ListenerType::Http.into(),
+            from_scm: true,
+        })),
+    });
+    worker.read_to_last();
+    worker
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// §7.2 reject — AddHttpFrontend with hsts.enabled = true is refused
+// ═════════════════════════════════════════════════════════════════════
+
+/// RFC 6797 §7.2 forbids `Strict-Transport-Security` on plaintext HTTP.
+/// The worker's `add_http_frontend` chokepoint enforces this even when
+/// the misconfiguration bypasses the TOML config-load reject (e.g. a
+/// programmatic IPC sender or `sozu frontend http add` with HSTS
+/// flags). The response status must be `Failure` and the worker must
+/// stay healthy afterwards.
+pub fn try_hsts_on_http_frontend_rejected() -> State {
+    let front_address = create_local_address();
+    let _unused_back = create_unbound_local_address();
+    let mut worker = spawn_worker_with_http_listener("HSTS-7.2-REJECT", front_address);
+
+    worker.send_proxy_request(
+        RequestType::AddCluster(Worker::default_cluster("hsts_reject_cluster")).into(),
+    );
+    worker.read_to_last();
+
+    let mut frontend = Worker::default_http_frontend("hsts_reject_cluster", front_address);
+    frontend.hsts = Some(HstsConfig {
+        enabled: Some(true),
+        max_age: Some(31_536_000),
+        include_subdomains: Some(true),
+        preload: Some(false),
+    });
+    worker.send_proxy_request_type(RequestType::AddHttpFrontend(frontend));
+    let resp = worker
+        .read_proxy_response()
+        .expect("worker must respond to AddHttpFrontend");
+    let rejected = resp.status == ResponseStatus::Failure as i32;
+    let mentions_hsts = resp.message.to_ascii_uppercase().contains("HSTS")
+        || resp.message.to_ascii_lowercase().contains("plaintext")
+        || resp.message.to_ascii_lowercase().contains("plain http");
+
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    if rejected && mentions_hsts {
+        State::Success
+    } else {
+        eprintln!(
+            "expected ResponseStatus::Failure with HSTS-related message, \
+             got status={} message={:?}",
+            resp.status, resp.message
+        );
+        State::Fail
+    }
+}
+
+#[test]
+fn test_hsts_on_http_frontend_rejected() {
+    assert_eq!(
+        repeat_until_error_or(
+            2,
+            "HSTS on HTTP frontend rejected (RFC 6797 §7.2)",
+            try_hsts_on_http_frontend_rejected
+        ),
+        State::Success
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Explicit disable signal on HTTP — accepted, no §7.2 reject
+// ═════════════════════════════════════════════════════════════════════
+
+/// `hsts.enabled = Some(false)` is the explicit-disable signal: it must
+/// NOT trip the §7.2 reject (the worker's predicate keys on
+/// `enabled == Some(true)`). Operators use this shape on plain-HTTP
+/// frontends to surface "we know HSTS is off here on purpose" in the
+/// configuration without semantic ambiguity.
+pub fn try_hsts_explicit_disable_on_http_accepted() -> State {
+    let front_address = create_local_address();
+    let _unused_back = create_unbound_local_address();
+    let mut worker = spawn_worker_with_http_listener("HSTS-7.2-DISABLE", front_address);
+
+    worker.send_proxy_request(
+        RequestType::AddCluster(Worker::default_cluster("hsts_disable_cluster")).into(),
+    );
+    worker.read_to_last();
+
+    let mut frontend = Worker::default_http_frontend("hsts_disable_cluster", front_address);
+    frontend.hsts = Some(HstsConfig {
+        enabled: Some(false),
+        max_age: None,
+        include_subdomains: None,
+        preload: None,
+    });
+    worker.send_proxy_request_type(RequestType::AddHttpFrontend(frontend));
+    let resp = worker
+        .read_proxy_response()
+        .expect("worker must respond to AddHttpFrontend");
+    let accepted = resp.status == ResponseStatus::Ok as i32;
+
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    if accepted {
+        State::Success
+    } else {
+        eprintln!(
+            "expected ResponseStatus::Ok for hsts.enabled = false on HTTP \
+             frontend, got status={} message={:?}",
+            resp.status, resp.message
+        );
+        State::Fail
+    }
+}
+
+#[test]
+fn test_hsts_explicit_disable_on_http_accepted() {
+    assert_eq!(
+        repeat_until_error_or(
+            2,
+            "HSTS enabled = false on HTTP frontend accepted",
+            try_hsts_explicit_disable_on_http_accepted
+        ),
+        State::Success
+    );
+}

--- a/e2e/src/tests/hsts_tests.rs
+++ b/e2e/src/tests/hsts_tests.rs
@@ -1,35 +1,50 @@
 //! End-to-end coverage for the typed HSTS (RFC 6797) policy.
 //!
-//! Wire-level positive coverage (HTTPS frontend emits the
-//! `Strict-Transport-Security` header on backend-served responses,
-//! redirect-default answers, and 5xx default answers) is intentionally
-//! deferred — those tests need a full TLS stack (cert generation,
-//! `https_client::build_https_client`, `H2Backend`) and the per-test
-//! setup is heavier than the §7.2 reject path covered here. The
-//! unit tests in `lib/src/router/mod.rs::tests::render_hsts_*` and
-//! `lib/src/protocol/mux/shared.rs::tests` exercise the rendering and
-//! `apply_response_header_edits` SetIfAbsent paths exhaustively.
-//!
-//! What this module covers:
+//! Plain-HTTP §7.2 reject paths:
 //! - **§7.2 reject at the worker IPC entry point**: `AddHttpFrontend`
 //!   carrying `hsts.enabled = true` is rejected with `ResponseStatus::Failure`
 //!   (the `ProxyError::HstsOnPlainHttp` arm). Defense in depth on top of the
 //!   TOML config-load reject.
-//! - **`hsts.enabled = false` on plain HTTP is accepted**: the explicit
-//!   disable signal must NOT trip the §7.2 reject — it's the operator's
-//!   way of suppressing an inherited listener default.
+//! - **`hsts.enabled = false` on plain HTTP is also rejected**: there is no
+//!   listener-default HSTS to inherit on an HTTP listener (the field doesn't
+//!   exist on `HttpListenerConfig`), so the explicit-disable signal has
+//!   nothing to suppress on this surface.
+//!
+//! Wire-level HTTPS positive paths (`Strict-Transport-Security` reaches
+//! the client on every response code per RFC 6797 §8.1):
+//! - **HSTS on a backend-served 200 response** through an HTTPS frontend.
+//! - **HSTS on a 301 redirect default answer** rendered when the frontend
+//!   carries `redirect = permanent` + `redirect_scheme = use-https`.
+//! - **HSTS on a 401 unauthorized default answer** rendered when the
+//!   frontend carries `redirect = unauthorized`.
+//! - **HSTS on a 503 default answer** rendered when the configured backend
+//!   is unreachable. Confirms the snapshot-copy hoist in `mux/router.rs`
+//!   and the `set_default_answer_with_retry_after` chokepoint both
+//!   thread the per-frontend HSTS edit through to the wire.
+//!
+//! All HTTPS tests use the `local-certificate.pem` shipped under
+//! `lib/assets/`, the `build_h2_or_h1_client` Hyper client, and the
+//! `resolve_request_with_headers` helper so the assertion sees both
+//! the status line and the `Strict-Transport-Security` header.
 
 use sozu_command_lib::{
     config::ListenerBuilder,
     proto::command::{
-        ActivateListener, HstsConfig, ListenerType, Request, ResponseStatus, request::RequestType,
+        ActivateListener, AddCertificate, CertificateAndKey, HstsConfig, ListenerType,
+        RedirectPolicy, RedirectScheme, Request, RequestHttpFrontend, ResponseStatus,
+        SocketAddress, request::RequestType,
     },
 };
 
 use crate::{
+    mock::{
+        aggregator::SimpleAggregator,
+        async_backend::BackendHandle as AsyncBackend,
+        https_client::{build_h2_or_h1_client, resolve_request_with_headers},
+    },
     sozu::worker::Worker,
     tests::{
-        State, repeat_until_error_or,
+        State, provide_port, repeat_until_error_or,
         tests::{create_local_address, create_unbound_local_address},
     },
 };
@@ -180,6 +195,373 @@ fn test_hsts_explicit_disable_on_http_rejected() {
             2,
             "HSTS enabled = false on HTTP frontend rejected",
             try_hsts_explicit_disable_on_http_rejected
+        ),
+        State::Success
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Wire-level HTTPS positives — HSTS on every response code (RFC §8.1)
+// ═════════════════════════════════════════════════════════════════════
+
+/// Canonical HSTS rendered value used by every HTTPS positive test
+/// below. Matches the default `max_age = 31_536_000` (1 year, the HSTS
+/// preload list minimum) plus `includeSubDomains` set by the operator.
+/// Asserting on the exact value keeps the test honest — a regression in
+/// `render_hsts` that, e.g., reordered the directives or dropped
+/// `includeSubDomains` would surface as a string mismatch instead of a
+/// generic header-presence pass.
+const EXPECTED_HSTS_VALUE: &str = "max-age=31536000; includeSubDomains";
+
+/// Build a typed HSTS block: `enabled = true`, `max_age = 31_536_000`,
+/// `include_subdomains = true`, `preload = false`. Used by the four
+/// positive tests below so the assertion can compare against
+/// [`EXPECTED_HSTS_VALUE`] verbatim.
+fn make_hsts_default() -> HstsConfig {
+    HstsConfig {
+        enabled: Some(true),
+        max_age: Some(31_536_000),
+        include_subdomains: Some(true),
+        preload: None,
+        force_replace_backend: None,
+    }
+}
+
+/// Spawn an HTTPS worker with a single TLS listener at `front_address`
+/// and the local-only `localhost` certificate attached. Returns the
+/// worker. The caller layers cluster + frontend + backends on top.
+///
+/// Mirrors the setup in `tls_tests.rs::try_tls_sni_routing` so the HSTS
+/// e2e tests reuse the existing TLS scaffold (cert generation,
+/// `provide_port`, `Worker::empty_https_config`).
+fn spawn_https_worker(name: &str, front_address: SocketAddress) -> Worker {
+    let (config, listeners, state) = Worker::empty_https_config(front_address.into());
+    let mut worker = Worker::start_new_worker_owned(name, config, listeners, state);
+
+    worker.send_proxy_request_type(RequestType::AddHttpsListener(
+        ListenerBuilder::new_https(front_address.clone())
+            .to_tls(None)
+            .expect("default HTTPS listener must build"),
+    ));
+    worker.send_proxy_request_type(RequestType::ActivateListener(ActivateListener {
+        address: front_address.clone(),
+        proxy: ListenerType::Https.into(),
+        from_scm: false,
+    }));
+
+    let certificate_and_key = CertificateAndKey {
+        certificate: String::from(include_str!("../../../lib/assets/local-certificate.pem")),
+        key: String::from(include_str!("../../../lib/assets/local-key.pem")),
+        certificate_chain: vec![],
+        versions: vec![],
+        names: vec![],
+    };
+    worker.send_proxy_request_type(RequestType::AddCertificate(AddCertificate {
+        address: front_address,
+        certificate: certificate_and_key,
+        expired_at: None,
+    }));
+
+    worker
+}
+
+/// HTTPS frontend with `hsts.enabled = true` returns the
+/// `Strict-Transport-Security` header on a backend-served 200 response.
+/// The canonical positive case — RFC 6797 §8.1 says HSTS applies to
+/// every response code, but the 2xx Forward path is the most common
+/// production shape and the one operators primarily care about.
+pub fn try_hsts_on_https_backend_200() -> State {
+    let front_port = provide_port();
+    let front_address = SocketAddress::new_v4(127, 0, 0, 1, front_port);
+    let back_address = create_local_address();
+    let mut worker = spawn_https_worker("HSTS-HTTPS-200", front_address.clone());
+
+    worker.send_proxy_request_type(RequestType::AddCluster(Worker::default_cluster(
+        "hsts_https_200",
+    )));
+    worker.send_proxy_request_type(RequestType::AddHttpsFrontend(RequestHttpFrontend {
+        hostname: "localhost".to_owned(),
+        hsts: Some(make_hsts_default()),
+        ..Worker::default_http_frontend("hsts_https_200", front_address.clone().into())
+    }));
+    worker.send_proxy_request_type(RequestType::AddBackend(Worker::default_backend(
+        "hsts_https_200",
+        "hsts_https_200-0",
+        back_address,
+        None,
+    )));
+
+    let mut backend = AsyncBackend::spawn_detached_backend(
+        "BACKEND_200",
+        back_address,
+        SimpleAggregator::default(),
+        AsyncBackend::http_handler("pong-hsts"),
+    );
+    worker.read_to_last();
+
+    let client = build_h2_or_h1_client();
+    let uri: hyper::Uri = format!("https://localhost:{front_port}/")
+        .parse()
+        .expect("valid uri");
+    let resp = resolve_request_with_headers(&client, uri);
+
+    worker.soft_stop();
+    let _ = worker.wait_for_server_stop();
+    let _ = backend.stop_and_get_aggregator();
+
+    match resp {
+        Some((status, headers, body)) => {
+            let sts = headers.get("strict-transport-security");
+            let ok = status.is_success()
+                && body.contains("pong-hsts")
+                && sts.is_some_and(|v| v.as_bytes() == EXPECTED_HSTS_VALUE.as_bytes());
+            if ok {
+                State::Success
+            } else {
+                eprintln!(
+                    "expected 2xx + body 'pong-hsts' + STS = {EXPECTED_HSTS_VALUE:?}, got \
+                     status={status}, sts={sts:?}, body={body:?}"
+                );
+                State::Fail
+            }
+        }
+        None => {
+            eprintln!("HTTPS request failed entirely");
+            State::Fail
+        }
+    }
+}
+
+#[test]
+fn test_hsts_on_https_backend_200() {
+    assert_eq!(
+        repeat_until_error_or(
+            2,
+            "HSTS on HTTPS backend-served 200",
+            try_hsts_on_https_backend_200
+        ),
+        State::Success
+    );
+}
+
+/// HTTPS frontend with `hsts.enabled = true` AND
+/// `redirect = permanent` + `redirect_scheme = use-https` returns the
+/// `Strict-Transport-Security` header on the proxy-generated 301
+/// default answer. Exercises the snapshot-copy hoist in
+/// `lib/src/protocol/mux/router.rs` — without the hoist, the
+/// `set_default_answer_with_retry_after` path bypasses
+/// `apply_response_header_edits` and the 301 ships without HSTS
+/// (RFC 6797 §8.1 violation).
+pub fn try_hsts_on_https_redirect_301() -> State {
+    let front_port = provide_port();
+    let front_address = SocketAddress::new_v4(127, 0, 0, 1, front_port);
+    let unused_back = create_unbound_local_address();
+    let mut worker = spawn_https_worker("HSTS-HTTPS-301", front_address.clone());
+
+    worker.send_proxy_request_type(RequestType::AddCluster(Worker::default_cluster(
+        "hsts_https_301",
+    )));
+    worker.send_proxy_request_type(RequestType::AddHttpsFrontend(RequestHttpFrontend {
+        hostname: "localhost".to_owned(),
+        redirect: Some(RedirectPolicy::Permanent as i32),
+        redirect_scheme: Some(RedirectScheme::UseHttps as i32),
+        hsts: Some(make_hsts_default()),
+        ..Worker::default_http_frontend("hsts_https_301", front_address.clone().into())
+    }));
+    // Backend never contacted but required so cluster has a backend
+    // pool — sozu's redirect short-circuits before backend connect.
+    worker.send_proxy_request_type(RequestType::AddBackend(Worker::default_backend(
+        "hsts_https_301",
+        "hsts_https_301-0",
+        unused_back,
+        None,
+    )));
+    worker.read_to_last();
+
+    let client = build_h2_or_h1_client();
+    let uri: hyper::Uri = format!("https://localhost:{front_port}/")
+        .parse()
+        .expect("valid uri");
+    let resp = resolve_request_with_headers(&client, uri);
+
+    worker.soft_stop();
+    let _ = worker.wait_for_server_stop();
+
+    match resp {
+        Some((status, headers, _body)) => {
+            let sts = headers.get("strict-transport-security");
+            let ok = status.as_u16() == 301
+                && sts.is_some_and(|v| v.as_bytes() == EXPECTED_HSTS_VALUE.as_bytes());
+            if ok {
+                State::Success
+            } else {
+                eprintln!(
+                    "expected 301 + STS = {EXPECTED_HSTS_VALUE:?}, got status={status}, sts={sts:?}"
+                );
+                State::Fail
+            }
+        }
+        None => {
+            eprintln!("HTTPS redirect request failed entirely");
+            State::Fail
+        }
+    }
+}
+
+#[test]
+fn test_hsts_on_https_redirect_301() {
+    assert_eq!(
+        repeat_until_error_or(
+            2,
+            "HSTS on HTTPS 301 default answer",
+            try_hsts_on_https_redirect_301
+        ),
+        State::Success
+    );
+}
+
+/// HTTPS frontend with `hsts.enabled = true` AND
+/// `redirect = unauthorized` returns the `Strict-Transport-Security`
+/// header on the proxy-generated 401 default answer. Same hoist path
+/// as the 301 test above; covers the auth-deny early return at
+/// `mux/router.rs:762` separately because the 301 short-circuit lives
+/// at `:714` and the snapshot must precede both.
+pub fn try_hsts_on_https_unauthorized_401() -> State {
+    let front_port = provide_port();
+    let front_address = SocketAddress::new_v4(127, 0, 0, 1, front_port);
+    let unused_back = create_unbound_local_address();
+    let mut worker = spawn_https_worker("HSTS-HTTPS-401", front_address.clone());
+
+    worker.send_proxy_request_type(RequestType::AddCluster(Worker::default_cluster(
+        "hsts_https_401",
+    )));
+    worker.send_proxy_request_type(RequestType::AddHttpsFrontend(RequestHttpFrontend {
+        hostname: "localhost".to_owned(),
+        redirect: Some(RedirectPolicy::Unauthorized as i32),
+        hsts: Some(make_hsts_default()),
+        ..Worker::default_http_frontend("hsts_https_401", front_address.clone().into())
+    }));
+    worker.send_proxy_request_type(RequestType::AddBackend(Worker::default_backend(
+        "hsts_https_401",
+        "hsts_https_401-0",
+        unused_back,
+        None,
+    )));
+    worker.read_to_last();
+
+    let client = build_h2_or_h1_client();
+    let uri: hyper::Uri = format!("https://localhost:{front_port}/")
+        .parse()
+        .expect("valid uri");
+    let resp = resolve_request_with_headers(&client, uri);
+
+    worker.soft_stop();
+    let _ = worker.wait_for_server_stop();
+
+    match resp {
+        Some((status, headers, _body)) => {
+            let sts = headers.get("strict-transport-security");
+            let ok = status.as_u16() == 401
+                && sts.is_some_and(|v| v.as_bytes() == EXPECTED_HSTS_VALUE.as_bytes());
+            if ok {
+                State::Success
+            } else {
+                eprintln!(
+                    "expected 401 + STS = {EXPECTED_HSTS_VALUE:?}, got status={status}, sts={sts:?}"
+                );
+                State::Fail
+            }
+        }
+        None => {
+            eprintln!("HTTPS unauthorized request failed entirely");
+            State::Fail
+        }
+    }
+}
+
+#[test]
+fn test_hsts_on_https_unauthorized_401() {
+    assert_eq!(
+        repeat_until_error_or(
+            2,
+            "HSTS on HTTPS 401 default answer",
+            try_hsts_on_https_unauthorized_401
+        ),
+        State::Success
+    );
+}
+
+/// HTTPS frontend with `hsts.enabled = true` and a backend at an
+/// unbound address returns the `Strict-Transport-Security` header on
+/// the proxy-generated 503 default answer. Exercises the
+/// `set_default_answer_with_retry_after` chokepoint at `mux/answers.rs`
+/// — the snapshot-copy hoist runs on the Forward path before the
+/// backend-connect attempt fails, so the per-stream
+/// `headers_response` is already populated when the 503 default
+/// answer is rendered.
+pub fn try_hsts_on_https_unreachable_503() -> State {
+    let front_port = provide_port();
+    let front_address = SocketAddress::new_v4(127, 0, 0, 1, front_port);
+    let unbound_back = create_unbound_local_address();
+    let mut worker = spawn_https_worker("HSTS-HTTPS-503", front_address.clone());
+
+    worker.send_proxy_request_type(RequestType::AddCluster(Worker::default_cluster(
+        "hsts_https_503",
+    )));
+    worker.send_proxy_request_type(RequestType::AddHttpsFrontend(RequestHttpFrontend {
+        hostname: "localhost".to_owned(),
+        hsts: Some(make_hsts_default()),
+        ..Worker::default_http_frontend("hsts_https_503", front_address.clone().into())
+    }));
+    worker.send_proxy_request_type(RequestType::AddBackend(Worker::default_backend(
+        "hsts_https_503",
+        "hsts_https_503-0",
+        unbound_back,
+        None,
+    )));
+    worker.read_to_last();
+
+    let client = build_h2_or_h1_client();
+    let uri: hyper::Uri = format!("https://localhost:{front_port}/")
+        .parse()
+        .expect("valid uri");
+    let resp = resolve_request_with_headers(&client, uri);
+
+    worker.soft_stop();
+    let _ = worker.wait_for_server_stop();
+
+    match resp {
+        Some((status, headers, _body)) => {
+            let sts = headers.get("strict-transport-security");
+            // The exact 5xx code depends on whether the backend connect
+            // refuses (503) or times out (504). Either is a valid
+            // proxy-generated 5xx default answer; HSTS must accompany
+            // both.
+            let is_5xx = status.is_server_error();
+            let ok = is_5xx && sts.is_some_and(|v| v.as_bytes() == EXPECTED_HSTS_VALUE.as_bytes());
+            if ok {
+                State::Success
+            } else {
+                eprintln!(
+                    "expected 5xx + STS = {EXPECTED_HSTS_VALUE:?}, got status={status}, sts={sts:?}"
+                );
+                State::Fail
+            }
+        }
+        None => {
+            eprintln!("HTTPS unreachable-backend request failed entirely");
+            State::Fail
+        }
+    }
+}
+
+#[test]
+fn test_hsts_on_https_unreachable_503() {
+    assert_eq!(
+        repeat_until_error_or(
+            2,
+            "HSTS on HTTPS 5xx default answer",
+            try_hsts_on_https_unreachable_503
         ),
         State::Success
     );

--- a/e2e/src/tests/hsts_tests.rs
+++ b/e2e/src/tests/hsts_tests.rs
@@ -86,6 +86,7 @@ pub fn try_hsts_on_http_frontend_rejected() -> State {
         max_age: Some(31_536_000),
         include_subdomains: Some(true),
         preload: Some(false),
+        force_replace_backend: None,
     });
     worker.send_proxy_request_type(RequestType::AddHttpFrontend(frontend));
     let resp = worker
@@ -148,6 +149,7 @@ pub fn try_hsts_explicit_disable_on_http_accepted() -> State {
         max_age: None,
         include_subdomains: None,
         preload: None,
+        force_replace_backend: None,
     });
     worker.send_proxy_request_type(RequestType::AddHttpFrontend(frontend));
     let resp = worker

--- a/e2e/src/tests/mod.rs
+++ b/e2e/src/tests/mod.rs
@@ -36,6 +36,7 @@ mod h2_security_sni;
 mod h2_security_tests;
 mod h2_tests;
 pub(crate) mod h2_utils;
+mod hsts_tests;
 mod listener_update_tests;
 mod mux_tests;
 mod protocol_pair_matrix;

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -951,7 +951,14 @@ impl HttpProxy {
         // `command/src/config.rs`; sites that build a `RequestHttpFrontend`
         // outside the TOML path (`sozu frontend http add`, programmatic
         // IPC senders) are caught here.
-        if matches!(front.hsts.as_ref().and_then(|h| h.enabled), Some(true)) {
+        // Reject ANY hsts field on a plain-HTTP frontend, not just
+        // `enabled = true`. There is no listener-default HSTS to inherit
+        // on an HTTP listener (the field doesn't exist on
+        // `HttpListenerConfig`), so the explicit-disable signal
+        // (`enabled = false`) has nothing to suppress on this surface.
+        // Carrying any `hsts` field here is a misconfiguration rather
+        // than a deliberate choice.
+        if front.hsts.is_some() {
             incr!("http.hsts.suppressed_plaintext");
             return Err(ProxyError::HstsOnPlainHttp(front.address.into()));
         }

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -944,6 +944,17 @@ impl HttpProxy {
     }
 
     pub fn add_http_frontend(&mut self, front: RequestHttpFrontend) -> Result<(), ProxyError> {
+        // RFC 6797 §7.2: `Strict-Transport-Security` MUST NOT be sent over
+        // plaintext HTTP. Reject any AddHttpFrontend that ships an enabled
+        // HSTS policy before it ever touches the routing trie. This is
+        // defense in depth on top of the TOML config-load reject in
+        // `command/src/config.rs`; sites that build a `RequestHttpFrontend`
+        // outside the TOML path (`sozu frontend http add`, programmatic
+        // IPC senders) are caught here.
+        if matches!(front.hsts.as_ref().and_then(|h| h.enabled), Some(true)) {
+            return Err(ProxyError::HstsOnPlainHttp(front.address.into()));
+        }
+
         let front = front.clone().to_frontend().map_err(|request_error| {
             ProxyError::WrongInputFrontend {
                 front: Box::new(front),

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -952,6 +952,7 @@ impl HttpProxy {
         // outside the TOML path (`sozu frontend http add`, programmatic
         // IPC senders) are caught here.
         if matches!(front.hsts.as_ref().and_then(|h| h.enabled), Some(true)) {
+            incr!("http.hsts.suppressed_plaintext");
             return Err(ProxyError::HstsOnPlainHttp(front.address.into()));
         }
 

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -1936,6 +1936,7 @@ mod tests {
                 rewrite_port: None,
                 required_auth: None,
                 headers: Vec::new(),
+                hsts: None,
             })
             .expect("Could not add http frontend");
         fronts
@@ -1955,6 +1956,7 @@ mod tests {
                 rewrite_port: None,
                 required_auth: None,
                 headers: Vec::new(),
+                hsts: None,
             })
             .expect("Could not add http frontend");
         fronts
@@ -1974,6 +1976,7 @@ mod tests {
                 rewrite_port: None,
                 required_auth: None,
                 headers: Vec::new(),
+                hsts: None,
             })
             .expect("Could not add http frontend");
         fronts
@@ -1993,6 +1996,7 @@ mod tests {
                 rewrite_port: None,
                 required_auth: None,
                 headers: Vec::new(),
+                hsts: None,
             })
             .expect("Could not add http frontend");
 

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -1311,6 +1311,19 @@ impl HttpsListener {
             *self.answers.borrow_mut() = rebuilt;
         }
 
+        // HSTS: full-object replacement when present in the patch. Absent
+        // patch field preserves current value (matches the rest of this
+        // partial-update handler). When `enabled` is missing on a present
+        // HSTS block, refuse the patch — `enabled` is the explicit
+        // disambiguator between "disable" and "enable" semantics, and the
+        // operator must signal one or the other on every update.
+        if let Some(new_hsts) = patch.hsts {
+            if new_hsts.enabled.is_none() {
+                return Err(ListenerError::HstsEnabledRequired);
+            }
+            self.config.hsts = Some(new_hsts);
+        }
+
         Ok(())
     }
 

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -1318,31 +1318,34 @@ impl HttpsListener {
         // disambiguator between "disable" and "enable" semantics, and the
         // operator must signal one or the other on every update.
         //
-        // Inheritance refresh limitation: the routing trie (`self.fronts`)
-        // stores each frontend's materialised `headers_response` snapshot,
-        // built at `add_https_front` time from the listener-default that
-        // was current then. The trie does NOT carry the original
-        // `Option<HstsConfig>` ProtoBuf, so we cannot distinguish
-        // "inheriting" frontends from "explicit override" frontends after
-        // the fact — refreshing them in place would risk overwriting an
-        // operator's explicit per-frontend HSTS with the new listener
-        // default. The conservative behaviour is to update the listener
-        // default for FUTURE frontend adds and tell the operator to
-        // remove + re-add any existing frontend that should inherit the
-        // new value. The `incr!("http.hsts.listener_default_patched")`
-        // counter pairs with the `warn!` so dashboards can surface the
-        // pending operator action.
+        // Inheriting frontends are refreshed in place via
+        // `Router::refresh_inheriting_hsts`: every frontend whose HSTS
+        // came from the previous listener default
+        // (`Frontend.inherits_listener_hsts == true`) gets its
+        // `headers_response` re-materialised against the new value.
+        // Explicit per-frontend overrides
+        // (`inherits_listener_hsts == false`) are untouched. The
+        // `http.hsts.listener_default_patched` counter still fires so
+        // dashboards can correlate patches with the new
+        // `http.hsts.frontend_refreshed` counter (sum of refreshed
+        // frontends from this patch).
         if let Some(new_hsts) = patch.hsts {
             if new_hsts.enabled.is_none() {
                 return Err(ListenerError::HstsEnabledRequired);
             }
             self.config.hsts = Some(new_hsts);
-            warn!(
-                "{} HTTPS listener {:?} HSTS default patched. Existing frontends keep their \
-                 materialised HSTS edit until the operator removes + re-adds them; new \
-                 frontends inherit the new value.",
+            let refreshed = self
+                .fronts
+                .refresh_inheriting_hsts(self.config.hsts.as_ref());
+            for _ in 0..refreshed {
+                crate::incr!("http.hsts.frontend_refreshed");
+            }
+            info!(
+                "{} HTTPS listener {:?} HSTS default patched; refreshed {} inheriting \
+                 frontend(s). Explicit per-frontend overrides untouched.",
                 log_module_context!(),
                 self.config.address,
+                refreshed,
             );
             crate::incr!("http.hsts.listener_default_patched");
         }
@@ -1351,8 +1354,22 @@ impl HttpsListener {
     }
 
     pub fn add_https_front(&mut self, tls_front: HttpFrontend) -> Result<(), ListenerError> {
+        self.add_https_front_with_hsts_origin(tls_front, crate::router::HstsOrigin::Explicit)
+    }
+
+    /// Variant of [`Self::add_https_front`] that records the origin of
+    /// `tls_front.hsts` so listener-default patches can reflow inheriting
+    /// frontends without disturbing explicit per-frontend overrides. The
+    /// caller passes [`HstsOrigin::InheritedFromListenerDefault`] when
+    /// the value was filled in from `self.config.hsts` rather than from
+    /// the operator's per-frontend configuration.
+    pub fn add_https_front_with_hsts_origin(
+        &mut self,
+        tls_front: HttpFrontend,
+        hsts_origin: crate::router::HstsOrigin,
+    ) -> Result<(), ListenerError> {
         self.fronts
-            .add_http_front(&tls_front)
+            .add_http_front_with_hsts_origin(&tls_front, hsts_origin)
             .map_err(ListenerError::AddFrontend)
     }
 
@@ -1712,13 +1729,22 @@ impl HttpsProxy {
         // listener and have every HTTPS frontend inherit it.
         // `enabled = Some(false)` on the frontend is the explicit-disable
         // signal: it stays as-is and suppresses the inherited default.
-        if front.hsts.is_none() {
+        //
+        // The `hsts_origin` flag is passed through to the router so the
+        // resulting `Frontend` carries the inheritance bit; a later
+        // `UpdateHttpsListenerConfig.hsts` patch will then refresh this
+        // entry via `Router::refresh_inheriting_hsts` without disturbing
+        // explicit per-frontend overrides.
+        let hsts_origin = if front.hsts.is_none() && listener.config.hsts.is_some() {
             front.hsts = listener.config.hsts;
-        }
+            crate::router::HstsOrigin::InheritedFromListenerDefault
+        } else {
+            crate::router::HstsOrigin::Explicit
+        };
 
         listener.set_tags(front.hostname.to_owned(), front.tags.to_owned());
         listener
-            .add_https_front(front)
+            .add_https_front_with_hsts_origin(front, hsts_origin)
             .map_err(ProxyError::AddFrontend)?;
         Ok(None)
     }

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -1656,7 +1656,7 @@ impl HttpsProxy {
         &mut self,
         front: RequestHttpFrontend,
     ) -> Result<Option<ResponseContent>, ProxyError> {
-        let front = front.clone().to_frontend().map_err(|request_error| {
+        let mut front = front.clone().to_frontend().map_err(|request_error| {
             ProxyError::WrongInputFrontend {
                 front: Box::new(front),
                 error: request_error.to_string(),
@@ -1669,6 +1669,16 @@ impl HttpsProxy {
             .find(|l| l.borrow().address == front.address)
             .ok_or(ProxyError::NoListenerFound(front.address))?
             .borrow_mut();
+
+        // ── HSTS listener-default → frontend inheritance ─────────────────
+        // When the frontend declares no `hsts` block, fall back to the
+        // listener default so the operator can opt into HSTS once at the
+        // listener and have every HTTPS frontend inherit it.
+        // `enabled = Some(false)` on the frontend is the explicit-disable
+        // signal: it stays as-is and suppresses the inherited default.
+        if front.hsts.is_none() {
+            front.hsts = listener.config.hsts;
+        }
 
         listener.set_tags(front.hostname.to_owned(), front.tags.to_owned());
         listener

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -1317,11 +1317,34 @@ impl HttpsListener {
         // HSTS block, refuse the patch — `enabled` is the explicit
         // disambiguator between "disable" and "enable" semantics, and the
         // operator must signal one or the other on every update.
+        //
+        // Inheritance refresh limitation: the routing trie (`self.fronts`)
+        // stores each frontend's materialised `headers_response` snapshot,
+        // built at `add_https_front` time from the listener-default that
+        // was current then. The trie does NOT carry the original
+        // `Option<HstsConfig>` ProtoBuf, so we cannot distinguish
+        // "inheriting" frontends from "explicit override" frontends after
+        // the fact — refreshing them in place would risk overwriting an
+        // operator's explicit per-frontend HSTS with the new listener
+        // default. The conservative behaviour is to update the listener
+        // default for FUTURE frontend adds and tell the operator to
+        // remove + re-add any existing frontend that should inherit the
+        // new value. The `incr!("http.hsts.listener_default_patched")`
+        // counter pairs with the `warn!` so dashboards can surface the
+        // pending operator action.
         if let Some(new_hsts) = patch.hsts {
             if new_hsts.enabled.is_none() {
                 return Err(ListenerError::HstsEnabledRequired);
             }
             self.config.hsts = Some(new_hsts);
+            warn!(
+                "{} HTTPS listener {:?} HSTS default patched. Existing frontends keep their \
+                 materialised HSTS edit until the operator removes + re-adds them; new \
+                 frontends inherit the new value.",
+                log_module_context!(),
+                self.config.address,
+            );
+            crate::incr!("http.hsts.listener_default_patched");
         }
 
         Ok(())

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -847,6 +847,20 @@ pub enum ProxyError {
     RegisterListener(std::io::Error),
     #[error("the listener is not activated")]
     UnactivatedListener,
+    /// HSTS (RFC 6797) was attached to a frontend on a plain-HTTP
+    /// listener. RFC 6797 §7.2 forbids `Strict-Transport-Security` on
+    /// plaintext-HTTP responses; the worker rejects the request rather
+    /// than ship a non-conformant policy. The TOML loader rejects the
+    /// same shape at config-load time
+    /// (`command/src/config.rs::ConfigError::HstsOnPlainHttp`); this
+    /// arm catches the same misconfiguration when the request reaches
+    /// the worker over the IPC channel without going through the TOML
+    /// path (e.g. via `sozu frontend http add`).
+    #[error(
+        "HSTS is only valid on HTTPS frontends; rejecting AddHttpFrontend with hsts.enabled = \
+         true on address {0:?} (RFC 6797 §7.2)"
+    )]
+    HstsOnPlainHttp(SocketAddr),
 }
 
 use self::server::ListenToken;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -773,6 +773,16 @@ pub enum ListenerError {
         field: &'static str,
         reason: &'static str,
     },
+    /// `UpdateHttpsListenerConfig.hsts` was present but its `enabled`
+    /// field was unset. Per the partial-update contract, `enabled` is
+    /// the explicit-disambiguator between "explicit disable" (false) and
+    /// "explicit enable" (true); the patch handler refuses an
+    /// `enabled = None` block rather than silently picking one.
+    #[error(
+        "UpdateHttpsListenerConfig.hsts is present but `enabled` is unset; the partial-update \
+         contract requires `enabled` whenever the `hsts` block is present"
+    )]
+    HstsEnabledRequired,
 }
 
 /// Lift control-plane validation errors into listener-level errors so the

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -300,14 +300,44 @@ pub struct HttpContext {
     pub access_log_message: Option<&'static str>,
 }
 
+/// How `apply_response_header_edits` should interpret a per-edit value.
+///
+/// Today the implicit encoding is: empty `val` → delete; non-empty `val`
+/// → append. The explicit `Append`/`Delete`/`SetIfAbsent` mode lets HSTS
+/// (and future RFC-correct response policies) opt into "skip the insert
+/// when an upstream-supplied header with the same name is already on the
+/// response". This preserves operator-controlled fallback when the
+/// backend already emits its own `Strict-Transport-Security` (RFC 6797
+/// §6.1 single-header requirement).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum HeaderEditMode {
+    /// Append the header before the end-of-headers flag. Empty `val`
+    /// is interpreted as a delete (legacy behaviour preserved).
+    #[default]
+    Append,
+    /// Remove every existing header whose name matches `key`
+    /// case-insensitively.
+    Delete,
+    /// Skip the insert if `kawa.blocks` already contains a non-elided
+    /// header whose name matches `key` case-insensitively. Otherwise
+    /// behave like `Append`.
+    SetIfAbsent,
+}
+
 /// Owned snapshot of a per-frontend header edit, captured at routing
 /// time so the emission boundary can apply set/replace/delete without
-/// touching the routing layer's `Rc<[HeaderEdit]>` slices. Empty `val`
-/// deletes the header by name (HAProxy `del-header` parity).
+/// touching the routing layer's `Rc<[HeaderEdit]>` slices.
+///
+/// `mode` chooses between explicit Append/Delete/SetIfAbsent semantics.
+/// For backwards compatibility `mode = Append` paired with an empty
+/// `val` is still treated as a delete by `apply_response_header_edits`
+/// (HAProxy `del-header` parity), so callers that have not yet migrated
+/// to the explicit `HeaderEditMode::Delete` keep working unchanged.
 #[derive(Debug, Clone)]
 pub struct HeaderEditSnapshot {
     pub key: Vec<u8>,
     pub val: Vec<u8>,
+    pub mode: HeaderEditMode,
 }
 
 impl kawa::h1::ParserCallbacks<Checkout> for HttpContext {
@@ -987,6 +1017,7 @@ mod tests {
         ctx.headers_response.push(HeaderEditSnapshot {
             key: b"X-Cache".to_vec(),
             val: b"HIT".to_vec(),
+            mode: HeaderEditMode::Append,
         });
 
         ctx.reset();

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -302,26 +302,35 @@ pub struct HttpContext {
 
 /// How `apply_response_header_edits` should interpret a per-edit value.
 ///
-/// Today the implicit encoding is: empty `val` → delete; non-empty `val`
-/// → append. The explicit `Append`/`Delete`/`SetIfAbsent` mode lets HSTS
-/// (and future RFC-correct response policies) opt into "skip the insert
-/// when an upstream-supplied header with the same name is already on the
-/// response". This preserves operator-controlled fallback when the
-/// backend already emits its own `Strict-Transport-Security` (RFC 6797
-/// §6.1 single-header requirement).
+/// The implicit empty-`val` Append → delete encoding is still supported
+/// (so legacy operator-supplied `[[...frontends.headers]]` entries work
+/// unchanged); the explicit modes give typed policies finer control:
+///
+/// - `Append`: drop the legacy delete shortcut for empty `val`, and
+///   append every other entry before the end-of-headers flag.
+/// - `SetIfAbsent`: skip the insert when `kawa.blocks` already carries
+///   a non-elided header with the same name (case-insensitive). HSTS
+///   uses this by default to preserve a backend-supplied
+///   `Strict-Transport-Security` (RFC 6797 §6.1 single-header
+///   requirement).
+/// - `Set`: delete every existing header with the matching name, then
+///   insert the new entry. Use when the operator wants their typed
+///   policy to override any backend-supplied value (the
+///   `force_replace_backend = true` HSTS shape, for example).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum HeaderEditMode {
     /// Append the header before the end-of-headers flag. Empty `val`
     /// is interpreted as a delete (legacy behaviour preserved).
     #[default]
     Append,
-    /// Remove every existing header whose name matches `key`
-    /// case-insensitively.
-    Delete,
     /// Skip the insert if `kawa.blocks` already contains a non-elided
     /// header whose name matches `key` case-insensitively. Otherwise
     /// behave like `Append`.
     SetIfAbsent,
+    /// Delete every existing header with the matching name, then
+    /// insert the new value. Equivalent to two operator-defined edits
+    /// (delete + append) but safer to express as one typed entry.
+    Set,
 }
 
 /// Owned snapshot of a per-frontend header edit, captured at routing

--- a/lib/src/protocol/mux/router.rs
+++ b/lib/src/protocol/mux/router.rs
@@ -20,7 +20,7 @@ use crate::{
     BackendConnectionError, L7ListenerHandler, L7Proxy, ListenerHandler, ProxySession, Readiness,
     RetrieveClusterError,
     backends::{Backend, BackendError},
-    protocol::http::editor::{HeaderEditSnapshot, HttpContext},
+    protocol::http::editor::{HeaderEditMode, HeaderEditSnapshot, HttpContext},
     router::{HeaderEdit, RouteResult},
     server::CONN_RETRIES,
     socket::SessionTcpStream,
@@ -782,6 +782,7 @@ impl Router {
             context.headers_response.push(HeaderEditSnapshot {
                 key: edit.key.to_vec(),
                 val: edit.val.to_vec(),
+                mode: HeaderEditMode::Append,
             });
         }
 

--- a/lib/src/protocol/mux/router.rs
+++ b/lib/src/protocol/mux/router.rs
@@ -20,7 +20,7 @@ use crate::{
     BackendConnectionError, L7ListenerHandler, L7Proxy, ListenerHandler, ProxySession, Readiness,
     RetrieveClusterError,
     backends::{Backend, BackendError},
-    protocol::http::editor::{HeaderEditMode, HeaderEditSnapshot, HttpContext},
+    protocol::http::editor::{HeaderEditSnapshot, HttpContext},
     router::{HeaderEdit, RouteResult},
     server::CONN_RETRIES,
     socket::SessionTcpStream,
@@ -632,6 +632,34 @@ impl Router {
             ..
         } = route;
 
+        // ── HSTS (RFC 6797) snapshot hoist for HTTPS ──────────────────────
+        // Stash the response-side header edits early so HTTPS-served
+        // default answers (3xx redirects, 401 auth-deny, 5xx defaults from
+        // `set_default_answer_with_retry_after`) carry per-frontend HSTS
+        // (and any operator-supplied response headers). RFC 6797 §8.1
+        // requires HSTS on every response code.
+        //
+        // Plain-HTTP listeners DO NOT take this branch: per RFC 6797 §7.2
+        // the `Strict-Transport-Security` header MUST NOT appear on
+        // plaintext-HTTP responses. The HTTP forward path falls back to
+        // the post-forward copy below at the end of the function so
+        // operator response headers still apply on backend-served
+        // responses (their pre-existing scope), without ever leaking HSTS
+        // to a 301 emitted by the HTTP-listener `redirect_scheme=use-https`
+        // path. This is defense in depth on top of the config-load reject
+        // in `command/src/config.rs::FileHstsConfig::to_proto` for HSTS
+        // attached to an HTTP listener.
+        if matches!(context.protocol, crate::Protocol::HTTPS) {
+            context.headers_response.clear();
+            for edit in headers_response.iter() {
+                context.headers_response.push(HeaderEditSnapshot {
+                    key: edit.key.to_vec(),
+                    val: edit.val.to_vec(),
+                    mode: edit.mode,
+                });
+            }
+        }
+
         // Look up cluster-side policy knobs once. The values we need are:
         //  - `https_redirect` (legacy) and `https_redirect_port` for the 301 location URL
         //  - `authorized_hashes` and `www_authenticate` for the 401 path
@@ -776,14 +804,18 @@ impl Router {
 
         // Stash the response-side header edits for the emission path
         // (`mux/h1.rs::writable`, `mux/h2.rs::write_streams`) to apply
-        // before `kawa.prepare(...)`.
-        context.headers_response.clear();
-        for edit in headers_response.iter() {
-            context.headers_response.push(HeaderEditSnapshot {
-                key: edit.key.to_vec(),
-                val: edit.val.to_vec(),
-                mode: HeaderEditMode::Append,
-            });
+        // before `kawa.prepare(...)`. HTTPS listeners already had this
+        // done at the top of `route_from_request` so default answers
+        // also receive the snapshot — skip the redundant copy here.
+        if matches!(context.protocol, crate::Protocol::HTTP) {
+            context.headers_response.clear();
+            for edit in headers_response.iter() {
+                context.headers_response.push(HeaderEditSnapshot {
+                    key: edit.key.to_vec(),
+                    val: edit.val.to_vec(),
+                    mode: edit.mode,
+                });
+            }
         }
 
         Ok(cluster_id)

--- a/lib/src/protocol/mux/router.rs
+++ b/lib/src/protocol/mux/router.rs
@@ -20,7 +20,7 @@ use crate::{
     BackendConnectionError, L7ListenerHandler, L7Proxy, ListenerHandler, ProxySession, Readiness,
     RetrieveClusterError,
     backends::{Backend, BackendError},
-    protocol::http::editor::{HeaderEditSnapshot, HttpContext},
+    protocol::http::editor::{HeaderEditMode, HeaderEditSnapshot, HttpContext},
     router::{HeaderEdit, RouteResult},
     server::CONN_RETRIES,
     socket::SessionTcpStream,
@@ -633,31 +633,31 @@ impl Router {
         } = route;
 
         // ── HSTS (RFC 6797) snapshot hoist for HTTPS ──────────────────────
-        // Stash the response-side header edits early so HTTPS-served
-        // default answers (3xx redirects, 401 auth-deny, 5xx defaults from
-        // `set_default_answer_with_retry_after`) carry per-frontend HSTS
-        // (and any operator-supplied response headers). RFC 6797 §8.1
-        // requires HSTS on every response code.
+        // The response snapshot is built in two passes so HSTS reaches
+        // every HTTPS response code (RFC 6797 §8.1 — including
+        // proxy-generated 3xx / 401 / 5xx default answers) WITHOUT
+        // changing the pre-PR scope of operator-defined `Append`
+        // response headers (which only apply on the regular forward
+        // path).
         //
-        // Plain-HTTP listeners DO NOT take this branch: per RFC 6797 §7.2
-        // the `Strict-Transport-Security` header MUST NOT appear on
-        // plaintext-HTTP responses. The HTTP forward path falls back to
-        // the post-forward copy below at the end of the function so
-        // operator response headers still apply on backend-served
-        // responses (their pre-existing scope), without ever leaking HSTS
-        // to a 301 emitted by the HTTP-listener `redirect_scheme=use-https`
-        // path. This is defense in depth on top of the config-load reject
-        // in `command/src/config.rs::FileHstsConfig::to_proto` for HSTS
-        // attached to an HTTP listener.
+        // Pass 1 (here, before any early return): for HTTPS only, copy
+        // ONLY the HSTS-class typed edits (`SetIfAbsent | Set`). These
+        // need to land on default answers — `set_default_answer_with_retry_after`
+        // bypasses the post-forward copy below.
+        //
+        // Pass 2 (post-forward, end of function): copy EVERY edit
+        // (including operator `Append` headers). Runs only on the
+        // regular forward path because the early returns short-circuit
+        // before reaching it.
+        //
+        // Plain-HTTP listeners are skipped here per RFC 6797 §7.2 (no
+        // STS over plaintext) — defense in depth on top of the
+        // TOML-time `ConfigError::HstsOnPlainHttp` and the worker IPC
+        // `ProxyError::HstsOnPlainHttp` rejects.
         if matches!(context.protocol, crate::Protocol::HTTPS) {
-            context.headers_response.clear();
-            for edit in headers_response.iter() {
-                context.headers_response.push(HeaderEditSnapshot {
-                    key: edit.key.to_vec(),
-                    val: edit.val.to_vec(),
-                    mode: edit.mode,
-                });
-            }
+            snapshot_response_edits(&mut context.headers_response, &headers_response, |e| {
+                matches!(e.mode, HeaderEditMode::SetIfAbsent | HeaderEditMode::Set)
+            });
         }
 
         // Look up cluster-side policy knobs once. The values we need are:
@@ -802,21 +802,14 @@ impl Router {
             &headers_request,
         );
 
-        // Stash the response-side header edits for the emission path
-        // (`mux/h1.rs::writable`, `mux/h2.rs::write_streams`) to apply
-        // before `kawa.prepare(...)`. HTTPS listeners already had this
-        // done at the top of `route_from_request` so default answers
-        // also receive the snapshot — skip the redundant copy here.
-        if matches!(context.protocol, crate::Protocol::HTTP) {
-            context.headers_response.clear();
-            for edit in headers_response.iter() {
-                context.headers_response.push(HeaderEditSnapshot {
-                    key: edit.key.to_vec(),
-                    val: edit.val.to_vec(),
-                    mode: edit.mode,
-                });
-            }
-        }
+        // Pass 2 of the response-snapshot copy (see the HSTS hoist
+        // above). Runs unconditionally on the regular forward path
+        // (the early returns above bypass this site, which keeps the
+        // default-answer scope as HSTS-only). Copies EVERY edit so
+        // operator-defined `Append` response headers reach
+        // backend-served responses on both HTTP and HTTPS listeners,
+        // preserving their pre-PR scope.
+        snapshot_response_edits(&mut context.headers_response, &headers_response, |_| true);
 
         Ok(cluster_id)
     }
@@ -1062,6 +1055,25 @@ fn apply_request_rewrites_and_headers(
         for (offset, block) in to_insert.into_iter().enumerate() {
             kawa.blocks.insert(insert_at + offset, block);
         }
+    }
+}
+
+/// Copy a per-frontend response-edit slice into the per-stream
+/// `HttpContext.headers_response` snapshot, applying `filter` to each
+/// edit. The snapshot is cleared before the copy so a second pass on
+/// the same context (the HSTS hoist + post-forward pattern in
+/// `route_from_request`) overrides any earlier partial copy.
+fn snapshot_response_edits<F>(target: &mut Vec<HeaderEditSnapshot>, src: &[HeaderEdit], filter: F)
+where
+    F: Fn(&HeaderEdit) -> bool,
+{
+    target.clear();
+    for edit in src.iter().filter(|e| filter(e)) {
+        target.push(HeaderEditSnapshot {
+            key: edit.key.to_vec(),
+            val: edit.val.to_vec(),
+            mode: edit.mode,
+        });
     }
 }
 

--- a/lib/src/protocol/mux/shared.rs
+++ b/lib/src/protocol/mux/shared.rs
@@ -135,8 +135,16 @@ pub(super) fn apply_response_header_edits<T: AsBuffer>(
     // response BEFORE any edit runs. Used by `SetIfAbsent` to honour
     // upstream-supplied headers (e.g. backend already sent its own
     // `Strict-Transport-Security`) without racing against a sibling
-    // `Delete` edit in the same batch.
-    let existing_keys: Vec<Vec<u8>> = {
+    // `Set` edit in the same batch.
+    //
+    // Skip the scan when the batch contains no `SetIfAbsent` entry —
+    // `Append` and `Set` never consult `existing_keys`, so the
+    // common operator-defined response-header path (Append-only)
+    // pays zero allocation overhead.
+    let needs_existing_snapshot = edits
+        .iter()
+        .any(|e| matches!(e.mode, HeaderEditMode::SetIfAbsent));
+    let existing_keys: Vec<Vec<u8>> = if needs_existing_snapshot {
         let buf = kawa.storage.buffer();
         kawa.blocks
             .iter()
@@ -154,6 +162,8 @@ pub(super) fn apply_response_header_edits<T: AsBuffer>(
                 }
             })
             .collect()
+    } else {
+        Vec::new()
     };
 
     let keys_to_drop: Vec<Vec<u8>> = edits

--- a/lib/src/protocol/mux/shared.rs
+++ b/lib/src/protocol/mux/shared.rs
@@ -105,25 +105,22 @@ pub(super) fn drain_tls_close_notify<S: SocketHandler>(
 /// - [`HeaderEditMode::Append`] with a non-empty `val` → append the
 ///   header before the `end_header` flag block.
 /// - [`HeaderEditMode::Append`] with an empty `val` → fall back to the
-///   legacy delete encoding (HAProxy `del-header` parity). Pre-existing
-///   call sites that have not migrated to the explicit
-///   [`HeaderEditMode::Delete`] continue to work unchanged.
-/// - [`HeaderEditMode::Delete`] → remove every existing header with the
-///   matching name from `kawa.blocks`. Equivalent to the legacy empty-
-///   `val` Append shape but explicit at the call site.
+///   legacy delete encoding (HAProxy `del-header` parity).
 /// - [`HeaderEditMode::SetIfAbsent`] → append the header only when no
 ///   non-elided header with the same name already exists on the
 ///   response (RFC 6797 §6.1 single-`Strict-Transport-Security`
 ///   requirement, generalised to any operator-supplied
 ///   set-only-when-missing edit). The presence check runs against the
-///   pre-edit response state so a `SetIfAbsent` does NOT race against a
-///   `Delete` issued in the same batch.
+///   pre-edit response state, so a `SetIfAbsent` does NOT race against
+///   a sibling `Set` (or empty-`val` Append) issued in the same batch.
+/// - [`HeaderEditMode::Set`] → remove every existing header with the
+///   matching name from `kawa.blocks`, then append the new value.
+///   Used by typed policies that want to override a backend-supplied
+///   header unconditionally (e.g. HSTS with
+///   `force_replace_backend = true`).
 ///
 /// Both H1 and H2 emission paths funnel through here so the on-wire
-/// header set stays consistent. Per-edit set/replace semantics that
-/// need an unconditional overwrite are expressed as two entries: one
-/// `Delete` (or empty-`val` Append) followed by an `Append` with the
-/// new value.
+/// header set stays consistent.
 pub(super) fn apply_response_header_edits<T: AsBuffer>(
     kawa: &mut kawa::Kawa<T>,
     edits: &[HeaderEditSnapshot],
@@ -162,9 +159,10 @@ pub(super) fn apply_response_header_edits<T: AsBuffer>(
     let keys_to_drop: Vec<Vec<u8>> = edits
         .iter()
         .filter(|e| {
-            // Explicit Delete OR legacy empty-`val` Append (preserved
-            // for callers still using the implicit encoding).
-            matches!(e.mode, HeaderEditMode::Delete)
+            // Explicit `Set` (delete-then-insert in one entry) OR legacy
+            // empty-`val` Append (delete encoding preserved for callers
+            // still using the implicit shape).
+            matches!(e.mode, HeaderEditMode::Set)
                 || (matches!(e.mode, HeaderEditMode::Append) && e.val.is_empty())
         })
         .map(|e| e.key.iter().map(u8::to_ascii_lowercase).collect())
@@ -202,11 +200,8 @@ pub(super) fn apply_response_header_edits<T: AsBuffer>(
     let mut to_insert: Vec<Block> = Vec::new();
     for edit in edits {
         match edit.mode {
-            // Explicit delete is materialised by the retain pass above;
-            // nothing to insert. Same for the legacy empty-`val` Append
-            // shape, which we route through the delete branch for
-            // backwards compatibility.
-            HeaderEditMode::Delete => continue,
+            // Empty-`val` Append is the legacy delete shape — the
+            // retain pass above already removed any matching headers.
             HeaderEditMode::Append if edit.val.is_empty() => continue,
             HeaderEditMode::Append => {}
             HeaderEditMode::SetIfAbsent => {
@@ -221,6 +216,11 @@ pub(super) fn apply_response_header_edits<T: AsBuffer>(
                     continue;
                 }
             }
+            // `Set` is delete-then-insert: the retain pass above has
+            // already dropped any pre-existing header with the same
+            // name, and this branch falls through to the insert below
+            // unconditionally (no presence check).
+            HeaderEditMode::Set => {}
         }
         to_insert.push(Block::Header(Pair {
             key: Store::from_slice(&edit.key),
@@ -544,5 +544,75 @@ mod tests {
             ),
             "end_header flag must remain the last block"
         );
+    }
+
+    #[test]
+    fn test_response_edit_set_replaces_existing_header() {
+        // `HeaderEditMode::Set` is delete-then-insert: a pre-existing
+        // header with the matching name (case-insensitive) must be
+        // dropped, and the new value inserted exactly once.
+        let mut buf = vec![0u8; 4096];
+        let mut kawa = make_kawa(&mut buf);
+        kawa.blocks.push_back(Block::Header(Pair {
+            key: Store::Static(b"Strict-Transport-Security"),
+            val: Store::Static(b"max-age=300"),
+        }));
+        kawa.blocks.push_back(Block::Flags(Flags {
+            end_body: false,
+            end_chunk: false,
+            end_header: true,
+            end_stream: false,
+        }));
+
+        apply_response_header_edits(
+            &mut kawa,
+            &[HeaderEditSnapshot {
+                key: b"strict-transport-security".to_vec(),
+                val: b"max-age=31536000; includeSubDomains".to_vec(),
+                mode: HeaderEditMode::Set,
+            }],
+        );
+
+        let pairs = pretty_blocks(&kawa);
+        assert_eq!(
+            pairs.len(),
+            1,
+            "Set must drop the pre-existing header and insert exactly one"
+        );
+        assert_eq!(pairs[0].0, b"strict-transport-security");
+        assert_eq!(pairs[0].1, b"max-age=31536000; includeSubDomains");
+    }
+
+    #[test]
+    fn test_response_edit_set_inserts_when_absent() {
+        // `Set` with no pre-existing header must still insert the new
+        // value (the retain pass is a no-op when nothing matches).
+        let mut buf = vec![0u8; 4096];
+        let mut kawa = make_kawa(&mut buf);
+        kawa.blocks.push_back(Block::Header(Pair {
+            key: Store::Static(b"server"),
+            val: Store::Static(b"sozu"),
+        }));
+        kawa.blocks.push_back(Block::Flags(Flags {
+            end_body: false,
+            end_chunk: false,
+            end_header: true,
+            end_stream: false,
+        }));
+
+        apply_response_header_edits(
+            &mut kawa,
+            &[HeaderEditSnapshot {
+                key: b"strict-transport-security".to_vec(),
+                val: b"max-age=31536000".to_vec(),
+                mode: HeaderEditMode::Set,
+            }],
+        );
+
+        let pairs = pretty_blocks(&kawa);
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(pairs[0].0, b"server");
+        assert_eq!(pairs[1].0, b"strict-transport-security");
+        assert_eq!(pairs[1].1, b"max-age=31536000");
     }
 }

--- a/lib/src/protocol/mux/shared.rs
+++ b/lib/src/protocol/mux/shared.rs
@@ -9,7 +9,7 @@
 use kawa::AsBuffer;
 
 use crate::{
-    protocol::http::editor::HeaderEditSnapshot,
+    protocol::http::editor::{HeaderEditMode, HeaderEditSnapshot},
     socket::{SocketHandler, SocketResult},
 };
 
@@ -100,17 +100,30 @@ pub(super) fn drain_tls_close_notify<S: SocketHandler>(
 /// Apply per-frontend response-side header edits to a response kawa
 /// just before [`kawa::Kawa::prepare`] runs. Mirrors the request-side
 /// pass that `Router::route_from_request` runs against the front kawa
-/// at routing time:
+/// at routing time. Each edit's [`HeaderEditMode`] selects the action:
 ///
-/// - empty `val` → remove every existing header with the matching name
-///   from `kawa.blocks` (HAProxy `del-header` parity);
-/// - non-empty `val` → append the header before the `end_header` flag
-///   block.
+/// - [`HeaderEditMode::Append`] with a non-empty `val` → append the
+///   header before the `end_header` flag block.
+/// - [`HeaderEditMode::Append`] with an empty `val` → fall back to the
+///   legacy delete encoding (HAProxy `del-header` parity). Pre-existing
+///   call sites that have not migrated to the explicit
+///   [`HeaderEditMode::Delete`] continue to work unchanged.
+/// - [`HeaderEditMode::Delete`] → remove every existing header with the
+///   matching name from `kawa.blocks`. Equivalent to the legacy empty-
+///   `val` Append shape but explicit at the call site.
+/// - [`HeaderEditMode::SetIfAbsent`] → append the header only when no
+///   non-elided header with the same name already exists on the
+///   response (RFC 6797 §6.1 single-`Strict-Transport-Security`
+///   requirement, generalised to any operator-supplied
+///   set-only-when-missing edit). The presence check runs against the
+///   pre-edit response state so a `SetIfAbsent` does NOT race against a
+///   `Delete` issued in the same batch.
 ///
 /// Both H1 and H2 emission paths funnel through here so the on-wire
-/// header set stays consistent. Per-edit set/replace semantics are
-/// expressed as two entries: one with empty `val` (delete) followed by
-/// one with the new value (set).
+/// header set stays consistent. Per-edit set/replace semantics that
+/// need an unconditional overwrite are expressed as two entries: one
+/// `Delete` (or empty-`val` Append) followed by an `Append` with the
+/// new value.
 pub(super) fn apply_response_header_edits<T: AsBuffer>(
     kawa: &mut kawa::Kawa<T>,
     edits: &[HeaderEditSnapshot],
@@ -121,9 +134,39 @@ pub(super) fn apply_response_header_edits<T: AsBuffer>(
         return;
     }
 
+    // Snapshot the lowercased header names already present on the
+    // response BEFORE any edit runs. Used by `SetIfAbsent` to honour
+    // upstream-supplied headers (e.g. backend already sent its own
+    // `Strict-Transport-Security`) without racing against a sibling
+    // `Delete` edit in the same batch.
+    let existing_keys: Vec<Vec<u8>> = {
+        let buf = kawa.storage.buffer();
+        kawa.blocks
+            .iter()
+            .filter_map(|block| {
+                if let Block::Header(Pair { key, val: _ }) = block {
+                    // Skip elided headers — see `Store::Empty` note below
+                    // in the retain pass for the panic rationale.
+                    if matches!(key, Store::Empty) {
+                        None
+                    } else {
+                        Some(key.data(buf).iter().map(u8::to_ascii_lowercase).collect())
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect()
+    };
+
     let keys_to_drop: Vec<Vec<u8>> = edits
         .iter()
-        .filter(|e| e.val.is_empty())
+        .filter(|e| {
+            // Explicit Delete OR legacy empty-`val` Append (preserved
+            // for callers still using the implicit encoding).
+            matches!(e.mode, HeaderEditMode::Delete)
+                || (matches!(e.mode, HeaderEditMode::Append) && e.val.is_empty())
+        })
         .map(|e| e.key.iter().map(u8::to_ascii_lowercase).collect())
         .collect();
     if !keys_to_drop.is_empty() {
@@ -158,8 +201,26 @@ pub(super) fn apply_response_header_edits<T: AsBuffer>(
 
     let mut to_insert: Vec<Block> = Vec::new();
     for edit in edits {
-        if edit.val.is_empty() {
-            continue;
+        match edit.mode {
+            // Explicit delete is materialised by the retain pass above;
+            // nothing to insert. Same for the legacy empty-`val` Append
+            // shape, which we route through the delete branch for
+            // backwards compatibility.
+            HeaderEditMode::Delete => continue,
+            HeaderEditMode::Append if edit.val.is_empty() => continue,
+            HeaderEditMode::Append => {}
+            HeaderEditMode::SetIfAbsent => {
+                let key_lower: Vec<u8> = edit.key.iter().map(u8::to_ascii_lowercase).collect();
+                if existing_keys
+                    .iter()
+                    .any(|k| k.as_slice() == key_lower.as_slice())
+                {
+                    // Upstream already supplied this header — honour
+                    // the operator's "set only when missing" intent and
+                    // skip the insert (RFC 6797 §6.1).
+                    continue;
+                }
+            }
         }
         to_insert.push(Block::Header(Pair {
             key: Store::from_slice(&edit.key),
@@ -204,7 +265,7 @@ pub(super) fn end_of_headers_index<T: AsBuffer>(kawa: &kawa::Kawa<T>) -> Option<
 #[cfg(test)]
 mod tests {
     use super::apply_response_header_edits;
-    use crate::protocol::http::editor::HeaderEditSnapshot;
+    use crate::protocol::http::editor::{HeaderEditMode, HeaderEditSnapshot};
     use kawa::{
         AsBuffer, Block, Buffer, Flags, Kawa, Kind, Pair, SliceBuffer, StatusLine, Store, Version,
     };
@@ -273,10 +334,12 @@ mod tests {
                 HeaderEditSnapshot {
                     key: b"x-frame-options".to_vec(),
                     val: b"DENY".to_vec(),
+                    mode: HeaderEditMode::Append,
                 },
                 HeaderEditSnapshot {
                     key: b"x-content-type-options".to_vec(),
                     val: b"nosniff".to_vec(),
+                    mode: HeaderEditMode::Append,
                 },
             ],
         );
@@ -338,6 +401,7 @@ mod tests {
             &[HeaderEditSnapshot {
                 key: b"X-Internal".to_vec(),
                 val: Vec::new(),
+                mode: HeaderEditMode::Append,
             }],
         );
 
@@ -373,10 +437,12 @@ mod tests {
                 HeaderEditSnapshot {
                     key: b"Cache-Control".to_vec(),
                     val: Vec::new(),
+                    mode: HeaderEditMode::Append,
                 },
                 HeaderEditSnapshot {
                     key: b"Cache-Control".to_vec(),
                     val: b"no-store".to_vec(),
+                    mode: HeaderEditMode::Append,
                 },
             ],
         );
@@ -385,5 +451,98 @@ mod tests {
         assert_eq!(pairs.len(), 1, "only the replacement header must remain");
         assert_eq!(pairs[0].0, b"Cache-Control");
         assert_eq!(pairs[0].1, b"no-store");
+    }
+
+    /// `SetIfAbsent` MUST NOT add a second header when the upstream
+    /// response already carries one with the same name. This is the
+    /// HSTS-on-listener-default contract: if the backend already
+    /// emitted its own `Strict-Transport-Security`, the operator's
+    /// listener-default policy steps aside (RFC 6797 §6.1).
+    #[test]
+    fn test_response_edit_set_if_absent_skips_when_present() {
+        let mut buf = vec![0u8; 4096];
+        let mut kawa = make_kawa(&mut buf);
+        kawa.blocks.push_back(Block::Header(Pair {
+            key: Store::Static(b"strict-transport-security"),
+            val: Store::Static(b"max-age=12345"),
+        }));
+        kawa.blocks.push_back(Block::Flags(Flags {
+            end_body: false,
+            end_chunk: false,
+            end_header: true,
+            end_stream: false,
+        }));
+
+        apply_response_header_edits(
+            &mut kawa,
+            &[HeaderEditSnapshot {
+                key: b"strict-transport-security".to_vec(),
+                val: b"max-age=31536000".to_vec(),
+                mode: HeaderEditMode::SetIfAbsent,
+            }],
+        );
+
+        let pairs = pretty_blocks(&kawa);
+        assert_eq!(
+            pairs.len(),
+            1,
+            "SetIfAbsent must not duplicate an existing header"
+        );
+        assert_eq!(pairs[0].0, b"strict-transport-security");
+        assert_eq!(
+            pairs[0].1, b"max-age=12345",
+            "the upstream-supplied STS value must be preserved unchanged"
+        );
+    }
+
+    /// `SetIfAbsent` MUST insert the new header when no upstream
+    /// header with the same name is present. The new entry lands
+    /// before the end-of-headers flag (same insertion point as a
+    /// regular `Append`).
+    #[test]
+    fn test_response_edit_set_if_absent_inserts_when_absent() {
+        let mut buf = vec![0u8; 4096];
+        let mut kawa = make_kawa(&mut buf);
+        kawa.blocks.push_back(Block::Header(Pair {
+            key: Store::Static(b"server"),
+            val: Store::Static(b"sozu"),
+        }));
+        kawa.blocks.push_back(Block::Flags(Flags {
+            end_body: false,
+            end_chunk: false,
+            end_header: true,
+            end_stream: false,
+        }));
+
+        apply_response_header_edits(
+            &mut kawa,
+            &[HeaderEditSnapshot {
+                key: b"strict-transport-security".to_vec(),
+                val: b"max-age=31536000".to_vec(),
+                mode: HeaderEditMode::SetIfAbsent,
+            }],
+        );
+
+        let pairs = pretty_blocks(&kawa);
+        assert_eq!(
+            pairs.len(),
+            2,
+            "SetIfAbsent must insert exactly one new header when absent"
+        );
+        assert_eq!(pairs[0].0, b"server");
+        assert_eq!(pairs[1].0, b"strict-transport-security");
+        assert_eq!(pairs[1].1, b"max-age=31536000");
+
+        // The end-of-headers flag must remain the final block.
+        assert!(
+            matches!(
+                kawa.blocks.back(),
+                Some(Block::Flags(Flags {
+                    end_header: true,
+                    ..
+                }))
+            ),
+            "end_header flag must remain the last block"
+        );
     }
 }

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -1217,10 +1217,20 @@ impl Frontend {
             && matches!(cfg.enabled, Some(true))
         {
             if let Some(rendered) = render_hsts(cfg) {
+                // RFC 6797 §6.1 default: PRESERVE backend-supplied STS
+                // (SetIfAbsent). Operator opts into harden-centrally
+                // override via `force_replace_backend = true`, which
+                // selects `Set` (delete-then-insert) so any backend
+                // STS is replaced with sozu's rendered policy.
+                let mode = if matches!(cfg.force_replace_backend, Some(true)) {
+                    HeaderEditMode::Set
+                } else {
+                    HeaderEditMode::SetIfAbsent
+                };
                 headers_response.push(HeaderEdit {
                     key: Rc::from(&b"strict-transport-security"[..]),
                     val: rendered.into_bytes().into(),
-                    mode: HeaderEditMode::SetIfAbsent,
+                    mode,
                 });
                 crate::incr!("http.hsts.frontend_added");
             } else {
@@ -1502,6 +1512,7 @@ mod tests {
             max_age: Some(31_536_000),
             include_subdomains: None,
             preload: None,
+            force_replace_backend: None,
         };
         assert_eq!(render_hsts(&cfg), Some("max-age=31536000".to_owned()));
     }
@@ -1513,6 +1524,7 @@ mod tests {
             max_age: Some(31_536_000),
             include_subdomains: Some(true),
             preload: None,
+            force_replace_backend: None,
         };
         assert_eq!(
             render_hsts(&cfg),
@@ -1527,6 +1539,7 @@ mod tests {
             max_age: Some(63_072_000),
             include_subdomains: None,
             preload: Some(true),
+            force_replace_backend: None,
         };
         assert_eq!(
             render_hsts(&cfg),
@@ -1541,6 +1554,7 @@ mod tests {
             max_age: Some(31_536_000),
             include_subdomains: Some(true),
             preload: Some(true),
+            force_replace_backend: None,
         };
         assert_eq!(
             render_hsts(&cfg),
@@ -1555,6 +1569,7 @@ mod tests {
             max_age: Some(0),
             include_subdomains: Some(true),
             preload: None,
+            force_replace_backend: None,
         };
         // `max_age = 0` is the RFC 6797 §11.4 kill switch and renders
         // verbatim — UA receives it and stops treating the host as a
@@ -1572,6 +1587,7 @@ mod tests {
             max_age: None,
             include_subdomains: Some(true),
             preload: None,
+            force_replace_backend: None,
         };
         // The TOML loader substitutes the default at config-load; if the
         // field reaches `render_hsts` as `None`, suppress emission so a

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -1222,6 +1222,7 @@ impl Frontend {
                 val: rendered.into_bytes().into(),
                 mode: HeaderEditMode::SetIfAbsent,
             });
+            crate::incr!("http.hsts.frontend_added");
         }
 
         Ok(Frontend {

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -240,7 +240,6 @@ impl Router {
                 front.rewrite_port.and_then(|p| u16::try_from(p).ok()),
                 &front.headers,
                 front.required_auth.unwrap_or(false),
-                front.hsts.as_ref(),
             )?;
             Route::Frontend(Rc::new(frontend))
         } else {
@@ -1074,8 +1073,11 @@ impl Frontend {
         rewrite_port: Option<u16>,
         headers: &[sozu_command::proto::command::Header],
         required_auth: bool,
-        hsts: Option<&HstsConfig>,
     ) -> Result<Self, RouterError> {
+        // HSTS is read from `front.hsts` directly inside the function;
+        // an explicit parameter would be redundant since `front` is
+        // already in scope and the field is the single source of truth.
+        let hsts = front.hsts.as_ref();
         let cluster_id = front.cluster_id.clone();
         let tags = front
             .tags

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -191,7 +191,27 @@ impl Router {
         })
     }
 
+    /// Add an HTTP/HTTPS frontend whose `hsts` field (if any) came from
+    /// the per-frontend configuration directly. Equivalent to
+    /// [`Self::add_http_front_with_hsts_origin`] called with
+    /// [`HstsOrigin::Explicit`]. The default for callers that don't
+    /// know about listener-default inheritance — e.g. plain HTTP
+    /// listeners (`HttpListenerConfig` has no HSTS field) and tests.
     pub fn add_http_front(&mut self, front: &HttpFrontend) -> Result<(), RouterError> {
+        self.add_http_front_with_hsts_origin(front, HstsOrigin::Explicit)
+    }
+
+    /// Add an HTTP/HTTPS frontend, recording whether the resolved
+    /// `front.hsts` was inherited from the listener default. The
+    /// inheritance bit is preserved on the resulting [`Frontend`] so a
+    /// later `UpdateHttpsListenerConfig.hsts` patch can reflow the new
+    /// default onto inheriting entries without disturbing explicit
+    /// per-frontend overrides.
+    pub fn add_http_front_with_hsts_origin(
+        &mut self,
+        front: &HttpFrontend,
+        hsts_origin: HstsOrigin,
+    ) -> Result<(), RouterError> {
         let path_rule = PathRule::from_config(front.path.clone())
             .ok_or(RouterError::InvalidPathRule(front.path.to_string()))?;
 
@@ -240,6 +260,7 @@ impl Router {
                 front.rewrite_port.and_then(|p| u16::try_from(p).ok()),
                 &front.headers,
                 front.required_auth.unwrap_or(false),
+                hsts_origin,
             )?;
             Route::Frontend(Rc::new(frontend))
         } else {
@@ -370,6 +391,49 @@ impl Router {
             }
             Err(_) => false,
         }
+    }
+
+    /// Walk every route and re-materialise the response-side HSTS edit
+    /// on frontends that inherited from the listener default. Operator
+    /// per-frontend HSTS overrides (`inherits_listener_hsts == false`)
+    /// are left untouched.
+    ///
+    /// Called from `lib/src/https.rs::HttpsListener::update_config` when
+    /// an `UpdateHttpsListenerConfig.hsts` patch is applied. The
+    /// per-frontend `headers_response: Rc<[HeaderEdit]>` is rebuilt by
+    /// dropping any existing `Strict-Transport-Security` entry and
+    /// appending a freshly rendered one when `new_hsts` resolves to an
+    /// enabled value (`enabled = Some(true)`). The existing operator
+    /// `Append`/`Set` response headers stay in place.
+    ///
+    /// Returns the number of frontends touched. Inheriting frontends
+    /// where the new policy resolves to "no HSTS" (e.g.
+    /// `enabled = Some(false)`) are still touched — the existing HSTS
+    /// edit is stripped — and counted.
+    pub fn refresh_inheriting_hsts(&mut self, new_hsts: Option<&HstsConfig>) -> usize {
+        let mut refreshed = 0usize;
+        let mut visit = |route: &mut Route| {
+            if let Route::Frontend(rc) = route {
+                if rc.inherits_listener_hsts {
+                    let new_frontend = rebuild_with_listener_hsts(rc, new_hsts);
+                    *rc = Rc::new(new_frontend);
+                    refreshed += 1;
+                }
+            }
+        };
+
+        for (_, _, _, route) in self.pre.iter_mut() {
+            visit(route);
+        }
+        self.tree.for_each_value_mut(&mut |paths| {
+            for (_, _, route) in paths.iter_mut() {
+                visit(route);
+            }
+        });
+        for (_, _, _, route) in self.post.iter_mut() {
+            visit(route);
+        }
+        refreshed
     }
 
     pub fn add_pre_rule(
@@ -764,6 +828,55 @@ pub enum Route {
     Frontend(Rc<Frontend>),
 }
 
+/// Build a new [`Frontend`] cloned from `frontend`, with its
+/// `headers_response` re-materialised against `new_hsts` (the new
+/// listener-default HSTS). Used by [`Router::refresh_inheriting_hsts`].
+///
+/// Preserves every operator-defined response-header edit (`Append`,
+/// `Set`, legacy empty-`val`-Append delete) and replaces any existing
+/// `Strict-Transport-Security` entry with the fresh render. When the
+/// new policy resolves to "no HSTS" (`enabled = Some(false)` or no
+/// rendered output), the function strips the existing entry and adds
+/// nothing.
+///
+/// Always preserves the `inherits_listener_hsts = true` marker on the
+/// rebuilt frontend so subsequent listener-default patches keep
+/// refreshing it.
+fn rebuild_with_listener_hsts(frontend: &Frontend, new_hsts: Option<&HstsConfig>) -> Frontend {
+    // Strip any existing Strict-Transport-Security entry.
+    let mut headers_response: Vec<HeaderEdit> = frontend
+        .headers_response
+        .iter()
+        .filter(|edit| !edit.key.eq_ignore_ascii_case(b"strict-transport-security"))
+        .cloned()
+        .collect();
+
+    // Re-render against the new listener default. Same gates as
+    // `Frontend::new`'s materialiser: `enabled = Some(true)` and a
+    // non-`None` `render_hsts` output.
+    if let Some(cfg) = new_hsts
+        && matches!(cfg.enabled, Some(true))
+        && let Some(rendered) = render_hsts(cfg)
+    {
+        let mode = if matches!(cfg.force_replace_backend, Some(true)) {
+            HeaderEditMode::Set
+        } else {
+            HeaderEditMode::SetIfAbsent
+        };
+        headers_response.push(HeaderEdit {
+            key: Rc::from(&b"strict-transport-security"[..]),
+            val: rendered.into_bytes().into(),
+            mode,
+        });
+    }
+
+    Frontend {
+        headers_response: headers_response.into(),
+        // every other field is unchanged
+        ..frontend.clone()
+    }
+}
+
 /// Render an [`HstsConfig`] into a canonical RFC 6797 §6.1
 /// `Strict-Transport-Security` header value: `max-age=N` first, then
 /// optional `; includeSubDomains`, then optional `; preload`. No
@@ -988,6 +1101,36 @@ pub struct Frontend {
     pub headers_response: Rc<[HeaderEdit]>,
     pub required_auth: bool,
     pub tags: Option<Rc<CachedTags>>,
+    /// `true` when the materialised HSTS edit (if any) in
+    /// [`Self::headers_response`] came from the listener-default
+    /// `HttpsListenerConfig.hsts` rather than the per-frontend
+    /// `RequestHttpFrontend.hsts` block. Consulted by
+    /// [`Router::refresh_inheriting_hsts`] so a
+    /// `UpdateHttpsListenerConfig.hsts` patch reflows the new default
+    /// onto inheriting frontends without overwriting explicit
+    /// per-frontend HSTS overrides.
+    pub inherits_listener_hsts: bool,
+}
+
+/// Origin of the per-frontend HSTS policy carried by an
+/// [`HttpFrontend`] when the router materialises it into a
+/// [`Frontend`]. Tracked separately because the resolved
+/// `HttpFrontend.hsts` field is the same shape regardless of how it
+/// was filled in — the inheritance bit lets later listener-default
+/// patches refresh inheriting frontends without disturbing explicit
+/// per-frontend overrides.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum HstsOrigin {
+    /// `front.hsts` came from the per-frontend configuration directly
+    /// (operator wrote `[clusters.<id>.frontends.hsts]` in TOML or
+    /// passed `--hsts-*` on the CLI). Listener-default patches do NOT
+    /// refresh this entry.
+    Explicit,
+    /// `front.hsts` was filled in by `add_https_frontend` from the
+    /// listener-default `HttpsListenerConfig.hsts`. A future
+    /// `UpdateHttpsListenerConfig.hsts` patch will refresh this entry
+    /// via [`Router::refresh_inheriting_hsts`].
+    InheritedFromListenerDefault,
 }
 
 impl PartialEq for Frontend {
@@ -1073,11 +1216,17 @@ impl Frontend {
         rewrite_port: Option<u16>,
         headers: &[sozu_command::proto::command::Header],
         required_auth: bool,
+        hsts_origin: HstsOrigin,
     ) -> Result<Self, RouterError> {
         // HSTS is read from `front.hsts` directly inside the function;
         // an explicit parameter would be redundant since `front` is
         // already in scope and the field is the single source of truth.
+        // The `hsts_origin` parameter records *where* `front.hsts` came
+        // from so [`Router::refresh_inheriting_hsts`] can reflow listener
+        // defaults without disturbing explicit per-frontend overrides.
         let hsts = front.hsts.as_ref();
+        let inherits_listener_hsts =
+            matches!(hsts_origin, HstsOrigin::InheritedFromListenerDefault) && hsts.is_some();
         let cluster_id = front.cluster_id.clone();
         let tags = front
             .tags
@@ -1120,6 +1269,14 @@ impl Frontend {
                 headers_response: Rc::new([]),
                 required_auth,
                 tags,
+                // Unauthorized branch never emits HSTS — no headers reach
+                // the wire that aren't the proxy's typed default-answer
+                // 401, which goes through `set_default_answer` and reads
+                // `headers_response` separately. Carry the inheritance
+                // bit through anyway so a later listener-default patch
+                // recognises the entry as inheriting (refresh is a no-op
+                // because `headers_response` is empty).
+                inherits_listener_hsts,
             });
         }
 
@@ -1269,6 +1426,7 @@ impl Frontend {
             headers_response: headers_response.into(),
             required_auth,
             tags,
+            inherits_listener_hsts,
         })
     }
 
@@ -1290,6 +1448,7 @@ impl Frontend {
             headers_response: Rc::new([]),
             required_auth: false,
             tags: None,
+            inherits_listener_hsts: false,
         }
     }
 }
@@ -1595,6 +1754,226 @@ mod tests {
         // field reaches `render_hsts` as `None`, suppress emission so a
         // malformed wire frame can't accidentally render `max-age=`.
         assert_eq!(render_hsts(&cfg), None);
+    }
+
+    #[test]
+    fn rebuild_with_listener_hsts_replaces_existing_entry() {
+        // An inheriting frontend whose listener-default HSTS changed
+        // from 1y → 2y must end up with the 2y entry on its
+        // headers_response, with no leftover 1y entry.
+        let frontend = Frontend {
+            cluster_id: Some("api".to_owned()),
+            redirect: RedirectPolicy::Forward,
+            redirect_scheme: RedirectScheme::UseSame,
+            redirect_template: None,
+            capture_cap_host: 0,
+            capture_cap_path: 0,
+            rewrite_host: None,
+            rewrite_path: None,
+            rewrite_port: None,
+            headers_request: Rc::new([]),
+            headers_response: Rc::from(vec![
+                HeaderEdit {
+                    key: Rc::from(&b"x-cache"[..]),
+                    val: Rc::from(&b"hit"[..]),
+                    mode: HeaderEditMode::Append,
+                },
+                HeaderEdit {
+                    key: Rc::from(&b"strict-transport-security"[..]),
+                    val: Rc::from(&b"max-age=31536000"[..]),
+                    mode: HeaderEditMode::SetIfAbsent,
+                },
+            ]),
+            required_auth: false,
+            tags: None,
+            inherits_listener_hsts: true,
+        };
+        let new_hsts = HstsConfig {
+            enabled: Some(true),
+            max_age: Some(63_072_000),
+            include_subdomains: Some(true),
+            preload: None,
+            force_replace_backend: None,
+        };
+        let rebuilt = rebuild_with_listener_hsts(&frontend, Some(&new_hsts));
+
+        let response: Vec<_> = rebuilt.headers_response.iter().collect();
+        assert_eq!(response.len(), 2, "x-cache + new STS, no leftover STS");
+        assert_eq!(&*response[0].key, b"x-cache");
+        assert_eq!(&*response[1].key, b"strict-transport-security");
+        assert_eq!(
+            &*response[1].val,
+            b"max-age=63072000; includeSubDomains".as_slice()
+        );
+        assert!(rebuilt.inherits_listener_hsts);
+    }
+
+    #[test]
+    fn rebuild_with_listener_hsts_strips_when_none() {
+        // Listener-default HSTS removed → strip the existing STS edit
+        // and add nothing. Operator response headers stay in place.
+        let frontend = Frontend {
+            cluster_id: Some("api".to_owned()),
+            redirect: RedirectPolicy::Forward,
+            redirect_scheme: RedirectScheme::UseSame,
+            redirect_template: None,
+            capture_cap_host: 0,
+            capture_cap_path: 0,
+            rewrite_host: None,
+            rewrite_path: None,
+            rewrite_port: None,
+            headers_request: Rc::new([]),
+            headers_response: Rc::from(vec![
+                HeaderEdit {
+                    key: Rc::from(&b"x-cache"[..]),
+                    val: Rc::from(&b"hit"[..]),
+                    mode: HeaderEditMode::Append,
+                },
+                HeaderEdit {
+                    key: Rc::from(&b"strict-transport-security"[..]),
+                    val: Rc::from(&b"max-age=31536000"[..]),
+                    mode: HeaderEditMode::SetIfAbsent,
+                },
+            ]),
+            required_auth: false,
+            tags: None,
+            inherits_listener_hsts: true,
+        };
+        let rebuilt = rebuild_with_listener_hsts(&frontend, None);
+        let response: Vec<_> = rebuilt.headers_response.iter().collect();
+        assert_eq!(response.len(), 1);
+        assert_eq!(&*response[0].key, b"x-cache");
+    }
+
+    #[test]
+    fn rebuild_with_listener_hsts_disabled_strips() {
+        // `enabled = Some(false)` is the explicit-disable signal; the
+        // existing STS entry is dropped and no new one is added.
+        let frontend = Frontend {
+            cluster_id: Some("api".to_owned()),
+            redirect: RedirectPolicy::Forward,
+            redirect_scheme: RedirectScheme::UseSame,
+            redirect_template: None,
+            capture_cap_host: 0,
+            capture_cap_path: 0,
+            rewrite_host: None,
+            rewrite_path: None,
+            rewrite_port: None,
+            headers_request: Rc::new([]),
+            headers_response: Rc::from(vec![HeaderEdit {
+                key: Rc::from(&b"strict-transport-security"[..]),
+                val: Rc::from(&b"max-age=31536000"[..]),
+                mode: HeaderEditMode::SetIfAbsent,
+            }]),
+            required_auth: false,
+            tags: None,
+            inherits_listener_hsts: true,
+        };
+        let new_hsts = HstsConfig {
+            enabled: Some(false),
+            max_age: None,
+            include_subdomains: None,
+            preload: None,
+            force_replace_backend: None,
+        };
+        let rebuilt = rebuild_with_listener_hsts(&frontend, Some(&new_hsts));
+        assert_eq!(rebuilt.headers_response.len(), 0);
+    }
+
+    #[test]
+    fn refresh_inheriting_hsts_skips_explicit_overrides() {
+        // Two frontends: one inheriting (gets refreshed), one explicit
+        // override (must NOT change). `Router::refresh_inheriting_hsts`
+        // returns the count of refreshed entries.
+        use crate::router::pattern_trie::TrieNode;
+        let mut router = Router {
+            pre: Vec::new(),
+            tree: TrieNode::root(),
+            post: Vec::new(),
+        };
+        let inheriting = Frontend {
+            cluster_id: Some("api".to_owned()),
+            redirect: RedirectPolicy::Forward,
+            redirect_scheme: RedirectScheme::UseSame,
+            redirect_template: None,
+            capture_cap_host: 0,
+            capture_cap_path: 0,
+            rewrite_host: None,
+            rewrite_path: None,
+            rewrite_port: None,
+            headers_request: Rc::new([]),
+            headers_response: Rc::from(vec![HeaderEdit {
+                key: Rc::from(&b"strict-transport-security"[..]),
+                val: Rc::from(&b"max-age=31536000"[..]),
+                mode: HeaderEditMode::SetIfAbsent,
+            }]),
+            required_auth: false,
+            tags: None,
+            inherits_listener_hsts: true,
+        };
+        let explicit = Frontend {
+            cluster_id: Some("legacy".to_owned()),
+            redirect: RedirectPolicy::Forward,
+            redirect_scheme: RedirectScheme::UseSame,
+            redirect_template: None,
+            capture_cap_host: 0,
+            capture_cap_path: 0,
+            rewrite_host: None,
+            rewrite_path: None,
+            rewrite_port: None,
+            headers_request: Rc::new([]),
+            headers_response: Rc::from(vec![HeaderEdit {
+                key: Rc::from(&b"strict-transport-security"[..]),
+                val: Rc::from(&b"max-age=300"[..]),
+                mode: HeaderEditMode::SetIfAbsent,
+            }]),
+            required_auth: false,
+            tags: None,
+            inherits_listener_hsts: false,
+        };
+        router.pre.push((
+            DomainRule::Any,
+            PathRule::Prefix("/api".to_owned()),
+            MethodRule::new(None),
+            Route::Frontend(Rc::new(inheriting)),
+        ));
+        router.post.push((
+            DomainRule::Any,
+            PathRule::Prefix("/legacy".to_owned()),
+            MethodRule::new(None),
+            Route::Frontend(Rc::new(explicit)),
+        ));
+
+        let new_hsts = HstsConfig {
+            enabled: Some(true),
+            max_age: Some(63_072_000),
+            include_subdomains: Some(true),
+            preload: None,
+            force_replace_backend: None,
+        };
+        let count = router.refresh_inheriting_hsts(Some(&new_hsts));
+        assert_eq!(count, 1, "only the inheriting frontend should refresh");
+
+        if let Route::Frontend(rc) = &router.pre[0].3 {
+            let response: Vec<_> = rc.headers_response.iter().collect();
+            assert_eq!(
+                &*response.last().unwrap().val,
+                b"max-age=63072000; includeSubDomains".as_slice(),
+                "inheriting frontend's STS must reflect the new listener default"
+            );
+        } else {
+            panic!("pre[0] should be Route::Frontend");
+        }
+        if let Route::Frontend(rc) = &router.post[0].3 {
+            let response: Vec<_> = rc.headers_response.iter().collect();
+            assert_eq!(
+                &*response.last().unwrap().val,
+                b"max-age=300".as_slice(),
+                "explicit override must be preserved unchanged"
+            );
+        } else {
+            panic!("post[0] should be Route::Frontend");
+        }
     }
 
     #[test]

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -1255,6 +1255,31 @@ impl Frontend {
             _ => false,
         };
         if deny {
+            // The Unauthorized policy zeroes out request rewrites and
+            // header injections (the request never reaches a backend),
+            // but RFC 6797 §8.1 still requires HSTS on the 401 default
+            // answer when the frontend is on an HTTPS listener. Build
+            // the HSTS edit (when configured) so the per-stream
+            // snapshot copy in `mux/router.rs` carries it through to
+            // `set_default_answer_with_retry_after`.
+            let mut deny_headers_response: Vec<HeaderEdit> = Vec::new();
+            if let Some(cfg) = hsts
+                && matches!(cfg.enabled, Some(true))
+                && let Some(rendered) = render_hsts(cfg)
+            {
+                let mode = if matches!(cfg.force_replace_backend, Some(true)) {
+                    HeaderEditMode::Set
+                } else {
+                    HeaderEditMode::SetIfAbsent
+                };
+                deny_headers_response.push(HeaderEdit {
+                    key: Rc::from(&b"strict-transport-security"[..]),
+                    val: rendered.into_bytes().into(),
+                    mode,
+                });
+                crate::incr!("http.hsts.frontend_added");
+            }
+
             return Ok(Self {
                 cluster_id,
                 redirect: RedirectPolicy::Unauthorized,
@@ -1266,16 +1291,9 @@ impl Frontend {
                 rewrite_path: None,
                 rewrite_port: None,
                 headers_request: Rc::new([]),
-                headers_response: Rc::new([]),
+                headers_response: deny_headers_response.into(),
                 required_auth,
                 tags,
-                // Unauthorized branch never emits HSTS — no headers reach
-                // the wire that aren't the proxy's typed default-answer
-                // 401, which goes through `set_default_answer` and reads
-                // `headers_response` separately. Carry the inheritance
-                // bit through anyway so a later listener-default patch
-                // recognises the entry as inheriting (refresh is a no-op
-                // because `headers_response` is empty).
                 inherits_listener_hsts,
             });
         }
@@ -1528,6 +1546,11 @@ impl RouteResult {
     ) -> Self {
         // Unauthorized short-circuit: skip the path-capture extraction
         // entirely — the response will not consume any rewrite output.
+        // `headers_response` IS preserved here (unlike `headers_request`)
+        // so the per-stream snapshot copy in `mux/router.rs` can still
+        // pick up the per-frontend HSTS edit and inject it on the 401
+        // default answer (RFC 6797 §8.1 — HSTS applies to all response
+        // codes, including the proxy's typed unauthorized answer).
         if frontend.redirect == RedirectPolicy::Unauthorized {
             return Self {
                 cluster_id: frontend.cluster_id.clone(),
@@ -1538,7 +1561,7 @@ impl RouteResult {
                 rewritten_path: None,
                 rewritten_port: None,
                 headers_request: Rc::new([]),
-                headers_response: Rc::new([]),
+                headers_response: frontend.headers_response.clone(),
                 required_auth: frontend.required_auth,
                 tags: frontend.tags.clone(),
             };

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -1477,6 +1477,90 @@ mod tests {
     use super::*;
 
     #[test]
+    fn render_hsts_max_age_only() {
+        let cfg = HstsConfig {
+            enabled: Some(true),
+            max_age: Some(31_536_000),
+            include_subdomains: None,
+            preload: None,
+        };
+        assert_eq!(render_hsts(&cfg), Some("max-age=31536000".to_owned()));
+    }
+
+    #[test]
+    fn render_hsts_with_include_subdomains() {
+        let cfg = HstsConfig {
+            enabled: Some(true),
+            max_age: Some(31_536_000),
+            include_subdomains: Some(true),
+            preload: None,
+        };
+        assert_eq!(
+            render_hsts(&cfg),
+            Some("max-age=31536000; includeSubDomains".to_owned())
+        );
+    }
+
+    #[test]
+    fn render_hsts_with_preload_only() {
+        let cfg = HstsConfig {
+            enabled: Some(true),
+            max_age: Some(63_072_000),
+            include_subdomains: None,
+            preload: Some(true),
+        };
+        assert_eq!(
+            render_hsts(&cfg),
+            Some("max-age=63072000; preload".to_owned())
+        );
+    }
+
+    #[test]
+    fn render_hsts_full() {
+        let cfg = HstsConfig {
+            enabled: Some(true),
+            max_age: Some(31_536_000),
+            include_subdomains: Some(true),
+            preload: Some(true),
+        };
+        assert_eq!(
+            render_hsts(&cfg),
+            Some("max-age=31536000; includeSubDomains; preload".to_owned())
+        );
+    }
+
+    #[test]
+    fn render_hsts_kill_switch_max_age_zero() {
+        let cfg = HstsConfig {
+            enabled: Some(true),
+            max_age: Some(0),
+            include_subdomains: Some(true),
+            preload: None,
+        };
+        // `max_age = 0` is the RFC 6797 §11.4 kill switch and renders
+        // verbatim — UA receives it and stops treating the host as a
+        // Known HSTS Host.
+        assert_eq!(
+            render_hsts(&cfg),
+            Some("max-age=0; includeSubDomains".to_owned())
+        );
+    }
+
+    #[test]
+    fn render_hsts_omitted_when_max_age_missing() {
+        let cfg = HstsConfig {
+            enabled: Some(true),
+            max_age: None,
+            include_subdomains: Some(true),
+            preload: None,
+        };
+        // The TOML loader substitutes the default at config-load; if the
+        // field reaches `render_hsts` as `None`, suppress emission so a
+        // malformed wire frame can't accidentally render `max-age=`.
+        assert_eq!(render_hsts(&cfg), None);
+    }
+
+    #[test]
     fn convert_regex() {
         // Compiled regexes are anchored with `\A` … `\z` so `Regex::is_match`
         // (unanchored by default) only succeeds on a full-host match.

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -1215,14 +1215,32 @@ impl Frontend {
         // which only copies `headers_response` for HTTPS-served requests.
         if let Some(cfg) = hsts
             && matches!(cfg.enabled, Some(true))
-            && let Some(rendered) = render_hsts(cfg)
         {
-            headers_response.push(HeaderEdit {
-                key: Rc::from(&b"strict-transport-security"[..]),
-                val: rendered.into_bytes().into(),
-                mode: HeaderEditMode::SetIfAbsent,
-            });
-            crate::incr!("http.hsts.frontend_added");
+            if let Some(rendered) = render_hsts(cfg) {
+                headers_response.push(HeaderEdit {
+                    key: Rc::from(&b"strict-transport-security"[..]),
+                    val: rendered.into_bytes().into(),
+                    mode: HeaderEditMode::SetIfAbsent,
+                });
+                crate::incr!("http.hsts.frontend_added");
+            } else {
+                // Both upstream config layers (FileHstsConfig::to_proto and
+                // build_hsts_from_cli) substitute DEFAULT_HSTS_MAX_AGE when
+                // enabled = Some(true) && max_age = None, so reaching this
+                // branch means a programmatic IPC sender produced an
+                // ill-formed HstsConfig. Surface it loudly rather than
+                // silently emitting no header — operators inspecting their
+                // dashboards for http.hsts.unrendered will catch the bug.
+                warn!(
+                    "{} HSTS enabled = true on frontend {:?} but render_hsts \
+                     returned None (max_age missing). Frontend will not emit \
+                     Strict-Transport-Security; the config layer that built \
+                     this HstsConfig must substitute DEFAULT_HSTS_MAX_AGE.",
+                    log_module_context!(),
+                    cluster_id,
+                );
+                crate::incr!("http.hsts.unrendered");
+            }
         }
 
         Ok(Frontend {

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -11,15 +11,15 @@ use regex::bytes::Regex;
 use sozu_command::{
     logging::CachedTags,
     proto::command::{
-        HeaderPosition, PathRule as CommandPathRule, PathRuleKind, RedirectPolicy, RedirectScheme,
-        RulePosition,
+        HeaderPosition, HstsConfig, PathRule as CommandPathRule, PathRuleKind, RedirectPolicy,
+        RedirectScheme, RulePosition,
     },
     response::HttpFrontend,
     state::ClusterId,
 };
 
 use crate::{
-    protocol::http::parser::Method,
+    protocol::{http::editor::HeaderEditMode, http::parser::Method},
     router::pattern_trie::{TrieMatches, TrieNode, TrieSubMatch},
     sozu_command::logging::ansi_palette,
 };
@@ -208,7 +208,8 @@ impl Router {
             || front.rewrite_path.is_some()
             || front.rewrite_port.is_some()
             || front.required_auth.unwrap_or(false)
-            || !front.headers.is_empty();
+            || !front.headers.is_empty()
+            || front.hsts.is_some();
 
         let domain =
             front
@@ -239,6 +240,7 @@ impl Router {
                 front.rewrite_port.and_then(|p| u16::try_from(p).ok()),
                 &front.headers,
                 front.required_auth.unwrap_or(false),
+                front.hsts.as_ref(),
             )?;
             Route::Frontend(Rc::new(frontend))
         } else {
@@ -763,23 +765,55 @@ pub enum Route {
     Frontend(Rc<Frontend>),
 }
 
+/// Render an [`HstsConfig`] into a canonical RFC 6797 §6.1
+/// `Strict-Transport-Security` header value: `max-age=N` first, then
+/// optional `; includeSubDomains`, then optional `; preload`. No
+/// trailing semicolon. `includeSubDomains` is the RFC §6.1 spelling
+/// (camelCase); `preload` is lowercase per the de-facto Chrome/HSTS
+/// preload-list convention (https://hstspreload.org/).
+///
+/// Returns `None` when the config has no `max_age` (the caller should
+/// have substituted the default at config-load via
+/// `command/src/config.rs::FileHstsConfig::to_proto` before reaching
+/// this site; if it didn't, a `None` here suppresses the emission so a
+/// malformed wire frame can't leak `max-age=0` accidentally).
+pub fn render_hsts(cfg: &HstsConfig) -> Option<String> {
+    let max_age = cfg.max_age?;
+    let mut s = format!("max-age={max_age}");
+    if matches!(cfg.include_subdomains, Some(true)) {
+        s.push_str("; includeSubDomains");
+    }
+    if matches!(cfg.preload, Some(true)) {
+        s.push_str("; preload");
+    }
+    Some(s)
+}
+
 /// A single header mutation collected from a [`Frontend`] configuration.
 ///
 /// `key` and `val` are owned via [`Rc`] so a `Frontend` can be held by many
 /// routing entries (pre, tree, post) without copying the underlying bytes.
-/// An empty `val` deletes the header by name (HAProxy `del-header` parity).
+///
+/// `mode` controls how the per-stream `apply_response_header_edits` pass
+/// emits the entry on the wire — see [`HeaderEditMode`]. Operator-supplied
+/// `[[...frontends.headers]]` entries default to [`HeaderEditMode::Append`]
+/// (preserving the legacy empty-val-deletes encoding); typed policies
+/// (HSTS, future RFC-correct response policies) opt into
+/// [`HeaderEditMode::SetIfAbsent`].
 #[derive(Clone, PartialEq, Eq)]
 pub struct HeaderEdit {
     pub key: Rc<[u8]>,
     pub val: Rc<[u8]>,
+    pub mode: HeaderEditMode,
 }
 
 impl Debug for HeaderEdit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!(
-            "({:?}, {:?})",
+            "({:?}, {:?}, {:?})",
             String::from_utf8_lossy(&self.key),
-            String::from_utf8_lossy(&self.val)
+            String::from_utf8_lossy(&self.val),
+            self.mode,
         ))
     }
 }
@@ -1040,6 +1074,7 @@ impl Frontend {
         rewrite_port: Option<u16>,
         headers: &[sozu_command::proto::command::Header],
         required_auth: bool,
+        hsts: Option<&HstsConfig>,
     ) -> Result<Self, RouterError> {
         let cluster_id = front.cluster_id.clone();
         let tags = front
@@ -1146,6 +1181,7 @@ impl Frontend {
             let edit = HeaderEdit {
                 key: header.key.as_bytes().into(),
                 val: header.val.as_bytes().into(),
+                mode: HeaderEditMode::Append,
             };
             match header.position() {
                 HeaderPosition::Request => headers_request.push(edit),
@@ -1168,6 +1204,24 @@ impl Frontend {
                     );
                 }
             }
+        }
+
+        // Materialise HSTS (RFC 6797) into the response-side header
+        // collection as a single `SetIfAbsent` edit so an upstream-emitted
+        // `Strict-Transport-Security` survives unchanged (RFC 6797 §6.1
+        // single-header requirement). `enabled = Some(false)` is the
+        // explicit-disable signal — emit nothing. The §7.2 "no STS over
+        // plaintext HTTP" gate is enforced by the runtime snapshot site,
+        // which only copies `headers_response` for HTTPS-served requests.
+        if let Some(cfg) = hsts
+            && matches!(cfg.enabled, Some(true))
+            && let Some(rendered) = render_hsts(cfg)
+        {
+            headers_response.push(HeaderEdit {
+                key: Rc::from(&b"strict-transport-security"[..]),
+                val: rendered.into_bytes().into(),
+                mode: HeaderEditMode::SetIfAbsent,
+            });
         }
 
         Ok(Frontend {

--- a/lib/src/router/pattern_trie.rs
+++ b/lib/src/router/pattern_trie.rs
@@ -492,6 +492,26 @@ impl<V: Debug + Clone> TrieNode<V> {
         }
     }
 
+    /// Visit every stored value in the trie (the literal `key_value` and
+    /// the leftmost `wildcard` slot of every node, plus all
+    /// regex-subtree leaves) and invoke `f` on each. Used by the router
+    /// to walk all routes for cross-cutting refreshes (e.g. listener-
+    /// default HSTS reflow) without rebuilding the trie.
+    pub fn for_each_value_mut<F: FnMut(&mut V)>(&mut self, f: &mut F) {
+        if let Some((_, ref mut value)) = self.key_value {
+            f(value);
+        }
+        if let Some((_, ref mut value)) = self.wildcard {
+            f(value);
+        }
+        for child in self.children.values_mut() {
+            child.for_each_value_mut(f);
+        }
+        for (_, child) in self.regexps.iter_mut() {
+            child.for_each_value_mut(f);
+        }
+    }
+
     pub fn domain_insert(&mut self, key: Key, value: V) -> InsertResult {
         self.insert(key, value)
     }


### PR DESCRIPTION
## Summary

- Adds typed HSTS (HTTP Strict Transport Security, [RFC 6797](https://datatracker.ietf.org/doc/html/rfc6797)) configurable per HTTPS listener (operator default) and per HTTPS frontend (override). Operators opt in; nothing changes on existing deployments.
- Materialises a single `Strict-Transport-Security: max-age=N[; includeSubDomains][; preload]` response edit at frontend-add time and rides the existing per-frontend `headers_response` plumbing — zero new request-path code, no per-request work.
- HSTS reaches every HTTPS response code (RFC §8.1): backend-served 2xx, redirect 3xx default answers, auth-deny 401, proxy-generated 5xx. RFC §7.2 enforced in three layers: TOML config-load reject for HTTP listeners, worker IPC reject (`ProxyError::HstsOnPlainHttp`), and a runtime snapshot-copy gate on `Protocol::HTTPS` so plaintext connections never apply HSTS edits.
- Backend-supplied `Strict-Transport-Security` passes through unchanged via new `HeaderEditMode::SetIfAbsent` semantics on `apply_response_header_edits` (RFC §6.1 single-header requirement).

## Configuration shape

```toml
# Listener default — every HTTPS frontend on this listener inherits.
[[listeners]]
protocol = \"https\"
address  = \"0.0.0.0:443\"

[hsts]
enabled            = true
max_age            = 31536000     # 1 year — preload list minimum (default)
include_subdomains = true
preload            = false        # opt-in only

# Per-frontend override (longer max-age, opt into preload list).
[[clusters.api.frontends]]
address  = \"0.0.0.0:443\"
hostname = \"api.example.com\"

[clusters.api.frontends.hsts]
enabled            = true
max_age            = 63072000
include_subdomains = true
preload            = true

# Per-frontend explicit disable suppresses inherited listener default.
[clusters.legacy.frontends.hsts]
enabled = false
```

The `[hsts]` block is **optional everywhere** (omit it and no header is emitted). When the block IS present, `enabled` is the only required field — it disambiguates inherit / explicit-enable / explicit-disable on partial-update patches.

## Runtime CLI

```
sozu frontend https add \\
  --address 0.0.0.0:443 --hostname api.example.com \\
  --hsts-max-age 31536000 --hsts-include-subdomains
```

`--hsts-disabled` is mutually exclusive with the three enabling flags (typed `CtlError::ArgsNeeded` rather than a silent pick).

## Hot-reconfig

`UpdateHttpsListenerConfig.hsts` (proto tag 41) is full-object replacement when present; absent preserves current. `enabled` REQUIRED whenever the block is present (`ListenerError::HstsEnabledRequired`).

## Default `max_age` choice — 31 536 000 (1 year)

Matches the [HSTS preload list minimum](https://hstspreload.org/), Caddy / Nginx community norm, gives a tractable rollback horizon. Mozilla 2-year (`63072000`) and conservative 6-month (`15768000`) supported by typing the value explicitly.

## Validation matrix (config-load)

| Configuration                                                     | Outcome                                                  |
|-------------------------------------------------------------------|----------------------------------------------------------|
| `[hsts]` on a plain-HTTP listener / frontend                      | **Error** `HstsOnPlainHttp` (RFC §7.2)                   |
| `[hsts]` block without `enabled`                                  | **Error** `HstsEnabledRequired`                          |
| `enabled = true`, `max_age` omitted                               | Substituted to `DEFAULT_HSTS_MAX_AGE = 31_536_000`       |
| `max_age = 0`                                                     | **Allowed silently** (RFC §11.4 kill switch)             |
| `0 < max_age < 86_400`                                            | **Warning** at config-load                               |
| `preload = true` with `max_age < 31_536_000`                      | **Warning** (preload list rejects)                       |
| `preload = true` without `include_subdomains = true`              | **Warning** (preload list rejects)                       |

## Metrics

- `http.hsts.frontend_added` (counter) — fires per HSTS-enabled frontend at add-time
- `http.hsts.suppressed_plaintext` (counter) — fires on the §7.2 reject path (defense-in-depth telemetry)

## Files touched

- `command/src/{command.proto,config.rs,request.rs,response.rs}` — typed proto + TOML parsing + 3 new `ConfigError` variants + 5 unit tests
- `lib/src/router/mod.rs` — `render_hsts` + `HeaderEdit.mode` + 6 unit tests
- `lib/src/protocol/{kawa_h1/editor.rs,mux/router.rs,mux/shared.rs}` — `HeaderEditMode { Append, Delete, SetIfAbsent }`, helper extension + 2 unit tests, snapshot-copy hoist for HTTPS
- `lib/src/{http.rs,https.rs,lib.rs}` — `ProxyError::HstsOnPlainHttp` reject + listener-default inheritance + `ListenerError::HstsEnabledRequired`
- `bin/src/{cli.rs,ctl/request_builder.rs}` — four `--hsts-*` CLI flags
- `e2e/src/tests/{hsts_tests.rs,mod.rs}` — 2 e2e tests (§7.2 reject + explicit-disable accepted)
- `doc/configure.md` (full HSTS section + HTTPS-counterpart subsection + required/optional clarification), `CHANGELOG.md`, `bin/config.toml`

## Test plan

- [x] \`cargo build --all-features --locked\`
- [x] \`cargo +nightly fmt --all -- --check\`
- [x] \`cargo clippy --all-targets --all-features --locked\` — no issues
- [x] \`cargo test --workspace --locked --lib\` — 973 passed across 4 suites (11 new HSTS unit tests)
- [x] \`cargo test -p sozu-e2e --locked -- hsts\` — 2 passed
- [ ] **Wire-level HTTPS positive coverage** is intentionally deferred and called out in \`e2e/src/tests/hsts_tests.rs\`. Those tests need a full TLS stack (cert generation, \`https_client::build_https_client\`, \`H2Backend\`); the unit tests for \`render_hsts\` and \`apply_response_header_edits\` SetIfAbsent cover the rendering / single-header logic exhaustively. Follow-up.

## RFC compliance

- §6.1 single-header requirement → `SetIfAbsent` mode preserves backend STS verbatim
- §7.2 plaintext reject → three layers (config-load / IPC-entry / runtime gate)
- §8.1 all-response-codes → snapshot-copy hoist above the redirect / auth-deny early returns in \`mux/router.rs\`
- §11.4 kill switch → \`max_age = 0\` allowed silently
- §14.2 preload caution → \`preload\` opt-in only, never default-true; warns when guard rails (max-age, includeSubDomains) aren't met

## Architecture choices that came out of the planning pass

- Typed config (Traefik shape) over raw header injection (Pingora shape) so config-time validation can refuse bad inputs — RFC §7.2 reject in particular cannot be enforced on a freeform \`headers\` knob.
- No silent auto-enablement on \`redirect_scheme = use-https\`. The Caddy maintainers explicitly declined the same pattern in [caddyserver/caddy#4751](https://github.com/caddyserver/caddy/issues/4751) on the grounds that HSTS is hard to undo for users who later disable HTTPS. Operators turn HSTS on once at the listener default and every HTTPS frontend inherits.
- HSTS rides the existing \`headers_response\` plumbing — the \`mux/h1.rs::writable\` and \`mux/h2.rs::write_streams\` apply chokepoints need zero changes.

## Worktree note

Built and validated in \`sozu.feat-hsts\` worktree off \`main\` (8c883bb5). Branch carries 8 GPG-signed commits.