### PR TITLE
fix(h1): bracket IPv6 literals in Forwarded header (#1254)

### DIFF
--- a/e2e/src/tests/tests.rs
+++ b/e2e/src/tests/tests.rs
@@ -4464,6 +4464,122 @@ fn test_x_real_ip_send_and_elide() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// RFC 7239 IPv6 bracketing in the synthesised `Forwarded` header.
+//
+// Regression for sozu issue #1254. Prior to the fix Sōzu emitted
+// `Forwarded: ... for="2001:db8::1:9000"` which the RFC explicitly calls out
+// as ambiguous — the trailing `:9000` could be the port or part of the
+// address. The on-wire contract must be `for="[2001:db8::1]:9000"` and
+// `by="[<ipv6>]"` (RFC 7239 §6, mirrors HAProxy `_7239_print_ip6`).
+//
+// We drive PROXY-v2 with an IPv6 source AND destination so `HttpContext`
+// sees IPv6 for both `session_address` (→ `for=`) and `public_address`
+// (→ `by=`) without needing the e2e port_registry to grow IPv6 support.
+// ---------------------------------------------------------------------------
+
+/// PROXY-v2 with IPv6 src + dst → backend must observe a bracketed
+/// `Forwarded` header for both `for=` and `by=`.
+fn try_forwarded_ipv6_brackets_via_proxy_v2() -> State {
+    use std::io::Write;
+    use std::net::TcpStream;
+
+    let (mut worker, front_address, back_address) = setup_x_real_ip_test(
+        "FORWARDED-IPV6-BRACKETS",
+        /* elide_x_real_ip */ false,
+        /* send_x_real_ip */ false,
+        /* expect_proxy */ true,
+    );
+
+    let mut backend = SyncBackend::new("BACKEND_0", back_address, http_ok_response("pong"));
+    backend.connect();
+
+    // IPv6 source + destination in the PROXY-v2 header. Sōzu uses
+    // `addresses.destination()` as `public_address` (→ `by=`) and
+    // `addresses.source()` as `session_address` (→ `for=`).
+    let pp_src: SocketAddr = "[2001:db8::1]:9000".parse().unwrap();
+    let pp_dst: SocketAddr = "[2001:db8::2]:443".parse().unwrap();
+    let pp_header = sozu_lib::protocol::proxy_protocol::header::HeaderV2::new(
+        sozu_lib::protocol::proxy_protocol::header::Command::Proxy,
+        pp_src,
+        pp_dst,
+    );
+    let pp_bytes = pp_header.into_bytes();
+
+    let http_payload = "GET /api HTTP/1.1\r\n\
+        Host: localhost\r\n\
+        Connection: close\r\n\
+        Content-Length: 4\r\n\
+        \r\n\
+        ping";
+
+    let mut stream = TcpStream::connect(front_address).expect("could not connect to sozu");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("set read timeout");
+    stream
+        .set_write_timeout(Some(Duration::from_secs(2)))
+        .expect("set write timeout");
+    stream
+        .write_all(&pp_bytes)
+        .expect("write proxy-protocol header");
+    stream
+        .write_all(http_payload.as_bytes())
+        .expect("write HTTP request");
+
+    backend.accept(0);
+    let request = backend.receive(0);
+    println!("backend received request: {request:?}");
+
+    backend.send(0);
+    let mut buf = [0u8; 4096];
+    let _ = stream.read(&mut buf);
+
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+
+    let Some(req) = request else {
+        println!("backend received no request");
+        return State::Fail;
+    };
+
+    // Assert the exact RFC 7239 wire format for both nodes.
+    let expected_for = r#"for="[2001:db8::1]:9000""#;
+    let expected_by = r#"by="[2001:db8::2]""#;
+
+    if !req.contains(expected_for) {
+        println!(
+            "missing bracketed `for=` in Forwarded header:\nwant: {expected_for}\ngot:\n{req}"
+        );
+        return State::Fail;
+    }
+    if !req.contains(expected_by) {
+        println!("missing bracketed `by=` in Forwarded header:\nwant: {expected_by}\ngot:\n{req}");
+        return State::Fail;
+    }
+
+    // The pre-fix, ambiguous form must never appear on the wire.
+    let ambiguous_for = r#"for="2001:db8::1:9000""#;
+    if req.contains(ambiguous_for) {
+        println!("Forwarded header is back to the ambiguous form #1254 (no brackets):\n{req}");
+        return State::Fail;
+    }
+
+    State::Success
+}
+
+#[test]
+fn test_forwarded_ipv6_brackets_via_proxy_v2() {
+    assert_eq!(
+        repeat_until_error_or(
+            10,
+            "Forwarded (RFC 7239) — IPv6 peer + public are bracketed in `for=` / `by=` (#1254)",
+            try_forwarded_ipv6_brackets_via_proxy_v2,
+        ),
+        State::Success
+    );
+}
+
 /// Codex cross-check finding: `pkawa::handle_trailer` bypasses the
 /// shared `HttpContext::on_request_headers` callback. Without dedicated
 /// trailer-side elision a naive H2 client could spoof `x-real-ip` as a

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -81,9 +81,17 @@ fn build_traceparent(trace_id: &[u8; 32], parent_id: &[u8; 16]) -> [u8; 55] {
 
 /// Write the ";for=..;by=.." portion of a Forwarded header into `buf`
 /// without heap-allocating a `String`.
+///
+/// RFC 7239 §6 requires IPv6 literals to be enclosed in square brackets
+/// inside a quoted string (the `IP-literal` production is `"[" IPv6address "]"`).
+/// Emitting a bare IPv6 like `for="2001:db8::1:8080"` is ambiguous: the
+/// trailing `:1:8080` could parse as `::1` + port `8080` or as the literal
+/// `:1:8080` with no port. Matches HAProxy's behaviour
+/// (`_7239_print_ip6` in `src/http_ext.c`), which is the de-facto reference
+/// implementation of RFC 7239 in the proxy world. See sozu issue #1254.
 fn write_forwarded_for_by(buf: &mut Vec<u8>, peer_ip: IpAddr, peer_port: u16, public_ip: IpAddr) {
     buf.extend_from_slice(b";for=\"");
-    let _ = write!(buf, "{peer_ip}");
+    write_ip_literal(buf, peer_ip);
     buf.push(b':');
     let mut port_buf = itoa::Buffer::new();
     buf.extend_from_slice(port_buf.format(peer_port).as_bytes());
@@ -94,8 +102,24 @@ fn write_forwarded_for_by(buf: &mut Vec<u8>, peer_ip: IpAddr, peer_port: u16, pu
         }
         IpAddr::V6(_) => {
             buf.push(b'"');
-            let _ = write!(buf, "{public_ip}");
+            write_ip_literal(buf, public_ip);
             buf.push(b'"');
+        }
+    }
+}
+
+/// Write an `IP-literal` per RFC 3986 §3.2.2 / RFC 7239 §6: IPv4 verbatim,
+/// IPv6 wrapped in `[...]`. Caller is responsible for any surrounding quotes
+/// required by the embedding syntax (RFC 7239 mandates them for IPv6).
+fn write_ip_literal(buf: &mut Vec<u8>, ip: IpAddr) {
+    match ip {
+        IpAddr::V4(_) => {
+            let _ = write!(buf, "{ip}");
+        }
+        IpAddr::V6(_) => {
+            buf.push(b'[');
+            let _ = write!(buf, "{ip}");
+            buf.push(b']');
         }
     }
 }
@@ -1111,6 +1135,86 @@ mod tests {
         assert_eq!(ctx.id, original_id);
         assert_eq!(ctx.protocol, original_protocol);
         assert_eq!(ctx.public_address, original_public_address);
+    }
+
+    // ── write_forwarded_for_by (RFC 7239 §6 IP-literal bracketing) ──────
+    //
+    // Locks in the IPv6 bracket+quote contract that matches HAProxy
+    // (`_7239_print_ip6` in `src/http_ext.c`) and prevents regression to
+    // the ambiguous `for="2001:db8::1:8080"` form flagged in issue #1254.
+
+    use std::net::Ipv6Addr;
+
+    fn render_for_by(peer: SocketAddr, public_ip: IpAddr) -> String {
+        let mut buf = Vec::new();
+        write_forwarded_for_by(&mut buf, peer.ip(), peer.port(), public_ip);
+        String::from_utf8(buf).expect("forwarded fragment must be ASCII")
+    }
+
+    fn render_suffix(proto: &str, peer: SocketAddr, public_ip: IpAddr) -> String {
+        let mut buf = Vec::new();
+        write_forwarded_suffix(&mut buf, proto, peer.ip(), peer.port(), public_ip);
+        String::from_utf8(buf).expect("forwarded fragment must be ASCII")
+    }
+
+    #[test]
+    fn test_forwarded_ipv4_peer_ipv4_by_unchanged() {
+        // IPv4 must keep the pre-fix wire format: unquoted `by=`, bare IPv4 in
+        // `for=`. Sōzu emits `for=` quoted unconditionally (HAProxy emits it
+        // quoted only when a port is attached; we always attach a port).
+        let peer = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7)), 54321);
+        let public_ip = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1));
+        assert_eq!(
+            render_for_by(peer, public_ip),
+            r#";for="203.0.113.7:54321";by=198.51.100.1"#,
+        );
+    }
+
+    #[test]
+    fn test_forwarded_ipv6_peer_brackets_disambiguate_port() {
+        // Regression for issue #1254: without brackets, `for="2001:db8::1:8080"`
+        // is ambiguous (could parse as `::1` + port `8080` or `:1:8080` literal).
+        let peer = SocketAddr::new(IpAddr::V6("2001:db8::1".parse::<Ipv6Addr>().unwrap()), 8080);
+        let public_ip = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1));
+        assert_eq!(
+            render_for_by(peer, public_ip),
+            r#";for="[2001:db8::1]:8080";by=198.51.100.1"#,
+        );
+    }
+
+    #[test]
+    fn test_forwarded_ipv6_public_address_bracketed_and_quoted() {
+        // `by=` carries no port but RFC 7239 §6 still requires the IP-literal
+        // brackets for IPv6, and the value must be quoted because the literal
+        // contains `:`.
+        let peer = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7)), 54321);
+        let public_ip = IpAddr::V6("2001:db8::2".parse::<Ipv6Addr>().unwrap());
+        assert_eq!(
+            render_for_by(peer, public_ip),
+            r#";for="203.0.113.7:54321";by="[2001:db8::2]""#,
+        );
+    }
+
+    #[test]
+    fn test_forwarded_ipv6_peer_and_public_both_bracketed() {
+        let peer = SocketAddr::new(IpAddr::V6("2001:db8::1".parse::<Ipv6Addr>().unwrap()), 8080);
+        let public_ip = IpAddr::V6("2001:db8::2".parse::<Ipv6Addr>().unwrap());
+        assert_eq!(
+            render_for_by(peer, public_ip),
+            r#";for="[2001:db8::1]:8080";by="[2001:db8::2]""#,
+        );
+    }
+
+    #[test]
+    fn test_forwarded_suffix_prepends_proto_and_brackets_ipv6() {
+        // The suffix form is what we append when an inbound `Forwarded`
+        // header already exists. Same bracketing contract must hold.
+        let peer = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 443);
+        let public_ip = IpAddr::V6("fe80::1".parse::<Ipv6Addr>().unwrap());
+        assert_eq!(
+            render_suffix("https", peer, public_ip),
+            r#", proto=https;for="[::1]:443";by="[fe80::1]""#,
+        );
     }
 
     // ── traceparent / opentelemetry helpers ─────────────────────────────


### PR DESCRIPTION
## Summary

Closes #1254. RFC 7239 §6 requires IPv6 literals in the `Forwarded`
header's `for=` / `by=` parameters to be wrapped in `[ ... ]` and the
whole value to be `"`-quoted; without brackets the address/port split
is ambiguous. Sōzu's renderer at `lib/src/protocol/kawa_h1/editor.rs`
emitted bare IPv6, so an IPv6 client `2001:db8::1` on port `8080`
produced `for="2001:db8::1:8080"` — the trailing `:1:8080` is
indistinguishable from `::1` plus port `8080`. `by=` was quoted but
also unbracketed.

This PR brackets IPv6 in both `for=` and `by=`. `X-Forwarded-For` keeps
its bare-IP convention (matches HAProxy / Apache / nginx). IPv4 wire
format is unchanged.

## Reference

Cross-checked against HAProxy, the de-facto reference implementation
of RFC 7239 in the proxy world:

- `_7239_print_ip6` in [`src/http_ext.c`](https://github.com/haproxy/haproxy/blob/master/src/http_ext.c#L498-L508) wraps any IPv6 literal in `[ ... ]` unconditionally and forces `"`-quoting.
- HAProxy's regression suite [`reg-tests/http-rules/forwarded-header-7239.vtc`](https://github.com/haproxy/haproxy/blob/master/reg-tests/http-rules/forwarded-header-7239.vtc#L137-L160) rejects unbracketed `by=[::1]` with HTTP 400 and accepts `by="[::1]"`, confirming brackets + quotes are mandatory.

Issue-thread analysis: https://github.com/sozu-proxy/sozu/issues/1254#issuecomment-4498194522

## Before / After (wire format) |                         | Before                              | After                                  |
|-------------------------|-------------------------------------|----------------------------------------|
| IPv6 peer + port (`for=`) | `for="2001:db8::1:8080"` (ambiguous) | `for="[2001:db8::1]:8080"`             |
| IPv6 public (`by=`)       | `by="2001:db8::2"` (unbracketed)     | `by="[2001:db8::2]"`                    |
| IPv4 (both nodes)         | unchanged                            | unchanged                              |
| `X-Forwarded-For`         | bare IPv6                            | bare IPv6 (unchanged)                  |

## Test plan

- [x] `cargo build --locked` + `cargo build --all-features --locked`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --locked` (no new warnings)
- [x] `cargo test -p sozu-lib --locked` — 578 passed, 4 ignored
- [x] 5 new unit tests in `editor::tests` covering IPv4 unchanged, IPv6 `for=`, IPv6 `by=`, IPv6 on both sides, and the `Forwarded` suffix (append-to-existing) path
- [x] 1 new e2e test `test_forwarded_ipv6_brackets_via_proxy_v2` drives a real worker with PROXY-v2 IPv6 src+dst and asserts the on-wire `Forwarded: proto=http; for="[2001:db8::1]:9000"; by="[2001:db8::2]"`, plus a negative assertion that the pre-fix ambiguous form never reappears — 10/10 iterations
- [x] Regression: existing `test_x_real_ip*` suite still green