### PR TITLE
fix(command): default missing repeated/map fields when loading older state files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,34 @@ upgrade. See `doc/upgrade/1.x-to-2.0.md` for the full migration guide.
 
 ### ⛑️ Fixed
 
+- **`LoadState` accepts JSON state files from older `sozu-command-lib` clients
+  (`1.1.1` forward-compat)**: `bin/src/command/requests.rs::load_state` reads
+  each `\n\0`-separated JSON record via
+  `command::parser::parse_several_requests::<WorkerRequest>`, which calls
+  `serde_json::from_slice` per record. The `command/build.rs` prost-build config
+  attaches `Serialize`/`Deserialize` derives to every generated message but did
+  not attach `#[serde(default)]` anywhere, so missing `repeated`/`map` fields
+  rejected the record (`Vec<T>` and `BTreeMap<K, V>` are required-by-serde
+  without an explicit default). Post-1.1.1 schema additions (`Cluster.answers`,
+  `Cluster.authorized_hashes`, `RequestHttpFrontend.headers` from #1231;
+  `HttpListenerConfig.answers`, `HttpsListenerConfig.alpn_protocols` /
+  `answers`, `TcpListenerConfig.answers` from the same wave) therefore broke
+  `LoadState` for any older client (e.g. `proxy-manager` pinned to
+  `sozu-command-lib = "1.1.1"`): the first `AddCluster` or `AddHttpFrontend`
+  failed to deserialize, `parse_several_requests`'s `many0(complete(...))` left
+  the unparsed bytes as the remainder, and the read loop in `load_state`
+  reported `"Error consuming load state message"` to the client at EOF. Each
+  post-1.1.1 `repeated`/`map` field on a state-file-emittable message now
+  carries `#[serde(default)]` via `command/build.rs` `field_attribute(...)`, so
+  missing fields default to empty (mirroring the protobuf wire-format default)
+  while required scalars stay strict. Without strictness on scalars,
+  `ConfigState::add_cluster` would silently insert a `""`-keyed entry — the
+  field-level annotation preserves that defense-in-depth. Forward additions are
+  guarded by `command/tests/state_compat_v1_1_1.rs`, which pins both the 1.1.1
+  fixture round-trip and the missing-required-scalar rejection contract; a
+  documentation comment at the top of `command/src/command.proto` and at the
+  relevant block in `command/build.rs` codifies the new rule for future
+  `repeated`/`map` field additions.
 - **Certificate chain dedup: drop the leaf when ACME `fullchain.pem` is supplied
   as the chain ([#1135](https://github.com/sozu-proxy/sozu/issues/1135),
   [#1148](https://github.com/sozu-proxy/sozu/issues/1148))**:

--- a/command/build.rs
+++ b/command/build.rs
@@ -41,6 +41,29 @@ pub fn main() {
         .message_attribute("HttpsListenerConfig", "#[derive(Hash, Eq)]")
         .message_attribute("UpdateHttpListenerConfig", "#[derive(Hash, Eq)]")
         .message_attribute("UpdateHttpsListenerConfig", "#[derive(Hash, Eq)]")
+        // JSON state-file forward compat: `SaveState`/`LoadState` files are
+        // JSON-encoded `WorkerRequest` records. Without `#[serde(default)]`,
+        // serde rejects records that don't carry every `Vec`/`map` field — so
+        // a payload written by an older `sozu-command-lib` (e.g. 1.1.1) fails
+        // to deserialize once a new `repeated`/`map` field lands on a message
+        // that older clients still emit. The annotations below mirror the
+        // protobuf wire-format default (empty repeated, empty map) for the
+        // post-1.1.1 additions on every state-file-emittable message.
+        // Required scalars stay strict on purpose: `add_cluster` keys the
+        // cluster map by `cluster_id` without a non-empty check, so a
+        // struct-level blanket would silently insert a bogus `""`-keyed
+        // entry. Whenever a new `repeated`/`map` field is added to a message
+        // that appears in `ConfigState::generate_requests` (or in any
+        // `RequestType` an external client builds and feeds through
+        // `LoadState`), append the matching `field_attribute` line here.
+        // Regression guard: `command/tests/state_compat_v1_1_1.rs`.
+        .field_attribute("Cluster.answers", "#[serde(default)]")
+        .field_attribute("Cluster.authorized_hashes", "#[serde(default)]")
+        .field_attribute("RequestHttpFrontend.headers", "#[serde(default)]")
+        .field_attribute("HttpListenerConfig.answers", "#[serde(default)]")
+        .field_attribute("HttpsListenerConfig.alpn_protocols", "#[serde(default)]")
+        .field_attribute("HttpsListenerConfig.answers", "#[serde(default)]")
+        .field_attribute("TcpListenerConfig.answers", "#[serde(default)]")
         .enum_attribute(".", "#[serde(rename_all = \"SCREAMING_SNAKE_CASE\")]")
         .enum_attribute(
             "ResponseContent.content_type",

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -1,6 +1,21 @@
 syntax = "proto2";
 package command;
 
+// JSON state-file forward compat: `SaveState`/`LoadState` write
+// `WorkerRequest`s as `\n\0`-separated JSON records. Older clients (e.g.
+// `sozu-command-lib = "1.1.1"`) emit only the field set their schema knew,
+// so missing `repeated` / `map` fields must default to empty when the
+// current schema deserializes them. New schema rules:
+//   - new fields must be additive — proto2 `optional`, or `repeated`/`map`,
+//   - never rename or change the type of an existing field,
+//   - when adding a `repeated` or `map` field to a message that appears in
+//     a state file (anything emitted by `ConfigState::generate_requests` or
+//     carried in a `RequestType` an external client may build), add the
+//     matching `field_attribute(... "#[serde(default)]")` line in
+//     `command/build.rs`. Required scalars stay strict on purpose so
+//     malformed records still fail before dispatch.
+// Regression guard: `command/tests/state_compat_v1_1_1.rs`.
+
 // A message received by Sōzu to change its state or query information
 message Request {
   oneof request_type {

--- a/command/tests/state_compat_v1_1_1.rs
+++ b/command/tests/state_compat_v1_1_1.rs
@@ -1,0 +1,138 @@
+//! Forward-compat regression for `SaveState` / `LoadState` JSON files.
+//!
+//! `proxy-manager` (and other tools pinned to `sozu-command-lib = "1.1.1"`)
+//! writes a state file as `\n\0`-separated JSON `WorkerRequest` records using
+//! the 1.1.1 schema, then asks Sōzu to `LoadState` it. Post-1.1.1 schema
+//! changes added `repeated` / `map` fields to messages those tools still
+//! emit (`Cluster.answers`, `Cluster.authorized_hashes`,
+//! `RequestHttpFrontend.headers`, plus listener-level `answers` /
+//! `alpn_protocols`). Without `#[serde(default)]` on each new repeated/map
+//! field, `serde_json::from_slice::<WorkerRequest>` rejects the older
+//! payload with `missing field 'answers'`; `parse_several_requests`'s
+//! `many0(complete(...))` then leaves the unparsed bytes as the remainder,
+//! and `bin/src/command/requests.rs::load_state` reports
+//! `"Error consuming load state message"`.
+//!
+//! These tests pin the contract:
+//!   1. A 1.1.1-shaped payload deserializes cleanly and the new repeated/map
+//!      fields default to empty.
+//!   2. A record missing a *required scalar* (`cluster_id`) still fails so
+//!      the strict path stays strict — guards against future drift toward
+//!      a struct-level `#[serde(default)]`, which would silently insert
+//!      bogus `""`-keyed clusters.
+
+use sozu_command_lib::{
+    parser::parse_several_requests,
+    proto::command::{WorkerRequest, request::RequestType},
+};
+
+/// `127.0.0.1` as the `IpAddress.Inner.V4` `fixed32` (`u32::from(Ipv4Addr)`
+/// per `command/src/request.rs::From<SocketAddr>`).
+const LOCALHOST_V4: u32 = 0x7F00_0001;
+
+/// Builds the JSON exactly as `sozu-command-lib = "1.1.1"` would emit it:
+/// only the field set the 1.1.1 schema knew about. None of the post-1.1.1
+/// `Cluster.answers`, `Cluster.authorized_hashes`,
+/// `RequestHttpFrontend.headers`, or the listener-level additions appear.
+fn v1_1_1_state_file_payload() -> Vec<u8> {
+    let add_cluster = r#"{"id":"PROXY-MANAGER-1","content":{"request_type":{"ADD_CLUSTER":{"cluster_id":"app-1","sticky_session":false,"https_redirect":false,"proxy_protocol":null,"load_balancing":0,"answer_503":null,"load_metric":0}}}}"#
+        .to_owned();
+
+    let add_http_frontend = format!(
+        r#"{{"id":"PROXY-MANAGER-2","content":{{"request_type":{{"ADD_HTTP_FRONTEND":{{"cluster_id":"app-1","address":{{"ip":{{"inner":{{"V4":{LOCALHOST_V4}}}}},"port":80}},"hostname":"example.com","path":{{"kind":0,"value":"/"}},"method":null,"position":2,"tags":{{}}}}}}}}}}"#,
+    );
+
+    let add_backend = format!(
+        r#"{{"id":"PROXY-MANAGER-3","content":{{"request_type":{{"ADD_BACKEND":{{"cluster_id":"app-1","backend_id":"app-1-backend-0","address":{{"ip":{{"inner":{{"V4":{LOCALHOST_V4}}}}},"port":8080}},"sticky_id":null,"load_balancing_parameters":null,"backup":null}}}}}}}}"#,
+    );
+
+    let mut payload = Vec::new();
+    for record in [&add_cluster, &add_http_frontend, &add_backend] {
+        payload.extend_from_slice(record.as_bytes());
+        payload.extend_from_slice(b"\n\0");
+    }
+    payload
+}
+
+#[test]
+fn deserialise_v1_1_1_state_file_records_through_parse_several() {
+    let payload = v1_1_1_state_file_payload();
+
+    let (rest, requests) = parse_several_requests::<WorkerRequest>(&payload)
+        .expect("1.1.1-shaped payload must parse against current schema");
+
+    assert!(
+        rest.is_empty(),
+        "leftover bytes after parsing: {} bytes — would fire 'Error consuming load state message'",
+        rest.len(),
+    );
+    assert_eq!(requests.len(), 3, "expected 3 records parsed");
+    assert_eq!(requests[0].id, "PROXY-MANAGER-1");
+    assert_eq!(requests[1].id, "PROXY-MANAGER-2");
+    assert_eq!(requests[2].id, "PROXY-MANAGER-3");
+
+    // Defaults pinned for the post-1.1.1 repeated/map fields the older payload
+    // omits — these are the actual fields the bug surfaced on.
+    let cluster = match requests[0].content.request_type.as_ref() {
+        Some(RequestType::AddCluster(c)) => c,
+        other => panic!("expected ADD_CLUSTER, got {other:?}"),
+    };
+    assert_eq!(cluster.cluster_id, "app-1");
+    assert!(
+        cluster.answers.is_empty(),
+        "Cluster.answers must default to empty"
+    );
+    assert!(
+        cluster.authorized_hashes.is_empty(),
+        "Cluster.authorized_hashes must default to empty",
+    );
+
+    let frontend = match requests[1].content.request_type.as_ref() {
+        Some(RequestType::AddHttpFrontend(f)) => f,
+        other => panic!("expected ADD_HTTP_FRONTEND, got {other:?}"),
+    };
+    assert_eq!(frontend.hostname, "example.com");
+    assert!(
+        frontend.headers.is_empty(),
+        "RequestHttpFrontend.headers must default to empty",
+    );
+}
+
+#[test]
+fn load_state_buffer_loop_consumes_v1_1_1_payload() {
+    // Mirrors the buffer shape of `bin/src/command/requests.rs::load_state`:
+    // one chunk fed to `parse_several_requests`, no leftover bytes => no
+    // "Error consuming load state message" branch.
+    let payload = v1_1_1_state_file_payload();
+    let (rest, requests) =
+        parse_several_requests::<WorkerRequest>(&payload).expect("payload must parse");
+    assert!(
+        rest.is_empty(),
+        "EOF + non-empty leftover would fail load_state"
+    );
+    assert_eq!(requests.len(), 3);
+}
+
+#[test]
+fn missing_required_scalar_still_fails() {
+    // Strictness contract: a record without the required `cluster_id` scalar
+    // must still be rejected. Without this guard, a future move to a
+    // struct-level `#[serde(default)]` would silently default `cluster_id`
+    // to "", and `ConfigState::add_cluster` would insert a `""`-keyed
+    // cluster (no non-empty validation at the dispatch site).
+    let bad = br#"{"id":"BAD","content":{"request_type":{"ADD_CLUSTER":{"sticky_session":false,"https_redirect":false,"load_balancing":0}}}}"# as &[u8];
+    let mut payload = Vec::new();
+    payload.extend_from_slice(bad);
+    payload.extend_from_slice(b"\n\0");
+
+    let (rest, requests) = parse_several_requests::<WorkerRequest>(&payload)
+        .expect("nom returns Ok with leftover bytes when serde rejects a record");
+    assert!(
+        requests.is_empty(),
+        "no record may be parsed when a required scalar is missing",
+    );
+    assert!(
+        !rest.is_empty(),
+        "the unparsed bytes must remain — load_state would surface them as the error",
+    );
+}


### PR DESCRIPTION
## Summary

`LoadState` on `main` rejected JSON state files written by older clients
(e.g. `proxy-manager` linked against `sozu-command-lib = "1.1.1"`) with
`error consuming load state message`. Root cause: `command/build.rs`
attaches `serde::Deserialize` to every prost message but never attaches
`#[serde(default)]`, so post-1.1.1 `repeated` / `map` field additions
on messages older clients still emit (`Cluster.answers`,
`Cluster.authorized_hashes`, `RequestHttpFrontend.headers`, plus the
listener-level `answers` / `alpn_protocols`) became required-by-serde
and rejected the older payload.

`bin/src/command/requests.rs::load_state` uses
`command::parser::parse_several_requests::<WorkerRequest>`; that parser
wraps each record in `nom::combinator::complete`, so a `serde_json`
failure on a record stops `many0` and leaves the unparsed bytes as the
remainder. The read loop reaches EOF with no progress and emits
`"Error consuming load state message"`.

The fix is entirely on the **sozu (server) side** — `command/build.rs`
of this repo. Existing client binaries compiled against
`sozu-command-lib = "1.1.1"` are not rebuilt and not affected. They
keep emitting the same 1.1.1-shaped JSON; sozu now accepts it.

The fix is field-level rather than struct-level. Required scalars stay
strict on purpose: `ConfigState::add_cluster` keys the cluster map by
`cluster_id` without a non-empty check, so a struct-level blanket
would silently insert a bogus `""`-keyed entry. Field-level
`#[serde(default)]` on the seven post-1.1.1 `repeated` / `map` fields
preserves that defense-in-depth while fixing the older-client load
path.

The new contract is inlined at the top of `command/src/command.proto`
and in the relevant block of `command/build.rs`: every future
`repeated` / `map` field added to a state-file-emittable message must
carry the matching `field_attribute(... "#[serde(default)]")` line.

## Files

- `command/build.rs` — seven `field_attribute(... "#[serde(default)]")` lines plus a contract comment.
- `command/src/command.proto` — schema-evolution rule documented at the top.
- `command/tests/state_compat_v1_1_1.rs` — three regression tests, all pinned to **the JSON shape that an unmodified `sozu-command-lib = "1.1.1"` client emits** (no rebuild required to verify):
  1. 1.1.1-shaped fixture deserializes through `parse_several_requests`,
  2. same payload through the read-buffer loop shape used by `load_state`,
  3. a record missing the required `cluster_id` scalar still fails (pins strictness against future struct-level drift).
- `CHANGELOG.md` — `Fixed` entry under `[Unreleased]`.

## Test plan

- [x] `cargo build --workspace --locked` (default features, on the rust-toolchain-pinned 1.88.0)
- [x] `cargo clippy --workspace --all-targets --locked` (clean)
- [x] `cargo +nightly fmt --all -- --check` (clean)
- [x] `cargo test -p sozu-command-lib --locked` — 82 unit + 3 new regression + 2 doc tests pass; the regression tests deserialize the **exact 1.1.1 JSON shape** an unrebuilt `sozu-command-lib = "1.1.1"` client emits.
- [x] `cargo test -p sozu-lib --lib --locked` — 501 lib tests pass
- [x] `cargo test -p sozu --bin sozu --locked` — 22 bin tests pass
- [x] **End-to-end with the published `sozu-command-lib = "=1.1.1"` from crates.io** (no source changes to the client, no rebuild of `proxy-manager`): a small emitter binary linked against `sozu-command-lib = "=1.1.1"` produced a `\n\0`-separated state file with `AddCluster` + `AddHttpFrontend` + `AddBackend` records. Feeding that same file through the **patched** `sozu-command-lib` (this branch's `parse_several_requests`) parses all 3 records with 0 leftover bytes; feeding it through the **unpatched** `main` `sozu-command-lib` parses 0 records with all 702 bytes leftover — the exact pre-condition that fires `"Error consuming load state message"`. Fix is both necessary and sufficient.

No version bump on `sozu-command-lib`; this is a backward-compatible fix to the JSON deserializer side.