### PR TITLE
chore(deps): bump pinned crates to latest ^x.y.z per cargo outdated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "loona-hpack"
@@ -1925,9 +1925,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmem"
@@ -2953,9 +2953,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ itoa = "^1.0.18"
 jemallocator = "^0.5.4"
 kawa = { version = "^0.6.8", default-features = false }
 libc = "^0.2.186"
-log = "^0.4.29"
-memchr = "^2.8.0"
+log = "^0.4.30"
+memchr = "^2.8.1"
 mio = "^1.2.0"
 nix = "^0.31.3"
 nom = "^7.1.3"
@@ -45,7 +45,7 @@ rustls = { version = "^0.23.40", default-features = false, features = [
 ] }
 rusty_ulid = "^2.0.0"
 serde = "^1.0.228"
-serde_json = "^1.0.149"
+serde_json = "^1.0.150"
 serial_test = "^3.4.0"
 sha2 = "^0.11.0"
 slab = "^0.4.12"
@@ -69,7 +69,7 @@ x509-parser = "^0.18.1"
 color-eyre           = "^0.6.5"
 crossbeam-channel    = "^0.5.15"
 crossterm            = { version = "^0.29.0", default-features = false }
-ctrlc                = "^3.4.5"
+ctrlc                = "^3.5.2"
 ratatui              = { version = "^0.30.0", default-features = false }
 throbber-widgets-tui = "^0.11.0"
 tui-big-text         = "^0.8.4"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -70,7 +70,7 @@ tempfile = { workspace = true }
 # `insta` is gated to `cfg(feature = "tui")` snapshot tests under `bin/src/ctl/top/`.
 # Auditor-locked: keep it on `[dev-dependencies]` only — never a production dep.
 # Tests run without `cargo insta review`; snapshots fail loudly the first time.
-insta = { version = "^1.43.2", default-features = false }
+insta = { version = "^1.47.2", default-features = false }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 num_cpus = { workspace = true }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -738,9 +738,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "loona-hpack"
@@ -754,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memoffset"
@@ -1246,9 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "^0.4.12"
-loona-hpack = "0.4"
+loona-hpack = "^0.4.3"
 sozu-lib = { path = "../lib", default-features = false, features = ["crypto-ring"] }
 
 # Prevent this from joining the workspace


### PR DESCRIPTION
Bumps the direct workspace dependency pins to match the latest crates.io versions, keeping the existing `^x.y.z` style.

Workspace Cargo.toml:
- log         ^0.4.29 -> ^0.4.30
- memchr      ^2.8.0  -> ^2.8.1
- serde_json  ^1.0.149 -> ^1.0.150
- ctrlc       ^3.4.5  -> ^3.5.2

bin/Cargo.toml:
- insta       ^1.43.2 -> ^1.47.2

fuzz/Cargo.toml:
- loona-hpack "0.4"   -> "^0.4.3" (normalize to ^x.y.z)

Lockfile-only refreshes (within compat range):
log 0.4.29 -> 0.4.30, memchr 2.8.0 -> 2.8.1,
serde_json 1.0.149 -> 1.0.150 (workspace + fuzz lockfiles).

nom 7.1.3 -> 8.0.0 is intentionally left out: it is a major version bump with breaking API changes (e.g. parser combinators moved out of `nom::bits`, error types reshaped) and needs a dedicated migration, not a constraint bump.

Validation:
- cargo build --all-features --locked: clean
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings: clean
- cargo +nightly fmt --all -- --check: clean
- cargo test --workspace --locked: 1186 passed, 7 ignored
- cargo check --locked in fuzz/: clean