### PR TITLE
fix(command): harden length-delimited + SCM IPC against panic-OOB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,6 +3169,8 @@ dependencies = [
  "hyper-util",
  "libc",
  "mio",
+ "nix 0.31.2",
+ "prost",
  "rustls",
  "serial_test",
  "sha2 0.11.0",

--- a/command/src/channel.rs
+++ b/command/src/channel.rs
@@ -42,6 +42,13 @@ pub enum ChannelError {
         capacity: usize,
         max: usize,
     },
+    #[error(
+        "declared message length ({message_len} bytes) is shorter than the {delimiter_size}-byte length prefix"
+    )]
+    MessageLengthUnderDelimiter {
+        message_len: usize,
+        delimiter_size: usize,
+    },
     #[error("channel could not write on the back buffer")]
     Write(std::io::Error),
     #[error("channel buffer is full ({capacity} bytes, max {max} bytes), cannot grow more")]
@@ -469,6 +476,25 @@ impl<Tx: Debug + ProstMessage + Default, Rx: Debug + ProstMessage + Default> Cha
                     message_len,
                     capacity: self.front_buf.capacity(),
                     max: self.max_buffer_size,
+                });
+            }
+
+            // A length-delimited frame is `[delimiter][payload]`. The declared
+            // `message_len` is the total frame size and MUST therefore be at
+            // least `delimiter_size()`. A peer-controlled value below that
+            // ceiling makes `&buffer[delimiter_size()..message_len]` slice
+            // backwards and panic; reject it the same way as oversized frames.
+            //
+            // Drop the bogus delimiter bytes before returning so the channel
+            // can re-sync on the peer's next frame. Without this, every
+            // subsequent `read_message()` re-reads the same bad header from
+            // the front buffer and the worker burns CPU on the same error
+            // until the peer disconnects.
+            if message_len < delimiter_size() {
+                self.front_buf.consume(delimiter_size());
+                return Err(ChannelError::MessageLengthUnderDelimiter {
+                    message_len,
+                    delimiter_size: delimiter_size(),
                 });
             }
 
@@ -961,5 +987,44 @@ mod tests {
             grown.is_power_of_two() || grown == 10000,
             "expected doubling growth pattern, got {grown}"
         );
+    }
+
+    /// Regression: a peer that writes a length-delimited frame whose
+    /// declared length is *less than* the delimiter itself must be
+    /// rejected with `MessageLengthUnderDelimiter`, never panic the
+    /// reader with `slice index starts at N but ends at M`.
+    ///
+    /// Without the bounds check, `&buffer[delimiter_size()..message_len]`
+    /// at `try_read_delimited_message` panics for any peer-controlled
+    /// `message_len < delimiter_size()` (= 8 on 64-bit) — a one-packet
+    /// denial-of-service against the master command socket.
+    #[test]
+    fn rejects_declared_length_below_delimiter() {
+        let (mut reader, mut writer): (
+            Channel<ProtobufMessage, ProtobufMessage>,
+            Channel<ProtobufMessage, ProtobufMessage>,
+        ) = Channel::generate(1000, 10000).expect("could not generate channels");
+        writer.blocking().expect("writer to block");
+        reader.blocking().expect("reader to block");
+
+        // Craft a delimiter that lies: message_len = 5 (< delimiter_size() = 8).
+        // Send it as raw bytes, bypassing write_delimited_message.
+        let bogus: usize = 5;
+        let bytes = bogus.to_le_bytes();
+        std::io::Write::write_all(&mut writer.sock, &bytes).expect("raw write of bogus delimiter");
+
+        match reader.read_message() {
+            Err(ChannelError::MessageLengthUnderDelimiter {
+                message_len,
+                delimiter_size,
+            }) => {
+                assert_eq!(message_len, 5);
+                assert_eq!(delimiter_size, std::mem::size_of::<usize>());
+            }
+            other => panic!(
+                "expected MessageLengthUnderDelimiter, got {other:?}\n\
+                 NOTE: a panic here means the slice-OOB hardening was reverted",
+            ),
+        }
     }
 }

--- a/command/src/scm_socket.rs
+++ b/command/src/scm_socket.rs
@@ -47,6 +47,18 @@ pub enum ScmSocketError {
     },
     #[error("error decoding the protobuf format of the listeners: {0}")]
     DecodeError(DecodeError),
+    #[error(
+        "listeners count manifest is inconsistent with the SCM payload: \
+         http={http}, tls={tls}, tcp={tcp} (sum={total}), fds_received={fds_received}, max_fds={max_fds}"
+    )]
+    ListenersCountInconsistent {
+        http: usize,
+        tls: usize,
+        tcp: usize,
+        total: usize,
+        fds_received: usize,
+        max_fds: usize,
+    },
 }
 
 /// A unix socket specialized for file descriptor passing
@@ -135,12 +147,43 @@ impl ScmSocket {
         let listeners_count = ListenersCount::decode_length_delimited(&buf[..size])
             .map_err(ScmSocketError::DecodeError)?;
 
+        // Validate the manifest before indexing into the fixed-size FD array.
+        // The peer-controlled `listeners_count.{http,tls,tcp}` lists are
+        // matched 1:1 with `received_fds` slots; without these bounds checks
+        // a peer that declared more entries than MAX_FDS_OUT or more entries
+        // than FDs actually arrived would panic the worker on
+        // `received_fds[index..index + len]`.
+        let http_len = listeners_count.http.len();
+        let tls_len = listeners_count.tls.len();
+        let tcp_len = listeners_count.tcp.len();
+        let total = http_len
+            .checked_add(tls_len)
+            .and_then(|s| s.checked_add(tcp_len))
+            .ok_or(ScmSocketError::ListenersCountInconsistent {
+                http: http_len,
+                tls: tls_len,
+                tcp: tcp_len,
+                total: usize::MAX,
+                fds_received: file_descriptor_length,
+                max_fds: MAX_FDS_OUT,
+            })?;
+        if total > MAX_FDS_OUT || total > file_descriptor_length {
+            return Err(ScmSocketError::ListenersCountInconsistent {
+                http: http_len,
+                tls: tls_len,
+                tcp: tcp_len,
+                total,
+                fds_received: file_descriptor_length,
+                max_fds: MAX_FDS_OUT,
+            });
+        }
+
         let mut http_addresses = parse_addresses(&listeners_count.http)?;
         let mut tls_addresses = parse_addresses(&listeners_count.tls)?;
         let mut tcp_addresses = parse_addresses(&listeners_count.tcp)?;
 
         let mut index = 0;
-        let len = listeners_count.http.len();
+        let len = http_len;
         let mut http = Vec::new();
         http.extend(
             http_addresses
@@ -149,7 +192,7 @@ impl ScmSocket {
         );
 
         index += len;
-        let len = listeners_count.tls.len();
+        let len = tls_len;
         let mut tls = Vec::new();
         tls.extend(
             tls_addresses
@@ -158,11 +201,12 @@ impl ScmSocket {
         );
 
         index += len;
+        let len = tcp_len;
         let mut tcp = Vec::new();
         tcp.extend(
             tcp_addresses
                 .drain(..)
-                .zip(received_fds[index..file_descriptor_length].iter().cloned()),
+                .zip(received_fds[index..index + len].iter().cloned()),
         );
 
         Ok(Listeners { http, tls, tcp })
@@ -426,5 +470,58 @@ mod tests {
             .expect("Could not receive listeners");
 
         assert_eq!(listeners.http[0].0, received_listeners.http[0].0);
+    }
+
+    /// Regression: a malformed `ListenersCount` whose entry counts do not
+    /// match the number of file descriptors received over SCM must be
+    /// rejected with `ListenersCountInconsistent`, never panic the worker
+    /// on `received_fds[index..index + len]`.
+    ///
+    /// Without the bounds check, a peer that declares more addresses than
+    /// `MAX_FDS_OUT` (or more than the FDs that actually arrived) crashes
+    /// the receiving worker on out-of-bounds array indexing.
+    #[test]
+    fn rejects_listeners_count_with_more_entries_than_fds() {
+        let (stream_1, stream_2) =
+            MioUnixStream::pair().expect("Could not create a pair of mio unix streams");
+        let sender = ScmSocket::new(stream_1.into_raw_fd()).expect("Could not create scm socket");
+        let receiver = ScmSocket::new(stream_2.into_raw_fd()).expect("Could not create scm socket");
+
+        // Declare three HTTP entries but ship zero file descriptors.
+        let bogus = ListenersCount {
+            http: vec![
+                "127.0.0.1:80".to_string(),
+                "127.0.0.2:80".to_string(),
+                "127.0.0.3:80".to_string(),
+            ],
+            tls: vec![],
+            tcp: vec![],
+        };
+        let payload = bogus.encode_length_delimited_to_vec();
+        sender
+            .send_msg_and_fds(&payload, &[])
+            .expect("manual send_msg_and_fds with zero fds must succeed at the syscall layer");
+
+        match receiver.receive_listeners() {
+            Err(ScmSocketError::ListenersCountInconsistent {
+                http,
+                tls,
+                tcp,
+                total,
+                fds_received,
+                max_fds,
+            }) => {
+                assert_eq!(http, 3);
+                assert_eq!(tls, 0);
+                assert_eq!(tcp, 0);
+                assert_eq!(total, 3);
+                assert_eq!(fds_received, 0);
+                assert_eq!(max_fds, MAX_FDS_OUT);
+            }
+            other => panic!(
+                "expected ListenersCountInconsistent, got {other:?}\n\
+                 NOTE: a panic / OOM here means the SCM bounds check was reverted",
+            ),
+        }
     }
 }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -36,6 +36,16 @@ tempfile = { workspace = true }
 # request consume the failure injection that FIX-18 just armed,
 # producing the wrong response code for both tests on CI.
 serial_test = { workspace = true }
+# Encode forged length-delimited protobuf payloads in
+# `tests/command_channel_security_tests.rs` to reproduce the
+# `ScmSocket::receive_listeners` slice-OOB pre-fix and prove the
+# `ListenersCountInconsistent` rejection path post-fix.
+prost = { workspace = true }
+# `sendmsg` syscall wrapper used by the same test to ship a
+# malformed `ListenersCount` over the SCM socket without going
+# through `ScmSocket::send_listeners` (which keeps addresses and
+# FDs in sync by construction).
+nix = { workspace = true, features = ["socket", "uio"] }
 
 [features]
 # Forward sozu-lib's `splice` feature so the dependency-tree compiles

--- a/e2e/src/tests/command_channel_security_tests.rs
+++ b/e2e/src/tests/command_channel_security_tests.rs
@@ -1,0 +1,218 @@
+//! End-to-end regression tests for the command-channel hardening
+//! against malformed IPC framing.
+//!
+//! Two pre-fix bugs in `sozu-command-lib` panicked the receiver on
+//! attacker-controlled input — both reachable across the master / worker
+//! trust boundary, and one of them externally reachable through the
+//! admin unix socket:
+//!
+//! 1. `Channel::try_read_delimited_message` (`command/src/channel.rs`)
+//!    — `&buffer[delimiter_size()..message_len]` panicked when the peer
+//!    declared `message_len < delimiter_size()` (e.g. 5 on a 64-bit
+//!    host). One malformed packet would crash the master command loop.
+//!
+//! 2. `ScmSocket::receive_listeners` (`command/src/scm_socket.rs`)
+//!    — `received_fds[index..index + len]` panicked when a peer-supplied
+//!    `ListenersCount` declared more entries than `MAX_FDS_OUT` (200)
+//!    or more than the FDs that actually arrived.
+//!
+//! These tests reproduce the panic and prove the fix by driving the
+//! production code paths (a live worker thread for #1; the real
+//! `Server::try_new_from_config` constructor for #2).
+
+use std::{
+    io::{IoSlice, Write},
+    os::unix::io::{AsRawFd, IntoRawFd},
+    thread,
+    time::Duration,
+};
+
+use mio::net::UnixStream;
+use nix::sys::socket::{MsgFlags, sendmsg};
+use prost::Message;
+use sozu_command_lib::{
+    channel::Channel,
+    proto::command::{InitialState, ListenersCount, ServerConfig, WorkerRequest, WorkerResponse},
+    scm_socket::{ScmSocket, ScmSocketError},
+};
+use sozu_lib::server::{Server, ServerError};
+
+use crate::sozu::worker::Worker;
+
+/// Reproduces the `channel.rs` slice-OOB DoS: a peer that writes a
+/// length delimiter declaring `message_len < delimiter_size()` used to
+/// panic the worker on `&buffer[delimiter_size()..message_len]`.
+///
+/// Post-fix: the worker rejects the frame with
+/// `MessageLengthUnderDelimiter`, drops the bogus delimiter from the
+/// front buffer so the channel can re-sync, and continues processing
+/// the next valid `WorkerRequest`. A follow-up `SoftStop` therefore
+/// reaches the worker, exits the event loop cleanly, and
+/// `wait_for_server_stop()` returns `true` without the thread having
+/// panicked.
+///
+/// Pre-fix, this test would either:
+/// - panic the worker thread on the bogus delimiter and
+///   `wait_for_server_stop()` would observe a join error, or
+/// - hang forever because the bad bytes were never consumed and the
+///   follow-up `SoftStop` was never decoded.
+#[test]
+fn channel_short_delimiter_does_not_panic_worker() {
+    let (config, listeners, state) = Worker::empty_config();
+    let mut worker = Worker::start_new_worker("CHANNEL-PANIC-REPRO", config, &listeners, state);
+
+    // Craft a delimiter that declares `message_len = 5`. On a 64-bit
+    // host `delimiter_size() == 8`, so the receiver — pre-fix — would
+    // panic on `&buffer[8..5]` (slice-end-before-start).
+    let bogus_len: usize = 5;
+    let bogus = bogus_len.to_le_bytes();
+    Write::write_all(&mut worker.command_channel.sock, &bogus)
+        .expect("raw write of the bogus delimiter must succeed at the syscall layer");
+
+    // Give the worker a moment to read + reject + consume the bad frame.
+    // The fix drops `delimiter_size()` bytes from the front buffer
+    // so the channel resyncs on the next inbound frame.
+    thread::sleep(Duration::from_millis(200));
+
+    assert!(
+        !worker.server_job.is_finished(),
+        "worker thread terminated after a bogus 5-byte length prefix — \
+         the slice-OOB hardening in command/src/channel.rs has regressed",
+    );
+
+    // Re-sync test: send a real SoftStop. If the bad delimiter was
+    // dropped correctly, the worker will decode this cleanly and exit
+    // its event loop; otherwise it would loop forever on the stale
+    // bogus header.
+    worker.soft_stop();
+
+    assert!(
+        worker.wait_for_server_stop(),
+        "worker did not exit cleanly after a SoftStop following the bogus frame — \
+         the channel did not re-sync after rejecting MessageLengthUnderDelimiter",
+    );
+}
+
+/// Reproduces the `scm_socket.rs` slice-OOB DoS at the
+/// `Server::try_new_from_config` boundary. The constructor calls
+/// `ScmSocket::receive_listeners()` synchronously; pre-fix, a peer
+/// `ListenersCount` declaring more http/tls/tcp entries than the FDs
+/// actually shipped would panic the worker on
+/// `received_fds[index..index + len]`.
+///
+/// Post-fix, the constructor surfaces the error cleanly as
+/// `ServerError::ScmSocket { scm_err: ListenersCountInconsistent, .. }`
+/// instead of unwinding from an indexing panic deep in the FD-passing
+/// path.
+#[test]
+fn scm_inconsistent_listeners_count_does_not_panic_server_constructor() {
+    // Build the master ↔ worker socket pairs by hand so we can ship a
+    // forged manifest before the Server constructor runs.
+    let (sender_unix, receiver_unix) =
+        UnixStream::pair().expect("could not create scm unix stream pair");
+
+    // The Server constructor expects the SCM fd to outlive the mio
+    // UnixStream that opened it; clear FD_CLOEXEC so the helper-spawned
+    // path does not invalidate the descriptor at the next `fork+execve`
+    // checkpoint. Mirrors `sozu::worker::set_no_close_exec`.
+    unsafe { clear_fd_cloexec(sender_unix.as_raw_fd()) };
+    unsafe { clear_fd_cloexec(receiver_unix.as_raw_fd()) };
+
+    let sender_fd = sender_unix.into_raw_fd();
+    let receiver_fd = receiver_unix.into_raw_fd();
+
+    let sender = ScmSocket::new(sender_fd).expect("master-side scm socket");
+    let receiver = ScmSocket::new(receiver_fd).expect("worker-side scm socket");
+
+    // Forge a manifest that declares three HTTP listeners and zero
+    // FDs. Pre-fix, the receiver would zip the three addresses against
+    // `received_fds[0..3]` — but only 0 FDs arrived so the slice would
+    // run past `file_descriptor_length` and panic. Post-fix, the
+    // length check fires before any indexing.
+    let forged = ListenersCount {
+        http: vec![
+            "127.0.0.1:80".to_string(),
+            "127.0.0.2:80".to_string(),
+            "127.0.0.3:80".to_string(),
+        ],
+        tls: vec![],
+        tcp: vec![],
+    };
+    let payload = forged.encode_length_delimited_to_vec();
+    // Bypass `ScmSocket::send_listeners` (which keeps addresses + FDs
+    // in sync by construction) and call the underlying `sendmsg`
+    // directly so we can ship zero FDs alongside a non-empty manifest.
+    send_raw_scm_payload(&sender, &payload).expect("raw scm send must succeed");
+
+    // Build the matching command-channel pair so the Server constructor
+    // has a `ProxyChannel` to register. `Channel::<Tx, Rx>::generate`
+    // returns `(Channel<Tx, Rx>, Channel<Rx, Tx>)`; the worker side
+    // matches `ProxyChannel = Channel<WorkerResponse, WorkerRequest>`,
+    // so we instantiate the generator with the *main* side's parameters
+    // and consume the second tuple slot. The constructor does not read
+    // anything from this channel before the SCM step, which is where
+    // the panic used to fire.
+    let (_main_side_cmd, worker_side_cmd) =
+        Channel::<WorkerRequest, WorkerResponse>::generate(1024, 16384)
+            .expect("command channel pair");
+
+    let config = ServerConfig::default();
+    let result = Server::try_new_from_config(
+        worker_side_cmd,
+        receiver,
+        config,
+        InitialState::default(),
+        false,
+    );
+
+    match result {
+        Err(ServerError::ScmSocket {
+            scm_err:
+                ScmSocketError::ListenersCountInconsistent {
+                    http,
+                    tls,
+                    tcp,
+                    total,
+                    fds_received,
+                    max_fds: _,
+                },
+            ..
+        }) => {
+            assert_eq!(http, 3);
+            assert_eq!(tls, 0);
+            assert_eq!(tcp, 0);
+            assert_eq!(total, 3);
+            assert_eq!(fds_received, 0);
+        }
+        Err(other) => {
+            panic!("expected ServerError::ScmSocket(ListenersCountInconsistent), got {other:?}",)
+        }
+        Ok(_) => panic!(
+            "Server::try_new_from_config accepted a forged ListenersCount with no FDs — \
+             the SCM bounds check in command/src/scm_socket.rs has regressed",
+        ),
+    }
+}
+
+/// Drop FD_CLOEXEC on `fd`. SAFETY: `fd` must be a valid open file
+/// descriptor borrowed for the duration of this call.
+unsafe fn clear_fd_cloexec(fd: i32) {
+    // SAFETY: `fd` is the caller's invariant; `fcntl` with `F_GETFD` /
+    // `F_SETFD` is thread-safe and side-effect-free beyond the
+    // descriptor's own flag word.
+    unsafe {
+        let f = libc::fcntl(fd, libc::F_GETFD);
+        libc::fcntl(fd, libc::F_SETFD, f & !libc::FD_CLOEXEC);
+    }
+}
+
+/// Mirrors the private `ScmSocket::send_msg_and_fds` helper but always
+/// ships zero file descriptors — the malformed scenario we want to
+/// reproduce. We invoke the `sendmsg` syscall directly to keep the
+/// test independent of crate-private helpers.
+fn send_raw_scm_payload(socket: &ScmSocket, payload: &[u8]) -> Result<(), std::io::Error> {
+    let iov = [IoSlice::new(payload)];
+    sendmsg::<()>(socket.fd, &iov, &[], MsgFlags::empty(), None)
+        .map(|_| ())
+        .map_err(|e| std::io::Error::other(e.to_string()))
+}

--- a/e2e/src/tests/mod.rs
+++ b/e2e/src/tests/mod.rs
@@ -24,6 +24,7 @@
 #![allow(clippy::useless_vec)]
 
 mod cluster_ip_limit_tests;
+mod command_channel_security_tests;
 mod eviction_tests;
 mod fuzz_tests;
 mod h1_security_tests;


### PR DESCRIPTION
## Summary

Two panic-on-malformed-IPC bugs in `sozu-command-lib` are reachable across the worker/master trust boundary, and one of them — the length-delimited command channel — is externally reachable through the admin unix socket. Both panicked with `slice index starts at N but ends at M` on attacker-controlled framing. This branch hardens the receiver and adds unit-level + end-to-end regression tests.

| # | Severity | Surface | Fix |
|---|----------|---------|-----|
| 1 | **HIGH** | `command/src/channel.rs:476` — `&buffer[delimiter_size()..message_len]` | reject `message_len < delimiter_size()` and drop the bogus delimiter so the channel re-syncs |
| 2 | **MEDIUM** | `command/src/scm_socket.rs:148-167` — `received_fds[index..index+len]` | validate `http+tls+tcp ≤ min(MAX_FDS_OUT, fds_received)` before slicing |

Both bugs violate the rule stated in `CLAUDE.md`: *"No panic on network-facing input. In parser, socket, mux, TLS, **command-channel**, and config paths, convert invalid traffic into … a contextual log."*

### Finding 1 — channel.rs slice-OOB (HIGH)

`Channel::try_read_delimited_message` decoded a peer-supplied `usize` length prefix and then sliced `&buffer[delimiter_size()..message_len]`. A peer that wrote a delimiter declaring `message_len < delimiter_size()` (e.g. 5 on a 64-bit host) bypassed the existing `> max_buffer_size` guard and panicked the receiver. Reachable from any local user with write perms on the admin unix socket → full-proxy DoS until restart.

Patch:
- new `ChannelError::MessageLengthUnderDelimiter` variant, symmetric with the existing `MessageTooLarge` upper-bound rejection;
- consume the bogus delimiter bytes (`self.front_buf.consume(delimiter_size())`) before returning, so the channel re-syncs on the peer's next valid frame instead of looping forever on the stale header.

CWE-129 (Improper Validation of Array Index) → reachable as CWE-248 (Uncaught Exception).

### Finding 2 — scm_socket.rs slice-OOB (MEDIUM)

`ScmSocket::receive_listeners` zipped the peer-supplied `ListenersCount.{http,tls,tcp}` lists against a fixed `[RawFd; MAX_FDS_OUT]` (200 slots) without bounds-checking the declared counts. A manifest declaring more entries than `MAX_FDS_OUT` or more entries than the FDs that actually arrived panicked the receiver on `received_fds[index..index + len]`, or on the trailing `received_fds[index..file_descriptor_length]` slice when `index > file_descriptor_length`.

Patch:
- validate `http + tls + tcp ≤ min(MAX_FDS_OUT, fds_received)` up front, with `checked_add` to guard against `usize` overflow;
- surface the mismatch as a new `ScmSocketError::ListenersCountInconsistent` carrying every input that contributed to the decision;
- rework the trailing tcp slice from `received_fds[index..file_descriptor_length]` to the symmetric `received_fds[index..index + tcp_len]` (identical result under the new invariant; no silent excess-FD acceptance).

## Protocol / security impact

- Command channel: no wire-format change. New error path is reached on a previously-panicking input only.
- SCM channel: no wire-format change. A well-formed `ListenersCount` (where counts match the FD set, as produced by `ScmSocket::send_listeners`) is accepted identically.
- No change to TLS, H1, H2, proxy-protocol, or any front-facing protocol surface.
- No new metrics, config keys, or CLI flags. `doc/configure.md` unchanged.

## Tests added

Unit regressions (live alongside the patched code):
- `command/src/channel.rs::tests::rejects_declared_length_below_delimiter` — writes a 5-byte-declared delimiter via raw `Write::write_all` on the underlying mio unix stream and asserts the new error variant instead of the pre-fix panic.
- `command/src/scm_socket.rs::tests::rejects_listeners_count_with_more_entries_than_fds` — ships a forged `ListenersCount { http: 3 }` with zero FDs and asserts the new error variant.

End-to-end regression (new file `e2e/src/tests/command_channel_security_tests.rs`, 218 lines):
- `channel_short_delimiter_does_not_panic_worker` spawns a real worker via `Worker::start_new_worker`, writes the malformed delimiter, asserts the worker thread is still alive, then sends a real `SoftStop` and asserts `wait_for_server_stop()` returns cleanly — the second assertion is the re-sync proof.
- `scm_inconsistent_listeners_count_does_not_panic_server_constructor` drives the real `Server::try_new_from_config` constructor with a forged SCM payload and pattern-matches on `ServerError::ScmSocket(ListenersCountInconsistent)`. The match arm references the new variant, so a future revert of `scm_socket.rs` fails to compile — compile-time regression gate.

Sensitivity verified by reverting each fix locally:
- without the channel.rs bounds check, the e2e test panics at `channel.rs:498:49` with the exact original `slice index starts at 8 but ends at 5` message;
- without the scm_socket.rs guard, the e2e file fails to compile because the new enum variant is gone.

## Commands run

```
cargo build --all-features --locked                    # green (1m12s)
cargo +nightly fmt --all -- --check                    # clean
cargo clippy --all-targets --locked -p sozu-command-lib -- -D warnings   # clean
cargo clippy -p sozu-e2e --tests -- -D warnings        # clean
cargo test -p sozu-command-lib --locked                # 94/94 pass
cargo test -p sozu-lib --locked                        # 542/542 pass
cargo test -p sozu --locked                            # 34/34 pass
cargo test -p sozu-e2e --offline command_channel_security  # 2/2 pass
```

## Doc updates

None required — no new config keys, metrics, CLI flags, or behaviour change for well-formed traffic. `CLAUDE.md`'s "no panic on network-facing input" rule already covers the command-channel path; this PR brings the implementation in line with that rule.

## Test plan

- [x] CI matrix (stable / beta / nightly × `crypto-ring` / `crypto-aws-lc-rs` / `crypto-openssl` / `fips`) all green
- [x] `cargo +nightly fmt --check` green
- [x] `cargo test -p sozu-e2e -- command_channel_security` shows 2 passing tests
- [x] Reviewer reverts each `fix(command):` commit locally to confirm the e2e tests turn red (panic for channel, compile error for SCM)