### PR TITLE
fix(otel): capture wall-clock start time for accurate span reconstruc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### ✨ Added
+
+- **`fix(otel)`: wall-clock `start_time` field in `ProtobufAccessLog`** (field 30, optional `Uint128`).
+  Access-log consumers reconstructing OpenTelemetry spans no longer need to compute `time - request_time` — a subtraction that mixed `CLOCK_REALTIME` and `CLOCK_MONOTONIC` and produced unreliable start timestamps on short-lived requests. The new field is captured at request start via `SessionMetrics::mark_request_start()` and should be preferred whenever present. Old consumers ignore the unknown field; new consumers with old producers see `None` and can fall back to the subtraction.
+
 ## 2.0.1 - 2026-05-27
 
 Patch release with release-pipeline fixes uncovered by the 2.0.0 tag push. No runtime, protocol, API, configuration, metric, or log-format changes — only `Cargo.toml` `include` lists, the GitHub Actions release matrix, and `CHANGELOG.md` formatting were touched. `sozu-command-lib` consumers can bump from `^2.0.0` to `^2.0.1` without code changes.

--- a/command/src/command.proto
+++ b/command/src/command.proto
@@ -1806,6 +1806,14 @@ message ProtobufAccessLog {
     // proxy hops (e.g. `"203.0.113.5, 198.51.100.10"`). `None` if no
     // upstream proxy supplied the header.
     optional string xff_chain = 29;
+    // Wall-clock timestamp (POSIX nanoseconds since epoch) captured at the
+    // start of the request. Enables accurate OTel span reconstruction
+    // without subtracting a monotonic `request_time` duration from the
+    // wall-clock `time` field — a computation that mixes two unsynchronised
+    // clock sources (CLOCK_MONOTONIC vs CLOCK_REALTIME) and produces
+    // unreliable start timestamps, especially for short-lived requests or
+    // across NTP adjustments. Optional for backwards compatibility.
+    optional Uint128 start_time = 30;
 }
 
 message ProtobufEndpoint {

--- a/command/src/logging/access_logs.rs
+++ b/command/src/logging/access_logs.rs
@@ -201,6 +201,12 @@ pub struct RequestRecord<'a> {
     pub response_time: Option<Duration>,
     /// time between first byte of the request and last byte of the response
     pub request_time: Duration,
+    /// Wall-clock start time as nanoseconds since the Unix epoch. Captured
+    /// from the same `SystemTime::now()` call as the monotonic `start`
+    /// instant, so consumers can use it directly as the span start time
+    /// instead of computing `precise_time - request_time` (which mixes
+    /// CLOCK_REALTIME and CLOCK_MONOTONIC).
+    pub start_time_ns: Option<i128>,
     pub bytes_in: usize,
     pub bytes_out: usize,
     pub otel: Option<&'a OpenTelemetry>,
@@ -293,6 +299,7 @@ impl RequestRecord<'_> {
                         .as_ref()
                         .map(|id| std::str::from_utf8_unchecked(id).duplicate()),
                 }),
+                start_time: self.start_time_ns.map(Into::into),
             })
         }
     }

--- a/command/src/logging/access_logs.rs
+++ b/command/src/logging/access_logs.rs
@@ -202,10 +202,11 @@ pub struct RequestRecord<'a> {
     /// time between first byte of the request and last byte of the response
     pub request_time: Duration,
     /// Wall-clock start time as nanoseconds since the Unix epoch. Captured
-    /// from the same `SystemTime::now()` call as the monotonic `start`
-    /// instant, so consumers can use it directly as the span start time
-    /// instead of computing `precise_time - request_time` (which mixes
-    /// CLOCK_REALTIME and CLOCK_MONOTONIC).
+    /// immediately alongside the monotonic `start` instant (via
+    /// `SessionMetrics::mark_request_start`), so consumers can use it
+    /// directly as the span start time instead of computing
+    /// `precise_time - request_time` (which mixes CLOCK_REALTIME and
+    /// CLOCK_MONOTONIC).
     pub start_time_ns: Option<i128>,
     pub bytes_in: usize,
     pub bytes_out: usize,

--- a/doc/observability.md
+++ b/doc/observability.md
@@ -248,6 +248,12 @@ feature flag:
 - A new span ID is generated per Sōzu hop; the value is rewritten on the
   outgoing request and stored on `HttpContext.otel`.
 - Access logs surface `trace_id`, `span_id`, `parent_span_id`.
+- Access logs include `start_time` (proto field 30, `Uint128`, nanoseconds
+  since epoch) — a wall-clock timestamp captured at the start of the request
+  via `SessionMetrics::mark_request_start()`. Consumers reconstructing OTel
+  spans should prefer this field over `time - request_time`, which mixes
+  `CLOCK_REALTIME` and `CLOCK_MONOTONIC` and produces unreliable start
+  timestamps on short-lived requests.
 
 To go further (real spans, OTLP exporter, B3/Datadog propagation), see the
 "Out of scope" section in [`configure.md`](configure.md). It would land

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1232,11 +1232,11 @@ impl SessionMetrics {
     }
 
     pub fn service_start(&mut self) {
-        if self.start.is_none() {
-            self.mark_request_start();
-        }
-
-        let now = Instant::now();
+        let now = if self.start.is_none() {
+            self.mark_request_start()
+        } else {
+            Instant::now()
+        };
         self.service_start = Some(now);
         self.wait_time += now - self.wait_start;
     }
@@ -1265,9 +1265,13 @@ impl SessionMetrics {
     /// Arm both the monotonic and wall-clock start timestamps together.
     /// This must be the single place that sets `start` + `start_wall` outside
     /// of `new()`, so the two fields can never desynchronize.
-    pub fn mark_request_start(&mut self) {
-        self.start = Some(Instant::now());
+    /// Returns the monotonic instant so callers that need it (e.g.
+    /// `service_start`) can reuse it without a second syscall.
+    pub fn mark_request_start(&mut self) -> Instant {
+        let now = Instant::now();
+        self.start = Some(now);
         self.start_wall = Some(SystemTime::now());
+        now
     }
 
     /// time elapsed since the beginning of the session

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1232,13 +1232,11 @@ impl SessionMetrics {
     }
 
     pub fn service_start(&mut self) {
-        let now = Instant::now();
-
         if self.start.is_none() {
-            self.start = Some(now);
-            self.start_wall = Some(SystemTime::now());
+            self.mark_request_start();
         }
 
+        let now = Instant::now();
         self.service_start = Some(now);
         self.wait_time += now - self.wait_start;
     }
@@ -1262,6 +1260,14 @@ impl SessionMetrics {
             }
             None => self.service_time,
         }
+    }
+
+    /// Arm both the monotonic and wall-clock start timestamps together.
+    /// This must be the single place that sets `start` + `start_wall` outside
+    /// of `new()`, so the two fields can never desynchronize.
+    pub fn mark_request_start(&mut self) {
+        self.start = Some(Instant::now());
+        self.start_wall = Some(SystemTime::now());
     }
 
     /// time elapsed since the beginning of the session

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -343,7 +343,7 @@ use std::{
     net::SocketAddr,
     rc::Rc,
     str,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime},
 };
 
 use backends::BackendError;
@@ -1170,6 +1170,11 @@ impl fmt::Debug for Readiness {
 pub struct SessionMetrics {
     /// date at which we started handling that request
     pub start: Option<Instant>,
+    /// wall-clock timestamp captured alongside `start`, for access-log
+    /// consumers that need an absolute start time (e.g. OTel span
+    /// reconstruction) without subtracting a monotonic duration from a
+    /// wall-clock end time — which mixes two unsynchronised clock sources.
+    pub start_wall: Option<SystemTime>,
     /// time actually spent handling the request
     pub service_time: Duration,
     /// time spent waiting for its turn
@@ -1195,6 +1200,7 @@ impl SessionMetrics {
     pub fn new(wait_time: Option<Duration>) -> SessionMetrics {
         SessionMetrics {
             start: Some(Instant::now()),
+            start_wall: Some(SystemTime::now()),
             service_time: Duration::from_secs(0),
             wait_time: wait_time.unwrap_or_else(|| Duration::from_secs(0)),
             bin: 0,
@@ -1212,6 +1218,7 @@ impl SessionMetrics {
 
     pub fn reset(&mut self) {
         self.start = None;
+        self.start_wall = None;
         self.service_time = Duration::from_secs(0);
         self.wait_time = Duration::from_secs(0);
         self.bin = 0;
@@ -1229,6 +1236,7 @@ impl SessionMetrics {
 
         if self.start.is_none() {
             self.start = Some(now);
+            self.start_wall = Some(SystemTime::now());
         }
 
         self.service_start = Some(now);
@@ -1262,6 +1270,16 @@ impl SessionMetrics {
             Some(start) => Instant::now() - start,
             None => Duration::from_secs(0),
         }
+    }
+
+    /// Wall-clock start time as nanoseconds since the Unix epoch, or `None`
+    /// if the monotonic start has not been set yet (post-`reset()`, pre-`service_start()`).
+    pub fn start_wall_ns(&self) -> Option<i128> {
+        self.start_wall.and_then(|t| {
+            t.duration_since(SystemTime::UNIX_EPOCH)
+                .ok()
+                .map(|d| d.as_nanos() as i128)
+        })
     }
 
     pub fn backend_start(&mut self) {

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -1049,6 +1049,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             service_time: metrics.service_time(),
             response_time: metrics.backend_response_time(),
             request_time: metrics.request_time(),
+            start_time_ns: metrics.start_wall_ns(),
             bytes_in: metrics.bin,
             bytes_out: metrics.bout,
             user_agent: self.context.user_agent.as_deref(),

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -5,7 +5,7 @@
 //! same routing / shutdown / readiness machinery applies across H1 and H2
 //! connections. Long-form lifecycle: `lib/src/protocol/mux/LIFECYCLE.md`.
 
-use std::{io::IoSlice, time::Instant};
+use std::io::IoSlice;
 
 use rusty_ulid::Ulid;
 use sozu_command::{logging::ansi_palette, ready::Ready};
@@ -214,7 +214,7 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         let answers_rc = context.listener.borrow().get_answers().clone();
         let stream = &mut context.streams[stream_id];
         if stream.metrics.start.is_none() {
-            stream.metrics.start = Some(Instant::now());
+            stream.metrics.mark_request_start();
         }
         let parts = stream.split(&self.position);
         let kawa = parts.rbuffer;

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -571,8 +571,7 @@ impl<L: ListenerHandler + L7ListenerHandler> Context<L> {
             stream.front.clear();
             stream.front.storage.clear();
             stream.metrics.reset();
-            stream.metrics.start = Some(Instant::now());
-            stream.metrics.start_wall = Some(std::time::SystemTime::now());
+            stream.metrics.mark_request_start();
             // After recycling a slot, check if the Vec has excessive trailing
             // Recycle entries (more than 2x active streams of total capacity).
             let active = self.active_len();

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -572,6 +572,7 @@ impl<L: ListenerHandler + L7ListenerHandler> Context<L> {
             stream.front.storage.clear();
             stream.metrics.reset();
             stream.metrics.start = Some(Instant::now());
+            stream.metrics.start_wall = Some(std::time::SystemTime::now());
             // After recycling a slot, check if the Vec has excessive trailing
             // Recycle entries (more than 2x active streams of total capacity).
             let active = self.active_len();

--- a/lib/src/protocol/mux/stream.rs
+++ b/lib/src/protocol/mux/stream.rs
@@ -322,6 +322,7 @@ impl Stream {
             service_time: self.metrics.service_time(),
             response_time: self.metrics.backend_response_time(),
             request_time: self.metrics.request_time(),
+            start_time_ns: self.metrics.start_wall_ns(),
             bytes_in: self.metrics.bin,
             bytes_out: self.metrics.bout,
             user_agent: context.user_agent.as_deref(),

--- a/lib/src/protocol/pipe.rs
+++ b/lib/src/protocol/pipe.rs
@@ -325,6 +325,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             service_time: metrics.service_time(),
             response_time: metrics.backend_response_time(),
             request_time: metrics.request_time(),
+            start_time_ns: metrics.start_wall_ns(),
             bytes_in: metrics.bin,
             bytes_out: metrics.bout,
             user_agent: None,

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -295,6 +295,7 @@ impl TcpSession {
             service_time: self.metrics.service_time(),
             response_time: self.metrics.backend_response_time(),
             request_time: self.metrics.request_time(),
+            start_time_ns: self.metrics.start_wall_ns(),
             bytes_in: self.metrics.bin,
             bytes_out: self.metrics.bout,
             otel: None,


### PR DESCRIPTION
…tion

Access-log consumers reconstructing OTel spans computed the request start timestamp as `precise_time - request_time`. This subtraction mixes two unsynchronised clock sources:

- `precise_time` is a wall-clock reading (`CLOCK_REALTIME` via `OffsetDateTime::now_utc()`), captured at log-emission time.
- `request_time` is a monotonic duration (`CLOCK_MONOTONIC` via `Instant::now() - start`), captured in `SessionMetrics` *before* the wall-clock reading.

The two clocks drift independently (NTP adjustments affect CLOCK_REALTIME but not CLOCK_MONOTONIC), and they are sampled at different instants within the log-emission path. On short-lived requests the resulting error can exceed the request duration itself, producing spans whose computed start time falls after a subsequent request's start — visibly broken traces.

This commit adds a `start_wall: Option<SystemTime>` field to `SessionMetrics`, captured at the same point as the existing monotonic `start: Option<Instant>`. A new `start_wall_ns()` accessor converts it to nanoseconds-since-epoch for the access log.

Wire changes:
- `ProtobufAccessLog.start_time` (field 30, optional `Uint128`) in `command.proto` — backwards-compatible: old consumers ignore it, new consumers with old producers see `None` and can fall back to the subtraction.
- `RequestRecord.start_time_ns: Option<i128>` plumbed through all four access-log emission sites (kawa_h1, mux/stream, pipe, tcp).

Consumers should now prefer `start_time` over `time - request_time` whenever the field is present.