### PR TITLE
feat(cli): expose HSTS knobs on `sozu listener https update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -315,6 +315,24 @@ upgrade. See `doc/upgrade/1.x-to-2.0.md` for the full migration guide.
   HTTPS-served default answers carry HSTS (RFC 6797 §8.1) while plaintext HTTP
   listeners can never leak the header (defense in depth on top of config-load
   validation).
+- **`sozu listener https update` exposes the HSTS knobs**: the
+  `UpdateHttpsListenerConfig.hsts` partial-update path is now reachable from
+  the CLI without crafting a typed IPC message. `bin/src/cli.rs` adds
+  `--hsts-max-age`, `--hsts-include-subdomains`, `--hsts-preload`,
+  `--hsts-force-replace-backend`, and the kill-switch `--hsts-disabled` (with
+  `conflicts_with_all` against the four enabling flags) on
+  `HttpsListenerCmd::Update`; the request builder reuses the existing
+  `build_hsts_from_cli` helper so mutual-exclusion validation and the
+  `DEFAULT_HSTS_MAX_AGE = 31_536_000` substitution stay in lock-step with
+  `frontend https add`. Supplying any flag flips the listener's policy and
+  triggers the existing `Router::refresh_inheriting_hsts` reflow on every
+  frontend that did not declare a per-frontend `[hsts]` block at add time;
+  `--hsts-disabled` substitutes the `enabled = Some(false)` block. Coverage:
+  five new clap-parse tests under `bin/src/cli.rs::tests` cover the
+  enabling-flags happy path, the `--hsts-disabled`-alone path, the
+  no-flag-at-all sanity case (existing surface unchanged), and the two
+  conflict cases (`--hsts-disabled` with `--hsts-max-age` /
+  `--hsts-force-replace-backend`).
 - **Per-cluster availability surface
   ([#892](https://github.com/sozu-proxy/sozu/issues/892))**: closes the
   long-standing observability gap in which a cluster losing every backend

--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -1273,6 +1273,41 @@ pub enum HttpsListenerCmd {
         answer_504: Option<PathBuf>,
         #[clap(long, help = "path to file for the 507 answer body")]
         answer_507: Option<PathBuf>,
+
+        // ── HSTS (RFC 6797) listener-default knobs ──
+        // Same surface as `frontend https add`. The full `HstsConfig`
+        // patch follows the documented full-object replacement
+        // semantics on `UpdateHttpsListenerConfig.hsts`: when any of
+        // these flags is supplied the listener's HSTS policy is
+        // replaced wholesale, and `Router::refresh_inheriting_hsts`
+        // reflows the new policy onto every frontend that inherits
+        // from this listener (no per-frontend override).
+        #[clap(
+            long = "hsts-max-age",
+            help = "HSTS (RFC 6797) `max-age` directive in seconds. Setting any of the --hsts-* flags replaces the listener's HSTS policy and refreshes inheriting frontends. Defaults to 31536000 (1 year, HSTS preload list minimum) when --hsts-max-age is omitted but another --hsts-* flag is set. `0` is the RFC 6797 §11.4 kill switch."
+        )]
+        hsts_max_age: Option<u32>,
+        #[clap(
+            long = "hsts-include-subdomains",
+            help = "Append `; includeSubDomains` to the rendered HSTS header. Implies HSTS enabled."
+        )]
+        hsts_include_subdomains: bool,
+        #[clap(
+            long = "hsts-preload",
+            help = "Append `; preload` to the rendered HSTS header (Chrome HSTS preload list — see https://hstspreload.org/). Implies HSTS enabled. Opt-in only; once submitted, removal from the preload list is slow and partial (RFC 6797 §14.2)."
+        )]
+        hsts_preload: bool,
+        #[clap(
+            long = "hsts-disabled",
+            conflicts_with_all = ["hsts_max_age", "hsts_include_subdomains", "hsts_preload", "hsts_force_replace_backend"],
+            help = "Explicitly disable the listener-default HSTS, suppressing it for inheriting frontends. Mutually exclusive with --hsts-max-age / --hsts-include-subdomains / --hsts-preload / --hsts-force-replace-backend."
+        )]
+        hsts_disabled: bool,
+        #[clap(
+            long = "hsts-force-replace-backend",
+            help = "Override any backend-supplied `Strict-Transport-Security` header with sōzu's typed policy instead of preserving it (RFC 6797 §6.1 backend-wins is the default). Implies HSTS enabled."
+        )]
+        hsts_force_replace_backend: bool,
     },
 }
 
@@ -1516,5 +1551,165 @@ mod tests {
             ])),
             parse_tags(tags_to_parse)
         );
+    }
+
+    // ── HSTS flags on `sozu listener https update` ──
+    // Validates the clap surface exposed for the hot listener-default
+    // HSTS patch path (UpdateHttpsListenerConfig.hsts). The destructure
+    // has to stay in lock-step with `request_builder.rs::https_listener_command`
+    // — these tests catch a missed field rename or a forgotten dispatch
+    // arg the next time clap-derive grows another `Update` knob.
+
+    fn extract_https_update(args: super::Args) -> super::HttpsListenerCmd {
+        match args.cmd {
+            super::SubCmd::Listener {
+                cmd: super::ListenerCmd::Https { cmd },
+            } => cmd,
+            other => panic!("expected listener https subcommand, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn listener_https_update_parses_hsts_enabling_flags() {
+        use super::*;
+
+        let args = Args::try_parse_from([
+            "sozu",
+            "listener",
+            "https",
+            "update",
+            "-a",
+            "127.0.0.1:443",
+            "--hsts-max-age",
+            "31536000",
+            "--hsts-include-subdomains",
+            "--hsts-force-replace-backend",
+        ])
+        .expect("clap should accept --hsts-* on listener https update");
+
+        let HttpsListenerCmd::Update {
+            hsts_max_age,
+            hsts_include_subdomains,
+            hsts_preload,
+            hsts_disabled,
+            hsts_force_replace_backend,
+            ..
+        } = extract_https_update(args)
+        else {
+            panic!("expected HttpsListenerCmd::Update");
+        };
+        assert_eq!(hsts_max_age, Some(31_536_000));
+        assert!(hsts_include_subdomains);
+        assert!(!hsts_preload);
+        assert!(!hsts_disabled);
+        assert!(hsts_force_replace_backend);
+    }
+
+    #[test]
+    fn listener_https_update_parses_hsts_disabled_alone() {
+        use super::*;
+
+        let args = Args::try_parse_from([
+            "sozu",
+            "listener",
+            "https",
+            "update",
+            "-a",
+            "127.0.0.1:443",
+            "--hsts-disabled",
+        ])
+        .expect("clap should accept --hsts-disabled on listener https update");
+
+        let HttpsListenerCmd::Update {
+            hsts_disabled,
+            hsts_max_age,
+            hsts_include_subdomains,
+            hsts_preload,
+            hsts_force_replace_backend,
+            ..
+        } = extract_https_update(args)
+        else {
+            panic!("expected HttpsListenerCmd::Update");
+        };
+        assert!(hsts_disabled);
+        assert_eq!(hsts_max_age, None);
+        assert!(!hsts_include_subdomains);
+        assert!(!hsts_preload);
+        assert!(!hsts_force_replace_backend);
+    }
+
+    #[test]
+    fn listener_https_update_no_hsts_flags_inherits_listener_default() {
+        use super::*;
+
+        // Sanity: the new flags are all optional and the existing
+        // surface still parses with no `--hsts-*` argument at all.
+        let args = Args::try_parse_from([
+            "sozu",
+            "listener",
+            "https",
+            "update",
+            "-a",
+            "127.0.0.1:443",
+            "--front-timeout",
+            "120",
+        ])
+        .expect("clap should accept the existing listener-update surface unchanged");
+
+        let HttpsListenerCmd::Update {
+            hsts_max_age,
+            hsts_include_subdomains,
+            hsts_preload,
+            hsts_disabled,
+            hsts_force_replace_backend,
+            front_timeout,
+            ..
+        } = extract_https_update(args)
+        else {
+            panic!("expected HttpsListenerCmd::Update");
+        };
+        assert_eq!(hsts_max_age, None);
+        assert!(!hsts_include_subdomains);
+        assert!(!hsts_preload);
+        assert!(!hsts_disabled);
+        assert!(!hsts_force_replace_backend);
+        assert_eq!(front_timeout, Some(120));
+    }
+
+    #[test]
+    fn listener_https_update_hsts_disabled_conflicts_with_max_age() {
+        use super::*;
+
+        let err = Args::try_parse_from([
+            "sozu",
+            "listener",
+            "https",
+            "update",
+            "-a",
+            "127.0.0.1:443",
+            "--hsts-disabled",
+            "--hsts-max-age",
+            "31536000",
+        ])
+        .expect_err("clap should reject --hsts-disabled with --hsts-max-age");
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn listener_https_update_hsts_disabled_conflicts_with_force_replace_backend() {
+        use super::*;
+
+        let err = Args::try_parse_from([
+            "sozu",
+            "listener",
+            "https",
+            "update",
+            "-a",
+            "127.0.0.1:443",
+            "--hsts-disabled",
+            "--hsts-force-replace-backend",
+        ])
+        .expect_err("clap should reject --hsts-disabled with --hsts-force-replace-backend");
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 }

--- a/bin/src/ctl/request_builder.rs
+++ b/bin/src/ctl/request_builder.rs
@@ -518,6 +518,11 @@ impl CommandManager {
                 answer_503,
                 answer_504,
                 answer_507,
+                hsts_max_age,
+                hsts_include_subdomains,
+                hsts_preload,
+                hsts_disabled,
+                hsts_force_replace_backend,
             } => self.update_https_listener_command(
                 address,
                 public_address,
@@ -563,6 +568,11 @@ impl CommandManager {
                 answer_503,
                 answer_504,
                 answer_507,
+                hsts_max_age,
+                hsts_include_subdomains,
+                hsts_preload,
+                hsts_disabled,
+                hsts_force_replace_backend,
             ),
         }
     }
@@ -874,6 +884,11 @@ impl CommandManager {
         answer_503: Option<PathBuf>,
         answer_504: Option<PathBuf>,
         answer_507: Option<PathBuf>,
+        hsts_max_age: Option<u32>,
+        hsts_include_subdomains: bool,
+        hsts_preload: bool,
+        hsts_disabled: bool,
+        hsts_force_replace_backend: bool,
     ) -> Result<(), CtlError> {
         let expect_proxy = if expect_proxy_flag {
             Some(true)
@@ -913,6 +928,18 @@ impl CommandManager {
             answer_502, answer_503, answer_504, answer_507,
         )?;
 
+        // Reuses the same builder as `frontend https add` so the
+        // mutual-exclusion rules and the canonical
+        // `DEFAULT_HSTS_MAX_AGE` substitution stay in lock-step
+        // between the two CLI surfaces.
+        let hsts = build_hsts_from_cli(
+            hsts_max_age,
+            hsts_include_subdomains,
+            hsts_preload,
+            hsts_disabled,
+            hsts_force_replace_backend,
+        )?;
+
         let patch = UpdateHttpsListenerConfig {
             address: address.into(),
             public_address: public_address.map(|a| a.into()),
@@ -944,6 +971,7 @@ impl CommandManager {
             h2_graceful_shutdown_deadline_seconds,
             h2_max_window_update_stream0_per_window,
             sozu_id_header,
+            hsts,
             ..Default::default()
         };
         self.send_request(RequestType::UpdateHttpsListener(patch).into())

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -327,6 +327,8 @@ enabled = false
 
 ##### Runtime CLI surface
 
+Per-frontend override (replaces the listener default for one frontend):
+
 ```
 sozu frontend https add \
   --address 0.0.0.0:443 \
@@ -335,11 +337,20 @@ sozu frontend https add \
   --hsts-include-subdomains
 ```
 
-`--hsts-disabled` is mutually exclusive with `--hsts-max-age` / `--hsts-include-subdomains` / `--hsts-preload`; combining them surfaces `CtlError::ArgsNeeded` rather than a silent pick.
+Listener-default patch (replaces the policy for every frontend that inherits from the listener):
+
+```
+sozu listener https update \
+  -a 0.0.0.0:443 \
+  --hsts-max-age 31536000 \
+  --hsts-include-subdomains
+```
+
+Both surfaces share the same flag set: `--hsts-max-age`, `--hsts-include-subdomains`, `--hsts-preload`, `--hsts-force-replace-backend`, and the kill-switch `--hsts-disabled`. The latter is mutually exclusive with the four enabling flags on either path; combining them surfaces `CtlError::ArgsNeeded` from the shared `build_hsts_from_cli` helper rather than a silent pick.
 
 ##### Hot-reconfig partial-update
 
-`UpdateHttpsListenerConfig.hsts` follows full-object replacement semantics: when present in the patch, the entire HSTS block replaces the listener's current value. `enabled` is REQUIRED whenever `hsts` is present (`ListenerError::HstsEnabledRequired` rejects an `enabled = None` block). Absent `hsts` field on the patch preserves the current value.
+`UpdateHttpsListenerConfig.hsts` follows full-object replacement semantics: when present in the patch, the entire HSTS block replaces the listener's current value. `enabled` is REQUIRED whenever `hsts` is present (`ListenerError::HstsEnabledRequired` rejects an `enabled = None` block). Absent `hsts` field on the patch preserves the current value. The CLI surface above (`sozu listener https update --hsts-*`) feeds this same partial-update message; supplying any `--hsts-*` flag on the command line replaces the listener's HSTS policy and supplying `--hsts-disabled` substitutes the explicit-disable block (`enabled = Some(false)`).
 
 **Inheriting frontends are refreshed automatically.** Patching the listener-default HSTS reflows the new policy onto every existing frontend that inherited from the listener (i.e. has no per-frontend `[hsts]` block at add time). `Router::refresh_inheriting_hsts` walks the routing trie, identifies inheriting entries via the `Frontend.inherits_listener_hsts` marker, and rebuilds their `headers_response` against the new value — stripping any prior `Strict-Transport-Security` entry and appending a freshly rendered one. Per-frontend explicit overrides (`inherits_listener_hsts == false`) are left untouched. The `http.hsts.listener_default_patched` counter fires once per patch and `http.hsts.frontend_refreshed` increments per refreshed frontend, so dashboards can correlate the rate of patches with the size of the affected fleet.
 


### PR DESCRIPTION
## Summary

- Expose `--hsts-max-age` / `--hsts-include-subdomains` / `--hsts-preload` / `--hsts-force-replace-backend` / `--hsts-disabled` on `sozu listener https update`. The IPC path (`UpdateHttpsListenerConfig.hsts` + `Router::refresh_inheriting_hsts` reflow on every inheriting frontend) was already wired but only reachable by hand-crafting the typed message.
- Reuse `build_hsts_from_cli` so mutual-exclusion validation and the `DEFAULT_HSTS_MAX_AGE = 31_536_000` substitution stay in lock-step with the existing `frontend https add` surface; `--hsts-disabled` is `conflicts_with_all` against the four enabling flags.
- Documentation (`doc/configure.md` Hot-reconfig partial-update section) and `CHANGELOG.md` Unreleased entry updated alongside the code.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --locked` — no issues
- [x] `cargo build --all-features --locked`
- [x] `cargo test -p sozu --lib --bins` — 68 tests passed, including five new clap-parse tests covering: enabling-flags happy path, `--hsts-disabled` alone, no-flag-at-all sanity (existing surface unchanged), and the two `--hsts-disabled` ↔ enabling-flags conflict cases.
- [ ] Manual hot-reconfig smoke test on a running worker (out of scope for this PR; the runtime path is unchanged).

## Notes for reviewers

- Worker side is untouched: this PR is purely CLI plumbing on top of existing `UpdateHttpsListenerConfig.hsts` semantics. No proto change.
- Counters `http.hsts.listener_default_patched` and `http.hsts.frontend_refreshed` continue to fire from the same code paths.
- `frontend https add --hsts-*` and `listener https update --hsts-*` now share the same flag set and the same validation helper.