### PR TITLE
fix(release): include build.rs in published tarballs

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -16,7 +16,7 @@ authors = [
 categories = ["network-programming"]
 edition = "2024"
 rust-version = "1.88.0"
-include = ["README.md", "Cargo.toml", "src/**/*"]
+include = ["README.md", "Cargo.toml", "build.rs", "src/**/*"]
 
 [lib]
 name = "sozu"

--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -19,6 +19,7 @@ rust-version = "1.88.0"
 include = [
   "./README.md",
   "Cargo.toml",
+  "build.rs",
   "src/**/*",
   "assets/certificate.pem",
   "assets/key.pem",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -20,6 +20,8 @@ rust-version = "1.88.0"
 include = [
   "./README.md",
   "Cargo.toml",
+  "build.rs",
+  "log_scanner.rs",
   "src/**/*",
   "/examples/*",
   "benches/**/*",


### PR DESCRIPTION
## Summary

`cargo publish -p sozu` failed verifying the 2.0.0 tarball with:

```
error: environment variable `SOZU_BUILD_FEATURES` not defined at compile time
  --> src/cli.rs:51:30
error: environment variable `SOZU_BUILD_GIT` not defined at compile time
  --> src/cli.rs:74:13
error: environment variable `SOZU_BUILD_GIT_SHA` not defined at compile time
  --> src/command/requests.rs:1091:34
```

Root cause: `bin/Cargo.toml`'s `include = ["README.md", "Cargo.toml", "src/**/*"]` omits `build.rs`. The tarball ships without the build script, so the `cargo:rustc-env=SOZU_BUILD_*` lines are never emitted, and the `env!()` calls in `src/cli.rs` and `src/command/requests.rs` blow up during verify.

`command/Cargo.toml` and `lib/Cargo.toml` have the same shape of bug. `command/` only publishes today because `src/proto/command.rs` (the prost output) gets swept up by `src/**/*` when a prior local build left it on disk; `lib/`'s `log_scanner.rs`-driven layout warning silently stops running on published tarballs. Both are latent.

This patch adds `build.rs` to all three `include` lists, plus `log_scanner.rs` to `lib/`'s list (it's `include!`'d by `lib/build.rs`).

## Test plan

- [x] `cargo package -p sozu --list --allow-dirty` now contains `build.rs`
- [x] `cargo package -p sozu-lib --list --allow-dirty` now contains `build.rs` and `log_scanner.rs`
- [x] `cargo package -p sozu-command-lib --list --allow-dirty` now contains `build.rs` (and `src/command.proto` as before)
- [x] `cargo check -p sozu --locked` clean
- [ ] After merge: confirm `cargo publish -p sozu` succeeds for the next 2.x release