### PR TITLE
docs: refresh CLAUDE.md and README after H2 mux merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-Sōzu — a hot-reconfigurable HTTP/1.x + HTTP/2 reverse proxy (AGPL-3.0). Rust 2024 (MSRV 1.88.0, matching the `1.88.0` toolchain pinned in `rust-toolchain`). Upstream: `github.com/sozu-proxy/sozu`. The `feat/h2-mux` branch carries the H2 multiplexer rewrite; PR #1209 is open against `main`.
+Sōzu — a hot-reconfigurable HTTP/1.x + HTTP/2 reverse proxy (AGPL-3.0). Rust 2024 (MSRV 1.88.0, matching the `1.88.0` toolchain pinned in `rust-toolchain`). Upstream: `github.com/sozu-proxy/sozu`. The H2 multiplexer rewrite landed on `main` via PR #1209 (merged commit `98c56a4c`); subsequent hardening (parser, command IPC, metrics, audit fixes) builds on it.
 
 This file is the primary agent instruction for the repo. It is symlinked to `AGENTS.md` so OpenAI Codex picks up the same content. Anthropic's global `~/.claude/CLAUDE.md` conventions (worktree-first, GPG sign-off, commitizen style) still apply and are not duplicated here.
 
@@ -21,12 +21,12 @@ Dependency graph: `lib → command`; `bin → lib + command`; `e2e → lib + com
 
 ```bash
 cargo build --locked                            # debug, all workspace members
-cargo build --all-features --locked             # currently builds (verified 2026-04 on feat/h2-mux)
+cargo build --all-features --locked             # all features on main (verified 2026-05)
 cargo build -p sozu --release --locked          # production binary (release = lto + codegen-units=1)
 cargo +nightly fmt --all -- --check             # nightly REQUIRED: rustfmt.toml uses `ignore = [...]` which stable treats as nightly-only
-cargo clippy --all-targets --locked             # currently emits one `clippy::if_same_then_else` in e2e/src/tests/h2_correctness_tests.rs — `-D warnings` fails until fixed
+cargo clippy --all-targets --locked -- -D warnings  # clean on main; keep it that way
 cargo test --workspace --locked                 # unit + e2e
-cargo test -p sozu-e2e -- h2_                   # filter to H2 e2e tests (~149 tests)
+cargo test -p sozu-e2e -- h2_                   # filter to H2 e2e tests (~181 tests across h2_*.rs)
 cargo +nightly fuzz run fuzz_frame_parser       # from fuzz/, requires cargo-fuzz + nightly
 ```
 
@@ -68,9 +68,11 @@ Crypto-provider features live in `bin/Cargo.toml` + `lib/Cargo.toml`; CI exercis
 
 Unit tests live beside their modules (`#[cfg(test)] mod tests` in `lib/src/**`). Integration tests are in `e2e/src/tests/` and registered via `e2e/src/tests/mod.rs`:
 
-- `h2_tests.rs`, `h2_correctness_tests.rs`, `h2_security_tests.rs`, `h2_security_{parser,session,sni,header_injection}.rs` — H2 mux coverage (~130 tests on this branch).
+- `h2_tests.rs`, `h2_correctness_tests.rs`, `h2_security_tests.rs`, `h2_security_{parser,session,sni,header_injection}.rs`, `h2_priority_rearm_tests.rs` — H2 mux coverage (~181 tests on `main`).
 - `mux_tests.rs` — H1 + proxy-protocol + keepalive/hup edge cases.
-- `h1_security_tests.rs`, `tls_tests.rs`, `tcp_tests.rs`.
+- `h1_security_tests.rs`, `tls_tests.rs`, `tcp_tests.rs`, `hsts_tests.rs`.
+- `command_channel_security_tests.rs` — command-channel and SCM FD-passing hardening (panic-OOB, length-prefix validation).
+- `cluster_ip_limit_tests.rs`, `eviction_tests.rs`, `listener_update_tests.rs`, `protocol_pair_matrix.rs`, `redirect_rewrite_auth_tests.rs` — feature coverage for per-IP rate-limit, accept-queue eviction, listener hot-update, the H1↔H2 protocol matrix, and the answer/redirect/rewrite/auth pipeline.
 - `fuzz_tests.rs` — `#[ignore]` wrappers around the cargo-fuzz targets. Run with `cargo test -p sozu-e2e -- --ignored fuzz`.
 - `h2_utils.rs` — shared helpers, including `loop_read_*` (absorbs TCP segmentation in assertions).
 - `tests.rs` — `setup_sync_test`, `setup_async_test`, worker harness, port-registry integration.
@@ -114,7 +116,7 @@ Crypto-provider features (`crypto-ring`, `crypto-aws-lc-rs`, `crypto-openssl`, `
 - **Branch naming**: `feat/<scope>`, `fix/<scope>`, `refactor/<scope>`, `chore/<scope>`, `docs/<scope>`, `test/<scope>`, `perf/<scope>`, `style/<scope>`, `ci/<scope>`, `bench/<scope>`.
 - **Conventional commits** with scope: `feat(h2): ...`, `fix(mux): ...`, `test(e2e): ...`, etc. No commitizen config — follow the existing `git log` style manually.
 - **Sign + GPG**: `git commit -s -S` for new commits. History on this branch has a minority of unsigned/unsignedoff commits; keep new ones signed.
-- **PR base is `main`.** For sub-worktrees forked off `feat/h2-mux` (most in-flight work), manually target `feat/h2-mux` when merging back. `wt merge -y` defaults to the repo default (`main`) — confirm the target before using it.
+- **PR base is `main`.** Default-branch development now — `feat/h2-mux` was merged via PR #1209 and is no longer a long-lived integration branch. `wt merge -y` defaults to `main`; confirm the target before using it for the rare follow-up forked off another in-flight branch.
 - **After committing: push.** On this repo, `git push` is part of the commit task; don't stop at `git commit`. Post the resulting `github.com/sozu-proxy/sozu/actions` run URL.
 - **PRs** are reviewed by CODEOWNERS (`@FlorentinDUBOIS @Wonshtrum @llenotre`) and gated by the CLA in `CONTRIBUTING.md`. PR descriptions should call out protocol/security impact, commands run, tests added, and doc updates.
 

--- a/README.md
+++ b/README.md
@@ -65,18 +65,29 @@ To get started check out our [documentation](./doc/README.md) !
 
 - **From source.** See [`doc/getting_started.md`](./doc/getting_started.md) for compilation prerequisites (`protoc`, Rust toolchain pinned via `rust-toolchain`).
 
+## Quickstart
+
+Once the prerequisites (`protoc`, Rust 1.88 via the pinned `rust-toolchain`) are installed, building and starting Sōzu takes two commands:
+
+```sh
+cargo build -p sozu --release --locked
+target/release/sozu start -c bin/config.toml
+```
+
+`bin/config.toml` is the in-tree sample config — copy it next to your TLS certs and edit listener/cluster blocks before going to production. The live operator dashboard is available with `cargo build -p sozu --release --locked --features tui` then `target/release/sozu top`. Configuration reference: [`doc/configure.md`](./doc/configure.md).
+
 ## Exploring the source
 
 The Cargo workspace ships four crates (Rust 2024 edition, MSRV 1.88):
 
-- `lib/`: the `sozu-lib` reverse proxy library hosts the single-threaded mio event loop, the HTTP/1.1, HTTP/2 multiplexer, TCP and TLS protocols, routing, sockets, metrics, and the buffer pool.
-- `bin/`: the `sozu` binary wraps the library in a master/worker supervisor, exposes the unix command socket, and orchestrates hot reconfiguration and zero-downtime upgrades.
-- `command/`: the `sozu-command-lib` ships the protobuf IPC schema, configuration parser, replicated state, channels, and FD-passing helpers used by both `lib` and `bin`.
-- `e2e/`: the `sozu-e2e` integration harness spawns real workers plus mock clients and backends to exercise the H1, H2, TLS, and PROXY-protocol paths.
+- `lib/`: the `sozu-lib` reverse proxy library hosts the single-threaded mio event loop, the HTTP/1.1 (Kawa) and HTTP/2 multiplexer, TCP and TLS protocols, routing, per-IP rate limiting, sockets, metrics, and the buffer pool.
+- `bin/`: the `sozu` binary wraps the library in a master/worker supervisor, exposes the unix command socket, orchestrates hot reconfiguration and zero-downtime upgrades, and ships the optional `sozu top` TUI behind the `tui` feature.
+- `command/`: the `sozu-command-lib` ships the protobuf IPC schema, configuration parser, replicated state, length-prefixed channels, and SCM FD-passing helpers used by both `lib` and `bin`.
+- `e2e/`: the `sozu-e2e` integration harness spawns real workers plus mock clients and backends to exercise the H1, H2, TLS, PROXY-protocol, command-channel hardening, and listener/upgrade hot-reconfig paths.
 
 The `fuzz/` crate (`fuzz_frame_parser`, `fuzz_hpack_decoder`) lives outside the Cargo workspace and is built with `cargo +nightly fuzz` from inside `fuzz/`.
 
-HTTP/2 support (frontend and backend) is driven through the multiplexer in `lib/src/protocol/mux/` and TLS ALPN negotiation in `lib/src/protocol/rustls.rs`.
+HTTP/2 support (frontend and backend) is driven through the multiplexer in `lib/src/protocol/mux/` and TLS ALPN negotiation in `lib/src/protocol/rustls.rs`; the multiplexer includes flood mitigations for CVE-2023-44487 (Rapid Reset), CVE-2024-27316 (CONTINUATION flood), and CVE-2025-8671 (MadeYouReset), plus PING/SETTINGS/priority floods.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Drop `feat/h2-mux` integration-branch references from `CLAUDE.md` now that PR #1209 has landed on `main` (merge commit `98c56a4c`). Refresh the build/test guidance: clippy is clean (`-D warnings` viable), the H2 e2e suite is ~181 tests, and the testing section lists the new files added since merge (priority rearm, command-channel security, cluster IP limit, eviction, HSTS, listener update, protocol pair matrix, redirect/rewrite/auth).
- Add a **Quickstart** section to `README.md` and rework **Exploring the source** to mention Kawa/H1, per-IP rate limiting, command-IPC hardening, listener hot-reconfig in `e2e/`, and the H2 flood mitigations (CVE-2023-44487, CVE-2024-27316, CVE-2025-8671).

Docs-only. `AGENTS.md` follows automatically (symlink to `CLAUDE.md`).

## Protocol / security impact
None — documentation only.

## Commands run
- `git diff --stat` (2 files, +25 / -12)
- `git commit -s -S` (signed, GPG-signed)

## Tests added
None — docs-only changeset.

## Doc updates
- `CLAUDE.md` — sections "Workspace header", "Build", "Testing", "Branching & commits"
- `README.md` — new **Quickstart**, refreshed **Exploring the source**