### PR TITLE
docs(mux): consolidate plan-numbering references in docs and comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,21 @@ category at tag time.
   transitive version slots (`itertools 0.13.0`, `wit-bindgen 0.57.1`), plus
   criterion 0.8 dep fan-out. No MSRV impact — all movers declare
   MSRV ≤ 1.88.0.
+- **Docs and comments consolidation**: refreshed code comments, rustdoc, and
+  `lib/src/protocol/mux/LIFECYCLE.md` / `doc/h2_mux_internals.md` so they
+  describe behavior directly instead of citing now-retired plan labels
+  (router "Wave 1c/2b/3a", security-audit "Phase 1D", Codex review markers
+  "G5/G7/G10/G11/G12", h2-priority-rearm "Fix A/B/C/D", "B3-h/B3-p/B3-z"
+  test plan entries, and the "Phase 1/2/3" stage labels inside
+  `flush_pending_control_frames` and `graceful_goaway`). One
+  operator-visible side effect — the `h2.rs:4089` debug log
+  `GOAWAY (graceful, phase 1)` now reads `GOAWAY (graceful, initial)`. The
+  final GOAWAY continues to log via the generic `GOAWAY: {error}` line at
+  `h2.rs:4032` (unchanged), so only the initial-GOAWAY substring shifts.
+  Deployments running with `--features logs-debug` that scrape sozu logs
+  for the literal `phase 1` substring need to update their filters. The
+  RFC 9113 §6.8 double-GOAWAY behavior itself is unchanged. No other
+  metrics, config keys, or wire behavior change.
 
 ### 💥 Breaking changes (1.1.x → 2.0.0)
 

--- a/doc/h2_mux_internals.md
+++ b/doc/h2_mux_internals.md
@@ -405,8 +405,9 @@ Flushes control data before application frames, in order:
    eviction (which the per-stream error callers invoke synchronously after
    `reset_stream` returns). `finalize_write` retains `Ready::WRITABLE`
    whenever the queue is non-empty so a partial write that deferred the
-   flush (Phase 3 is gated on `expect_write.is_none()`) re-runs on the
-   next tick rather than stranding the queued RST.
+   flush (the RST_STREAM drain stage is gated on
+   `expect_write.is_none()`) re-runs on the next tick rather than
+   stranding the queued RST.
 
 Returns `Some(MuxResult)` if the caller should return early, `None` to proceed.
 

--- a/e2e/src/tests/h2_correctness_tests.rs
+++ b/e2e/src/tests/h2_correctness_tests.rs
@@ -1574,8 +1574,8 @@ fn test_h2_incremental_round_robin_closes_every_stream() {
 ///   last DATA frame.
 ///
 /// MUST FAIL on `feat/h2-mux` HEAD (commit `fe528e75` landed the RFC 9218
-/// scheduling that introduced the strand); MUST PASS after Fix A (skip
-/// incremental yield when `incremental_peer_count <= 1`).
+/// scheduling that introduced the strand); MUST PASS once the scheduler
+/// skips its incremental yield when `incremental_peer_count <= 1`.
 fn try_h2_solo_incremental_drains_fully() -> State {
     const BODY_SIZE: usize = 80 * 1024;
 

--- a/e2e/src/tests/h2_priority_rearm_tests.rs
+++ b/e2e/src/tests/h2_priority_rearm_tests.rs
@@ -1,36 +1,35 @@
-//! End-to-end regression tests for the H2 "rearm + peer-signal" gaps
-//! identified by the `/ask --with-codex` follow-up on PR #1209.
+//! End-to-end regression guards for the H2 scheduler/readiness contract
+//! at the boundary between `signal_pending_write` and `Ready::WRITABLE`.
+//! Each test pins one previously-broken interaction so a regression
+//! manifests as a wall-clock stall the harness can catch. See
+//! `lib/src/protocol/mux/LIFECYCLE.md` invariants 15/16/17 for the
+//! underlying readiness invariants.
 //!
-//! Three production-grade `signal_pending_write`/`Ready::WRITABLE` pairing
-//! gaps plus one scheduler staleness bug are covered here. See the
-//! canonical plan at `~/.claude/plans/ask-h2-prio-truncation-plan.md` and
-//! `lib/src/protocol/mux/LIFECYCLE.md` invariants 15/16/17.
-//!
-//! * [`test_h2_backend_silent_triggers_504_within_back_timeout`]: Fix A —
+//! * [`test_h2_backend_silent_triggers_504_within_back_timeout`] —
 //!   defence-in-depth for invariant 15 on the `set_default_answer` path.
 //!   On HEAD the synchronous drain loop at `mux/mod.rs:1402-1423` already
 //!   flushes the 504 body before the session closes, so this test is a
-//!   lock-in regression guard rather than a RED-to-green flip. The actual
-//!   RED for Fix A is the unit test shipped alongside the patch in
+//!   lock-in regression guard rather than a RED-to-green flip. The
+//!   matching RED that exercises `set_default_answer` directly lives in
 //!   `mux/answers.rs::tests`.
-//! * [`test_h2_priority_update_rearms_writable`]: Fix B — two streams,
-//!   a mid-flight PRIORITY_UPDATE bumps the second to `u=0, i`. Asserts
+//! * [`test_h2_priority_update_rearms_writable`] — two streams, a
+//!   mid-flight PRIORITY_UPDATE bumps the second to `u=0, i`. Asserts
 //!   both streams drain full bodies + END_STREAM within the 5-second
 //!   post-PU budget. On HEAD the observed post-PU drain is O(100 µs),
 //!   well under the budget; on a regressed scheduler the rearm gap
 //!   strands the reprioritised stream past the deadline.
-//! * [`test_h2_backend_silent_headers_data_peer_signal`]: Fix C — exercises
+//! * [`test_h2_backend_silent_headers_data_peer_signal`] — exercises
 //!   the H2-backend → H2-frontend peer-rearm path using the
 //!   [`RawH2ResponseBackend::set_body_with_delay`] mode that emits
-//!   HEADERS, sleeps 50 ms, then streams DATA frames. Passes post-fix
-//!   (`fead8eb0`); a regression that drops the peer signal stalls the
-//!   client past the 1-second budget.
-//! * [`test_h2_mid_pass_rst_does_not_force_yield`]: Fix D — structural
+//!   HEADERS, sleeps 50 ms, then streams DATA frames. A regression
+//!   that drops the peer's `signal_pending_write` stalls the client
+//!   past the 1-second budget.
+//! * [`test_h2_mid_pass_rst_does_not_force_yield`] — structural
 //!   regression guard. Asserts that RST_STREAM'ing a middle peer
 //!   mid-flight does not corrupt the surviving `u=1, i` streams'
-//!   body delivery. The one-yield-saved delta from `1de3faad`'s
-//!   mid-pass bucket decrement is below CI timing noise and is not
-//!   asserted directly (see memory `project_sozu_h2_flood_family_flakes`).
+//!   body delivery. The one-yield-saved delta from the mid-pass
+//!   bucket decrement is below CI timing noise and is not asserted
+//!   directly (see memory `project_sozu_h2_flood_family_flakes`).
 
 use std::{
     io::{Read, Write},
@@ -165,7 +164,7 @@ fn teardown_simple<T>(tls: T, front_port: u16, mut worker: Worker) -> bool {
 }
 
 // ============================================================================
-// Test 1 — Fix A lock-in: backend silence yields a 504 within back_timeout
+// Test 1 — backend silence yields a 504 within back_timeout
 // ============================================================================
 
 /// Single H2 stream → backend that accepts the TCP connection and never
@@ -180,11 +179,11 @@ fn teardown_simple<T>(tls: T, front_port: u16, mut worker: Worker) -> bool {
 ///    the body.
 ///
 /// On HEAD, path (a) masks the missing `signal_pending_write` pairing
-/// in `set_default_answer` (the Fix A gap). This test therefore passes
-/// on HEAD and remains green after Fix A — it's a lock-in regression
-/// guard for the end-to-end 504 path, not a RED-to-green flip. The
-/// actual RED for invariant 15 compliance lives in the unit test
-/// alongside Fix A (`mux/answers.rs::tests`).
+/// in `set_default_answer`. This test therefore passes on HEAD and
+/// remains green once the pairing is in place — it's a lock-in
+/// regression guard for the end-to-end 504 path, not a RED-to-green
+/// flip. The matching RED that exercises invariant 15 directly on
+/// `set_default_answer` lives in `mux/answers.rs::tests`.
 fn try_h2_backend_silent_triggers_504() -> State {
     let (worker, front_port, back_address) =
         setup_listener_with_back_timeout("H2-PRIO-REARM-504", 2);
@@ -271,7 +270,7 @@ fn test_h2_backend_silent_triggers_504_within_back_timeout() {
 }
 
 // ============================================================================
-// Test 2 — Fix B: PRIORITY_UPDATE rearms WRITABLE after a scheduler yield
+// Test 2 — PRIORITY_UPDATE rearms WRITABLE after a scheduler yield
 // ============================================================================
 
 /// Two concurrent H2 streams on the same connection, both `u=3, i` at
@@ -282,8 +281,8 @@ fn test_h2_backend_silent_triggers_504_within_back_timeout() {
 /// Setup pins the sozu scheduler in a state where `finalize_write`
 /// stripped `Ready::WRITABLE` on a voluntary incremental yield. At that
 /// point the client sends a PRIORITY_UPDATE for the second stream,
-/// bumping it to `u=0, i`. Without Fix B the scheduler does not
-/// rearm — the reprioritised stream waits for an external event
+/// bumping it to `u=0, i`. Without the rearm-on-PRIORITY_UPDATE path
+/// the scheduler does not rearm — the reprioritised stream waits for an external event
 /// (ping, window update, timeout tick) before draining.
 ///
 /// Post-fix, both streams complete within 2 s of HEADERS being sent.
@@ -309,7 +308,8 @@ fn try_h2_priority_update_rearms_writable() -> State {
     // Both streams start as `u=3, i`. Once the first DATA frame of each
     // stream has been observed, kick the second stream via PRIORITY_UPDATE
     // to `u=0, i` — this forces sozu to mutate `self.prioriser` via
-    // `handle_priority_update_frame`, which is the Fix B code path.
+    // `handle_priority_update_frame`, which is the code path that must
+    // rearm WRITABLE for the reprioritised stream.
     let sid_a: u32 = 1;
     let sid_b: u32 = 3;
     tls.write_all(&H2Frame::headers(sid_a, build_get_with_priority(3, "i"), true, true).encode())
@@ -443,7 +443,7 @@ fn test_h2_priority_update_rearms_writable() {
 }
 
 // ============================================================================
-// Test 3 — Fix C: peer signal_pending_write on H2 backend DATA/HEADERS
+// Test 3 — peer signal_pending_write on H2 backend DATA/HEADERS
 // ============================================================================
 
 /// An H2 backend that emits HEADERS → 50 ms pause → DATA (END_STREAM)
@@ -451,17 +451,18 @@ fn test_h2_priority_update_rearms_writable() {
 /// `feedback_h2_repro_multi_data_frames` notes that single-DATA
 /// responses pass by coincidence of the natural writable window).
 ///
-/// Before Fix C, `handle_data_frame` / `handle_headers_frame` insert
+/// Without the peer-side rearm in `handle_data_frame` /
+/// `handle_headers_frame`, the H2-backend → H2-frontend handoff inserts
 /// `Ready::WRITABLE` on the peer readiness without pairing it with
 /// `signal_pending_write`. Under edge-triggered epoll the frontend
 /// never wakes to forward the bytes sozu just received from the H2
 /// backend — they sit in `stream.back` until an unrelated event
 /// arrives.
 ///
-/// Post-fix (`fead8eb0`), the peer uses `Readiness::arm_writable`
-/// which pairs insert + signal. The client sees the full body
-/// within the 1-second budget below. Budget is intentionally wide
-/// (≥ 20× the backend delay) so CI jitter does not flip this test.
+/// With the peer-side `Readiness::arm_writable` (which pairs insert +
+/// signal) in place, the client sees the full body within the
+/// 1-second budget below. Budget is intentionally wide (≥ 20× the
+/// backend delay) so CI jitter does not flip this test.
 fn try_h2_backend_silent_headers_data_peer_signal() -> State {
     // Body must produce ≥ 2 DATA frames on the backend → sozu hop and
     // enough data that the frontend cannot flush everything from the
@@ -583,7 +584,7 @@ fn test_h2_backend_silent_headers_data_peer_signal() {
 }
 
 // ============================================================================
-// Test 4 — Fix D: mid-pass RST_STREAM does not corrupt surviving streams
+// Test 4 — mid-pass RST_STREAM does not corrupt surviving streams
 // ============================================================================
 
 /// Three concurrent `u=1, i` streams share a connection. Mid-flight —
@@ -591,14 +592,13 @@ fn test_h2_backend_silent_headers_data_peer_signal() {
 /// client RST_STREAMs the middle one (stream B). The surviving
 /// streams (A, C) MUST complete their full bodies cleanly.
 ///
-/// This is a **structural** regression guard for Fix D (`1de3faad`)
-/// and its mid-pass mutation of `ready_incremental_by_urgency`. We do
-/// not attempt to observe the one-yield-saved delta directly — that
-/// would require an `e2e-hooks` probe on `incremental_peer_count`,
-/// and the wire delta (≤ 1 DATA frame) sits below CI timing noise.
-/// Instead, we verify that Fix D's `saturating_sub` on the bucket
-/// counter under RST / retirement paths does not break the surviving
-/// streams' body delivery.
+/// This is a **structural** regression guard for the mid-pass mutation
+/// of `ready_incremental_by_urgency`. We do not attempt to observe the
+/// one-yield-saved delta directly — that would require an `e2e-hooks`
+/// probe on `incremental_peer_count`, and the wire delta (≤ 1 DATA
+/// frame) sits below CI timing noise. Instead, we verify that the
+/// `saturating_sub` on the bucket counter under RST / retirement paths
+/// does not break the surviving streams' body delivery.
 ///
 /// A regression here (e.g. bucket underflow, stale read, borrow-check
 /// typo) would manifest as A or C stalling indefinitely, which the
@@ -668,8 +668,8 @@ fn try_h2_mid_pass_rst_does_not_force_yield() -> State {
         }
     }
 
-    // Phase 2: RST stream B. Fix D must decrement the bucket count
-    // on the `rst_sent` mid-pass path AND on the completion path
+    // Phase 2: RST stream B. The scheduler must decrement the per-bucket
+    // count on the `rst_sent` mid-pass path AND on the completion path
     // without perturbing A or C.
     tls.write_all(&H2Frame::rst_stream(sid_b, H2_ERROR_NO_ERROR).encode())
         .unwrap();

--- a/e2e/src/tests/h2_tests.rs
+++ b/e2e/src/tests/h2_tests.rs
@@ -4312,7 +4312,7 @@ fn test_h2_to_h1_100_continue() {
 /// actually count the HEADERS frames sozu emits to the wire. The hyper-based
 /// counterpart only surfaces the final response, so it cannot prove that the
 /// intermediate `100 Continue` HEADERS frame made it to the client — it could
-/// just as well be swallowed. Codex B3-z / plan entry from 2026-04-21.
+/// just as well be swallowed.
 ///
 /// Scenario: the `ContinueBackend` (H1) replies `100 Continue` then `200 OK`.
 /// Sozu MUST translate the 1xx status into an H2 HEADERS frame without
@@ -4676,16 +4676,16 @@ fn test_h2_backend_disconnect_clean_error() {
     );
 }
 
-// ---- Backend disconnect: repeated fast-close does not leak stream state (B3-h / G4) ----
+// ---- Backend disconnect: repeated fast-close does not leak stream state ----
 
-/// Codex gap G4 / plan entry B3-h: "`Linked` stream whose backend dies
-/// mid-response may not be driven to `Unlinked` before buffer recycle;
-/// race window". Reviewer verified the cleanup path
-/// (`remove_dead_stream` → `rst_sent.remove` etc.), but only a single
-/// disconnect was previously covered by
-/// `test_h2_backend_disconnect_clean_error`. A one-shot leak of 1 slot is
-/// invisible; a leak-per-fast-close would show up only after dozens of
-/// rapid fast-closes through the same listener.
+/// Regression guard for the race window in which a `Linked` stream whose
+/// backend dies mid-response may not be driven to `Unlinked` before
+/// buffer recycle. The cleanup path (`remove_dead_stream` →
+/// `rst_sent.remove` etc.) was previously exercised only by
+/// `test_h2_backend_disconnect_clean_error`, which fires a single
+/// disconnect; a one-shot leak of 1 slot is invisible, while a
+/// leak-per-fast-close would show up only after dozens of rapid
+/// fast-closes through the same listener.
 ///
 /// This test fires 30 sequential H2 requests against the
 /// `DisconnectingBackend`. If sozu leaked any per-stream state between

--- a/e2e/src/tests/mux_tests.rs
+++ b/e2e/src/tests/mux_tests.rs
@@ -2103,7 +2103,7 @@ fn test_h1_rejects_ambiguous_cl_te() {
 }
 
 // =========================================================================
-// H1 chunked-trailer end-to-end forwarding (B3-p / #899)
+// H1 chunked-trailer end-to-end forwarding (#899)
 // =========================================================================
 
 /// Issue #899 asked whether sozu forwards HTTP/1.1 chunked trailers through

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -1018,12 +1018,13 @@ impl L7ListenerHandler for HttpsListener {
     }
 
     fn get_strict_sni_binding(&self) -> bool {
-        // Phase 1D enforced SNI↔:authority binding unconditionally; this
-        // listener knob preserves that behavior by default and lets
-        // operators opt out when cross-SNI routing is intentional.
+        // SNI↔:authority binding is enforced by default (closes
+        // CWE-346 / CWE-444); this listener knob preserves that
+        // behavior by default and lets operators opt out when cross-SNI
+        // routing is intentional.
         //
-        // Codex G10 note: `strict_sni_binding = false` theoretically allows
-        // an attacker to present many distinct SNIs on the same TCP
+        // Note: `strict_sni_binding = false` theoretically allows an
+        // attacker to present many distinct SNIs on the same TCP
         // connection. rustls 0.23 **bans TLS renegotiation outright** (see
         // `rustls::server::ClientHello` which is consumed during the initial
         // handshake only), so a single TCP connection gets exactly one SNI

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -604,12 +604,13 @@ pub trait L7ListenerHandler {
     /// Whether requests must have their `:authority` / `Host` exact-match
     /// the TLS SNI negotiated at handshake (CWE-346 / CWE-444).
     ///
-    /// Defaults to `true` — the safe setting enforced by Phase 1D of the
-    /// security audit. Operators can opt out per-listener via
-    /// `HttpsListenerConfig::strict_sni_binding = false` when cross-SNI
-    /// routing is explicitly required. Plaintext HTTP listeners return the
-    /// default value; they never have an SNI to compare against, so the
-    /// routing-layer check short-circuits on `tls_server_name: None`.
+    /// Defaults to `true` — the safe setting that closes the
+    /// CWE-346 / CWE-444 cross-SNI smuggling vector. Operators can opt
+    /// out per-listener via `HttpsListenerConfig::strict_sni_binding =
+    /// false` when cross-SNI routing is explicitly required. Plaintext
+    /// HTTP listeners return the default value; they never have an SNI
+    /// to compare against, so the routing-layer check short-circuits on
+    /// `tls_server_name: None`.
     fn get_strict_sni_binding(&self) -> bool {
         true
     }
@@ -660,7 +661,7 @@ pub trait L7ListenerHandler {
     }
 
     /// Wall-clock budget granted to in-flight H2 streams after soft-stop sent
-    /// the phase-1 `GOAWAY(NO_ERROR)`. Once the deadline elapses the mux
+    /// the initial `GOAWAY(NO_ERROR)`. Once the deadline elapses the mux
     /// transitions to a forced close (final GOAWAY + session teardown).
     ///
     /// Returning `None` disables the forced close entirely — shutdown waits

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -1454,10 +1454,11 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             }
         };
 
-        // Wave 2b carries the new RouteResult shape; the mux integration in
-        // Wave 3a will read every field. Until then, this legacy kawa_h1
-        // path collapses RouteResult down to its `cluster_id` and treats an
-        // absent cluster as the historical `Route::Deny`.
+        // `RouteResult` already carries the full routing decision, but the
+        // mux integration that consumes every field is not in place yet.
+        // Until it lands, this legacy kawa_h1 path collapses `RouteResult`
+        // down to its `cluster_id` and treats an absent cluster as the
+        // historical `Route::Deny`.
         let cluster_id = match route.cluster_id {
             Some(cluster_id) => cluster_id,
             None => {

--- a/lib/src/protocol/mux/LIFECYCLE.md
+++ b/lib/src/protocol/mux/LIFECYCLE.md
@@ -530,13 +530,13 @@ listener.
 
 ### 8.1 Graceful GOAWAY (double-GOAWAY per RFC 9113 §6.8)
 
-Two-phase in `ConnectionH2::graceful_goaway` (`h2.rs:3051`):
+Two GOAWAY frames in `ConnectionH2::graceful_goaway` (`h2.rs:3051`):
 
-1. **Phase 1** — send GOAWAY with `last_stream_id = 0x7FFFFFFF`
+1. **Initial GOAWAY** — send GOAWAY with `last_stream_id = 0x7FFFFFFF`
    (`STREAM_ID_MAX`, `h2.rs:178`); keep `READABLE` so in-flight request bodies
    can still arrive. Called first time from `Mux::shutting_down` at
    `mod.rs:1596`. Draining flag set.
-2. **Phase 2** — on the second invocation (draining already true), call
+2. **Final GOAWAY** — on the second invocation (draining already true), call
    `goaway(NoError)` (`h2.rs:3054`) with the actual `highest_peer_stream_id`,
    remove `READABLE` interest (`h2.rs:3026`), transition to `H2State::GoAway`.
    Caller is `finalize_write` when all streams drain (`h2.rs:2273`).
@@ -594,8 +594,9 @@ The three RST push sites retrofit to `enqueue_rst`:
   content-length mismatch, WINDOW_UPDATE zero-increment or overflow,
   unauthorised priority updates, self-dependent HEADERS).
 
-Serialisation happens in `flush_pending_control_frames` (`h2.rs:2867` → Phase 3
-at the pending-RST-streams check, which drains `self.pending_rst_streams` into
+Serialisation happens in `flush_pending_control_frames` (`h2.rs:2867` → the
+RST_STREAM cap-check-and-drain stage at the pending-RST-streams check, which
+drains `self.pending_rst_streams` into
 `self.zero` via `serializer::gen_rst_stream`). This path is independent of the
 owning `Stream` still being present in `self.streams`, so it survives the
 immediate `remove_dead_stream` call that every `reset_stream` caller performs
@@ -603,9 +604,10 @@ synchronously after return.
 
 `finalize_write` (`h2.rs:2795`) retains `Ready::WRITABLE` when the pass
 completes but `pending_rst_streams` or `flow_control.pending_window_updates` are
-still non-empty — otherwise a partial write that deferred the Phase-3 flush
-(gated on `expect_write.is_none()`) would strand a queued RST until an unrelated
-event re-raised the writable bit. This guard, together with the invariant-15 arm
+still non-empty — otherwise a partial write that deferred the RST_STREAM drain
+stage (gated on `expect_write.is_none()`) would strand a queued RST until an
+unrelated event re-raised the writable bit. This guard, together with the
+invariant-15 arm
 inside `enqueue_rst`, closes the 18-check h2spec 2.0 gap previously reported in
 RFC 9113 §§5.3, 6.9, 8.1.2.
 
@@ -687,10 +689,11 @@ touches `h2.rs`, `mod.rs`, or `stream.rs`.
    frames (PING / WINDOW_UPDATE / SETTINGS) do **not** reset `timeout_container`
    — enforced in `readable()` by setting it only on DATA payload (`h2.rs:1646`)
    and HEADERS (inside `handle_frame`).
-10. **Single `graceful_goaway` per session outside phase 2.**
+10. **Single `graceful_goaway` per session outside the final GOAWAY.**
     `Mux::shutting_down` (`mod.rs:1595`) only calls it if
-    `!self.frontend.is_draining()`; a second unconditional call would collapse
-    phase 1 into phase 2 and disconnect in-flight streams.
+    `!self.frontend.is_draining()`; a second unconditional call would
+    collapse the initial GOAWAY into the final one and disconnect
+    in-flight streams.
 11. **Frontend HUP defers close when output is pending.**
     `delay_close_for_frontend_flush` (`mod.rs:538`) must be consulted before
     returning `SessionResult::Close` so that unflushed TLS/GOAWAY records are

--- a/lib/src/protocol/mux/answers.rs
+++ b/lib/src/protocol/mux/answers.rs
@@ -409,7 +409,7 @@ mod tests {
     /// is the `signal_pending_write` side of the invariant-15 pair — under
     /// edge-triggered epoll, this is what causes the scheduler's next
     /// tick to re-enter `writable()` and flush the default answer without
-    /// waiting for an external epoll event. This is the RED for Fix A.
+    /// waiting for an external epoll event.
     #[test]
     fn set_default_answer_arms_writable_and_signals() {
         let (_pool, mut stream) = make_stream();

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -1243,7 +1243,7 @@ pub struct H2DrainState {
     /// drains via `handle_goaway_frame` don't arm the forced-close timer —
     /// the caller in `Mux::shutting_down` is the only writer).
     pub started_at: Option<Instant>,
-    /// Wall-clock budget granted to in-flight streams after the phase-1
+    /// Wall-clock budget granted to in-flight streams after the initial
     /// `GOAWAY(NO_ERROR)`. `None` means "wait indefinitely" (knob value `0`).
     /// Default when unset upstream: 5 s (see `L7ListenerHandler`).
     pub graceful_shutdown_deadline: Option<std::time::Duration>,
@@ -1666,13 +1666,13 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                         // RFC 9113 §6.8: after sending a GOAWAY, the proxy
                         // MUST NOT accept new streams.
                         // `graceful_goaway` sets `drain.draining = true`
-                        // and sends a phase-1 GOAWAY with last_stream_id =
+                        // and sends an initial GOAWAY with last_stream_id =
                         // STREAM_ID_MAX (so in-flight requests are still
                         // accepted), but the contract for *new* peer-
                         // initiated streams is that they must be refused.
                         // Without this check, a peer racing the drain
                         // window could open arbitrary new streams between
-                        // phase-1 and phase-2 GOAWAY emission.
+                        // the initial and final GOAWAY emission.
                         if self.drain.draining {
                             if stream_id > self.highest_peer_stream_id {
                                 self.highest_peer_stream_id = stream_id;
@@ -2858,9 +2858,9 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
     /// MUST be emptied of `stream_id` here — they are the only three
     /// per-stream caches that are not stored in the slab-allocated
     /// `Context.streams[]`. Forgetting any of them causes unbounded memory
-    /// growth on long-lived connections with many cancelled streams (Codex
-    /// gap G11). The `debug_assert`s below fail loudly in test builds if
-    /// someone adds a new per-stream cache without updating this function.
+    /// growth on long-lived connections with many cancelled streams. The
+    /// `debug_assert`s below fail loudly in test builds if someone adds a
+    /// new per-stream cache without updating this function.
     fn remove_dead_stream(&mut self, stream_id: StreamId, global_stream_id: GlobalStreamId) {
         if self.streams.remove(&stream_id).is_none() {
             error!(
@@ -3054,9 +3054,11 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             }
         }
 
-        // Phase 1: Resume flushing the zero buffer if a previous write was partial.
-        // Don't reset the timeout for control frame writes (SETTINGS ACK, PING
-        // response, WINDOW_UPDATE). Only application data writes should reset it.
+        // Stage — resume zero-buffer flush.
+        // If a previous write was partial, finish it before serialising any
+        // new control frames. Don't reset the timeout for control frame
+        // writes (SETTINGS ACK, PING response, WINDOW_UPDATE) — only
+        // application-data writes should reset it.
         if let Some(H2StreamId::Zero) = self.expect_write {
             if self.flush_zero_to_socket() {
                 self.ensure_tls_flushed();
@@ -3068,9 +3070,10 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             self.expect_write = None;
         }
 
-        // Phase 2: Serialize and flush pending WINDOW_UPDATE frames.
-        // Write them inline to avoid extra event loop iterations that could
-        // cause response data to be sent before validating subsequent frames.
+        // Stage — drain pending WINDOW_UPDATE frames.
+        // Serialize and flush them inline to avoid extra event loop
+        // iterations that could cause response data to be sent before
+        // subsequent frames are validated.
         if !self.flow_control.pending_window_updates.is_empty() && self.expect_write.is_none() {
             let kawa = &mut self.zero;
             kawa.storage.clear();
@@ -3113,10 +3116,11 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             }
         }
 
-        // Phase 3: Cap check + flush pending RST_STREAM frames.
-        // Check lifetime total (not just pending queue length) because writable()
-        // drains the queue between readable() calls, so the pending count alone
-        // may never reach the cap even under sustained misbehavior.
+        // Stage — RST_STREAM cap check + drain.
+        // Check the lifetime total (not just pending queue length) because
+        // writable() drains the queue between readable() calls, so the
+        // pending count alone may never reach the cap even under sustained
+        // misbehavior.
         if !matches!(self.state, H2State::GoAway | H2State::Error)
             && self.total_rst_streams_queued >= MAX_PENDING_RST_STREAMS
         {
@@ -4082,18 +4086,19 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         // tears the connection down instead of waiting forever.
         self.drain.started_at = Some(Instant::now());
         // Keep expect_read as-is: existing streams should continue reading
-        // data during phase 1. Only phase 2 (goaway()) removes READABLE.
+        // data during the drain window opened by the initial GOAWAY. Only
+        // the final GOAWAY (via `goaway()`) removes READABLE.
         let kawa = &mut self.zero;
         kawa.storage.clear();
         debug!(
-            "{} GOAWAY (graceful, phase 1): last_stream_id=0x7FFFFFFF",
+            "{} GOAWAY (graceful, initial): last_stream_id=0x7FFFFFFF",
             log_context!(self)
         );
-        // Phase 1 sends a NO_ERROR GOAWAY on the wire — count it under the
-        // same per-code key as phase 2. The downstream alert that wants to
-        // distinguish drain from termination compares against the
-        // `h2.goaway.sent.no_error` rate (drain) vs the other variants
-        // (termination on error).
+        // The initial GOAWAY sends NO_ERROR on the wire — count it under
+        // the same per-code key as the final GOAWAY. The downstream alert
+        // that wants to distinguish drain from termination compares
+        // against the `h2.goaway.sent.no_error` rate (drain) vs the other
+        // variants (termination on error).
         count!(metric_for_goaway_sent(H2Error::NoError), 1);
 
         match serializer::gen_goaway(kawa.storage.space(), STREAM_ID_MAX, H2Error::NoError) {
@@ -4101,9 +4106,10 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                 kawa.storage.fill(size);
                 incr!(names::h2::FRAMES_TX_GOAWAY);
                 // Stay in the current state so the connection can continue processing
-                // existing streams. The second GOAWAY will transition to GoAway state.
+                // existing streams. The final GOAWAY will transition to GoAway state.
                 // Keep READABLE so in-flight request bodies can still be received
-                // during phase 1. Only remove READABLE in the second GOAWAY (goaway()).
+                // during the drain window. Only remove READABLE in the final GOAWAY
+                // (via `goaway()`).
                 self.expect_write = Some(H2StreamId::Zero);
                 self.readiness.arm_writable();
                 MuxResult::Continue
@@ -7640,7 +7646,7 @@ mod tests {
         assert!(any_stream_has_pending_back(&streams_map, &[stream]));
     }
 
-    // ── Fix D: ready_incremental_by_urgency mid-pass consistency ─────────
+    // ── ready_incremental_by_urgency mid-pass consistency ────────────────
     //
     // The full RED is in e2e and currently #[ignore]'d (timing-sensitive).
     // The scalar logic below pins the saturating_sub + bucket-scoped

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -1811,10 +1811,10 @@ impl<Front: SocketHandler + std::fmt::Debug, L: ListenerHandler + L7ListenerHand
 
     fn shutting_down(&mut self) -> SessionIsToBeClosed {
         // RFC 9113 §6.8: initiate graceful shutdown with double-GOAWAY pattern.
-        // Only send the phase-1 GOAWAY once. Phase 2 (final GOAWAY with the real
+        // Only send the initial GOAWAY once. The final GOAWAY (with the real
         // last_stream_id) is handled by finalize_write() when all streams drain.
-        // Calling graceful_goaway() again would send phase 2 prematurely and
-        // force-disconnect before in-flight streams complete.
+        // Calling graceful_goaway() again would send the final GOAWAY
+        // prematurely and force-disconnect before in-flight streams complete.
         if !self.frontend.is_draining() {
             match self.frontend.graceful_goaway() {
                 MuxResult::CloseSession => return true,

--- a/lib/src/protocol/mux/parser.rs
+++ b/lib/src/protocol/mux/parser.rs
@@ -274,7 +274,7 @@ macro_rules! ensure_frame_size {
 
 // https://httpwg.org/specs/rfc7540.html#rfc.section.4.1
 //
-// Codex G12 invariant (production caller contract):
+// Production caller contract:
 // `max_frame_size` MUST be the *negotiated* `settings_max_frame_size` from
 // the peer's latest accepted SETTINGS frame (see `H2Settings` on
 // `ConnectionH2`). It MUST NOT be `DEFAULT_MAX_FRAME_SIZE` — that RFC

--- a/lib/src/protocol/mux/pkawa.rs
+++ b/lib/src/protocol/mux/pkawa.rs
@@ -1145,7 +1145,7 @@ pub fn handle_trailer(
         return Err((H2Error::ProtocolError, false));
     }
 
-    // Codex G7 / RFC 9110 §6.5: if the request/response was framed with a
+    // RFC 9110 §6.5: if the request/response was framed with a
     // fixed Content-Length (not chunked), the H1-side serializer cannot emit
     // trailers — HTTP/1.1 only carries trailers with chunked transfer-coding.
     // The trailer block stays in kawa but the downstream writer will never
@@ -1896,7 +1896,7 @@ mod tests {
 
     #[test]
     fn test_handle_header_rejects_empty_status() {
-        // Codex G5 concern: response pseudo-header emptiness could slip through
+        // Response pseudo-header emptiness could slip through
         // if the three-digit guard were removed. Locks in `v.len() != 3` as
         // the rejection gate for an empty :status (HPACK allows zero-length
         // field values, so this must be enforced explicitly). A server

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -860,7 +860,8 @@ impl MethodRule {
 
 /// What to do with a request that matches a frontend.
 ///
-/// Three variants coexist during the Wave 2b → Wave 1c transition:
+/// Three variants coexist today; the legacy two will retire once
+/// `HttpFrontend` itself carries the rich routing fields:
 ///
 /// - [`Route::ClusterId`] is the legacy "forward to this cluster" variant
 ///   used by call sites that build routes directly from
@@ -868,9 +869,10 @@ impl MethodRule {
 /// - [`Route::Deny`] is the legacy "send 401" variant used when a frontend
 ///   has no `cluster_id`.
 /// - [`Route::Frontend`] carries a richer [`Frontend`] decision (redirect
-///   policy, rewrite templates, header edits, auth gating). Wave 1c will
-///   migrate `add_http_front` to build `Route::Frontend` once
-///   `HttpFrontend` carries the matching proto fields.
+///   policy, rewrite templates, header edits, auth gating). Once
+///   `HttpFrontend` carries the matching proto fields, `add_http_front`
+///   will build `Route::Frontend` directly and the two legacy variants
+///   above can retire.
 ///
 /// `Eq`/`PartialEq` compare `Frontend` variants by `Rc` pointer identity to
 /// stay consistent with `Hash`/`Ord` on [`Rc`]; this is sufficient for the
@@ -884,8 +886,9 @@ pub enum Route {
     /// the cluster to which the frontend belongs
     ClusterId(ClusterId),
     /// rich routing decision carrying redirect, rewrite, header, and auth
-    /// configuration; supersedes the legacy variants once Wave 1c migrates
-    /// the in-memory frontend wiring.
+    /// configuration; supersedes the two legacy variants once the
+    /// in-memory frontend wiring is migrated to build `Route::Frontend`
+    /// directly.
     Frontend(Rc<Frontend>),
 }
 
@@ -1280,11 +1283,11 @@ impl Frontend {
     /// [`HttpFrontend`] configuration.
     ///
     /// The richer proto-level fields (`redirect`, `redirect_scheme`,
-    /// `redirect_template`, `rewrite_*`, `headers`, `required_auth`) will
-    /// arrive via Wave 1c; until they do, this constructor takes them as
-    /// explicit arguments so the data flow is testable today and the call
-    /// sites in `add_http_front` only need a one-line update once Wave 1c
-    /// plumbs the fields through `HttpFrontend`.
+    /// `redirect_template`, `rewrite_*`, `headers`, `required_auth`) are
+    /// not yet carried on `HttpFrontend`; until they are, this constructor
+    /// takes them as explicit arguments so the data flow is testable
+    /// today and the call sites in `add_http_front` only need a one-line
+    /// update once the fields are plumbed through.
     ///
     /// Coercions:
     /// - `redirect == UNAUTHORIZED` zeroes out rewrite/headers/auth — the
@@ -1607,8 +1610,8 @@ impl Frontend {
 /// against the captures collected during routing. Legacy [`Route::ClusterId`]
 /// and [`Route::Deny`] entries synthesize a minimal `RouteResult` with the
 /// proto enums set to defaults (`FORWARD` / `UNAUTHORIZED`) so existing
-/// session code keeps working until Wave 3a wires the rich fields into the
-/// mux layer.
+/// session code keeps working until the mux layer is updated to read every
+/// `RouteResult` field directly.
 ///
 /// Implements `PartialEq` for test parity: existing router tests compare
 /// `router.lookup(...)` against an expected route. Equality compares every


### PR DESCRIPTION
## Summary

Rewrites code comments, rustdoc, `lib/src/protocol/mux/LIFECYCLE.md`, and `doc/h2_mux_internals.md` so they describe behavior directly instead of citing now-retired plan labels. Comment/rustdoc only (one operator-visible debug-log substring change — see below).

Themes covered:

- **router "Wave 1c/2b/3a"** in `lib/src/router/mod.rs` + `lib/src/protocol/kawa_h1/mod.rs` → describe the legacy/rich variants directly
- **security-audit "Phase 1D"** in `lib/src/lib.rs` + `lib/src/https.rs` → cite the CWE-346 / CWE-444 rule directly
- **"Codex G5/G7/G10/G11/G12"** review markers in `mux/parser.rs`, `mux/pkawa.rs`, `mux/h2.rs`, `https.rs` → drop; surrounding prose already carries the RFC anchor / invariant
- **h2_priority_rearm "Fix A/B/C/D"** + **"B3-h/B3-p/B3-z"** test plan entries in `e2e/src/tests/h2_priority_rearm_tests.rs`, `h2_correctness_tests.rs`, `h2_tests.rs`, `mux_tests.rs`, `mux/answers.rs`, `mux/h2.rs` → describe the regression each test guards against
- **graceful-GOAWAY "Phase 1/2"** in `LIFECYCLE.md`, `mux/h2.rs`, `mux/mod.rs`, `lib/src/lib.rs` → renamed to "initial GOAWAY" / "final GOAWAY" (RFC 9113 §6.8 vocabulary; matches rustls/nghttp2/h2crate)
- **`flush_pending_control_frames` "Phase 1/2/3"** stage labels → descriptive stage names (resume zero-buffer flush / drain pending WINDOW_UPDATEs / RST_STREAM cap check + drain). Lock-stepped across `mux/h2.rs`, `LIFECYCLE.md`, `doc/h2_mux_internals.md`.

`CHANGELOG.md:2275` (verbatim commit-subject quote `Phase 4 security hardening`) deliberately left alone — rewriting it would desync the changelog from `git log`.

## Protocol / security impact

**RFC 9113 §6.8 double-GOAWAY behavior is unchanged.** No wire-level change. No metric rename, no config-knob rename.

All RFC anchors (9113 §6.8, 9110 §6.5, rfc7540 §4.1), CVE references (CVE-2023-44487, CVE-2024-27316, CVE-2025-8671), and CWE references (CWE-346, CWE-444) are preserved verbatim in every rewrite.

## Operator-visible change (one)

The `debug!`-level log line at `lib/src/protocol/mux/h2.rs:4094` (was `:4089` pre-rename) used to read:

```
{} GOAWAY (graceful, phase 1): last_stream_id=0x7FFFFFFF
```

It now reads:

```
{} GOAWAY (graceful, initial): last_stream_id=0x7FFFFFFF
```

The final GOAWAY continues to log via the generic `GOAWAY: {error}` line at `h2.rs:4032` (unchanged), so only the initial-GOAWAY substring shifts. Release builds without `--features logs-debug` strip this line entirely, so the blast radius is limited to deployments that opted into debug logs. Anyone scraping sozu logs for the literal `phase 1` substring needs to update their filters — flagged in the CHANGELOG bullet.

## Commands run

- ``cargo +nightly fmt --all -- --check`` — clean
- ``cargo clippy --all-targets --locked -- -D warnings`` — clean (no issues found)
- ``cargo test --workspace --locked`` — 368/370 e2e tests pass on first run; the two stragglers (`tests::tests::test_h1_to_h2_basic_request`, `tests::tests::test_issue_810_timeout`) flake under parallel load and pass on isolated rerun — same flaky pattern as the documented `test_tls_connection_close_large_response`. Both retried green.
- Plan-leak verification greps:
  - ``grep -rnE '\b(Wave|Phase) [0-9][A-Z]?'`` outside test files + CHANGELOG history → 0 hits
  - ``grep -rnE '\bFix [A-D]\b'`` outside CHANGELOG history → 0 hits
  - ``grep -rnE 'Codex G[0-9]+'`` → 0 hits
  - ``grep -rniE 'phase[ -][12]\b'`` outside test files + CHANGELOG history → 0 hits
  - ``grep -F "GOAWAY (graceful, phase 1)" lib/`` → 0 hits
  - ``grep -F "GOAWAY (graceful, initial)" lib/`` → exactly 1 hit at `lib/src/protocol/mux/h2.rs:4094`

## Tests added

None — comment-only / rustdoc-only.

## Doc updates in this changeset

`CHANGELOG.md` carries a bullet under `## [Unreleased]` / `### 🔄 Changed` describing the consolidation and calling out the operator-visible debug-log substring shift.

## Test plan

- [x] cargo +nightly fmt --all -- --check
- [x] cargo clippy --all-targets --locked -- -D warnings
- [x] cargo test --workspace --locked (plus isolated rerun of the two parallel-load flakes)
- [x] All five plan-leak greps return zero hits outside expected carve-outs
- [x] Debug-log substring rename verified (old: 0 hits, new: 1 hit)
- [ ] CI green across all four crypto cells (`crypto-ring`, `crypto-aws-lc-rs`, `crypto-openssl`, `fips`)