### PR TITLE
docs(migration): two missing 2.0 breaking-change entries in upgrade guide

### DIFF
--- a/doc/upgrade/1.x-to-2.0.md
+++ b/doc/upgrade/1.x-to-2.0.md
@@ -145,6 +145,54 @@ auto-strips labels into the metric name, you may see new
 `http.errors{cluster_id=…,backend_id=…}` series. Confirm
 `metrics.detail` matches your operator intent.
 
+### Default `metrics.detail = "cluster"` suppresses per-backend StatsD series
+
+`metrics.detail` is a new TOML knob (config key `metrics.detail`,
+default `"cluster"`) that filters `(cluster_id, backend_id)` labels
+**before** the StatsD network drain encodes them. The default value
+matches the per-cluster aggregation level — `backend_id` is dropped on
+every metric.
+
+In 1.1.x there was no such filter: any emission that originated with
+`Some(cluster_id)` AND `Some(backend_id)` — `bytes_in`, `bytes_out`,
+`backend_response_time`, `backend_connection_time`, per-backend
+`requests` — hit BOTH the cluster-aggregate and the backend-detail
+storage of `network_drain::WriteBuf`, so the StatsD wire carried two
+series:
+
+```
+sozu.cluster.bytes_in,cluster_id=foo:42|c
+sozu.backend.bytes_in,cluster_id=foo,backend_id=foo-0:42|c
+```
+
+In 2.0.0 with the default `metrics.detail = "cluster"`, only the first
+series is emitted. The `sozu.backend.*` series silently disappears
+unless the operator opts into `metrics.detail = "backend"`.
+
+**Operator impact**: dashboards / alerting rules that grouped by
+`backend_id` will go blank at upgrade if `metrics.detail` is left at
+the default. This is independent of the `http.errors` labelling change
+above — it affects every metric that previously carried a backend label
+(`bytes_in`, `bytes_out`, `backend_response_time`,
+`backend_connection_time`, per-backend `requests`).
+
+**Action**: if any of your dashboards group `sozu.backend.*` series by
+`backend_id`, set the following in your config TOML **before** rolling
+out 2.0.0:
+
+```toml
+[metrics]
+# ... existing fields ...
+detail = "backend"
+```
+
+The runtime `SetMetricDetail` TTL-lease verb — exposed through
+`sozu top --detail backend --lease-ttl-seconds N` (default: `Backend`
+level auto-applied on TUI startup) — can also raise the level for a
+bounded window without restarting the worker; useful for one-off
+investigations without committing to the permanent cardinality cost.
+See `doc/sozu-top.md` § Cardinality.
+
 ### Pattern-trie segment regex anchoring (CWE-1023 fix)
 
 Every segment-level regex inserted into the routing trie is now wrapped

--- a/doc/upgrade/1.x-to-2.0.md
+++ b/doc/upgrade/1.x-to-2.0.md
@@ -328,6 +328,22 @@ desired. Two new metrics ship: `http.302.redirection` and
 `http.308.redirection` (cluster + backend labelled, mirroring the
 existing `http.301.redirection`).
 
+### Renamed inline-template compile-error counter
+
+Inline-template compile failures previously surfaced under the
+per-status counter `http.301.redirect_template.compile_error`. Now that
+302 and 308 templates can fail the same way, the per-status form would
+leave those failures unmonitored — so the counter is collapsed into a
+single status-agnostic key:
+
+| Before (1.1.x)                              | After (2.0.0)                           |
+| ------------------------------------------- | --------------------------------------- |
+| `http.301.redirect_template.compile_error`  | `http.redirect_template.compile_error`  |
+
+**Operator impact**: dashboards or alerts scraping the old key need
+updating. The new key is documented in `doc/configure.md` alongside the
+new `http.302.redirection` and `http.308.redirection` success counters.
+
 ## What is NOT in 2.0.0 (release-notes asterisks)
 
 | Asterisk                                                                                                                                                                                  | Tracked in                                                                                                                                                            | Roadmap                                                   |


### PR DESCRIPTION
## Summary

Two breaking-change entries already in the `## [Unreleased]` section of `CHANGELOG.md` were missing from `doc/upgrade/1.x-to-2.0.md`. Operators following the guide alone would silently miss dashboard rewires required at 2.0 cutover.

- **`http.redirect_template.compile_error` rename** — `CHANGELOG.md` (Breaking section) calls out the status-agnostic rename from `http.301.redirect_template.compile_error`; the guide only mentioned the success counter `http.301.redirection`. Adds a dedicated subsection with the before/after table and the operator action.
- **`metrics.detail = "cluster"` default suppresses per-backend StatsD series** — the new `MetricDetailLevel::Cluster` default at `command/src/config.rs:1174` filters `backend_id` out of every emission via `filter_labels_for_detail` (`lib/src/metrics/mod.rs:51`) before the StatsD network drain. In 1.1.x the same metrics (`bytes_in`, `bytes_out`, `backend_response_time`, `backend_connection_time`, per-backend `requests`) were emitted with BOTH a cluster-aggregate AND a backend-detail series on the wire (cf. `1.1.1:lib/src/metrics/network_drain.rs:196,280`). Dashboards grouping by `backend_id` go blank at upgrade unless the operator sets `metrics.detail = "backend"`. The c357a73a commit message claimed `Default::Cluster` "preserves the historical pre-knob behaviour" — accurate for the worker-side storage shape, not for the StatsD wire. The new subsection patches this doc gap and points operators at the `sozu top --detail backend --lease-ttl-seconds N` runtime override.

The second entry was surfaced by a `codex review --base 1.1.1` pass; it confirmed the regression by tracing the 1.1.1 → main behaviour through `network_drain.rs` and the new `Aggregator::receive_metric` filter.

## Test plan

- [x] `wt step diff -- --stat` shows only `doc/upgrade/1.x-to-2.0.md` changed (+64 lines, no code touched).
- [x] All cited file:line references checked against current `main`: `command/src/config.rs:1170-1175`, `lib/src/metrics/mod.rs:45-53`, `1.1.1:lib/src/metrics/network_drain.rs:196,280`, `doc/sozu-top.md:81-92`, `doc/configure.md:1493`.
- [x] Cross-checked TOML key shape against `lib/src/metrics/mod.rs` (`MetricDetailLevel` deserialises with `#[serde(rename_all = "lowercase")]`, so `detail = "backend"` is the correct case).
- [x] Cross-checked CLI shape against `doc/sozu-top.md`: `sozu top --detail process|frontend|cluster|backend` exists, `--lease-ttl-seconds` exists; there is no flat `sozu metrics detail` verb.
- [ ] Reviewer to confirm whether the per-backend suppression should instead be addressed at the **code** level by flipping the default to `Backend` (would change the cardinality cost out of the box but preserve 1.1.x scrape shape). This PR documents the as-shipped behaviour; happy to follow up with the code change in a separate PR if that's the preferred path.

## Security / protocol impact

None — docs only.