### PR TITLE
fix(metrics): drop hourly reset; cumulative local drain + lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,13 +196,21 @@ upgrade. See `doc/upgrade/1.x-to-2.0.md` for the full migration guide.
   (`MetricsConfiguration::Clear`) now wipes everything (counts, gauges,
   histograms, proxy-wide and per-cluster, AND the master-process
   `main_metrics`) — formerly it preserved gauges and never touched
-  `proxy_metrics` or `main_metrics`. On cluster removal, the cluster is
-  dropped immediately from both the local drain and the StatsD
-  `network_drain` (`cluster_metrics`, `backend_metrics`, queued
-  `MetricLine`s); any unsent statsd interval for the cluster is discarded
-  rather than emitted. Formerly the cluster lingered for up to 10 minutes
-  via the idle GC. The StatsD wire format is unchanged (per-second deltas
-  as before). `Time` histograms are widened from `Histogram<u32>` to
+  `proxy_metrics` or `main_metrics`. The master-side wipe runs on the
+  scatter-completion path AFTER the operator audit row is emitted, so the
+  audit `count!(metrics_configured, 1)` increment driven by the clear
+  operation does not immediately repopulate the freshly-cleared
+  `main_metrics`. On cluster removal, the cluster is dropped immediately
+  from both the local drain and the StatsD `network_drain`
+  (`cluster_metrics`, `backend_metrics`, queued `MetricLine`s); any unsent
+  statsd interval for the cluster is discarded rather than emitted.
+  Formerly the cluster lingered for up to 10 minutes via the idle GC. A
+  per-drain `removed_clusters` tombstone now drops late session emissions
+  for the removed cluster id so long-lived H2 / WebSocket / TCP sessions
+  cannot resurrect the cluster row via `entry().or_default()` —
+  `AddCluster` for the same id and `sozu metrics clear` both clear the
+  tombstone. The StatsD wire format is unchanged (per-second deltas as
+  before). `Time` histograms are widened from `Histogram<u32>` to
   `Histogram<u64>` so per-bucket counters do not saturate under sustained
   high-RPS traffic; memory cost is roughly 2× per histogram, bounded.
 - **Removed the `proto_version` capability handshake**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,26 @@ upgrade. See `doc/upgrade/1.x-to-2.0.md` for the full migration guide.
   Dashboards scraping the old per-status name need updating; the new key is
   documented in `doc/configure.md` alongside the new `http.302.redirection` and
   `http.308.redirection` counters.
+- **Per-cluster local-drain metrics are now cumulative since worker start**
+  (`lib/src/metrics/local_drain.rs`, `lib/src/server.rs`). The previous
+  behaviour reset `Count` and `Time` entries in `cluster_metrics` at every UTC
+  hour boundary; that wall-clock timer is gone. `proxy_metrics` was already
+  cumulative, so this aligns the two map shapes. Operator dashboards that
+  consumed `sozu metrics` snapshots and assumed an hourly window must wrap
+  the counter in `rate()` / `irate()` (or take a successive-snapshot diff
+  client-side). The CLI verb `sozu metrics clear`
+  (`MetricsConfiguration::Clear`) now wipes everything (counts, gauges,
+  histograms, proxy-wide and per-cluster, AND the master-process
+  `main_metrics`) — formerly it preserved gauges and never touched
+  `proxy_metrics` or `main_metrics`. On cluster removal, the cluster is
+  dropped immediately from both the local drain and the StatsD
+  `network_drain` (`cluster_metrics`, `backend_metrics`, queued
+  `MetricLine`s); any unsent statsd interval for the cluster is discarded
+  rather than emitted. Formerly the cluster lingered for up to 10 minutes
+  via the idle GC. The StatsD wire format is unchanged (per-second deltas
+  as before). `Time` histograms are widened from `Histogram<u32>` to
+  `Histogram<u64>` so per-bucket counters do not saturate under sustained
+  high-RPS traffic; memory cost is roughly 2× per histogram, bounded.
 - **Removed the `proto_version` capability handshake**.
   `WorkerInfo.proto_version` (proto tag 4) and
   `MetricDetailStatus.unsupported_workers` (proto tag 5) are now
@@ -731,6 +751,23 @@ upgrade. See `doc/upgrade/1.x-to-2.0.md` for the full migration guide.
   dashboards configured for the unlabelled metric keep working at `Process`
   detail. Closes [#892](https://github.com/sozu-proxy/sozu/issues/892)
   (alongside the new cluster-availability surface listed under `### 🌟 Added`).
+- **No more hourly drop-to-zero on per-cluster counters and percentiles**
+  (`lib/src/server.rs`, `lib/src/metrics/local_drain.rs`). The wall-clock
+  block at the run-loop tail (`if now.minute() == 0 && now.second() == 0`)
+  that called `LocalDrain::clear` every hour produced apparent spikes and
+  inconsistent values in `sozu metrics` snapshots taken near the top of the
+  hour. Removed. The memory bound is now provided by explicit
+  cluster-removal lifecycle hooks (`Aggregator::remove_cluster`,
+  `Aggregator::remove_backend`) wired into the worker IPC dispatch for
+  `RequestType::RemoveCluster` and `RequestType::RemoveBackend`. Master-side
+  `main_metrics` is also wiped by `MetricsConfiguration::Clear` (formerly
+  scattered to workers but never applied locally, so `sozu metrics` would
+  still report the master's stale view).
+- **`MetricValue::update` no longer panics on gauge underflow in debug
+  builds** (`lib/src/metrics/mod.rs`). The `debug_assert!` is gone;
+  saturating clamp to 0 + `error!` log is now the single, symmetric
+  behaviour across both `MetricValue::update` and
+  `AggregatedMetric::update`, in debug and release.
 
 ### 🌟 Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3232,7 +3232,6 @@ dependencies = [
  "sozu-command-lib",
  "subtle",
  "thiserror 2.0.18",
- "time",
  "tiny_http",
 ]
 

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -1930,7 +1930,24 @@ pub fn worker_request(
     // returned by `dump_local_proxy_metrics` would survive the operator
     // clear and `sozu metrics` would still report stale values).
     let metrics_configuration = if let RequestType::ConfigureMetrics(value) = &request_content {
-        Some(MetricsConfiguration::try_from(*value).unwrap_or(MetricsConfiguration::Disabled))
+        // `try_from` rejects any i32 outside the proto-known set. An
+        // unknown variant lands here only if the master has been deployed
+        // ahead of a worker schema bump (or a malformed IPC payload slips
+        // past the dispatch whitelist). Log loudly and fall back to
+        // `Disabled` — silently treating "unknown" as "disabled" would
+        // mask future enum drift, e.g. a `Clear` value the master no
+        // longer recognises would silently skip the master-side wipe.
+        match MetricsConfiguration::try_from(*value) {
+            Ok(cfg) => Some(cfg),
+            Err(err) => {
+                error!(
+                    "ConfigureMetrics IPC carries unknown enum value {} ({:?}), \
+                     falling back to MetricsConfiguration::Disabled",
+                    value, err
+                );
+                Some(MetricsConfiguration::Disabled)
+            }
+        }
     } else {
         None
     };

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -1820,6 +1820,15 @@ struct WorkerTask {
     /// them through `target`. `None` for any verb that is not
     /// `SetMetricDetail`.
     metric_detail_audit: Option<MetricDetailAuditFields>,
+    /// `MetricsConfiguration::Clear` deferred-clear flag. When `true`, the
+    /// completion handler wipes the master-side `METRICS` aggregator AFTER
+    /// the audit row has been emitted. Done post-audit so the
+    /// `count!(metrics_configured, 1)` increment driven by the audit row
+    /// itself is not what the operator sees in `sozu metrics` immediately
+    /// after `sozu metrics clear` — otherwise the master would be wiped,
+    /// the audit would repopulate one counter, and the "wipes everything"
+    /// contract would silently drift by exactly one row per clear.
+    clear_master_metrics_on_finish: bool,
 }
 
 /// Carry the per-verb metadata needed to emit a completion-time audit
@@ -2077,16 +2086,14 @@ pub fn worker_request(
         );
     }
 
-    // Master-side clear: the main process keeps its own `main_metrics`
-    // aggregator (read by `dump_local_proxy_metrics` at this file's
-    // metrics-query handler) that is NOT reached by the worker scatter.
-    // Apply the clear locally before fanning out so master and workers
-    // are wiped consistently.
-    if metrics_configuration == Some(MetricsConfiguration::Clear) {
-        METRICS.with(|metrics| {
-            (*metrics.borrow_mut()).clear_local();
-        });
-    }
+    // Master-side clear: deferred to `WorkerTask::on_finish` AFTER the
+    // audit emission so the `count!(metrics_configured, 1)` driven by the
+    // completion-time audit row does not immediately repopulate the
+    // freshly-cleared `main_metrics`. Without this deferral, the documented
+    // "wipes everything" contract drifts by exactly one row per clear and
+    // `sozu metrics` snapshot taken right after `sozu metrics clear` would
+    // report `config.metrics_configured = 1`.
+    let clear_master_metrics_on_finish = metrics_configuration == Some(MetricsConfiguration::Clear);
 
     client.return_processing("Processing worker request...");
 
@@ -2099,6 +2106,7 @@ pub fn worker_request(
             audit: audit_for_task,
             inline_audit,
             metric_detail_audit: metric_detail_audit_completion,
+            clear_master_metrics_on_finish,
         }),
         Timeout::Default,
         None,
@@ -2216,6 +2224,17 @@ impl GatheringTask for WorkerTask {
                 result,
                 extras,
             );
+        }
+
+        // Deferred master-side `MetricsConfiguration::Clear`. Runs AFTER
+        // the audit emission above so the `count!(metrics_configured, 1)`
+        // increment driven by that audit row is wiped here. Operators
+        // running `sozu metrics clear; sozu metrics` see an empty master
+        // dump, matching the PR contract.
+        if self.clear_master_metrics_on_finish {
+            METRICS.with(|metrics| {
+                (*metrics.borrow_mut()).clear_local();
+            });
         }
 
         if errors > 0 || timed_out {

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -1914,15 +1914,20 @@ pub fn worker_request(
     let started_at = Instant::now();
 
     // Special-case ConfigureMetrics — the proto payload is an i32 enum (no
-    // dedicated message), so we synthesise the audit entry inline.
-    let metrics_target = if let RequestType::ConfigureMetrics(value) = &request_content {
-        Some(format!(
-            "metrics:{:?}",
-            MetricsConfiguration::try_from(*value).unwrap_or(MetricsConfiguration::Disabled)
-        ))
+    // dedicated message), so we synthesise the audit entry inline. The
+    // resolved enum value is reused below to clear the main-process METRICS
+    // aggregator on `MetricsConfiguration::Clear` (workers see the clear
+    // through the scatter; without this the master's own `main_metrics`
+    // returned by `dump_local_proxy_metrics` would survive the operator
+    // clear and `sozu metrics` would still report stale values).
+    let metrics_configuration = if let RequestType::ConfigureMetrics(value) = &request_content {
+        Some(MetricsConfiguration::try_from(*value).unwrap_or(MetricsConfiguration::Disabled))
     } else {
         None
     };
+    let metrics_target = metrics_configuration
+        .as_ref()
+        .map(|cfg| format!("metrics:{cfg:?}"));
 
     // Special-case SetMetricDetail — the same shape as ConfigureMetrics above
     // (no dedicated audit factory in `audit_entry_for`), so we synthesise the
@@ -2070,6 +2075,17 @@ pub fn worker_request(
             AuditResult::Ok,
             extras,
         );
+    }
+
+    // Master-side clear: the main process keeps its own `main_metrics`
+    // aggregator (read by `dump_local_proxy_metrics` at this file's
+    // metrics-query handler) that is NOT reached by the worker scatter.
+    // Apply the clear locally before fanning out so master and workers
+    // are wiped consistently.
+    if metrics_configuration == Some(MetricsConfiguration::Clear) {
+        METRICS.with(|metrics| {
+            (*metrics.borrow_mut()).clear_local();
+        });
     }
 
     client.return_processing("Processing worker request...");

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -1458,11 +1458,11 @@ Metrics are collected via thread-local storage macros (`count!`, `gauge!`,
 
 Metric types:
 
-| Type    | Macro                      | StatsD suffix | Description                                                        |
-| ------- | -------------------------- | ------------- | ------------------------------------------------------------------ |
-| Counter | `count!`, `incr!`, `decr!` | `\|c`         | Monotonically increasing value, reset to 0 after each network send |
-| Gauge   | `gauge!`, `gauge_add!`     | `\|g`         | Snapshot value (absolute or delta)                                 |
-| Time    | `time!`                    | `\|ms`        | Latency in milliseconds, stored as HDR histogram locally           |
+| Type    | Macro                      | StatsD suffix | Description                                                                                                                                         |
+| ------- | -------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Counter | `count!`, `incr!`, `decr!` | `\|c`         | Monotonically increasing. Network drain: zeroed after each successful UDP send (per-interval delta). Local drain: cumulative since worker start.    |
+| Gauge   | `gauge!`, `gauge_add!`     | `\|g`         | Snapshot value (absolute or delta). Last-value-wins; never automatically reset.                                                                     |
+| Time    | `time!`                    | `\|ms`        | Latency in milliseconds. Local drain stores an HDR histogram (`Histogram<u64>`, sigfig=3); samples accumulate since worker start.                   |
 
 Metrics have three scopes:
 
@@ -1489,6 +1489,28 @@ address = "127.0.0.1:8125"
 Metrics are sent at most once per second per key (if updated). Cluster/backend
 metrics that have not been updated for 10 minutes are automatically dropped from
 the network drain.
+
+#### Metrics scopes (local CLI vs network drain)
+
+- The **network drain** (StatsD UDP) sends per-second deltas; counters are
+  zeroed after each successful send. On `RemoveCluster` / `RemoveBackend`,
+  the drain immediately drops the cluster's `cluster_metrics`,
+  `backend_metrics`, and queued `MetricLine` entries — any unsent statsd
+  interval for the cluster is discarded (no final flush). Without an
+  explicit `RemoveCluster`, the existing 10-minute idle GC still applies.
+- The **local drain** (queryable via `sozu metrics`) is **cumulative since
+  worker start** for both `proxy_metrics` and per-cluster /
+  per-backend `cluster_metrics`. There is no implicit hourly reset.
+  Operators reset it explicitly with `sozu metrics clear`, which wipes
+  everything (counts, gauges, histograms, proxy-wide and per-cluster, AND
+  the master-process `main_metrics` aggregator).
+- Per-cluster local-drain entries are dropped on `RemoveCluster` /
+  `RemoveBackend` so the keyspace is bounded by the live configuration.
+- Implication for dashboards: counters in `sozu metrics` output are
+  monotonic. Charts must compute `rate()` / `irate()` rather than treat
+  successive snapshots as windowed counts. Histograms accumulate every
+  sample since worker start, so percentiles in the CLI snapshot are
+  lifetime values, not windowed.
 
 #### Cardinality knob (`metrics.detail`)
 

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -1529,6 +1529,16 @@ Each level is a SUPERSET of the previous one:
 | `cluster`  | Keeps `cluster_id`, drops `backend_id`. **Default** — preserves the historical pre-knob behaviour.                                                                                                                                 | The current shape of every existing dashboard.                                                             |
 | `backend`  | Keeps both labels. Highest cardinality.                                                                                                                                                                                            | Per-backend SLOs / hotspot debugging when the cluster has few backends.                                    |
 
+Memory note for `Time` histograms: per-bucket counters are `Histogram<u64>`
+(widened from `Histogram<u32>` to avoid saturation at sustained
+high-RPS — `u32` saturates a single popular bucket in ≈72 minutes at
+1 M samples/s in a 64-bit count). Memory footprint per Time histogram is
+bounded by `hdrhistogram`'s sigfig=3 shape, roughly 16–32 KB per
+histogram, doubled vs. the prior `u32` shape. With `cluster`-level
+cardinality this multiplies by the number of live clusters × Time-key
+distinct names; with `backend`-level, also by per-cluster backend count.
+Plan capacity accordingly.
+
 Filtering happens centrally in `Aggregator::receive_metric`
 (`lib/src/metrics/mod.rs`) via the pure helper `filter_labels_for_detail`,
 unit-tested exhaustively across all four levels. Workers receive the level over

--- a/doc/observability.md
+++ b/doc/observability.md
@@ -71,10 +71,12 @@ teardown after this exact bug went unnoticed for a while.
 ### Gauge underflow
 
 Past production incidents (`a650ad69`, `d2f01ed4`) all came from
-`gauge_add!(-1)` running without a paired `+1` having run earlier.
-`MetricValue::update` panics in debug builds (and clamps to zero in release)
-on underflow, but the metric is wrong either way. Two patterns prevent this
-class of bug:
+`gauge_add!(-1)` running without a paired `+1` having run earlier. Both
+`MetricValue::update` and `AggregatedMetric::update` saturate the value to
+0 and emit a single `error!` log line on underflow, in both debug and
+release builds; neither panics. The metric is still wrong on the next
+snapshot, but the process keeps running and the log line names the
+offending key. Two patterns prevent this class of bug:
 
 1. **Co-locate increments and decrements with the state being tracked.** If
    the gauge measures "active backend connections", emit the `+1` at the same
@@ -100,6 +102,51 @@ StatsD (UDP) is forgiving but Prometheus / influxdb is not. Two rules:
    `process | frontend | cluster | backend`. Mirrors HAProxy's
    `extra-counters` opt-in. New label dimensions should respect this knob;
    the wiring layer is a follow-up MR.
+
+### Local drain reset cadence
+
+The local drain (`LocalDrain` in `lib/src/metrics/local_drain.rs`) keeps two
+maps: `proxy_metrics` (proxy-wide) and `cluster_metrics` (per-cluster +
+per-backend). **Both are cumulative since worker start.** There is no
+automatic timer that resets them — the wall-clock `if now.minute() == 0
+&& now.second() == 0` block that used to clear `cluster_metrics` every UTC
+hour was removed because it produced apparent spikes / drops to zero in
+operator dashboards, and because gauges had to be preserved across the
+clear anyway (long-lived H2 sessions could close after the clear and
+underflow the gauge counter). Operators who want to reset issue
+`sozu metrics clear` (proto: `MetricsConfiguration::Clear`), which wipes
+both maps in one shot AND wipes the master process's own `main_metrics`.
+Per-cluster entries are also dropped on `RemoveCluster` /
+`RemoveBackend` IPC so retired clusters do not leak metric keys; on the
+StatsD `network_drain` the same two events drop the cluster's
+`cluster_metrics`, `backend_metrics`, and queued `MetricLine`s, so the
+wire side goes silent immediately (any unsent statsd interval for the
+cluster is discarded — bounded by `metrics_send_interval`, typically
+≤1 second).
+
+Late session emissions can briefly recreate ghost rows in
+`cluster_metrics` after a `RemoveCluster` — `LocalDrain::receive_cluster_metric`
+calls `entry().or_default()`, so a teardown that fires after the IPC
+inserts a stub cluster row. The single-threaded mio worker makes this
+trivially benign (no real race); the row sits idle until the next
+`RemoveCluster`, the next `AddCluster` for the same id, or the next
+operator clear.
+
+Implication for dashboards: counters in `sozu metrics` output are
+monotonic; charts should compute `rate()` / `irate()` rather than
+treating successive snapshots as windowed counts. Histograms accumulate
+every sample since worker start, so `Percentiles.p_99` is the lifetime
+p99, not a windowed one. Per-bucket counters are `u64` so saturation is
+not a concern under realistic uptime / RPS combinations.
+
+Operator clear caveat: issuing `sozu metrics clear` during live traffic
+resets in-flight gauge accuracy. Sessions that opened before the clear
+and decrement gauges on close (e.g. `connections_per_backend`) land on
+the saturating-to-zero path and emit one `error!` log line per
+occurrence, naming the offending key. This is intentional; the gauge
+recovers as new sessions arrive. Operators who want to reset counts but
+keep live gauges intact should not use `sozu metrics clear` — wait for
+the cumulative counters to roll over in their dashboard math instead.
 
 ## Log primitives
 

--- a/doc/observability.md
+++ b/doc/observability.md
@@ -121,16 +121,22 @@ Per-cluster entries are also dropped on `RemoveCluster` /
 StatsD `network_drain` the same two events drop the cluster's
 `cluster_metrics`, `backend_metrics`, and queued `MetricLine`s, so the
 wire side goes silent immediately (any unsent statsd interval for the
-cluster is discarded — bounded by `metrics_send_interval`, typically
-≤1 second).
+cluster is discarded — bounded by the one-second network-drain cadence
+hard-coded in `NetworkDrain::send_metrics`).
 
-Late session emissions can briefly recreate ghost rows in
-`cluster_metrics` after a `RemoveCluster` — `LocalDrain::receive_cluster_metric`
-calls `entry().or_default()`, so a teardown that fires after the IPC
-inserts a stub cluster row. The single-threaded mio worker makes this
-trivially benign (no real race); the row sits idle until the next
-`RemoveCluster`, the next `AddCluster` for the same id, or the next
-operator clear.
+`RemoveCluster` also arms a per-drain tombstone (`removed_clusters:
+HashSet<String>`) so subsequent emissions for the same cluster id are
+dropped on the floor rather than resurrecting the row via
+`entry().or_default()`. This matters in production: the per-proxy
+`remove_cluster` paths in `lib/src/http.rs` / `https.rs` / `tcp.rs`
+drop cluster config but do NOT close in-flight sessions, so long-lived
+H2 / WebSocket / TCP sessions continue emitting access-log /
+response-time / gauge metrics for the removed cluster. Without the
+tombstone those emissions would keep growing the cluster row until the
+last session closed; with it, the wire and the local drain stay quiet.
+The tombstone is cleared on `AddCluster` for the same id (a cluster can
+come back after a remove) and on `sozu metrics clear` (operator-initiated
+full reset).
 
 Implication for dashboards: counters in `sozu metrics` output are
 monotonic; charts should compute `rate()` / `irate()` rather than

--- a/e2e/src/tests/metrics_lifecycle_tests.rs
+++ b/e2e/src/tests/metrics_lifecycle_tests.rs
@@ -167,8 +167,13 @@ fn try_remove_cluster_drops_metric_row() -> State {
     let cluster_id = "lifecycle_cluster_remove";
     let backend_id = "lifecycle_back_remove";
 
-    let mut worker =
-        setup_worker_with_cluster("METRICS-LIFECYCLE-REMOVE", cluster_id, backend_id, front_address, back_address);
+    let mut worker = setup_worker_with_cluster(
+        "METRICS-LIFECYCLE-REMOVE",
+        cluster_id,
+        backend_id,
+        front_address,
+        back_address,
+    );
 
     prime_with_one_request(front_address, back_address);
 
@@ -219,8 +224,13 @@ fn try_remove_then_add_cluster_re_arms_metrics() -> State {
     let cluster_id = "lifecycle_cluster_readd";
     let backend_id = "lifecycle_back_readd";
 
-    let mut worker =
-        setup_worker_with_cluster("METRICS-LIFECYCLE-READD", cluster_id, backend_id, front_address, back_address);
+    let mut worker = setup_worker_with_cluster(
+        "METRICS-LIFECYCLE-READD",
+        cluster_id,
+        backend_id,
+        front_address,
+        back_address,
+    );
 
     prime_with_one_request(front_address, back_address);
 

--- a/e2e/src/tests/metrics_lifecycle_tests.rs
+++ b/e2e/src/tests/metrics_lifecycle_tests.rs
@@ -1,0 +1,327 @@
+//! End-to-end coverage for the metrics lifecycle IPC bridge added in
+//! PR #1252 (`RemoveCluster` / `RemoveBackend` →
+//! `Aggregator::remove_cluster` / `remove_backend`) and the follow-up
+//! tombstone (`AddCluster` → `Aggregator::add_cluster`).
+//!
+//! Unit tests in `lib/src/metrics/local_drain.rs` and
+//! `network_drain.rs` cover the data-structure methods directly. These
+//! e2e tests exercise the IPC wiring: master scatters `RemoveCluster`,
+//! worker dispatches into `Server::notify_proxys`, the metrics removal
+//! fires from there, and a subsequent `QueryMetrics` returns NoMetrics
+//! for the removed cluster. The integration point that previously
+//! silently regressed (10-min idle GC lingering after a `RemoveCluster`)
+//! lives here.
+
+use std::{net::SocketAddr, thread, time::Duration};
+
+use sozu_command_lib::{
+    config::FileConfig,
+    proto::command::{
+        ActivateListener, ListenerType, QueryMetricsOptions, RemoveBackend, Request,
+        RequestHttpFrontend, ResponseStatus, ServerConfig, request::RequestType,
+        response_content::ContentType,
+    },
+    scm_socket::Listeners,
+    state::ConfigState,
+};
+
+use crate::{
+    mock::sync_backend::Backend as SyncBackend,
+    port_registry::attach_reserved_http_listener,
+    sozu::worker::Worker,
+    tests::{State, repeat_until_error_or},
+};
+
+use super::tests::create_local_address;
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/// Default config — nothing exotic, just enough to spin up an HTTP
+/// listener and a routed cluster.
+fn default_config() -> ServerConfig {
+    Worker::into_config(FileConfig::default())
+}
+
+/// Boot a worker, attach an HTTP listener at `front_address`, register a
+/// single cluster + frontend + backend, and return the worker handle.
+fn setup_worker_with_cluster(
+    name: &str,
+    cluster_id: &str,
+    backend_id: &str,
+    front_address: SocketAddr,
+    back_address: SocketAddr,
+) -> Worker {
+    let config = default_config();
+    let mut listeners = Listeners::default();
+    attach_reserved_http_listener(&mut listeners, front_address);
+    let state = ConfigState::new();
+
+    let mut worker = Worker::start_new_worker_owned(name, config, listeners, state);
+
+    worker.send_proxy_request(Request {
+        request_type: Some(RequestType::AddHttpListener(
+            sozu_command_lib::config::ListenerBuilder::new_http(front_address.into())
+                .to_http(None)
+                .unwrap(),
+        )),
+    });
+    worker.send_proxy_request(Request {
+        request_type: Some(RequestType::ActivateListener(ActivateListener {
+            address: front_address.into(),
+            proxy: ListenerType::Http.into(),
+            from_scm: false,
+        })),
+    });
+    worker.send_proxy_request(RequestType::AddCluster(Worker::default_cluster(cluster_id)).into());
+    worker.send_proxy_request(
+        RequestType::AddHttpFrontend(RequestHttpFrontend {
+            ..Worker::default_http_frontend(cluster_id, front_address)
+        })
+        .into(),
+    );
+    worker.send_proxy_request(
+        RequestType::AddBackend(Worker::default_backend(
+            cluster_id,
+            backend_id,
+            back_address,
+            None,
+        ))
+        .into(),
+    );
+    worker.read_to_last();
+    worker
+}
+
+/// Drive one HTTP/1.1 request through the worker so the metrics layer
+/// records cluster-scoped samples (access log, response time, backend
+/// counters). Without this primer the cluster row never materialises.
+fn prime_with_one_request(front_address: SocketAddr, back_address: SocketAddr) {
+    let mut backend = SyncBackend::new(
+        "metrics_lifecycle_backend",
+        back_address,
+        "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\npong",
+    );
+    backend.connect();
+
+    let mut client = crate::mock::client::Client::new(
+        "metrics_lifecycle_client",
+        front_address,
+        "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n".to_owned(),
+    );
+    client.connect();
+    client.send();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    while std::time::Instant::now() < deadline {
+        if backend.accept(0) {
+            backend.receive(0);
+            backend.send(0);
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    let _ = client.receive();
+}
+
+/// Query the worker for the per-cluster metrics row of `cluster_id`.
+/// Returns `true` when a row exists, `false` when the cluster is absent
+/// or the response carries no per-cluster content. Empty metric_names
+/// asks the drain to return whatever it has; the presence/absence of
+/// `cluster_id` in the response is the actual signal.
+fn cluster_row_present(worker: &mut Worker, cluster_id: &str) -> bool {
+    worker.send_proxy_request_type(RequestType::QueryMetrics(QueryMetricsOptions {
+        list: false,
+        cluster_ids: vec![cluster_id.to_owned()],
+        backend_ids: vec![],
+        metric_names: vec![],
+        no_clusters: false,
+        workers: false,
+    }));
+    let response = match worker.read_proxy_response() {
+        Some(r) => r,
+        None => return false,
+    };
+    if response.status != ResponseStatus::Ok as i32 {
+        return false;
+    }
+    let Some(content) = response.content.and_then(|c| c.content_type) else {
+        return false;
+    };
+    let ContentType::WorkerMetrics(metrics) = content else {
+        return false;
+    };
+    metrics
+        .clusters
+        .get(cluster_id)
+        .map(|m| !m.cluster.is_empty() || !m.backends.is_empty())
+        .unwrap_or(false)
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Test 1: RemoveCluster IPC drops the cluster row from the worker drain
+// ══════════════════════════════════════════════════════════════════════
+
+fn try_remove_cluster_drops_metric_row() -> State {
+    let front_address = create_local_address();
+    let back_address = create_local_address();
+    let cluster_id = "lifecycle_cluster_remove";
+    let backend_id = "lifecycle_back_remove";
+
+    let mut worker =
+        setup_worker_with_cluster("METRICS-LIFECYCLE-REMOVE", cluster_id, backend_id, front_address, back_address);
+
+    prime_with_one_request(front_address, back_address);
+
+    // Sanity: cluster row exists after one request.
+    if !cluster_row_present(&mut worker, cluster_id) {
+        worker.soft_stop();
+        worker.wait_for_server_stop();
+        return State::Undecided;
+    }
+
+    // Send RemoveCluster; the metrics removal happens inside the IPC
+    // dispatch in `Server::notify_proxys`.
+    worker.send_proxy_request_type(RequestType::RemoveCluster(cluster_id.to_owned()));
+    worker.read_to_last();
+
+    let absent = !cluster_row_present(&mut worker, cluster_id);
+
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    if absent { State::Success } else { State::Fail }
+}
+
+#[test]
+fn test_remove_cluster_drops_metric_row() {
+    assert_eq!(
+        repeat_until_error_or(
+            3,
+            "RemoveCluster IPC drops the cluster row from the worker LocalDrain",
+            try_remove_cluster_drops_metric_row,
+        ),
+        State::Success,
+    );
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Test 2: RemoveCluster + AddCluster re-arms; fresh emissions visible
+// ══════════════════════════════════════════════════════════════════════
+//
+// Without the `Aggregator::add_cluster` hook wired into the AddCluster
+// arm, the per-drain `removed_clusters` tombstone added in this PR
+// follow-up would silently keep dropping every emission for the
+// resurrected cluster id forever.
+
+fn try_remove_then_add_cluster_re_arms_metrics() -> State {
+    let front_address = create_local_address();
+    let back_address = create_local_address();
+    let cluster_id = "lifecycle_cluster_readd";
+    let backend_id = "lifecycle_back_readd";
+
+    let mut worker =
+        setup_worker_with_cluster("METRICS-LIFECYCLE-READD", cluster_id, backend_id, front_address, back_address);
+
+    prime_with_one_request(front_address, back_address);
+
+    // Remove, then re-add the same cluster id + frontend + backend.
+    worker.send_proxy_request_type(RequestType::RemoveCluster(cluster_id.to_owned()));
+    worker.send_proxy_request_type(RequestType::AddCluster(Worker::default_cluster(cluster_id)));
+    worker.send_proxy_request_type(RequestType::AddHttpFrontend(RequestHttpFrontend {
+        ..Worker::default_http_frontend(cluster_id, front_address)
+    }));
+    worker.send_proxy_request_type(RequestType::AddBackend(Worker::default_backend(
+        cluster_id,
+        backend_id,
+        back_address,
+        None,
+    )));
+    worker.read_to_last();
+
+    // Drive a fresh request — without the AddCluster re-arm of the
+    // tombstone, this emission would be dropped on the floor.
+    prime_with_one_request(front_address, back_address);
+
+    let present = cluster_row_present(&mut worker, cluster_id);
+
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    if present { State::Success } else { State::Fail }
+}
+
+#[test]
+fn test_remove_then_add_cluster_re_arms_metrics() {
+    assert_eq!(
+        repeat_until_error_or(
+            3,
+            "AddCluster after RemoveCluster re-arms the metrics drain (tombstone clear)",
+            try_remove_then_add_cluster_re_arms_metrics,
+        ),
+        State::Success,
+    );
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Test 3: RemoveBackend drops the backend row but keeps the cluster row
+// ══════════════════════════════════════════════════════════════════════
+
+fn try_remove_backend_keeps_cluster_row_when_others_remain() -> State {
+    let front_address = create_local_address();
+    let back_address_a = create_local_address();
+    let back_address_b = create_local_address();
+    let cluster_id = "lifecycle_cluster_two_backends";
+    let backend_a = "lifecycle_back_a";
+    let backend_b = "lifecycle_back_b";
+
+    let mut worker = setup_worker_with_cluster(
+        "METRICS-LIFECYCLE-BACKEND",
+        cluster_id,
+        backend_a,
+        front_address,
+        back_address_a,
+    );
+    // Second backend on the same cluster.
+    worker.send_proxy_request_type(RequestType::AddBackend(Worker::default_backend(
+        cluster_id,
+        backend_b,
+        back_address_b,
+        None,
+    )));
+    worker.read_to_last();
+
+    prime_with_one_request(front_address, back_address_a);
+    // Run a second request to give backend_b a chance at the load-balancer.
+    // Either of the two backends may have served, so we just need one of
+    // them to have recorded samples.
+    prime_with_one_request(front_address, back_address_b);
+
+    // Remove backend A only.
+    worker.send_proxy_request_type(RequestType::RemoveBackend(RemoveBackend {
+        cluster_id: cluster_id.to_owned(),
+        backend_id: backend_a.to_owned(),
+        address: back_address_a.into(),
+    }));
+    worker.read_to_last();
+
+    let present = cluster_row_present(&mut worker, cluster_id);
+
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    // Cluster row must remain because the cluster still exists (only
+    // one backend was removed).
+    if present { State::Success } else { State::Fail }
+}
+
+#[test]
+fn test_remove_backend_keeps_cluster_row_when_others_remain() {
+    assert_eq!(
+        repeat_until_error_or(
+            3,
+            "RemoveBackend drops per-backend row but keeps cluster row when others remain",
+            try_remove_backend_keeps_cluster_row_when_others_remain,
+        ),
+        State::Success,
+    );
+}

--- a/e2e/src/tests/mod.rs
+++ b/e2e/src/tests/mod.rs
@@ -39,6 +39,7 @@ mod h2_tests;
 pub(crate) mod h2_utils;
 mod hsts_tests;
 mod listener_update_tests;
+mod metrics_lifecycle_tests;
 mod mux_tests;
 mod protocol_pair_matrix;
 mod redirect_rewrite_auth_tests;

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1375,7 +1375,6 @@ dependencies = [
  "sozu-command-lib",
  "subtle",
  "thiserror 2.0.18",
- "time",
 ]
 
 [[package]]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -53,7 +53,6 @@ slab = { workspace = true }
 socket2 = { workspace = true, features = ["all"] }
 subtle = { workspace = true }
 thiserror = { workspace = true }
-time = { workspace = true }
 
 sozu-command-lib = { workspace = true }
 

--- a/lib/src/backends.rs
+++ b/lib/src/backends.rs
@@ -452,20 +452,31 @@ impl BackendMap {
     }
 
     // TODO: return <Result, BackendError>, log the error downstream
-    pub fn remove_backend(&mut self, cluster_id: &str, backend_address: &SocketAddr) {
-        if let Some(backends) = self.backends.get_mut(cluster_id) {
-            backends.remove_backend(backend_address);
+    /// Remove every backend at `backend_address` from `cluster_id` and
+    /// return the list of `backend_id`s that were dropped. Callers (e.g.
+    /// `Server::remove_backend`) iterate over the returned ids to tear
+    /// down per-backend metrics so the identity used by the runtime
+    /// (address-keyed) matches the identity used by the metrics layer
+    /// (id-keyed) — see PR #1252 follow-up review MEDIUM-3.
+    pub fn remove_backend(
+        &mut self,
+        cluster_id: &str,
+        backend_address: &SocketAddr,
+    ) -> Vec<String> {
+        let removed = if let Some(backends) = self.backends.get_mut(cluster_id) {
+            backends.remove_backend(backend_address)
         } else {
             error!(
                 "Backend was already removed: cluster id {}, address {:?}",
                 cluster_id, backend_address
             );
-            return;
-        }
+            return Vec::new();
+        };
         // Re-evaluate so removing the last backend logs an explicit
         // `AllDown` transition (or, with `total == 0`, drops back to
         // silent gauges).
         self.record_cluster_availability(cluster_id);
+        removed
     }
 
     // TODO: return <Result, BackendError>, log the error downstream
@@ -692,9 +703,25 @@ impl BackendList {
         }
     }
 
-    pub fn remove_backend(&mut self, backend_address: &SocketAddr) {
-        self.backends
-            .retain(|backend| &backend.borrow().address != backend_address);
+    /// Remove every backend at `backend_address` and return the list of
+    /// `backend_id`s that were dropped. Two backends with the same address
+    /// but distinct ids (A/B test, weighted variant, dedup race) are both
+    /// removed here; the caller relies on the returned ids to tear down
+    /// matching per-backend state (metrics, health-check). Returning the
+    /// ids closes the identity drift between runtime-removal-by-address
+    /// and metrics-removal-by-id.
+    pub fn remove_backend(&mut self, backend_address: &SocketAddr) -> Vec<String> {
+        let mut removed = Vec::new();
+        self.backends.retain(|backend| {
+            let b = backend.borrow();
+            if &b.address == backend_address {
+                removed.push(b.backend_id.clone());
+                false
+            } else {
+                true
+            }
+        });
+        removed
     }
 
     pub fn has_backend(&self, backend_address: &SocketAddr) -> bool {

--- a/lib/src/metrics/local_drain.rs
+++ b/lib/src/metrics/local_drain.rs
@@ -42,7 +42,12 @@ use crate::metrics::{MetricError, MetricValue, Subscriber};
 pub enum AggregatedMetric {
     Gauge(usize),
     Count(i64),
-    Time(Histogram<u32>),
+    /// `Histogram<u64>` so per-bucket counters do not saturate on long-running
+    /// workers. Counts are cumulative since worker start; at sustained
+    /// ≥1 M samples/s in a single popular bucket, `u32` would saturate in
+    /// roughly 72 minutes — unacceptable for a continuous proxy. Memory cost
+    /// is bounded (sigfig=3) and roughly 2× the previous shape per histogram.
+    Time(Histogram<u64>),
 }
 
 impl AggregatedMetric {
@@ -132,7 +137,7 @@ impl AggregatedMetric {
     }
 }
 
-pub fn histogram_to_percentiles(hist: &Histogram<u32>) -> Percentiles {
+pub fn histogram_to_percentiles(hist: &Histogram<u64>) -> Percentiles {
     let sum = hist.len() as f64 * hist.mean();
     Percentiles {
         samples: hist.len(),
@@ -148,10 +153,10 @@ pub fn histogram_to_percentiles(hist: &Histogram<u32>) -> Percentiles {
 }
 
 /// convert a collected histogram to a prometheus-compatible format
-pub fn filter_histogram(hist: &Histogram<u32>) -> FilteredMetrics {
+pub fn filter_histogram(hist: &Histogram<u64>) -> FilteredMetrics {
     let sum: u64 = hist
         .iter_recorded()
-        .map(|item| item.value_iterated_to() * item.count_at_value() as u64)
+        .map(|item| item.value_iterated_to() * item.count_at_value())
         .sum();
 
     let mut count = 0;
@@ -231,14 +236,6 @@ impl MetricsMap {
     fn metric_names(&self) -> impl Iterator<Item = &str> {
         self.map.keys().map(|name| name.as_str())
     }
-
-    /// Remove all Count and Time entries, keeping Gauge entries intact.
-    /// Gauges track live resource state and must survive the hourly clear;
-    /// counters and histograms are cumulative and can be safely reset.
-    fn retain_gauges(&mut self) {
-        self.map
-            .retain(|_, v| matches!(v, AggregatedMetric::Gauge(_)));
-    }
 }
 
 /// local equivalent to proto::command::ClusterMetrics
@@ -313,17 +310,6 @@ impl LocalClusterMetrics {
         }
         false
     }
-
-    /// Clear cumulative metrics (Count, Time) while preserving Gauge entries
-    /// that track live resource state (e.g. connections_per_backend).
-    fn clear_non_gauges(&mut self) {
-        self.cluster.retain_gauges();
-        for backend in &mut self.backends {
-            backend.metrics.retain_gauges();
-        }
-        // Drop backends that have no remaining metrics after the purge
-        self.backends.retain(|b| !b.metrics.map.is_empty());
-    }
 }
 
 /// local equivalent to proto::command::BackendMetrics
@@ -384,18 +370,59 @@ impl LocalDrain {
         }
     }
 
+    /// Operator-issued reset (`sozu metrics clear`,
+    /// [`MetricsConfiguration::Clear`]). Wipes everything: counts, gauges,
+    /// and histograms, proxy-wide and per-cluster. Operators ask for this
+    /// explicitly via the CLI; gauge preservation across an explicit clear
+    /// is surprising. The wall-clock hourly clear (formerly in
+    /// `lib/src/server.rs`) has been removed; the local drain is now
+    /// cumulative since worker start, with explicit cluster-removal
+    /// lifecycle hooks ([`Self::remove_cluster`], [`Self::remove_backend`])
+    /// providing the memory bound the hourly clear used to provide.
+    ///
+    /// Caveat: issuing `clear()` during live traffic resets in-flight gauge
+    /// accuracy. Sessions opened before the clear that decrement gauges on
+    /// close (e.g. `connections_per_backend`) land on the saturating-to-zero
+    /// path in [`AggregatedMetric::update`] and emit one `error!` log line
+    /// per occurrence, naming the offending key. The counter recovers as
+    /// new sessions arrive.
     pub fn clear(&mut self) {
-        // Preserve Gauge entries that track live resource state (e.g.
-        // connections_per_backend, backend.connections). Only clear
-        // cumulative metrics (Count, Time) which can safely reset.
-        // Wiping gauges causes underflows when long-lived connections
-        // (especially H2) close after the hourly clear.
-        for cluster in self.cluster_metrics.values_mut() {
-            cluster.clear_non_gauges();
+        self.proxy_metrics = MetricsMap::new();
+        self.cluster_metrics.clear();
+    }
+
+    /// Drop all metrics for a cluster from the local drain. Called from the
+    /// worker IPC dispatch on [`RequestType::RemoveCluster`]. Ignores
+    /// `disable_cluster_metrics`: this method only deletes, never emits, so
+    /// it is safe to call regardless of the runtime metrics configuration.
+    ///
+    /// Race note: late access-log / session metrics can fire from
+    /// `lib/src/lib.rs` and `lib/src/protocol/mux/stream.rs` after the IPC
+    /// removal. `LocalDrain::receive_cluster_metric` will reinsert a cluster
+    /// row via `entry().or_default()` for any such late emission. The ghost
+    /// row sits idle until the next `RemoveCluster`, the next `AddCluster`
+    /// for the same id, or the next operator clear. Single-threaded worker
+    /// makes this trivially correct (no actual race) — a "removed clusters"
+    /// denylist would be over-engineered for the resulting cosmetic noise.
+    pub fn remove_cluster(&mut self, cluster_id: &str) {
+        self.cluster_metrics.remove(cluster_id);
+    }
+
+    /// Drop all metrics for one backend within a cluster. Called from the
+    /// IPC dispatch on [`RequestType::RemoveBackend`]. Leaves the cluster
+    /// entry in place if cluster-level metrics or other backends remain;
+    /// otherwise drops the empty cluster row to avoid phantom keyspace.
+    /// Ignores `disable_cluster_metrics`: deletes only, never emits.
+    pub fn remove_backend(&mut self, cluster_id: &str, backend_id: &str) {
+        let drop_cluster = if let Some(cluster) = self.cluster_metrics.get_mut(cluster_id) {
+            cluster.backends.retain(|b| b.backend_id != backend_id);
+            cluster.cluster.map.is_empty() && cluster.backends.is_empty()
+        } else {
+            false
+        };
+        if drop_cluster {
+            self.cluster_metrics.remove(cluster_id);
         }
-        // Drop clusters that have no remaining metrics after the purge
-        self.cluster_metrics
-            .retain(|_, c| !c.cluster.map.is_empty() || !c.backends.is_empty());
     }
 
     pub fn query(&mut self, options: &QueryMetricsOptions) -> Result<ResponseContent, MetricError> {
@@ -863,12 +890,59 @@ mod tests {
     }
 
     #[test]
-    fn clear_preserves_gauges_and_removes_counters() {
-        // The hourly clear should preserve Gauge entries (live resource state)
-        // while removing Count and Time entries (cumulative data).
+    fn clear_wipes_everything() {
+        // Operator-issued clear (`MetricsConfiguration::Clear`) must wipe
+        // every map: proxy_metrics, per-cluster gauges, counts, histograms,
+        // and per-backend metrics. The wall-clock hourly clear is gone;
+        // this is now the only bulk reset and is operator-explicit.
         let mut local_drain = LocalDrain::new("prefix".to_string());
 
-        // Add a gauge (connections_per_backend) for a backend.
+        local_drain.receive_metric("proxy_count", None, None, MetricValue::Count(7));
+        local_drain.receive_metric("proxy_gauge", None, None, MetricValue::Gauge(11));
+        local_drain.receive_metric(
+            "connections_per_backend",
+            Some("test-cluster"),
+            Some("test-backend-1"),
+            MetricValue::GaugeAdd(3),
+        );
+        local_drain.receive_metric(
+            "backend.connections.error",
+            Some("test-cluster"),
+            Some("test-backend-1"),
+            MetricValue::Count(5),
+        );
+        local_drain.receive_metric(
+            "backend.response.time",
+            Some("test-cluster"),
+            Some("test-backend-1"),
+            MetricValue::Time(42),
+        );
+
+        local_drain.clear();
+
+        // Proxy-wide map: empty.
+        let proxy = local_drain.dump_proxy_metrics(&Vec::new());
+        assert!(proxy.is_empty(), "proxy_metrics must be empty after clear");
+
+        // Per-cluster lookup: NoMetrics for both cluster-id and backend-id.
+        let cluster_lookup = local_drain.metrics_of_one_cluster("test-cluster", &[]);
+        assert!(
+            cluster_lookup.is_err(),
+            "cluster row must be gone after clear"
+        );
+        let backend_lookup = local_drain.metrics_of_one_backend("test-backend-1", &[]);
+        assert!(
+            backend_lookup.is_err(),
+            "backend row must be gone after clear"
+        );
+    }
+
+    #[test]
+    fn clear_then_gauge_increment_starts_from_zero() {
+        // After a full clear, a fresh Gauge increment must start from 0,
+        // not stack onto the pre-clear value.
+        let mut local_drain = LocalDrain::new("prefix".to_string());
+
         local_drain.receive_metric(
             names::backend::CONNECTIONS_PER_BACKEND,
             Some("test-cluster"),
@@ -876,70 +950,13 @@ mod tests {
             MetricValue::GaugeAdd(3),
         );
 
-        // Add a counter (backend.connections.error) for the same backend.
-        local_drain.receive_metric(
-            "backend.connections.error",
-            Some("test-cluster"),
-            Some("test-backend-1"),
-            MetricValue::Count(5),
-        );
-
-        // Clear — should preserve the gauge, remove the counter.
         local_drain.clear();
 
-        let result = local_drain
-            .metrics_of_one_backend(
-                "test-backend-1",
-                [
-                    names::backend::CONNECTIONS_PER_BACKEND.to_string(),
-                    "backend.connections.error".to_string(),
-                ]
-                .as_ref(),
-            )
-            .expect("could not query metrics for this backend");
-
-        // Gauge should still be 3.
-        let gauge_value = match result
-            .metrics
-            .get(names::backend::CONNECTIONS_PER_BACKEND)
-            .and_then(|m| m.inner.as_ref())
-        {
-            Some(Inner::Gauge(v)) => *v,
-            other => panic!("expected Gauge, got {other:?}"),
-        };
-        assert_eq!(gauge_value, 3, "gauge must survive clear()");
-
-        // Counter should be gone (not present in the filtered output).
-        assert!(
-            !result.metrics.contains_key("backend.connections.error"),
-            "counter must be removed by clear()"
-        );
-    }
-
-    #[test]
-    fn clear_then_gauge_decrement_works() {
-        // Simulate the hourly-clear scenario: H2 connection opened before
-        // the clear, closed after. The gauge should survive the clear and
-        // then decrement correctly to 0.
-        let mut local_drain = LocalDrain::new("prefix".to_string());
-
-        // Connection opens: gauge goes to 1.
         local_drain.receive_metric(
             names::backend::CONNECTIONS_PER_BACKEND,
             Some("test-cluster"),
             Some("test-backend-1"),
-            MetricValue::GaugeAdd(1),
-        );
-
-        // Hourly clear fires.
-        local_drain.clear();
-
-        // Connection closes: gauge goes from 1 to 0 (not 0 to -1).
-        local_drain.receive_metric(
-            names::backend::CONNECTIONS_PER_BACKEND,
-            Some("test-cluster"),
-            Some("test-backend-1"),
-            MetricValue::GaugeAdd(-1),
+            MetricValue::GaugeAdd(2),
         );
 
         let result = local_drain
@@ -947,7 +964,7 @@ mod tests {
                 "test-backend-1",
                 [names::backend::CONNECTIONS_PER_BACKEND.to_string()].as_ref(),
             )
-            .expect("could not query metrics for this backend");
+            .expect("backend row must exist after fresh emission");
 
         let gauge_value = match result
             .metrics
@@ -959,8 +976,8 @@ mod tests {
         };
 
         assert_eq!(
-            gauge_value, 0,
-            "gauge should be 0 after surviving clear + decrement"
+            gauge_value, 2,
+            "post-clear GaugeAdd(2) must start from 0, not stack onto pre-clear 3"
         );
     }
 
@@ -1024,5 +1041,359 @@ mod tests {
                 inner: Some(Inner::Count(1)),
             })
         );
+    }
+
+    #[test]
+    fn remove_cluster_drops_all_cluster_metrics() {
+        // RemoveCluster IPC must wipe every per-cluster + per-backend entry
+        // for the cluster, including gauges. Mirrors the worker dispatch arm
+        // wired into `Server::notify_proxys` in `lib/src/server.rs`.
+        let mut local_drain = LocalDrain::new("prefix".to_string());
+
+        local_drain.receive_metric(
+            "connections_per_backend",
+            Some("cluster-a"),
+            Some("backend-a"),
+            MetricValue::GaugeAdd(2),
+        );
+        local_drain.receive_metric(
+            "backend.connections.error",
+            Some("cluster-a"),
+            Some("backend-a"),
+            MetricValue::Count(3),
+        );
+        local_drain.receive_metric(
+            "backend.response.time",
+            Some("cluster-a"),
+            Some("backend-a"),
+            MetricValue::Time(11),
+        );
+
+        local_drain.remove_cluster("cluster-a");
+
+        assert!(
+            local_drain
+                .metrics_of_one_cluster("cluster-a", &[])
+                .is_err(),
+            "cluster row must be gone after remove_cluster"
+        );
+        assert!(
+            local_drain
+                .metrics_of_one_backend("backend-a", &[])
+                .is_err(),
+            "backend row must be gone after remove_cluster"
+        );
+    }
+
+    #[test]
+    fn remove_cluster_does_not_touch_other_clusters() {
+        let mut local_drain = LocalDrain::new("prefix".to_string());
+
+        local_drain.receive_metric(
+            "backend.connections.error",
+            Some("cluster-a"),
+            Some("backend-a"),
+            MetricValue::Count(1),
+        );
+        local_drain.receive_metric(
+            "backend.connections.error",
+            Some("cluster-b"),
+            Some("backend-b"),
+            MetricValue::Count(7),
+        );
+
+        local_drain.remove_cluster("cluster-a");
+
+        assert!(
+            local_drain
+                .metrics_of_one_cluster("cluster-a", &[])
+                .is_err(),
+            "cluster-a must be gone"
+        );
+        let surviving = local_drain
+            .metrics_of_one_backend(
+                "backend-b",
+                ["backend.connections.error".to_string()].as_ref(),
+            )
+            .expect("backend-b must still be reachable");
+        match surviving
+            .metrics
+            .get("backend.connections.error")
+            .and_then(|m| m.inner.as_ref())
+        {
+            Some(Inner::Count(v)) => assert_eq!(*v, 7, "cluster-b counter intact"),
+            other => panic!("expected Count for cluster-b, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn remove_backend_drops_one_backend_keeps_cluster_row() {
+        // Removing one backend must leave the cluster row alive when other
+        // backends or cluster-level metrics remain.
+        let mut local_drain = LocalDrain::new("prefix".to_string());
+
+        // Cluster-level metric (no backend_id).
+        local_drain.receive_metric(
+            "cluster.connections.error",
+            Some("cluster-a"),
+            None,
+            MetricValue::Count(2),
+        );
+        // Two backends under cluster-a.
+        local_drain.receive_metric(
+            "backend.connections.error",
+            Some("cluster-a"),
+            Some("backend-1"),
+            MetricValue::Count(5),
+        );
+        local_drain.receive_metric(
+            "backend.connections.error",
+            Some("cluster-a"),
+            Some("backend-2"),
+            MetricValue::Count(9),
+        );
+
+        local_drain.remove_backend("cluster-a", "backend-1");
+
+        assert!(
+            local_drain
+                .metrics_of_one_backend("backend-1", &[])
+                .is_err(),
+            "backend-1 must be gone"
+        );
+        let backend_2 = local_drain
+            .metrics_of_one_backend(
+                "backend-2",
+                ["backend.connections.error".to_string()].as_ref(),
+            )
+            .expect("backend-2 must still be reachable");
+        match backend_2
+            .metrics
+            .get("backend.connections.error")
+            .and_then(|m| m.inner.as_ref())
+        {
+            Some(Inner::Count(v)) => assert_eq!(*v, 9, "backend-2 counter intact"),
+            other => panic!("expected Count for backend-2, got {other:?}"),
+        }
+        // Cluster row still reachable through its cluster-level metric.
+        let cluster = local_drain
+            .metrics_of_one_cluster(
+                "cluster-a",
+                ["cluster.connections.error".to_string()].as_ref(),
+            )
+            .expect("cluster-a row must survive when cluster-level metrics remain");
+        match cluster
+            .cluster
+            .get("cluster.connections.error")
+            .and_then(|m| m.inner.as_ref())
+        {
+            Some(Inner::Count(v)) => assert_eq!(*v, 2, "cluster-level counter intact"),
+            other => panic!("expected Count for cluster-level, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn remove_backend_drops_empty_cluster_row() {
+        // Removing the only backend with no cluster-level metrics must drop
+        // the cluster row to avoid phantom keyspace.
+        let mut local_drain = LocalDrain::new("prefix".to_string());
+
+        local_drain.receive_metric(
+            "backend.connections.error",
+            Some("cluster-a"),
+            Some("backend-1"),
+            MetricValue::Count(5),
+        );
+
+        local_drain.remove_backend("cluster-a", "backend-1");
+
+        assert!(
+            local_drain
+                .metrics_of_one_cluster("cluster-a", &[])
+                .is_err(),
+            "empty cluster row must be dropped"
+        );
+    }
+
+    #[test]
+    fn remove_backend_unknown_cluster_is_noop() {
+        let mut local_drain = LocalDrain::new("prefix".to_string());
+
+        local_drain.receive_metric(
+            "backend.connections.error",
+            Some("cluster-a"),
+            Some("backend-1"),
+            MetricValue::Count(5),
+        );
+
+        // Should not panic, should not mutate.
+        local_drain.remove_backend("nonexistent", "backend-x");
+
+        let backend = local_drain
+            .metrics_of_one_backend(
+                "backend-1",
+                ["backend.connections.error".to_string()].as_ref(),
+            )
+            .expect("backend-1 must still be reachable");
+        match backend
+            .metrics
+            .get("backend.connections.error")
+            .and_then(|m| m.inner.as_ref())
+        {
+            Some(Inner::Count(v)) => assert_eq!(*v, 5),
+            other => panic!("expected Count, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn count_is_cumulative_across_many_emissions() {
+        // Counters in `cluster_metrics` must be cumulative since worker
+        // start (no hourly clear). Verifies the contract that replaces the
+        // wall-clock reset.
+        let mut local_drain = LocalDrain::new("prefix".to_string());
+
+        for _ in 0..100 {
+            local_drain.receive_metric(
+                "backend.connections.error",
+                Some("cluster-a"),
+                Some("backend-1"),
+                MetricValue::Count(1),
+            );
+        }
+        let backend = local_drain
+            .metrics_of_one_backend(
+                "backend-1",
+                ["backend.connections.error".to_string()].as_ref(),
+            )
+            .expect("backend-1 must be reachable");
+        match backend
+            .metrics
+            .get("backend.connections.error")
+            .and_then(|m| m.inner.as_ref())
+        {
+            Some(Inner::Count(v)) => assert_eq!(*v, 100),
+            other => panic!("expected Count(100), got {other:?}"),
+        }
+
+        for _ in 0..100 {
+            local_drain.receive_metric(
+                "backend.connections.error",
+                Some("cluster-a"),
+                Some("backend-1"),
+                MetricValue::Count(1),
+            );
+        }
+        let backend = local_drain
+            .metrics_of_one_backend(
+                "backend-1",
+                ["backend.connections.error".to_string()].as_ref(),
+            )
+            .expect("backend-1 must be reachable");
+        match backend
+            .metrics
+            .get("backend.connections.error")
+            .and_then(|m| m.inner.as_ref())
+        {
+            Some(Inner::Count(v)) => assert_eq!(*v, 200, "counter must remain cumulative"),
+            other => panic!("expected Count(200), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn time_histogram_is_cumulative_across_many_emissions() {
+        // HDR histogram samples accumulate since worker start. With
+        // Histogram<u64>, per-bucket counters do not saturate at realistic
+        // sample volumes.
+        let mut local_drain = LocalDrain::new("prefix".to_string());
+
+        for ms in 0..100 {
+            local_drain.receive_metric(
+                "backend.response.time",
+                Some("cluster-a"),
+                Some("backend-1"),
+                MetricValue::Time(ms),
+            );
+        }
+        let backend = local_drain
+            .metrics_of_one_backend("backend-1", ["backend.response.time".to_string()].as_ref())
+            .expect("backend-1 must be reachable");
+        let pct = match backend
+            .metrics
+            .get("backend.response.time")
+            .and_then(|m| m.inner.as_ref())
+        {
+            Some(Inner::Percentiles(p)) => *p,
+            other => panic!("expected Percentiles, got {other:?}"),
+        };
+        assert_eq!(pct.samples, 100, "first batch: 100 samples");
+        let p99_first = pct.p_99;
+
+        for ms in 0..100 {
+            local_drain.receive_metric(
+                "backend.response.time",
+                Some("cluster-a"),
+                Some("backend-1"),
+                MetricValue::Time(ms),
+            );
+        }
+        let backend = local_drain
+            .metrics_of_one_backend("backend-1", ["backend.response.time".to_string()].as_ref())
+            .expect("backend-1 must be reachable");
+        let pct = match backend
+            .metrics
+            .get("backend.response.time")
+            .and_then(|m| m.inner.as_ref())
+        {
+            Some(Inner::Percentiles(p)) => *p,
+            other => panic!("expected Percentiles, got {other:?}"),
+        };
+        assert_eq!(
+            pct.samples, 200,
+            "second batch: histogram still cumulative, total 200 samples"
+        );
+        // Same value distribution, so p99 should be stable around the same value.
+        assert!(
+            pct.p_99 >= p99_first.saturating_sub(1) && pct.p_99 <= p99_first.saturating_add(1),
+            "p99 stable across cumulative batches (first={p99_first}, second={})",
+            pct.p_99
+        );
+    }
+
+    #[test]
+    fn gauge_add_underflow_no_panic_in_debug() {
+        // After `clear()` (or first emission), a negative GaugeAdd must
+        // saturate to 0 and emit an `error!` log line — never panic, in
+        // either debug or release builds. This guards the symmetry between
+        // `MetricValue::update` and `AggregatedMetric::update` after the
+        // `debug_assert!` was removed from the former.
+        let mut local_drain = LocalDrain::new("prefix".to_string());
+
+        local_drain.receive_metric(
+            "connections_per_backend",
+            Some("cluster-a"),
+            Some("backend-1"),
+            MetricValue::Gauge(0),
+        );
+        local_drain.receive_metric(
+            "connections_per_backend",
+            Some("cluster-a"),
+            Some("backend-1"),
+            MetricValue::GaugeAdd(-5),
+        );
+
+        let backend = local_drain
+            .metrics_of_one_backend(
+                "backend-1",
+                ["connections_per_backend".to_string()].as_ref(),
+            )
+            .expect("backend-1 must be reachable");
+        match backend
+            .metrics
+            .get("connections_per_backend")
+            .and_then(|m| m.inner.as_ref())
+        {
+            Some(Inner::Gauge(v)) => assert_eq!(*v, 0, "underflow must saturate to 0"),
+            other => panic!("expected Gauge, got {other:?}"),
+        }
     }
 }

--- a/lib/src/metrics/local_drain.rs
+++ b/lib/src/metrics/local_drain.rs
@@ -344,6 +344,14 @@ pub struct LocalDrain {
     pub proxy_metrics: MetricsMap,
     /// cluster_id -> cluster_metrics
     cluster_metrics: BTreeMap<String, LocalClusterMetrics>,
+    /// Cluster ids that received a `RemoveCluster` IPC and have not yet
+    /// been re-introduced by `AddCluster`. Late session emissions for
+    /// these ids are dropped on the floor by [`Self::receive_cluster_metric`]
+    /// / [`Self::receive_backend_metric`] so a long-lived H2 / WebSocket /
+    /// TCP session against a removed cluster cannot resurrect (and keep
+    /// growing) the cluster's metric row via `entry().or_default()`.
+    /// Cleared on [`Self::clear`] and on [`Self::add_cluster`].
+    removed_clusters: HashSet<String>,
     use_tagged_metrics: bool,
     origin: String,
     disable_cluster_metrics: bool,
@@ -356,6 +364,7 @@ impl LocalDrain {
             created: Instant::now(),
             proxy_metrics: MetricsMap::new(),
             cluster_metrics: BTreeMap::new(),
+            removed_clusters: HashSet::new(),
             use_tagged_metrics: false,
             origin: String::from("x"),
             disable_cluster_metrics: false,
@@ -371,14 +380,14 @@ impl LocalDrain {
     }
 
     /// Operator-issued reset (`sozu metrics clear`,
-    /// [`MetricsConfiguration::Clear`]). Wipes everything: counts, gauges,
-    /// and histograms, proxy-wide and per-cluster. Operators ask for this
-    /// explicitly via the CLI; gauge preservation across an explicit clear
-    /// is surprising. The wall-clock hourly clear (formerly in
-    /// `lib/src/server.rs`) has been removed; the local drain is now
-    /// cumulative since worker start, with explicit cluster-removal
-    /// lifecycle hooks ([`Self::remove_cluster`], [`Self::remove_backend`])
-    /// providing the memory bound the hourly clear used to provide.
+    /// [`MetricsConfiguration::Clear`]). Wipes every map: counts, gauges,
+    /// and histograms, proxy-wide and per-cluster, AND clears the
+    /// removed-cluster tombstone so previously-removed cluster ids can
+    /// receive metrics again without going through `AddCluster`. Operators
+    /// ask for this explicitly via the CLI; the prior gauge-preserving
+    /// shape was a workaround for the now-deleted hourly clear (long-lived
+    /// H2 sessions decrementing gauges past a fresh-zero baseline) and is
+    /// no longer needed.
     ///
     /// Caveat: issuing `clear()` during live traffic resets in-flight gauge
     /// accuracy. Sessions opened before the clear that decrement gauges on
@@ -389,23 +398,41 @@ impl LocalDrain {
     pub fn clear(&mut self) {
         self.proxy_metrics = MetricsMap::new();
         self.cluster_metrics.clear();
+        self.removed_clusters.clear();
     }
 
-    /// Drop all metrics for a cluster from the local drain. Called from the
-    /// worker IPC dispatch on [`RequestType::RemoveCluster`]. Ignores
-    /// `disable_cluster_metrics`: this method only deletes, never emits, so
-    /// it is safe to call regardless of the runtime metrics configuration.
+    /// Drop all metrics for a cluster from the local drain and mark the
+    /// cluster id as a tombstone so subsequent emissions are dropped on
+    /// the floor rather than resurrecting a row via `entry().or_default()`.
+    /// Called from the worker IPC dispatch on
+    /// [`RequestType::RemoveCluster`]. Ignores `disable_cluster_metrics`:
+    /// this method only deletes, never emits, so it is safe to call
+    /// regardless of the runtime metrics configuration.
     ///
-    /// Race note: late access-log / session metrics can fire from
-    /// `lib/src/lib.rs` and `lib/src/protocol/mux/stream.rs` after the IPC
-    /// removal. `LocalDrain::receive_cluster_metric` will reinsert a cluster
-    /// row via `entry().or_default()` for any such late emission. The ghost
-    /// row sits idle until the next `RemoveCluster`, the next `AddCluster`
-    /// for the same id, or the next operator clear. Single-threaded worker
-    /// makes this trivially correct (no actual race) — a "removed clusters"
-    /// denylist would be over-engineered for the resulting cosmetic noise.
+    /// Lifetime of the tombstone: cleared on [`Self::add_cluster`] (the
+    /// same cluster id comes back) and on [`Self::clear`] (operator-
+    /// initiated full reset). Otherwise it lives forever — fine, since the
+    /// tombstone is a small `String` per actually-removed cluster, the
+    /// cardinality of which is bounded by operator activity.
+    ///
+    /// Why this matters: `HttpProxy::remove_cluster` and the equivalent on
+    /// the HTTPS / TCP proxies remove cluster *config* but do NOT close
+    /// in-flight sessions. Long-lived H2 streams, WebSocket upgrades, and
+    /// TCP frontends with persistent backends continue to emit
+    /// access-log / response-time / gauge-decrement metrics for the
+    /// removed cluster, which without the tombstone would re-create the
+    /// cluster row and keep growing it until the last session closes.
     pub fn remove_cluster(&mut self, cluster_id: &str) {
         self.cluster_metrics.remove(cluster_id);
+        self.removed_clusters.insert(cluster_id.to_owned());
+    }
+
+    /// Re-arm a previously-removed cluster id so its metrics flow again.
+    /// Called from the worker IPC dispatch on
+    /// [`RequestType::AddCluster`]. Idempotent on ids that were never
+    /// removed.
+    pub fn add_cluster(&mut self, cluster_id: &str) {
+        self.removed_clusters.remove(cluster_id);
     }
 
     /// Drop all metrics for one backend within a cluster. Called from the
@@ -413,6 +440,10 @@ impl LocalDrain {
     /// entry in place if cluster-level metrics or other backends remain;
     /// otherwise drops the empty cluster row to avoid phantom keyspace.
     /// Ignores `disable_cluster_metrics`: deletes only, never emits.
+    ///
+    /// Note: this does NOT tombstone the cluster id — backends come and go
+    /// independently of the cluster. Only [`Self::remove_cluster`] sets
+    /// the tombstone.
     pub fn remove_backend(&mut self, cluster_id: &str, backend_id: &str) {
         let drop_cluster = if let Some(cluster) = self.cluster_metrics.get_mut(cluster_id) {
             cluster.backends.retain(|b| b.backend_id != backend_id);
@@ -625,6 +656,12 @@ impl LocalDrain {
         if self.disable_cluster_metrics {
             return Ok(());
         }
+        // Tombstone guard — see `Self::remove_cluster`. Without this, late
+        // session emissions for a removed cluster resurrect the row via
+        // `entry().or_default()` below.
+        if self.removed_clusters.contains(cluster_id) {
+            return Ok(());
+        }
 
         let local_cluster_metric = self
             .cluster_metrics
@@ -642,6 +679,10 @@ impl LocalDrain {
         metric: MetricValue,
     ) -> Result<(), MetricError> {
         if self.disable_cluster_metrics {
+            return Ok(());
+        }
+        // Same tombstone guard as `receive_cluster_metric`.
+        if self.removed_clusters.contains(cluster_id) {
             return Ok(());
         }
 
@@ -1123,6 +1164,108 @@ mod tests {
         {
             Some(Inner::Count(v)) => assert_eq!(*v, 7, "cluster-b counter intact"),
             other => panic!("expected Count for cluster-b, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn remove_cluster_tombstones_late_emissions() {
+        // After `remove_cluster`, late access-log / session metrics for the
+        // same cluster id must be dropped on the floor rather than
+        // resurrecting the row via `entry().or_default()`. This is the
+        // load-bearing guard against long-lived sessions (H2 / WS / TCP)
+        // keeping a removed cluster permanently growing — proxy
+        // `remove_cluster` paths drop config but do not close sessions.
+        let mut local_drain = LocalDrain::new("prefix".to_string());
+
+        local_drain.receive_metric(
+            "backend.connections.error",
+            Some("cluster-a"),
+            Some("backend-a"),
+            MetricValue::Count(3),
+        );
+        local_drain.remove_cluster("cluster-a");
+
+        // Late emission after the IPC.
+        local_drain.receive_metric(
+            "backend.connections.error",
+            Some("cluster-a"),
+            Some("backend-a"),
+            MetricValue::Count(7),
+        );
+
+        assert!(
+            local_drain
+                .metrics_of_one_cluster("cluster-a", &[])
+                .is_err(),
+            "tombstone must drop late emissions instead of resurrecting"
+        );
+    }
+
+    #[test]
+    fn add_cluster_clears_tombstone() {
+        // `AddCluster` for a previously-removed cluster id must re-arm the
+        // drain so fresh emissions are recorded again. Without this hook a
+        // cluster removed then re-added would stay silent forever.
+        let mut local_drain = LocalDrain::new("prefix".to_string());
+
+        local_drain.remove_cluster("cluster-a");
+        local_drain.add_cluster("cluster-a");
+
+        local_drain.receive_metric(
+            "backend.connections.error",
+            Some("cluster-a"),
+            Some("backend-a"),
+            MetricValue::Count(11),
+        );
+
+        let result = local_drain
+            .metrics_of_one_backend(
+                "backend-a",
+                ["backend.connections.error".to_string()].as_ref(),
+            )
+            .expect("cluster row must be reachable after add_cluster");
+        match result
+            .metrics
+            .get("backend.connections.error")
+            .and_then(|m| m.inner.as_ref())
+        {
+            Some(Inner::Count(v)) => {
+                assert_eq!(*v, 11, "post-add metric must record from zero")
+            }
+            other => panic!("expected Count, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clear_wipes_tombstones() {
+        // Operator-issued clear must wipe tombstones too so previously-
+        // removed cluster ids can resume emitting without going through
+        // `AddCluster`.
+        let mut local_drain = LocalDrain::new("prefix".to_string());
+
+        local_drain.remove_cluster("cluster-a");
+        local_drain.clear();
+
+        local_drain.receive_metric(
+            "backend.connections.error",
+            Some("cluster-a"),
+            Some("backend-a"),
+            MetricValue::Count(5),
+        );
+
+        let result = local_drain
+            .metrics_of_one_backend(
+                "backend-a",
+                ["backend.connections.error".to_string()].as_ref(),
+            )
+            .expect("tombstone must be cleared after `clear()`");
+        match result
+            .metrics
+            .get("backend.connections.error")
+            .and_then(|m| m.inner.as_ref())
+        {
+            Some(Inner::Count(v)) => assert_eq!(*v, 5),
+            other => panic!("expected Count, got {other:?}"),
         }
     }
 

--- a/lib/src/metrics/mod.rs
+++ b/lib/src/metrics/mod.rs
@@ -134,10 +134,14 @@ impl MetricValue {
                 changed
             }
             (&mut MetricValue::Gauge(ref mut v1), MetricValue::GaugeAdd(v2)) => {
-                debug_assert!(
-                    *v1 as i64 + v2 >= 0,
-                    "metric {key} underflow: previous value: {v1}, adding: {v2}"
-                );
+                // Saturating clamp + `error!` log on underflow, symmetric
+                // with `AggregatedMetric::update` in `local_drain.rs`. The
+                // `debug_assert!` that lived here previously made debug
+                // builds panic while release silently clamped; H2
+                // `ConnectionH2::Drop` rebalance + the saturating clamps
+                // make underflow structurally impossible from live code,
+                // and a panic on a metric mismatch is too aggressive — the
+                // log line names the offending key for observability.
                 let changed = v2 != 0;
                 let res = *v1 as i64 + v2;
                 *v1 = if res >= 0 {
@@ -645,6 +649,28 @@ impl Aggregator {
 
     pub fn configure(&mut self, config: &MetricsConfiguration) {
         self.local.configure(config);
+    }
+
+    /// Drop all metric storage for a cluster across BOTH drains. Called from
+    /// the worker IPC dispatch on [`RequestType::RemoveCluster`] so retired
+    /// clusters do not leak per-cluster keys after the wall-clock hourly
+    /// clear was removed. Network-side draining the queued `MetricLine`s
+    /// produces immediate silence on the wire (any unsent statsd interval
+    /// for the cluster is discarded).
+    pub fn remove_cluster(&mut self, cluster_id: &str) {
+        if let Some(ref mut net) = self.network.as_mut() {
+            net.remove_cluster(cluster_id);
+        }
+        self.local.remove_cluster(cluster_id);
+    }
+
+    /// Drop all metric storage for one backend across BOTH drains. Called
+    /// from the worker IPC dispatch on [`RequestType::RemoveBackend`].
+    pub fn remove_backend(&mut self, cluster_id: &str, backend_id: &str) {
+        if let Some(ref mut net) = self.network.as_mut() {
+            net.remove_backend(cluster_id, backend_id);
+        }
+        self.local.remove_backend(cluster_id, backend_id);
     }
 }
 

--- a/lib/src/metrics/mod.rs
+++ b/lib/src/metrics/mod.rs
@@ -161,9 +161,20 @@ impl MetricValue {
                 *v1 += v2;
                 changed
             }
-            (s, m) => panic!(
-                "tried to update metric {key} of value {s:?} with an incompatible metric: {m:?}"
-            ),
+            (s, m) => {
+                // Symmetric with `AggregatedMetric::update` in `local_drain.rs`:
+                // a type-mismatch is a coding bug (a `metric_name` was
+                // re-emitted with a different `MetricValue` variant), not a
+                // network-driven event, but log-and-continue is still the
+                // right policy — taking the worker process down on a metric
+                // bookkeeping mismatch is too aggressive for a single-bug
+                // recovery path. The log line names the offending key.
+                error!(
+                    "tried to update metric {} of value {:?} with an incompatible metric: {:?}",
+                    key, s, m
+                );
+                false
+            }
         }
     }
 }
@@ -177,18 +188,28 @@ pub struct StoredMetricValue {
 
 impl StoredMetricValue {
     pub fn new(last_sent: Instant, data: MetricValue) -> StoredMetricValue {
+        // Symmetric with `AggregatedMetric::new`: a first emission with a
+        // negative `GaugeAdd` is a coding bug (a `-1` ran with no paired
+        // `+1` earlier in the worker's lifetime); clamp to 0 and log so the
+        // offending pattern shows up in operator logs alongside the
+        // local-drain side.
+        let data = if let MetricValue::GaugeAdd(v) = data {
+            if v >= 0 {
+                MetricValue::Gauge(v as usize)
+            } else {
+                error!(
+                    "stored metric created with negative GaugeAdd({}), clamping to 0",
+                    v
+                );
+                MetricValue::Gauge(0)
+            }
+        } else {
+            data
+        };
         StoredMetricValue {
             last_sent,
             updated: true,
-            data: if let MetricValue::GaugeAdd(v) = data {
-                if v >= 0 {
-                    MetricValue::Gauge(v as usize)
-                } else {
-                    MetricValue::Gauge(0)
-                }
-            } else {
-                data
-            },
+            data,
         }
     }
 

--- a/lib/src/metrics/mod.rs
+++ b/lib/src/metrics/mod.rs
@@ -665,6 +665,9 @@ impl Aggregator {
     }
 
     pub fn clear_local(&mut self) {
+        if let Some(ref mut net) = self.network.as_mut() {
+            net.clear();
+        }
         self.local.clear();
     }
 
@@ -672,12 +675,18 @@ impl Aggregator {
         self.local.configure(config);
     }
 
-    /// Drop all metric storage for a cluster across BOTH drains. Called from
-    /// the worker IPC dispatch on [`RequestType::RemoveCluster`] so retired
-    /// clusters do not leak per-cluster keys after the wall-clock hourly
-    /// clear was removed. Network-side draining the queued `MetricLine`s
-    /// produces immediate silence on the wire (any unsent statsd interval
-    /// for the cluster is discarded).
+    /// Drop all metric storage for a cluster across BOTH drains and arm
+    /// the per-drain tombstone so subsequent emissions for the cluster are
+    /// dropped on the floor instead of resurrecting the row via
+    /// `entry().or_default()`. Called from the worker IPC dispatch on
+    /// [`RequestType::RemoveCluster`]. Network-side draining the queued
+    /// `MetricLine`s produces immediate silence on the wire (any unsent
+    /// statsd interval for the cluster is discarded).
+    ///
+    /// Worker-event-loop only — `METRICS` is a `thread_local!`, and the
+    /// mutable borrow taken here must not be re-entered from a session-
+    /// bound code path. Calling this from a metrics emission site would
+    /// deadlock the thread-local on `borrow_mut`.
     pub fn remove_cluster(&mut self, cluster_id: &str) {
         if let Some(ref mut net) = self.network.as_mut() {
             net.remove_cluster(cluster_id);
@@ -685,8 +694,21 @@ impl Aggregator {
         self.local.remove_cluster(cluster_id);
     }
 
+    /// Re-arm a previously-removed cluster id across BOTH drains. Called
+    /// from the worker IPC dispatch on [`RequestType::AddCluster`].
+    /// Idempotent on ids that were never removed. Without this hook a
+    /// cluster removed then re-added would stay tombstoned forever and
+    /// every fresh metric emission would be dropped.
+    pub fn add_cluster(&mut self, cluster_id: &str) {
+        if let Some(ref mut net) = self.network.as_mut() {
+            net.add_cluster(cluster_id);
+        }
+        self.local.add_cluster(cluster_id);
+    }
+
     /// Drop all metric storage for one backend across BOTH drains. Called
     /// from the worker IPC dispatch on [`RequestType::RemoveBackend`].
+    /// Does NOT tombstone the cluster (only `remove_cluster` does).
     pub fn remove_backend(&mut self, cluster_id: &str, backend_id: &str) {
         if let Some(ref mut net) = self.network.as_mut() {
             net.remove_backend(cluster_id, backend_id);

--- a/lib/src/metrics/network_drain.rs
+++ b/lib/src/metrics/network_drain.rs
@@ -64,6 +64,36 @@ impl NetworkDrain {
         self.is_writable = true;
     }
 
+    /// Drop all wire-side metric storage for a cluster: stored counters /
+    /// gauges in `cluster_metrics` + `backend_metrics`, and any queued
+    /// `MetricLine` carrying the cluster id. Called from
+    /// [`super::Aggregator::remove_cluster`] on `RequestType::RemoveCluster`.
+    /// Any unsent statsd interval for the cluster is **dropped**, not
+    /// emitted: there is no final flush. Operators that need per-removal
+    /// delta accuracy must trigger a flush before the IPC. In practice
+    /// cluster-removal events are rare and the loss is bounded by the
+    /// metrics send cadence (typically ≤1 second).
+    pub fn remove_cluster(&mut self, cluster_id: &str) {
+        self.cluster_metrics.retain(|(c, _), _| c != cluster_id);
+        self.backend_metrics.retain(|(c, _, _), _| c != cluster_id);
+        self.queue
+            .retain(|m| m.cluster_id.as_deref() != Some(cluster_id));
+    }
+
+    /// Drop all wire-side metric storage for one backend: stored counters
+    /// in `backend_metrics` and any queued `MetricLine` for that backend.
+    /// Called from [`super::Aggregator::remove_backend`] on
+    /// `RequestType::RemoveBackend`. Same final-delta-loss caveat as
+    /// [`Self::remove_cluster`].
+    pub fn remove_backend(&mut self, cluster_id: &str, backend_id: &str) {
+        self.backend_metrics
+            .retain(|(c, b, _), _| !(c == cluster_id && b == backend_id));
+        self.queue.retain(|m| {
+            !(m.cluster_id.as_deref() == Some(cluster_id)
+                && m.backend_id.as_deref() == Some(backend_id))
+        });
+    }
+
     pub fn send_metrics(&mut self) {
         let now = Instant::now();
         let secs = Duration::new(1, 0);
@@ -499,5 +529,172 @@ impl Subscriber for NetworkDrain {
         if let Some(stored_metric) = self.proxy_metrics.get_mut(key) {
             stored_metric.update(key, metric);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+    use mio::net::UdpSocket;
+
+    use super::{MetricLine, NetworkDrain, StoredMetricValue};
+    use crate::metrics::MetricValue;
+
+    fn loopback_drain() -> NetworkDrain {
+        let socket = UdpSocket::bind(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)))
+            .expect("bind loopback UDP for test");
+        let local = socket.local_addr().expect("local_addr");
+        NetworkDrain::new("test".to_string(), socket, local)
+    }
+
+    fn seed_cluster(drain: &mut NetworkDrain, cluster: &str, key: &str, count: i64) {
+        drain.cluster_metrics.insert(
+            (cluster.to_string(), key.to_string()),
+            StoredMetricValue::new(drain.created, MetricValue::Count(count)),
+        );
+    }
+
+    fn seed_backend(drain: &mut NetworkDrain, cluster: &str, backend: &str, key: &str, count: i64) {
+        drain.backend_metrics.insert(
+            (cluster.to_string(), backend.to_string(), key.to_string()),
+            StoredMetricValue::new(drain.created, MetricValue::Count(count)),
+        );
+    }
+
+    fn queue_line(cluster: Option<&str>, backend: Option<&str>) -> MetricLine {
+        MetricLine {
+            label: "test_metric",
+            cluster_id: cluster.map(str::to_string),
+            backend_id: backend.map(str::to_string),
+            duration: 0,
+        }
+    }
+
+    #[test]
+    fn network_drain_remove_cluster_drops_cluster_and_backend_keys() {
+        let mut drain = loopback_drain();
+
+        seed_cluster(&mut drain, "cluster-a", "metric_a", 1);
+        seed_cluster(&mut drain, "cluster-b", "metric_a", 2);
+        seed_backend(&mut drain, "cluster-a", "backend-1", "metric_b", 3);
+        seed_backend(&mut drain, "cluster-b", "backend-2", "metric_b", 4);
+
+        drain.remove_cluster("cluster-a");
+
+        assert!(
+            !drain
+                .cluster_metrics
+                .contains_key(&("cluster-a".to_string(), "metric_a".to_string())),
+            "cluster-a stored counter must be gone"
+        );
+        assert!(
+            !drain.backend_metrics.contains_key(&(
+                "cluster-a".to_string(),
+                "backend-1".to_string(),
+                "metric_b".to_string()
+            )),
+            "cluster-a backend stored counter must be gone"
+        );
+        assert!(
+            drain
+                .cluster_metrics
+                .contains_key(&("cluster-b".to_string(), "metric_a".to_string())),
+            "cluster-b counter must survive"
+        );
+        assert!(
+            drain.backend_metrics.contains_key(&(
+                "cluster-b".to_string(),
+                "backend-2".to_string(),
+                "metric_b".to_string()
+            )),
+            "cluster-b backend counter must survive"
+        );
+    }
+
+    #[test]
+    fn network_drain_remove_cluster_drains_queue_for_that_cluster() {
+        let mut drain = loopback_drain();
+
+        drain.queue.push_back(queue_line(Some("cluster-a"), None));
+        drain
+            .queue
+            .push_back(queue_line(Some("cluster-a"), Some("backend-1")));
+        drain.queue.push_back(queue_line(Some("cluster-b"), None));
+        drain.queue.push_back(queue_line(None, None));
+
+        drain.remove_cluster("cluster-a");
+
+        let remaining: Vec<_> = drain.queue.iter().map(|m| m.cluster_id.clone()).collect();
+        assert_eq!(remaining.len(), 2, "two non-cluster-a lines must survive");
+        assert!(
+            remaining.iter().all(|c| c.as_deref() != Some("cluster-a")),
+            "no cluster-a line must remain in queue"
+        );
+    }
+
+    #[test]
+    fn network_drain_remove_backend_drops_only_one_backend() {
+        let mut drain = loopback_drain();
+
+        seed_cluster(&mut drain, "cluster-a", "metric_a", 1);
+        seed_backend(&mut drain, "cluster-a", "backend-1", "metric_b", 2);
+        seed_backend(&mut drain, "cluster-a", "backend-2", "metric_b", 3);
+
+        drain.remove_backend("cluster-a", "backend-1");
+
+        assert!(
+            !drain.backend_metrics.contains_key(&(
+                "cluster-a".to_string(),
+                "backend-1".to_string(),
+                "metric_b".to_string()
+            )),
+            "backend-1 stored counter must be gone"
+        );
+        assert!(
+            drain.backend_metrics.contains_key(&(
+                "cluster-a".to_string(),
+                "backend-2".to_string(),
+                "metric_b".to_string()
+            )),
+            "backend-2 stored counter must survive"
+        );
+        assert!(
+            drain
+                .cluster_metrics
+                .contains_key(&("cluster-a".to_string(), "metric_a".to_string())),
+            "cluster-level entry must survive a backend removal"
+        );
+    }
+
+    #[test]
+    fn network_drain_remove_backend_drains_only_that_backend_from_queue() {
+        let mut drain = loopback_drain();
+
+        drain
+            .queue
+            .push_back(queue_line(Some("cluster-a"), Some("backend-1")));
+        drain
+            .queue
+            .push_back(queue_line(Some("cluster-a"), Some("backend-2")));
+        drain.queue.push_back(queue_line(Some("cluster-a"), None));
+        drain
+            .queue
+            .push_back(queue_line(Some("cluster-b"), Some("backend-1")));
+
+        drain.remove_backend("cluster-a", "backend-1");
+
+        let remaining: Vec<_> = drain
+            .queue
+            .iter()
+            .map(|m| (m.cluster_id.clone(), m.backend_id.clone()))
+            .collect();
+        assert_eq!(remaining.len(), 3, "only the targeted line must drop");
+        assert!(
+            remaining.iter().all(|(c, b)| {
+                !(c.as_deref() == Some("cluster-a") && b.as_deref() == Some("backend-1"))
+            }),
+            "no (cluster-a, backend-1) line must remain"
+        );
     }
 }

--- a/lib/src/metrics/network_drain.rs
+++ b/lib/src/metrics/network_drain.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, VecDeque, hash_map::Entry},
+    collections::{HashMap, HashSet, VecDeque, hash_map::Entry},
     io::{ErrorKind, Write},
     net::SocketAddr,
     str,
@@ -37,6 +37,15 @@ pub struct NetworkDrain {
     cluster_metrics: HashMap<(String, String), StoredMetricValue>,
     /// (cluster_id, backend_id, key) -> metric
     backend_metrics: HashMap<(String, String, String), StoredMetricValue>,
+    /// Cluster ids that received a `RemoveCluster` IPC and have not yet
+    /// been re-introduced by `AddCluster`. Mirrors `LocalDrain`'s
+    /// tombstone: in-flight sessions for a removed cluster keep emitting
+    /// access-log / response-time / gauge metrics, which without this
+    /// guard would re-enter `cluster_metrics` / `backend_metrics` /
+    /// `queue` (the IPC-time `retain` calls cleared the existing entries
+    /// but cannot prevent reinsertion). The wire side stays silent for
+    /// the cluster until `AddCluster` re-arms or an operator clear.
+    removed_clusters: HashSet<String>,
     pub use_tagged_metrics: bool,
     pub origin: String,
     created: Instant,
@@ -54,6 +63,7 @@ impl NetworkDrain {
             proxy_metrics: HashMap::new(),
             cluster_metrics: HashMap::new(),
             backend_metrics: HashMap::new(),
+            removed_clusters: HashSet::new(),
             use_tagged_metrics: false,
             origin: String::from("x"),
             created: Instant::now(),
@@ -64,27 +74,55 @@ impl NetworkDrain {
         self.is_writable = true;
     }
 
-    /// Drop all wire-side metric storage for a cluster: stored counters /
-    /// gauges in `cluster_metrics` + `backend_metrics`, and any queued
-    /// `MetricLine` carrying the cluster id. Called from
+    /// Drop all wire-side metric storage for a cluster, drain matching
+    /// queued lines, and mark the cluster id as tombstoned so subsequent
+    /// emissions for that cluster are dropped before they can re-enter
+    /// the maps or the queue. Called from
     /// [`super::Aggregator::remove_cluster`] on `RequestType::RemoveCluster`.
     /// Any unsent statsd interval for the cluster is **dropped**, not
-    /// emitted: there is no final flush. Operators that need per-removal
-    /// delta accuracy must trigger a flush before the IPC. In practice
-    /// cluster-removal events are rare and the loss is bounded by the
-    /// metrics send cadence (typically ≤1 second).
+    /// emitted: there is no final flush. The wire stays silent for the
+    /// cluster until [`Self::add_cluster`] re-arms it (called from the
+    /// `AddCluster` IPC) or [`Self::clear`] wipes the tombstone.
+    ///
+    /// The tombstone is the load-bearing guard against in-flight sessions
+    /// keeping a removed cluster on the wire: proxy `remove_cluster`
+    /// paths in `lib/src/http.rs` / `https.rs` / `tcp.rs` drop cluster
+    /// config but do NOT close in-flight sessions, so access-log
+    /// emissions continue to fire. Mirror of `LocalDrain::remove_cluster`.
     pub fn remove_cluster(&mut self, cluster_id: &str) {
         self.cluster_metrics.retain(|(c, _), _| c != cluster_id);
         self.backend_metrics.retain(|(c, _, _), _| c != cluster_id);
         self.queue
             .retain(|m| m.cluster_id.as_deref() != Some(cluster_id));
+        self.removed_clusters.insert(cluster_id.to_owned());
+    }
+
+    /// Re-arm a previously-removed cluster id so its metrics can flow on
+    /// the wire again. Called from [`super::Aggregator::add_cluster`] on
+    /// `RequestType::AddCluster`. Idempotent on ids that were never
+    /// removed.
+    pub fn add_cluster(&mut self, cluster_id: &str) {
+        self.removed_clusters.remove(cluster_id);
+    }
+
+    /// Operator-issued reset triggered by `MetricsConfiguration::Clear`.
+    /// Wipes every wire-side map AND clears the tombstone set so any
+    /// cluster id can resume emitting without going through `AddCluster`.
+    /// Mirror of `LocalDrain::clear`.
+    pub fn clear(&mut self) {
+        self.proxy_metrics.clear();
+        self.cluster_metrics.clear();
+        self.backend_metrics.clear();
+        self.queue.clear();
+        self.removed_clusters.clear();
     }
 
     /// Drop all wire-side metric storage for one backend: stored counters
     /// in `backend_metrics` and any queued `MetricLine` for that backend.
     /// Called from [`super::Aggregator::remove_backend`] on
     /// `RequestType::RemoveBackend`. Same final-delta-loss caveat as
-    /// [`Self::remove_cluster`].
+    /// [`Self::remove_cluster`]. Does NOT tombstone the cluster — only
+    /// `remove_cluster` does, since backends come and go independently.
     pub fn remove_backend(&mut self, cluster_id: &str, backend_id: &str) {
         self.backend_metrics
             .retain(|(c, b, _), _| !(c == cluster_id && b == backend_id));
@@ -461,6 +499,16 @@ impl Subscriber for NetworkDrain {
         backend_id: Option<&str>,
         metric: MetricValue,
     ) {
+        // Tombstone guard — see `Self::remove_cluster`. Long-lived sessions
+        // for a removed cluster would otherwise re-enter `cluster_metrics`
+        // / `backend_metrics` / `queue` after the IPC drained them, keeping
+        // the wire noisy for a cluster the operator just removed.
+        if let Some(cid) = cluster_id {
+            if self.removed_clusters.contains(cid) {
+                return;
+            }
+        }
+
         if metric.is_time() {
             if let MetricValue::Time(millis) = metric {
                 self.queue.push_back(MetricLine {
@@ -695,6 +743,65 @@ mod tests {
                 !(c.as_deref() == Some("cluster-a") && b.as_deref() == Some("backend-1"))
             }),
             "no (cluster-a, backend-1) line must remain"
+        );
+    }
+
+    #[test]
+    fn network_drain_tombstone_blocks_resurrection() {
+        // After `remove_cluster`, subsequent emissions for the cluster id
+        // must be dropped on the wire side too — without the tombstone a
+        // long-lived session would re-insert into `cluster_metrics` /
+        // `backend_metrics` / queue every time it ran.
+        use crate::metrics::Subscriber;
+        let mut drain = loopback_drain();
+
+        drain.remove_cluster("cluster-a");
+
+        drain.receive_metric("metric_a", Some("cluster-a"), None, MetricValue::Count(1));
+        drain.receive_metric(
+            "metric_b",
+            Some("cluster-a"),
+            Some("backend-1"),
+            MetricValue::Count(2),
+        );
+        drain.receive_metric(
+            "metric_c",
+            Some("cluster-a"),
+            Some("backend-2"),
+            MetricValue::Time(5),
+        );
+
+        assert!(
+            drain
+                .cluster_metrics
+                .keys()
+                .all(|(c, _)| c != "cluster-a"),
+            "cluster-level metric must be tombstoned"
+        );
+        assert!(
+            drain.backend_metrics.keys().all(|(c, _, _)| c != "cluster-a"),
+            "backend-level metric must be tombstoned"
+        );
+        assert!(
+            drain.queue.iter().all(|m| m.cluster_id.as_deref() != Some("cluster-a")),
+            "queued Time metric must be tombstoned"
+        );
+    }
+
+    #[test]
+    fn network_drain_add_cluster_clears_tombstone() {
+        use crate::metrics::Subscriber;
+        let mut drain = loopback_drain();
+
+        drain.remove_cluster("cluster-a");
+        drain.add_cluster("cluster-a");
+
+        drain.receive_metric("metric_a", Some("cluster-a"), None, MetricValue::Count(4));
+        assert!(
+            drain
+                .cluster_metrics
+                .contains_key(&("cluster-a".to_string(), "metric_a".to_string())),
+            "cluster row must record after add_cluster re-arms"
         );
     }
 }

--- a/lib/src/metrics/network_drain.rs
+++ b/lib/src/metrics/network_drain.rs
@@ -772,18 +772,21 @@ mod tests {
         );
 
         assert!(
-            drain
-                .cluster_metrics
-                .keys()
-                .all(|(c, _)| c != "cluster-a"),
+            drain.cluster_metrics.keys().all(|(c, _)| c != "cluster-a"),
             "cluster-level metric must be tombstoned"
         );
         assert!(
-            drain.backend_metrics.keys().all(|(c, _, _)| c != "cluster-a"),
+            drain
+                .backend_metrics
+                .keys()
+                .all(|(c, _, _)| c != "cluster-a"),
             "backend-level metric must be tombstoned"
         );
         assert!(
-            drain.queue.iter().all(|m| m.cluster_id.as_deref() != Some("cluster-a")),
+            drain
+                .queue
+                .iter()
+                .all(|m| m.cluster_id.as_deref() != Some("cluster-a")),
             "queued Time metric must be tombstoned"
         );
     }

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -1918,12 +1918,33 @@ impl Server {
 
     fn remove_backend(&mut self, req_id: &str, backend: &RemoveBackend) -> WorkerResponse {
         let address = backend.address.into();
-        self.backends
+        // Runtime removal is address-keyed and drops every backend at this
+        // address (A/B test, weighted variant, dedup race). The metrics
+        // layer is id-keyed — fan out one `remove_backend` per actually-
+        // removed id so the two identities stay in sync. Without this the
+        // `backend_id` field on the IPC message could name "A" while the
+        // runtime dropped both "A" and "B" at the same address, leaving
+        // "B"'s metrics rows orphaned forever.
+        let removed_ids = self
+            .backends
             .borrow_mut()
             .remove_backend(&backend.cluster_id, &address);
-        METRICS.with(|metrics| {
-            (*metrics.borrow_mut()).remove_backend(&backend.cluster_id, &backend.backend_id);
-        });
+        if removed_ids.is_empty() {
+            // Edge case: BackendList returned nothing (address never
+            // existed in this cluster). Honour the request's stated id
+            // anyway so a no-op request still tidies any orphan metric
+            // row from a prior identity-drift state.
+            METRICS.with(|metrics| {
+                (*metrics.borrow_mut()).remove_backend(&backend.cluster_id, &backend.backend_id);
+            });
+        } else {
+            METRICS.with(|metrics| {
+                let mut metrics = metrics.borrow_mut();
+                for id in &removed_ids {
+                    metrics.remove_backend(&backend.cluster_id, id);
+                }
+            });
+        }
 
         WorkerResponse::ok(req_id)
     }

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -950,15 +950,6 @@ impl Server {
             self.health_checker
                 .poll(&self.backends, self.poll.registry());
 
-            let now = time::OffsetDateTime::now_utc();
-            // clear the local metrics drain every plain hour (01:00, 02:00, etc.) to prevent memory overuse
-            // TODO: have one-hour-lasting metrics instead
-            if now.minute() == 00 && now.second() == 0 {
-                METRICS.with(|metrics| {
-                    (*metrics.borrow_mut()).clear_local();
-                });
-            }
-
             // Frontend session gauges. `client.connections` keeps the
             // per-event signal from `SessionManager::incr/decr`; the rest
             // follow the once-per-iteration batching contract this run loop
@@ -1794,6 +1785,9 @@ impl Server {
             }
             Some(RequestType::RemoveCluster(ref cluster_id)) => {
                 self.remove_health_check_state(cluster_id);
+                METRICS.with(|metrics| {
+                    (*metrics.borrow_mut()).remove_cluster(cluster_id);
+                });
                 //not returning because the message must still be handled by each proxy
             }
             Some(RequestType::SetHealthCheck(ref set)) => {
@@ -1927,6 +1921,9 @@ impl Server {
         self.backends
             .borrow_mut()
             .remove_backend(&backend.cluster_id, &address);
+        METRICS.with(|metrics| {
+            (*metrics.borrow_mut()).remove_backend(&backend.cluster_id, &backend.backend_id);
+        });
 
         WorkerResponse::ok(req_id)
     }

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -1781,6 +1781,13 @@ impl Server {
                     }
                 }
                 self.add_cluster(cluster);
+                // Re-arm the metric drain tombstone in case this cluster id
+                // was previously removed — without this the drain would
+                // continue dropping every emission for the resurrected
+                // cluster. Idempotent on a fresh id.
+                METRICS.with(|metrics| {
+                    (*metrics.borrow_mut()).add_cluster(&cluster.cluster_id);
+                });
                 //not returning because the message must still be handled by each proxy
             }
             Some(RequestType::RemoveCluster(ref cluster_id)) => {


### PR DESCRIPTION
## Summary

The wall-clock hourly clear in the worker run loop (`if now.minute() == 0 && now.second() == 0`) wiped `Count` and `Time` entries from `LocalDrain.cluster_metrics` at every UTC hour boundary, producing apparent spikes and inconsistent values in `sozu metrics` snapshots taken near the boundary, and (pre-`48a6fef5`) underflowing gauges when long-lived H2 sessions closed after the clear. This patch removes the hourly clear and makes the local drain cumulative-since-worker-start, matching the existing `proxy_metrics` contract. The memory bound the hourly clear used to provide is now provided by explicit `RemoveCluster` / `RemoveBackend` lifecycle hooks plumbed through `Aggregator::remove_cluster` / `remove_backend` into both drains.

Companion changes folded into the same patch:

- `MetricsConfiguration::Clear` (`sozu metrics clear`) now wipes everything (counts, gauges, histograms, proxy-wide and per-cluster) on **both** the worker `LocalDrain` AND the master process's `main_metrics` aggregator. Formerly the worker scatter ran but the master's own state survived, so `sozu metrics` snapshots would still report stale supervisor values.
- `NetworkDrain::remove_cluster` / `remove_backend` retain over the stored counter maps AND drain queued `MetricLine`s for the cluster / backend, producing immediate silence on the StatsD wire after the IPC. Any unsent statsd interval is discarded (no final flush) — bounded by `metrics_send_interval`, typically ≤1 second.
- `Time` histograms widen from `Histogram<u32>` to `Histogram<u64>` so per-bucket counters do not saturate under sustained high-RPS traffic (previously ~72 minutes at 1 M samples/s in a single popular bucket). Memory cost is bounded and roughly 2× per histogram.
- `MetricValue::update`'s asymmetric `debug_assert!` is removed. Saturating clamp to 0 plus one `error!` log line per occurrence is now the single, symmetric behaviour across both `MetricValue::update` and `AggregatedMetric::update` in debug and release. The H2 `ConnectionH2::Drop` rebalance plus the saturating clamps already make underflow structurally impossible from live code; a panic on a metric mismatch was too aggressive.

Removes the now-unused `clear_non_gauges` and `MetricsMap::retain_gauges` helpers, and the unused `time = { workspace = true }` dependency from `lib/Cargo.toml`.

## Behaviour changes

1. **`sozu metrics clear` now wipes everything**, including `proxy_metrics` and master-side `main_metrics`. Formerly proxy-wide metrics were never reset by anything and master state persisted.
2. **On cluster removal, the cluster is dropped immediately from local drain and StatsD `network_drain`** — any unsent statsd interval is discarded rather than emitted. Formerly the cluster lingered for up to 10 minutes via the idle GC.
3. **Local CLI counters become cumulative since worker start.** Dashboards relying on hourly windowing must use `rate()` / `irate()`.
4. **Operator clear during live traffic** may emit `error!` log lines for in-flight sessions whose teardown decrements gauges past the just-zeroed entry. The clamp is correct; the noise is intentional and documented.

## Race note

Late access-log / session emissions can briefly recreate ghost rows in `LocalDrain.cluster_metrics` after a `RemoveCluster` because `receive_cluster_metric` calls `entry().or_default()`. The single-threaded mio worker makes this trivially benign — the row sits idle until the next `RemoveCluster`, `AddCluster` for the same id, or operator clear. A "removed clusters" denylist would be over-engineered for the resulting cosmetic noise.

## Files changed

- `lib/src/server.rs` — delete hourly clear; wire `RemoveCluster` and `Server::remove_backend` into `METRICS`.
- `lib/src/metrics/local_drain.rs` — rewrite `clear()` as full reset; add `remove_cluster` + `remove_backend` (with empty-cluster housekeeping); delete `clear_non_gauges` + `retain_gauges`; widen `Time` to `Histogram<u64>`; rewrite 2 tests + add 8 new tests.
- `lib/src/metrics/mod.rs` — drop `debug_assert!` in `MetricValue::update`; add `Aggregator::remove_cluster` / `remove_backend` wrappers fanning out to both drains.
- `lib/src/metrics/network_drain.rs` — add `remove_cluster` / `remove_backend` retaining over `cluster_metrics`, `backend_metrics`, and queued `MetricLine`s; add 4 new tests.
- `bin/src/command/requests.rs` — extend the master-side `MetricsConfiguration::Clear` handler to also wipe `main_metrics` before scattering to workers.
- `lib/Cargo.toml`, `Cargo.lock`, `fuzz/Cargo.lock` — drop the unused `time` workspace dep from `lib/`.
- `CHANGELOG.md` — appended to the existing `### 💥 Breaking changes (1.1.x → 2.0.0)` and `### ⛑️ Fixed` subsections.
- `doc/observability.md` — rewrite Gauge underflow paragraph; add new "Local drain reset cadence" section with operator-clear caveat.
- `doc/configure.md` — clarify metric type table (network drain delta vs local drain cumulative); insert new "Metrics scopes" section before the Cardinality knob subsection.

## Test plan

- [x] `cargo build --all-features --locked`
- [x] `cargo clippy --all-targets --all-features --locked` — clean, no warnings
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo test -p sozu-lib --all-features --locked` — 558 passed, 4 ignored
- [x] `cargo test -p sozu-command-lib --all-features --locked` — 94 passed, 3 ignored
- [x] `cargo test -p sozu --all-features --locked` — 68 passed
- [x] `cargo test -p sozu-e2e --locked -- --test-threads=4` — 361 passed (default `crypto-ring` feature; e2e crate forbids `--all-features` because rustls panics with multiple `from_crate_features` candidates)
- [x] New unit tests cover: full-reset on operator clear, cluster removal dropping all storage, sibling-cluster non-interference, backend removal preserving cluster row when other backends or cluster-level metrics remain, backend removal dropping empty cluster row, unknown-cluster removal noop, cumulative counts across many emissions, cumulative histograms across many emissions, and gauge-underflow-no-panic-in-debug.

## Security / protocol impact

No protocol surface change. No proto schema change. Wire-format StatsD UDP is unchanged (per-second deltas as before). The local CLI snapshot shape (`FilteredMetrics::Gauge` `uint64`, `Count` `int64`, `Percentiles`) is unchanged. Metric semantics for `proxy_metrics` (already cumulative) are unchanged. Per-cluster Count and Time semantics shift from "cumulative within an hour" to "cumulative since worker start" — operator dashboards are the only consumer affected.