### PR TITLE
ci: trigger CI once per change instead of twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,21 @@
 ---
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+    tags: ['**']
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always
 
-# Cancel superseded push+PR runs on feature branches; preserve runs on
-# `main` so artefacts produced under one SHA aren't lost when a newer
-# push lands.
+# Cancel superseded PR runs only. `main` pushes and tag pushes are
+# preserved so artefacts produced under one SHA aren't lost when a
+# newer push lands (and release tags must complete).
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # ┌──────────────────────────────────────────────────────────────┐


### PR DESCRIPTION
## Summary

`on: [push, pull_request]` fires CI twice for every commit on a branch with an open PR (once for the `push` event, once for the `pull_request` event). This change makes CI run once per change.

- Restrict `push` to `main` + tags. Feature branches now run only via `pull_request`; `main` merges and release tags still validate.
- Switch `concurrency.cancel-in-progress` from `github.ref != 'refs/heads/main'` to `github.event_name == 'pull_request'`. The previous expression evaluated to `true` for `refs/tags/*` and would have cancelled superseded tag runs; the new expression preserves both `main` pushes and tag pushes and only cancels supersedable PR runs.

## Trade-offs

- Pushing a feature branch without a PR no longer triggers CI — open the PR to get a run.
- Fork PRs continue to work via the `pull_request` event (forks can't fire `push` against the upstream repo anyway).
- The `dockerhub` job's `:${SHA}` publish now fires once per PR-bearing commit and once per `main` merge, instead of twice per same-repo feature push.
- `release.yml` is unaffected (already scoped to `push.tags`).

## Test plan

- [ ] CI run triggered by this PR completes (single `pull_request` run, no duplicate `push` run)
- [ ] On merge to `main`, the `push` event fires CI once on the merge commit
- [ ] Future tag push triggers CI without being cancelled by a follow-up push