### PR TITLE
refactor(lib): TigerStyle assertion density on protocols + data plane (+ trie underflow fix)

### DIFF
--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -326,6 +326,45 @@ impl Server {
         // cost is one env-var lookup per command in non-systemd
         // deployments.
         let mutating = is_mutating_verb(&request_type);
+        // INVARIANT: the systemd bracket is symmetric. `mutating` is the
+        // sole gate for BOTH the RELOADING=1 (entry) and READY=1 (exit)
+        // notifications below, so it must be captured exactly once into this
+        // local and reused — never recomputed against a moved/mutated verb —
+        // otherwise a verb that opened the reload window could skip closing
+        // it (leaving the unit stuck in `reloading`) or vice versa.
+        debug_assert_eq!(
+            mutating,
+            is_mutating_verb(&request_type),
+            "is_mutating_verb must be a pure function of the verb (RELOADING/READY bracket gate)"
+        );
+        // INVARIANT: read-only verbs are never bracketed. The pure dashboard
+        // polls (Status / Query* / List* / Count) are dispatched WITHOUT
+        // touching `ConfigState` or the fleet, so flapping the systemd unit
+        // through `reloading` for them would be a correctness bug for any
+        // unit-state-watching tooling. SetMetricDetail is also excluded by
+        // design (runtime lease, not a transition — see the doc on the fn).
+        debug_assert!(
+            !mutating
+                || !matches!(
+                    request_type,
+                    RequestType::Status(_)
+                        | RequestType::ListWorkers(_)
+                        | RequestType::ListFrontends(_)
+                        | RequestType::ListListeners(_)
+                        | RequestType::QueryClustersHashes(_)
+                        | RequestType::QueryClustersByDomain(_)
+                        | RequestType::QueryClusterById(_)
+                        | RequestType::QueryCertificatesFromWorkers(_)
+                        | RequestType::QueryCertificatesFromTheState(_)
+                        | RequestType::QueryMetrics(_)
+                        | RequestType::QueryHealthChecks(_)
+                        | RequestType::CountRequests(_)
+                        | RequestType::SubscribeEvents(_)
+                        | RequestType::QueryMaxConnectionsPerIp(_)
+                        | RequestType::SetMetricDetail(_)
+                ),
+            "read-only / non-transition verbs must not open the systemd reload window"
+        );
         if mutating {
             if let Err(e) = sd_notify::notify(sd_notify::STATE_RELOADING) {
                 warn!("could not notify systemd RELOADING=1: {}", e);
@@ -434,10 +473,18 @@ impl Server {
                 let cluster_ids = self
                     .state
                     .get_cluster_ids_by_domain(domain.hostname, domain.path);
-                let vec = cluster_ids
+                let vec: Vec<_> = cluster_ids
                     .iter()
                     .filter_map(|cluster_id| self.state.cluster_state(cluster_id))
                     .collect();
+                // INVARIANT: `filter_map` can only drop entries, so the
+                // resolved cluster-info vec never exceeds the matched id set.
+                // A larger vec would mean we synthesised a cluster the domain
+                // index never resolved.
+                debug_assert!(
+                    vec.len() <= cluster_ids.len(),
+                    "QueryClustersByDomain result must not exceed the matched cluster-id set"
+                );
                 Some(ContentType::Clusters(ClusterInformations { vec }).into())
             }
             RequestType::QueryClustersHashes(_) => Some(
@@ -875,6 +922,16 @@ impl GatheringTask for LoadStaticConfigTask {
         client: &mut OptionalClient,
         _timed_out: bool,
     ) {
+        // PRECONDITION: `load_static_config` scatters with `Timeout::None`,
+        // so the task is released only once every expected worker answered.
+        debug_assert!(
+            self.gatherer.ok + self.gatherer.errors >= self.gatherer.expected_responses,
+            "LoadStaticConfigTask::on_finish: every expected worker must have answered (no timeout)"
+        );
+        // Snapshot the failure tally before the loop consumes `responses`; the
+        // failure-message list built below must contain exactly one entry per
+        // counted error. Read only inside the post-loop assert (ungated, E0425).
+        let errors_before = self.gatherer.errors;
         let mut messages = vec![];
         for (worker_id, response) in self.gatherer.responses {
             match ResponseStatus::try_from(response.status) {
@@ -885,6 +942,16 @@ impl GatheringTask for LoadStaticConfigTask {
                 Err(e) => warn!("error decoding response status: {}", e),
             }
         }
+        // INVARIANT: the gatherer's `errors` counter (incremented in
+        // `on_message` for every Failure status) must match the number of
+        // failure lines we just collected from the same `Failure` responses.
+        // A mismatch means the counter and the response log disagree on how
+        // many workers rejected the config.
+        debug_assert_eq!(
+            messages.len(),
+            errors_before,
+            "LoadStaticConfig failure-message count must equal the gatherer error tally"
+        );
 
         if self.gatherer.errors > 0 {
             client.finish_failure(format!(
@@ -1517,6 +1584,15 @@ fn audit_entry_for(
 /// clients, and write the structured audit log line at `info!` level. Used
 /// by every control-plane mutation handler.
 fn audit_emit(server: &mut Server, client: &ClientSession, entry: AuditEntry, result: AuditResult) {
+    // PRECONDITION: the verb tag and its counter key are non-empty. Both come
+    // from `audit_verb!` string literals; an empty `counter` would silently
+    // collapse every audited verb onto one metric series, and an empty `verb`
+    // would render an unattributable audit line. Bumping the counter exactly
+    // once per emission is the metric contract dashboards rely on.
+    debug_assert!(
+        !entry.counter.is_empty() && !entry.verb.is_empty(),
+        "audit entry must carry a non-empty verb tag and counter key"
+    );
     let request_id = Ulid::generate();
     // `entry.counter` is the pre-built `config.<verb>` static-str key
     // chosen at the construction site (paired with `verb` via
@@ -1599,6 +1675,21 @@ pub fn audit_worker_metric_detail_transition(
         let truncated: String = sanitized.chars().take(AUDIT_LEASE_ID_MAX_CHARS).collect();
         truncated
     });
+    // POSTCONDITION: the audit lease_id never exceeds the SIEM-visible cap.
+    // The operator-initiated path applies the same `take(AUDIT_LEASE_ID_MAX_CHARS)`
+    // bound; a worker-local line that slipped past it would give SOC tooling
+    // an inconsistent upper bound across the two emission sites.
+    debug_assert!(
+        lease_id
+            .as_deref()
+            .is_none_or(|id| id.chars().count() <= AUDIT_LEASE_ID_MAX_CHARS),
+        "worker-local audit lease_id must respect AUDIT_LEASE_ID_MAX_CHARS"
+    );
+    // The counter for this verb is bumped exactly once at entry (above).
+    debug_assert!(
+        !verb.is_empty() && !counter.is_empty(),
+        "worker-local metric-detail audit must carry a non-empty verb/counter"
+    );
 
     // Render the text-sink line. Match the operator-initiated envelope's
     // KV shape so a SOC analyst can correlate worker-local and operator
@@ -2047,10 +2138,46 @@ pub fn worker_request(
         None
     };
 
+    // INVARIANT: a single verb resolves to at most ONE audit channel. The
+    // three are derived from disjoint `RequestType` matches: a full
+    // `AuditEntry` (audit_entry_for), the inline ConfigureMetrics line
+    // (metrics_target), or the inline SetMetricDetail line
+    // (metric_detail_audit). If two were ever populated together, the
+    // dispatch/error/on_finish arms below — which are `if/else if` chains —
+    // would silently drop the second, producing an un-audited mutation. The
+    // `as u8` sum counts how many channels fired; it must never exceed one.
+    debug_assert!(
+        (audit.is_some() as u8)
+            + (metrics_target.is_some() as u8)
+            + (metric_detail_audit.is_some() as u8)
+            <= 1,
+        "a verb must map to at most one audit channel (entry / metrics / metric_detail)"
+    );
+
     let request: sozu_command_lib::proto::command::Request = request_content.into();
     let request_sha256 = compute_request_sha256(&request);
 
+    // Snapshot the state hash so the error path can assert the rejected
+    // dispatch was a true no-op on `ConfigState` — a partially-applied
+    // mutation that then errors would leave the master's persisted state
+    // diverged from every worker (which never saw the fan-out). The state
+    // handlers guarantee this (see `ConfigState::dispatch` postcondition),
+    // and we re-check it here at the request boundary. NOTE: we deliberately
+    // do NOT assert the success path *changed* the hash — many "mutating"
+    // verbs (ConfigureMetrics, SetMetricDetail, SetMaxConnectionsPerIp,
+    // Logging) are runtime/worker-only and `dispatch` is `Ok(())` no-op on
+    // ConfigState for them (see state.rs:138). `hash_state()` is a cheap
+    // per-cluster map; the snapshot is read ONLY inside the debug_assert
+    // below, so it is dead code in release but must stay ungated (E0425).
+    let state_hash_before = server.state.hash_state();
+
     if let Err(error) = server.state.dispatch(&request) {
+        // INVARIANT: a rejected dispatch must not mutate persisted state.
+        debug_assert_eq!(
+            server.state.hash_state(),
+            state_hash_before,
+            "a dispatch that returns Err must leave ConfigState byte-identical (no partial apply)"
+        );
         let reason = error.to_string();
         if let Some(mut entry) = audit {
             entry.extras.error_code = Some(AuditErrorCode::DispatchError);
@@ -2130,6 +2257,26 @@ pub fn worker_request(
             }
         })
     };
+    // INVARIANT: the completion-time channel threaded into `WorkerTask`
+    // mirrors the attempt-time channel exactly. `audit_for_task` carries the
+    // full-entry verbs; `inline_audit` carries the ConfigureMetrics /
+    // SetMetricDetail inline verbs. They are disjoint by construction (an
+    // entry-bearing verb has no metrics_target / metric_detail_audit) — if
+    // both were ever set, `WorkerTask::on_finish` would emit the entry arm
+    // and silently drop the inline completion line.
+    debug_assert!(
+        !(audit_for_task.is_some() && inline_audit.is_some()),
+        "WorkerTask carries at most one completion-time audit channel (entry XOR inline)"
+    );
+    // INVARIANT: the completion channel is present iff its attempt-time
+    // source was. `audit_for_task` is `audit.as_ref().map(...)` so it is Some
+    // exactly when `audit` is; losing it here would drop the completion line.
+    debug_assert_eq!(
+        audit_for_task.is_some(),
+        audit.is_some(),
+        "audit_for_task must be Some iff the attempt-time AuditEntry was Some"
+    );
+
     // Operator-controlled SetMetricDetail fields (lease_id + reason) we
     // need to thread into both the attempt-time Ok line below and the
     // completion-time line in `on_finish`. Cloning once keeps the
@@ -2210,6 +2357,26 @@ impl GatheringTask for WorkerTask {
         client: &mut OptionalClient,
         timed_out: bool,
     ) {
+        // PRECONDITION: the gatherer ran to completion. Either every expected
+        // worker answered (`ok + errors >= expected`, the `has_finished`
+        // predicate that drives the task off the in-flight queue) or the task
+        // tripped its timeout. A handler that fires with neither would be a
+        // dispatcher accounting bug (a response counted twice, or the task
+        // released before its workers replied). Read-only snapshots feed the
+        // debug_asserts only → dead code in release, but must stay ungated.
+        debug_assert!(
+            timed_out
+                || self.gatherer.ok + self.gatherer.errors >= self.gatherer.expected_responses,
+            "WorkerTask::on_finish: must be finished (ok+errors >= expected) unless timed out"
+        );
+        // INVARIANT: every accounted ok/err corresponds to a stored response.
+        // `on_message` pushes to `responses` for every ok/err/processing, so
+        // the response log can never be shorter than the ok+err tally.
+        debug_assert!(
+            self.gatherer.responses.len() >= self.gatherer.ok + self.gatherer.errors,
+            "responses log must hold at least one entry per accounted ok/err"
+        );
+
         let mut messages = vec![];
 
         for (worker_id, response) in self.gatherer.responses {
@@ -2257,6 +2424,24 @@ impl GatheringTask for WorkerTask {
             workers_err: u32::try_from(errors).unwrap_or(u32::MAX),
             workers_expected: u32::try_from(expected).unwrap_or(u32::MAX),
         };
+
+        // INVARIANT: the audit result mirrors the fanout status. A row tagged
+        // `result=ok` must never carry a Timeout/Partial fanout, and an
+        // `result=err` row must never claim a clean Ok/LocalOnly fanout —
+        // a SIEM correlating the two columns would otherwise see a row that
+        // contradicts itself.
+        debug_assert_eq!(
+            matches!(result, AuditResult::Err),
+            matches!(fanout_status, FanoutStatus::Timeout | FanoutStatus::Partial),
+            "AuditResult and FanoutStatus must agree on success vs failure"
+        );
+        // INVARIANT: `LocalOnly` means no worker was scattered to, so there
+        // can be no per-worker tallies. If a worker answered while the status
+        // says local-only, the expected-count accounting drifted.
+        debug_assert!(
+            !matches!(fanout_status, FanoutStatus::LocalOnly) || (ok == 0 && errors == 0),
+            "LocalOnly fanout must have zero worker ok/err tallies"
+        );
 
         // Completion-time audit: attributes the same verb as the attempt-time
         // line but with fanout / worker counts / elapsed_ms filled in. Skip
@@ -2341,11 +2526,20 @@ fn elapsed_ms(started_at: Instant) -> u64 {
 fn compute_request_sha256(request: &sozu_command_lib::proto::command::Request) -> String {
     let bytes = request.encode_to_vec();
     let digest = Sha256::digest(&bytes);
+    // INVARIANT: SHA-256 always yields 32 bytes; we render the first 8 as
+    // 2-hex-digit pairs, so the audit prefix is always exactly 16 chars.
+    debug_assert_eq!(digest.len(), 32, "SHA-256 digest must be 32 bytes");
     let mut hex = String::with_capacity(16);
     for byte in digest.iter().take(8) {
         use std::fmt::Write as _;
         let _ = write!(&mut hex, "{byte:02x}");
     }
+    // POSTCONDITION: greppable fixed-width 16-char (64-bit) audit prefix.
+    debug_assert_eq!(
+        hex.len(),
+        16,
+        "request sha256 audit prefix must be 16 hex chars"
+    );
     hex
 }
 
@@ -2356,11 +2550,22 @@ fn compute_request_sha256(request: &sozu_command_lib::proto::command::Request) -
 /// for log terseness — operators correlate via the 64-bit prefix.
 fn compute_certificate_fingerprint(certificate_pem: &[u8]) -> Option<String> {
     let fp = sozu_command_lib::certificate::calculate_fingerprint(certificate_pem).ok()?;
+    // INVARIANT: a SHA-256 fingerprint is 32 bytes; we render the first 8.
+    debug_assert!(
+        fp.len() >= 8,
+        "certificate fingerprint must hold at least the 8 bytes we truncate to"
+    );
     let mut hex = String::with_capacity(16);
     for byte in fp.iter().take(8) {
         use std::fmt::Write as _;
         let _ = write!(&mut hex, "{byte:02x}");
     }
+    // POSTCONDITION: fixed-width 16-char (64-bit) fingerprint prefix.
+    debug_assert_eq!(
+        hex.len(),
+        16,
+        "certificate fingerprint prefix must be 16 hex chars"
+    );
     Some(hex)
 }
 
@@ -2482,11 +2687,38 @@ pub fn set_metric_detail_request(
         reason: req.reason.clone().filter(|s| !s.is_empty()),
     };
 
+    // POSTCONDITION of the master-side pre-validation above: by the time we
+    // reach fan-out, the request honours both lease bounds (the two guards
+    // returned early otherwise). The worker enforces these again as
+    // defence-in-depth, but a request that slipped past here would amplify a
+    // bad input across every worker (N rejections + N audit lines).
+    debug_assert!(
+        req.client_id.len() <= sozu_lib::metrics::LEASE_CLIENT_ID_MAX_BYTES,
+        "SetMetricDetail must be length-validated before fan-out"
+    );
+    debug_assert!(
+        req.ttl_seconds
+            .is_none_or(|t| u64::from(t) <= sozu_lib::metrics::LEASE_TTL_MAX.as_secs()),
+        "SetMetricDetail must be TTL-validated before fan-out"
+    );
+
     let started_at = Instant::now();
+    // Snapshot the cluster-hash so we can confirm SetMetricDetail is a
+    // ConfigState no-op (it is runtime-only — `dispatch` returns `Ok(())`
+    // without touching persisted state; see state.rs:138). Read only inside
+    // the post-dispatch assert → ungated for the release build (E0425).
+    let state_hash_before = server.state.hash_state();
     let request: Request = RequestType::SetMetricDetail(req).into();
 
     // Attempt-time dispatch gate (mirrors `state.dispatch` in worker_request).
     if let Err(error) = server.state.dispatch(&request) {
+        // INVARIANT: a rejected runtime-only dispatch leaves ConfigState
+        // untouched (it never mutates it in the first place).
+        debug_assert_eq!(
+            server.state.hash_state(),
+            state_hash_before,
+            "SetMetricDetail dispatch must not mutate ConfigState"
+        );
         let reason = error.to_string();
         let (verb, counter) = audit_verb!("metric_detail_changed");
         let target = metric_detail_audit.target.clone();
@@ -2509,6 +2741,16 @@ pub fn set_metric_detail_request(
         ));
         return;
     }
+
+    // INVARIANT: even on the success path, SetMetricDetail is a ConfigState
+    // no-op — the runtime lease lives in each worker's `Aggregator`, never in
+    // the master's persisted `ConfigState`. If the hash changed, a future
+    // edit accidentally wired a runtime knob into persisted state.
+    debug_assert_eq!(
+        server.state.hash_state(),
+        state_hash_before,
+        "SetMetricDetail must not mutate ConfigState even on success"
+    );
 
     // Attempt-time audit Ok.
     let (verb, counter) = audit_verb!("metric_detail_changed");
@@ -2568,6 +2810,15 @@ impl GatheringTask for SetMetricDetailTask {
         client: &mut OptionalClient,
         timed_out: bool,
     ) {
+        // PRECONDITION: the scatter ran to completion (or timed out). Mirrors
+        // the generic `WorkerTask::on_finish` finished-or-timeout guard so a
+        // SetMetricDetail task released before its workers replied trips here.
+        debug_assert!(
+            timed_out
+                || self.gatherer.ok + self.gatherer.errors >= self.gatherer.expected_responses,
+            "SetMetricDetailTask::on_finish: must be finished (ok+errors >= expected) unless timed out"
+        );
+
         // Per-worker status: each worker now returns its own
         // `WorkerMetricDetailStatus` payload via
         // `ContentType::WorkerMetricDetailStatus` in the SetMetricDetail
@@ -2632,6 +2883,21 @@ impl GatheringTask for SetMetricDetailTask {
             workers_err: u32::try_from(errors).unwrap_or(u32::MAX),
             workers_expected: u32::try_from(expected).unwrap_or(u32::MAX),
         };
+        // INVARIANT: the per-worker status map holds only successfully-ACK'd
+        // workers (the loop above skips non-Ok responses), so it can never be
+        // larger than the OK tally. A larger map would mean a non-Ok worker
+        // leaked into the operator-visible `MetricDetailStatus.workers`.
+        debug_assert!(
+            status.workers.len() <= ok,
+            "MetricDetailStatus.workers must not exceed the OK worker tally"
+        );
+        // INVARIANT: audit result agrees with fanout status (same as the
+        // generic WorkerTask path).
+        debug_assert_eq!(
+            matches!(result, AuditResult::Err),
+            matches!(fanout_status, FanoutStatus::Timeout | FanoutStatus::Partial),
+            "AuditResult and FanoutStatus must agree on success vs failure"
+        );
         if let Some(client_ref) = client.as_deref() {
             let mut extras = self.metric_detail_audit.into_extras();
             extras.elapsed_ms = Some(elapsed_ms(self.started_at));
@@ -2893,7 +3159,20 @@ pub fn load_state(server: &mut Server, mut client: OptionalClient, path: &str) {
 
                 for request in requests {
                     if server.state.dispatch(&request.content).is_ok() {
+                        // INVARIANT: the scatter request_id advances by
+                        // exactly one per dispatched request. `scatter_on`
+                        // embeds it in the per-worker request id, so a stale
+                        // or repeated counter would collide two in-flight ids
+                        // and silently drop a worker's response, hanging the
+                        // task. Snapshot is read only inside the assert →
+                        // ungated for the release (E0425) build.
+                        let counter_before = scatter_request_counter;
                         scatter_request_counter += 1;
+                        debug_assert_eq!(
+                            scatter_request_counter,
+                            counter_before + 1,
+                            "load_state must advance the scatter request_id by exactly one per dispatch"
+                        );
                         server.scatter_on(request.content, task_id, scatter_request_counter, None);
                     }
                 }
@@ -2958,13 +3237,33 @@ impl GatheringTask for LoadStateTask {
         client: &mut OptionalClient,
         _timed_out: bool,
     ) {
-        let DefaultGatherer { ok, errors, .. } = self.gatherer;
+        let DefaultGatherer {
+            ok,
+            errors,
+            expected_responses,
+            ..
+        } = self.gatherer;
+        // PRECONDITION: `load_state` scatters with `Timeout::None`, so the
+        // task is only released once every worker has answered — never on a
+        // timeout. The ok/err tally must therefore cover the full expected
+        // fan-out.
+        debug_assert!(
+            ok + errors >= expected_responses,
+            "LoadStateTask::on_finish: every expected worker must have answered (no timeout path)"
+        );
         server.update_counts();
         let result = if errors == 0 {
             AuditResult::Ok
         } else {
             AuditResult::Err
         };
+        // INVARIANT: the audit result matches the error tally — an `ok:N
+        // errors:0` line must be tagged Ok, any error tagged Err.
+        debug_assert_eq!(
+            matches!(result, AuditResult::Ok),
+            errors == 0,
+            "LoadStateTask audit result must agree with the worker error tally"
+        );
         if let Some(client_ref) = client.as_deref() {
             let (verb, counter) = audit_verb!("state_loaded");
             audit_emit_inline(
@@ -3093,6 +3392,15 @@ fn stop(server: &mut Server, client: &mut ClientSession, hardness: bool) {
     });
 
     server.run_state = ServerState::WorkersStopping;
+    // POSTCONDITION: the stop request has opened the shutdown sequence. The
+    // matching `StopTask::on_finish` will later advance to `Stopping`. We do
+    // NOT assert the prior state was `Running` — an operator may legitimately
+    // re-issue stop while a soft-stop is already draining.
+    debug_assert_eq!(
+        server.run_state,
+        ServerState::WorkersStopping,
+        "stop() must move the master into WorkersStopping before fan-out"
+    );
     if hardness {
         client.return_processing("Performing hard stop...");
         server.scatter(
@@ -3127,6 +3435,17 @@ impl GatheringTask for StopTask {
         client: &mut OptionalClient,
         timed_out: bool,
     ) {
+        // PRECONDITION: a StopTask is only created by `stop()`, which moves
+        // the master to `WorkersStopping` BEFORE scattering. The server must
+        // therefore never still be `Running` when a stop task finishes —
+        // that would mean the run-state transition that brackets shutdown
+        // was skipped. (`Stopping` is also acceptable: a prior stop task may
+        // already have advanced it.)
+        debug_assert_ne!(
+            server.run_state,
+            ServerState::Running,
+            "StopTask::on_finish must observe a shutdown run-state, never Running"
+        );
         if timed_out && self.hardness {
             client.finish_failure(format!(
                 "Workers take too long to stop ({} ok, {} errors), stopping the main process to sever the link",
@@ -3134,6 +3453,12 @@ impl GatheringTask for StopTask {
             ));
         }
         server.run_state = ServerState::Stopping;
+        // POSTCONDITION: shutdown is now committed.
+        debug_assert_eq!(
+            server.run_state,
+            ServerState::Stopping,
+            "StopTask::on_finish must leave the master in the Stopping state"
+        );
         client.finish_ok(format!(
             "Successfully closed {} workers, {} errors, stopping the main process...",
             self.gatherer.ok, self.gatherer.errors

--- a/bin/src/command/server.rs
+++ b/bin/src/command/server.rs
@@ -153,7 +153,18 @@ pub struct DefaultGatherer {
 #[allow(unused)]
 impl Gatherer for DefaultGatherer {
     fn inc_expected_responses(&mut self, count: usize) {
+        let before = self.expected_responses;
         self.expected_responses += count;
+        // INVARIANT: the expected-response budget advances by exactly `count`
+        // — this is the number tracked against `ok + errors` to decide when a
+        // scattered task has heard from every worker. An off-by-one here means
+        // the task either finishes early (drops a worker's answer) or hangs
+        // until timeout.
+        debug_assert_eq!(
+            self.expected_responses,
+            before + count,
+            "inc_expected_responses must grow the budget by exactly count"
+        );
     }
 
     fn has_finished(&self) -> bool {
@@ -167,6 +178,12 @@ impl Gatherer for DefaultGatherer {
         worker_id: WorkerId,
         message: WorkerResponse,
     ) {
+        // Snapshot the accounting before classifying so the post-conditions
+        // can assert that each message bumps at most one terminal counter and
+        // is always recorded exactly once.
+        let ok_before = self.ok;
+        let errors_before = self.errors;
+        let responses_before = self.responses.len();
         match ResponseStatus::try_from(message.status) {
             Ok(ResponseStatus::Ok) => self.ok += 1,
             Ok(ResponseStatus::Failure) => self.errors += 1,
@@ -177,6 +194,28 @@ impl Gatherer for DefaultGatherer {
             Err(e) => warn!("error decoding response status: {}", e),
         }
         self.responses.push((worker_id, message));
+        // INVARIANT: a single worker message counts toward completion at most
+        // once. An Ok bumps `ok`, a Failure bumps `errors`, a Processing /
+        // undecodable status bumps neither (it is not terminal). Double-
+        // counting would let `has_finished` fire before every worker replied.
+        debug_assert!(
+            self.ok - ok_before <= 1 && self.errors - errors_before <= 1,
+            "on_message must advance a terminal counter by at most one"
+        );
+        debug_assert_eq!(
+            (self.ok - ok_before) + (self.errors - errors_before),
+            usize::from(matches!(
+                ResponseStatus::try_from(self.responses[responses_before].1.status),
+                Ok(ResponseStatus::Ok | ResponseStatus::Failure)
+            )),
+            "exactly one terminal counter advances iff the message was Ok/Failure"
+        );
+        // INVARIANT: every message is archived exactly once for `on_finish`.
+        debug_assert_eq!(
+            self.responses.len(),
+            responses_before + 1,
+            "on_message must record the response exactly once"
+        );
     }
 }
 
@@ -286,7 +325,29 @@ impl CommandHub {
             session.actor_comm_display()
         );
         debug!("registering client {:?}", session);
+        // `token` came from the monotonic `next_session_token`, so it must not
+        // already key a live client; a collision would evict an existing
+        // client session and leak its channel/fd.
+        debug_assert!(
+            !self.clients.contains_key(&token),
+            "register_client must use a fresh session token"
+        );
+        let clients_before = self.clients.len();
         self.clients.insert(token, session);
+        // INVARIANT: exactly one client was registered, and it maps back from
+        // its token carrying the id/token we stamped. Every later lookup
+        // (`get_client_mut`, the event-loop dispatch) keys on this token.
+        debug_assert_eq!(
+            self.clients.len(),
+            clients_before + 1,
+            "register_client must add exactly one client session"
+        );
+        debug_assert!(
+            self.clients
+                .get(&token)
+                .is_some_and(|c| c.token == token && c.id == id),
+            "registered client must map back from its token with matching id"
+        );
     }
 
     /// Drain audit events queued by the [Server] during a client request and
@@ -610,6 +671,13 @@ impl CommandHub {
         task.job.on_finish(&mut self.server, client, false);
         self.in_flight
             .retain(|_, in_flight_task_id| *in_flight_task_id != task_id);
+        // POST-CONDITION: every in-flight entry pointing at this finished task
+        // has been purged. A leftover would make a late/duplicate worker
+        // response resolve to a task that is already gone, mis-routing it.
+        debug_assert!(
+            self.in_flight.values().all(|id| *id != task_id),
+            "handle_finishing_task must purge all in-flight entries for the finished task"
+        );
     }
 }
 
@@ -911,25 +979,54 @@ impl Server {
     }
 
     fn next_session_token(&mut self) -> Token {
+        // Token(0) is permanently reserved for the UnixListener; every handed
+        // out session token must therefore be strictly positive.
+        debug_assert!(
+            self.next_session_id >= 1,
+            "session ids start at 1; Token(0) is reserved for the listener"
+        );
+        let before = self.next_session_id;
         let token = Token(self.next_session_id);
         self.next_session_id += 1;
+        debug_assert_eq!(
+            self.next_session_id,
+            before + 1,
+            "session id counter must advance by exactly one"
+        );
         token
     }
     fn next_client_id(&mut self) -> ClientId {
         let id = self.next_client_id;
         self.next_client_id += 1;
+        // Monotonic, gap-free allocation: the next id is exactly one past the
+        // one we just handed out, so no two clients ever share an id.
+        debug_assert_eq!(
+            self.next_client_id,
+            id + 1,
+            "client id counter must advance by exactly one"
+        );
         id
     }
 
     fn next_task_id(&mut self) -> TaskId {
         let id = self.next_task_id;
         self.next_task_id += 1;
+        debug_assert_eq!(
+            self.next_task_id,
+            id + 1,
+            "task id counter must advance by exactly one"
+        );
         id
     }
 
     fn next_worker_id(&mut self) -> WorkerId {
         let id = self.next_worker_id;
         self.next_worker_id += 1;
+        debug_assert_eq!(
+            self.next_worker_id,
+            id + 1,
+            "worker id counter must advance by exactly one"
+        );
         id
     }
 
@@ -956,10 +1053,33 @@ impl Server {
         scm_socket: ScmSocket,
     ) -> Result<&mut WorkerSession, ServerError> {
         let token = self.next_session_token();
+        // `next_session_token` hands out a strictly increasing token, so the
+        // slot we are about to fill must be empty — a collision would evict a
+        // live worker session and orphan its channel.
+        debug_assert!(
+            !self.workers.contains_key(&token),
+            "register_worker must use a fresh, unoccupied session token"
+        );
+        let workers_before = self.workers.len();
         self.register(token, &mut channel.sock)?;
         self.workers.insert(
             token,
             WorkerSession::new(channel, worker_id, pid, token, scm_socket),
+        );
+        // INVARIANT: exactly one worker session was added, and it is the one
+        // keyed by `token` carrying the id/pid we just registered. This is the
+        // bookkeeping anchor every later lookup (`scatter_on`, `close_worker`,
+        // `handle_worker_response`) relies on.
+        debug_assert_eq!(
+            self.workers.len(),
+            workers_before + 1,
+            "register_worker must add exactly one worker session"
+        );
+        debug_assert!(
+            self.workers
+                .get(&token)
+                .is_some_and(|w| w.token == token && w.id == worker_id && w.pid == pid),
+            "registered worker must map back from its token with matching id/pid"
         );
         self.workers
             .get_mut(&token)
@@ -969,6 +1089,13 @@ impl Server {
     /// Add a task in a queue to make it accessible until the next tick
     pub fn new_task(&mut self, job: Box<dyn GatheringTask>, timeout: Timeout) -> TaskId {
         let task_id = self.next_task_id();
+        // `next_task_id` is monotonic, so this id must be unused in the queue;
+        // reusing one would silently drop the job already parked there.
+        debug_assert!(
+            !self.queued_tasks.contains_key(&task_id),
+            "new_task must allocate a fresh, unused task id"
+        );
+        let queued_before = self.queued_tasks.len();
         let timeout = match timeout {
             Timeout::None => None,
             Timeout::Default => Some(Duration::from_secs(self.config.worker_timeout as u64)),
@@ -977,6 +1104,18 @@ impl Server {
         .map(|duration| Instant::now() + duration);
         self.queued_tasks
             .insert(task_id, TaskContainer { job, timeout });
+        // INVARIANT: exactly one task was queued, retrievable by the id we
+        // return — the caller (`scatter`/`scatter_on`) immediately looks it
+        // up by this id.
+        debug_assert_eq!(
+            self.queued_tasks.len(),
+            queued_before + 1,
+            "new_task must queue exactly one task"
+        );
+        debug_assert!(
+            self.queued_tasks.contains_key(&task_id),
+            "the queued task must be retrievable by the returned id"
+        );
         task_id
     }
 
@@ -1013,6 +1152,14 @@ impl Server {
             content: request,
         };
 
+        // Snapshot the in-flight map size before the fan-out so the
+        // post-condition can assert the per-call delta. Note the in-flight
+        // map and `expected_responses` both accumulate across repeated
+        // `scatter_on` calls on the same task (see `requests.rs::load_state`,
+        // `upgrade.rs`), so only the increment of THIS call is assertable,
+        // never an absolute total.
+        let in_flight_before = self.in_flight.len();
+
         for worker in self.workers.values_mut().filter(|w| {
             target
                 .map(|id| id == w.id && w.run_state != RunState::Stopped)
@@ -1031,6 +1178,18 @@ impl Server {
             self.in_flight.insert(worker_request.id, task_id);
         }
         task.job.get_gatherer().inc_expected_responses(worker_count);
+
+        // INVARIANT: every worker we scattered to within this call has a
+        // distinct request id (the id embeds the unique worker id, plus the
+        // task and request indices), so the in-flight map must have grown by
+        // exactly `worker_count`. A smaller delta would mean an id collision
+        // overwrote an in-flight entry, which would silently lose a worker's
+        // response and hang the task until timeout.
+        debug_assert_eq!(
+            self.in_flight.len(),
+            in_flight_before + worker_count,
+            "scatter_on must register exactly one in-flight entry per scattered worker"
+        );
     }
 
     pub fn cancel_task(&mut self, task_id: TaskId) {
@@ -1102,6 +1261,21 @@ impl Server {
             Err(_) => info!("worker {} was already dead", worker.id),
         }
         worker.run_state = RunState::Stopped;
+        // POST-CONDITION: a closed worker is terminal — `Stopped` excludes it
+        // from `is_active`/`alive_workers`/`scatter_on` targeting, so no later
+        // request can be fanned out to a killed process.
+        debug_assert_eq!(
+            self.workers.get(token).map(|w| w.run_state),
+            Some(RunState::Stopped),
+            "close_worker must leave the worker in the Stopped run state"
+        );
+        debug_assert!(
+            !self
+                .workers
+                .get(token)
+                .is_some_and(WorkerSession::is_active),
+            "a closed worker must not report as active"
+        );
     }
 
     /// Make the file descriptors of the channel survive the upgrade

--- a/bin/src/command/sessions.rs
+++ b/bin/src/command/sessions.rs
@@ -147,6 +147,13 @@ impl ClientSession {
             return;
         }
         self.channel.interest.insert(Ready::WRITABLE);
+        // POST-CONDITION: a successfully queued response arms WRITABLE so the
+        // event loop flushes it to the client; without this interest the
+        // response would sit unsent in the back buffer.
+        debug_assert!(
+            self.channel.interest.is_writable(),
+            "send must arm WRITABLE interest so the queued response gets flushed"
+        );
     }
 
     pub fn update_readiness(&mut self, events: Ready) {
@@ -412,6 +419,14 @@ impl WorkerSession {
             return;
         }
         self.channel.interest.insert(Ready::WRITABLE);
+        // POST-CONDITION: a successfully queued request leaves the channel
+        // registered for WRITABLE, so the event loop will flush it. Dropping
+        // this interest would strand the request in the back buffer and hang
+        // every task waiting on this worker's response.
+        debug_assert!(
+            self.channel.interest.is_writable(),
+            "send must arm WRITABLE interest so the queued request gets flushed"
+        );
     }
 
     pub fn update_readiness(&mut self, events: Ready) {
@@ -469,7 +484,18 @@ where
         match message {
             Ok(message) => messages.push(message),
             Err(_) => {
-                if old_capacity == channel.front_buf.capacity() {
+                let new_capacity = channel.front_buf.capacity();
+                // INVARIANT: the read buffer only ever grows while we drain it
+                // (the channel doubles capacity on a partial read, never
+                // shrinks mid-loop). A shrink here would mean `read_message`
+                // reallocated downward and dropped buffered bytes — silent
+                // message corruption. This is also the loop-termination
+                // anchor: we stop precisely when capacity stopped growing.
+                debug_assert!(
+                    new_capacity >= old_capacity,
+                    "channel read buffer must not shrink while draining messages"
+                );
+                if old_capacity == new_capacity {
                     return messages;
                 }
             }

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -99,7 +99,7 @@ fn main(args: Args) -> Result<(), MainError> {
             max_command_buffer_size,
         } => {
             let max_command_buffer_size =
-                max_command_buffer_size.unwrap_or(command_buffer_size * 2);
+                resolve_max_command_buffer_size(command_buffer_size, max_command_buffer_size);
             worker::begin_worker_process(
                 worker_to_main_channel_fd,
                 worker_to_main_scm_fd,
@@ -118,7 +118,7 @@ fn main(args: Args) -> Result<(), MainError> {
             max_command_buffer_size,
         } => {
             let max_command_buffer_size =
-                max_command_buffer_size.unwrap_or(command_buffer_size * 2);
+                resolve_max_command_buffer_size(command_buffer_size, max_command_buffer_size);
             upgrade::begin_new_main_process(
                 fd,
                 upgrade_fd,
@@ -134,6 +134,37 @@ fn main(args: Args) -> Result<(), MainError> {
         eprintln!("\n{main_error}\n");
     }
     result
+}
+
+/// Resolve the effective `max_command_buffer_size` for an internal `worker` /
+/// `main` re-exec subcommand. When the caller (always the `sozu` CLI during
+/// an upgrade — these subcommands are never operator-facing) omits an explicit
+/// max, it defaults to twice the base command buffer.
+///
+/// The default branch carries a hard logic invariant we assert here:
+/// `max >= base`, because doubling never shrinks a `u64`. We deliberately do
+/// NOT assert the relation across the explicit-`Some` branch: that value is
+/// caller/config-supplied input (`Config::max_command_buffer_size`, which
+/// defaults independently of `command_buffer_size`), so a `max < base` there
+/// is a misconfiguration to surface as a runtime error downstream, not a logic
+/// bug to panic on. The default uses the same `command_buffer_size * 2`
+/// expression as before (behaviour-identical); the assertion only observes it.
+fn resolve_max_command_buffer_size(command_buffer_size: u64, explicit_max: Option<u64>) -> u64 {
+    match explicit_max {
+        Some(max) => max,
+        None => {
+            let default_max = command_buffer_size * 2;
+            // INVARIANT: the defaulted max is at least the base buffer, so an
+            // IPC frame that fits the base can always grow into the max. This
+            // is the load-bearing relation the framing layer relies on; it is
+            // guaranteed for the default but NOT for an explicit caller value.
+            debug_assert!(
+                default_max >= command_buffer_size,
+                "defaulted max_command_buffer_size must be >= command_buffer_size"
+            );
+            default_max
+        }
+    }
 }
 
 fn register_panic_hook() {

--- a/bin/src/upgrade.rs
+++ b/bin/src/upgrade.rs
@@ -105,15 +105,81 @@ pub fn fork_main_into_new_main(
         }
     })?;
 
+    // Snapshot the count of worker sessions being handed off BEFORE we move
+    // `upgrade_data` into serialization, so we can reconcile it against what
+    // the re-execed master will recover (round-trip below). Gated to debug:
+    // the snapshots are read only inside the `#[cfg(debug_assertions)]` block.
+    #[cfg(debug_assertions)]
+    let workers_to_handoff = upgrade_data.workers.len();
+    #[cfg(debug_assertions)]
+    let boot_generation_handoff = upgrade_data.boot_generation;
+
     info!("Writing upgrade data to file");
     let upgrade_data_string =
         serde_json::to_string(&upgrade_data).map_err(UpgradeError::SerdeWriteError)?;
+
+    // The serialized payload must round-trip: deserializing what we are about
+    // to write back into `UpgradeData` and re-serializing must reproduce the
+    // exact same bytes. `UpgradeData` field order is fixed by declaration, so
+    // a stable serializer yields a canonical string — a mismatch would mean a
+    // (de)serialization bug that would silently corrupt the recovered master
+    // state on the other side of the re-exec. This is the cheap, in-process
+    // half of the write->read round-trip that `begin_new_main_process`
+    // completes after exec. (Guarded both let + assert: the re-parse only
+    // exists for the check, so it is dead code stripped in release.)
+    #[cfg(debug_assertions)]
+    {
+        match serde_json::from_str::<UpgradeData>(&upgrade_data_string) {
+            Ok(reparsed) => {
+                debug_assert_eq!(
+                    reparsed.workers.len(),
+                    workers_to_handoff,
+                    "round-tripped upgrade data must preserve the worker-session count"
+                );
+                debug_assert_eq!(
+                    reparsed.boot_generation, boot_generation_handoff,
+                    "round-tripped upgrade data must preserve the boot generation"
+                );
+                let reserialized = serde_json::to_string(&reparsed)
+                    .expect("re-serializing already-parsed upgrade data cannot fail");
+                debug_assert_eq!(
+                    reserialized, upgrade_data_string,
+                    "upgrade data must serialize->deserialize->serialize identically (canonical round-trip)"
+                );
+            }
+            Err(e) => debug_assert!(
+                false,
+                "upgrade data we just serialized must deserialize back: {e}"
+            ),
+        }
+    }
+
     upgrade_file
         .write_all(upgrade_data_string.as_bytes())
         .map_err(UpgradeError::WriteFile)?;
     upgrade_file.rewind().map_err(UpgradeError::Rewind)?;
 
     let (old_to_new, new_to_old) = UnixStream::pair().map_err(UpgradeError::CreateUnixStream)?;
+
+    // The descriptors the new binary inherits across the re-exec must be
+    // distinct kernel objects — none handed off twice. Three are in play at
+    // this site: the confirmation channel (`new_to_old`, passed as `--fd`),
+    // the upgrade-state file (passed as `--upgrade-fd`), and the unix command
+    // listener carried inside `UpgradeData` (`command_socket_fd`). A collision
+    // would mean a single fd is being used for two roles after exec — an
+    // fd-bookkeeping bug in the handoff.
+    debug_assert!(
+        new_to_old.as_raw_fd() != upgrade_file.as_raw_fd(),
+        "confirmation-channel fd must not alias the upgrade-state file fd"
+    );
+    debug_assert!(
+        new_to_old.as_raw_fd() != upgrade_data.command_socket_fd,
+        "confirmation-channel fd must not alias the inherited command-socket fd"
+    );
+    debug_assert!(
+        upgrade_file.as_raw_fd() != upgrade_data.command_socket_fd,
+        "upgrade-state file fd must not alias the inherited command-socket fd"
+    );
 
     util::disable_close_on_exec(new_to_old.as_raw_fd()).map_err(|util_err| {
         UpgradeError::DisableCloexec {
@@ -140,6 +206,15 @@ pub fn fork_main_into_new_main(
     // after that point.
     match unsafe { fork().map_err(UpgradeError::Fork)? } {
         ForkResult::Parent { child } => {
+            // The parent branch of a successful `fork()` always observes the
+            // child's pid, which is strictly positive (0 is the child branch;
+            // a failure returns `Err` above). A non-positive value here would
+            // mean we mis-classified the fork outcome and would report a bogus
+            // new-main pid to the operator.
+            debug_assert!(
+                child.as_raw() > 0,
+                "fork parent branch must observe a strictly positive new-main pid"
+            );
             info!("new main launched, with pid {}", child);
 
             Ok((child.into(), fork_confirmation_channel))
@@ -193,6 +268,25 @@ pub fn begin_new_main_process(
     command_buffer_size: u64,
     max_command_buffer_size: u64,
 ) -> Result<(), UpgradeError> {
+    // Both descriptors were handed to us across the re-exec by the old master
+    // (`fork_main_into_new_main`), each derived from a live `as_raw_fd()`: they
+    // are valid (>= 0) and reference two distinct kernel objects (the
+    // confirmation channel vs. the upgrade-state file). Aliasing them would be
+    // an fd-bookkeeping bug on the handoff side. (Stays a `debug_assert!`: a
+    // genuinely bad descriptor surfaces as a returned channel / read error.)
+    debug_assert!(
+        new_to_old_channel_fd >= 0,
+        "inherited new-main-to-old-main channel fd must be a valid descriptor"
+    );
+    debug_assert!(
+        upgrade_file_fd >= 0,
+        "inherited upgrade-state file fd must be a valid descriptor"
+    );
+    debug_assert!(
+        new_to_old_channel_fd != upgrade_file_fd,
+        "the confirmation channel and upgrade-state file must be two distinct fds"
+    );
+
     let mut fork_confirmation_channel: Channel<bool, ()> = Channel::new(
         // SAFETY: `new_to_old_channel_fd` was just inherited from the
         // pre-exec parent process via the `--fd` CLI argument. It is a valid
@@ -220,6 +314,22 @@ pub fn begin_new_main_process(
     let _ = upgrade_file
         .read_to_string(&mut content)
         .map_err(UpgradeError::ReadFile)?;
+
+    // This is the read side of the write->read round-trip started in
+    // `fork_main_into_new_main`: the old master wrote a non-empty serialized
+    // `UpgradeData` object. The recovered payload must therefore be non-empty
+    // and start with the JSON object delimiter. An empty/truncated read means
+    // the fd handoff or the file rewind was botched — a malformed payload
+    // still surfaces as a returned `SerdeReadError` below, this only flags the
+    // logic bug earlier and loudly.
+    debug_assert!(
+        !content.is_empty(),
+        "recovered upgrade state must not be empty (write->read round-trip)"
+    );
+    debug_assert!(
+        content.trim_start().starts_with('{'),
+        "recovered upgrade state must be a serialized JSON object"
+    );
 
     let upgrade_data: UpgradeData =
         serde_json::from_str(&content).map_err(UpgradeError::SerdeReadError)?;

--- a/bin/src/worker.rs
+++ b/bin/src/worker.rs
@@ -89,6 +89,33 @@ pub fn begin_worker_process(
     command_buffer_size: u64,
     max_command_buffer_size: u64,
 ) -> Result<(), WorkerError> {
+    // The three descriptors were handed to us by the master via
+    // `fork_main_into_worker`, each derived from a live `as_raw_fd()`, so
+    // they are always valid (>= 0) and pairwise distinct — three separate
+    // kernel objects (command channel, SCM socket, state file). A negative
+    // value or a collision would mean the master's fd bookkeeping aliased
+    // two handoffs, an internal logic bug. (Stays a `debug_assert!`: a
+    // genuinely bad descriptor surfaces downstream as a returned channel /
+    // file error, never a panic.)
+    debug_assert!(
+        worker_to_main_channel_fd >= 0,
+        "inherited worker-to-main channel fd must be a valid descriptor"
+    );
+    debug_assert!(
+        worker_to_main_scm_fd >= 0,
+        "inherited worker-to-main SCM fd must be a valid descriptor"
+    );
+    debug_assert!(
+        configuration_state_fd >= 0,
+        "inherited configuration-state fd must be a valid descriptor"
+    );
+    debug_assert!(
+        worker_to_main_channel_fd != worker_to_main_scm_fd
+            && worker_to_main_channel_fd != configuration_state_fd
+            && worker_to_main_scm_fd != configuration_state_fd,
+        "the channel, SCM and state descriptors must be three distinct fds, never aliased"
+    );
+
     let mut worker_to_main_channel: Channel<WorkerResponse, ServerConfig> = Channel::new(
         // SAFETY: `worker_to_main_channel_fd` was just inherited from the
         // pre-exec parent process via the `--fd` CLI argument. It is a valid
@@ -119,6 +146,19 @@ pub fn begin_worker_process(
         .map_err(WorkerError::ReadChannel)?;
 
     let worker_id = format!("{}-{:02}", "WRK", id);
+
+    // The display id is derived purely from the numeric `id` the master
+    // assigned (`WorkerId`, a monotonic counter handed in via `--id`): it
+    // must carry the canonical `WRK-` prefix and embed that very id so log
+    // correlation between master and worker is unambiguous.
+    debug_assert!(
+        worker_id.starts_with("WRK-"),
+        "worker display id must carry the canonical WRK- prefix"
+    );
+    debug_assert!(
+        id < 0 || worker_id.ends_with(&id.to_string()),
+        "worker display id must embed the numeric worker id handed in by the master"
+    );
 
     let access_log_format = AccessLogFormat::from(&worker_config.access_log_format());
 
@@ -257,6 +297,19 @@ pub fn fork_main_into_worker(
         }
     })?;
 
+    // The three descriptors the worker child will inherit via its CLI args are
+    // distinct kernel objects — none handed off twice: the command channel
+    // (`worker_to_main`, `--fd`), the SCM socket (`worker_to_main_scm`,
+    // `--scm`) and the state file (`--configuration-state-fd`). A collision
+    // would alias two roles onto one fd after exec. (The SCM listener fds
+    // themselves travel separately over `send_listeners`, not as CLI args.)
+    debug_assert!(
+        worker_to_main.as_raw_fd() != worker_to_main_scm.as_raw_fd()
+            && worker_to_main.as_raw_fd() != state_file.as_raw_fd()
+            && worker_to_main_scm.as_raw_fd() != state_file.as_raw_fd(),
+        "worker channel, SCM and state descriptors must be three distinct fds, never aliased"
+    );
+
     let worker_config = ServerConfig::from(config);
 
     let mut main_to_worker_channel: Channel<ServerConfig, WorkerResponse> = Channel::new(
@@ -279,6 +332,15 @@ pub fn fork_main_into_worker(
     // image entirely — no inherited state matters after that point.
     match unsafe { fork().map_err(WorkerError::Fork)? } {
         ForkResult::Parent { child: worker_pid } => {
+            // A successful `fork()` returns the child's pid in the parent
+            // branch, which is always strictly positive (0 is the child
+            // branch, < 0 never reaches here — `fork` would have returned
+            // `Err`). A non-positive pid here would mean we mis-classified
+            // the fork outcome and are about to register a bogus worker.
+            debug_assert!(
+                worker_pid.as_raw() > 0,
+                "fork parent branch must observe a strictly positive child pid"
+            );
             info!("launching worker {} with pid {}", worker_id, worker_pid);
             main_to_worker_channel
                 .write_message(&worker_config)

--- a/command/src/certificate.rs
+++ b/command/src/certificate.rs
@@ -16,6 +16,18 @@ use crate::{
     proto::command::{CertificateAndKey, TlsVersion},
 };
 
+/// Byte length of a SHA-256 digest. Every fingerprint Sōzu *computes*
+/// (as opposed to one it *parses* from operator hex, which may be any
+/// length) is a SHA-256 hash and therefore exactly this many bytes.
+///
+/// Intentionally NOT `#[cfg(debug_assertions)]`-gated: `debug_assert!`
+/// compiles its arguments in every profile (it gates execution, not
+/// compilation), so a cfg-gated const referenced inside one would fail
+/// the release build with E0425. Ungated, it is dead code in release and
+/// dropped by the optimizer.
+#[allow(dead_code)]
+const SHA256_FINGERPRINT_LEN: usize = 32;
+
 // -----------------------------------------------------------------------------
 // CertificateError
 
@@ -87,6 +99,17 @@ pub fn get_cn_and_san_attributes(x509: &X509Certificate) -> Vec<String> {
         }
     }
 
+    // POST: a dNSName SAN entry was observed iff at least one name has been
+    // collected from the SAN branch. `san_dns_seen` and a non-empty `names`
+    // must agree before the CN fallback runs — otherwise the RFC 6125
+    // §6.4.4 trust boundary (SAN dNSName is authoritative when present) is
+    // broken and the CN could smuggle an extra identity below.
+    debug_assert_eq!(
+        san_dns_seen,
+        !names.is_empty(),
+        "SAN dNSName presence must match the collected-names state before CN fallback"
+    );
+
     if !san_dns_seen {
         for name in x509.subject().iter_by_oid(&OID_X509_COMMON_NAME) {
             names.push(
@@ -96,7 +119,14 @@ pub fn get_cn_and_san_attributes(x509: &X509Certificate) -> Vec<String> {
             );
         }
     }
+    let before_dedup = names.len();
     names.dedup();
+    // POST: dedup only removes *consecutive* equal entries, so it can never
+    // grow the list; the deduped length is an invariant upper bound.
+    debug_assert!(
+        names.len() <= before_dedup,
+        "dedup must not grow the identity list"
+    );
     names
 }
 
@@ -234,13 +264,35 @@ impl<'de> serde::Deserialize<'de> for Fingerprint {
 
 /// Compute fingerprint from decoded pem as binary value
 pub fn calculate_fingerprint_from_der(certificate: &[u8]) -> Vec<u8> {
-    Sha256::digest(certificate).iter().cloned().collect()
+    let fingerprint: Vec<u8> = Sha256::digest(certificate).iter().cloned().collect();
+    // POST: a SHA-256 digest is unconditionally 32 bytes. Anything else
+    // means the digest collection went wrong and downstream fingerprint
+    // comparison / map keying would silently mismatch.
+    debug_assert_eq!(
+        fingerprint.len(),
+        SHA256_FINGERPRINT_LEN,
+        "SHA-256 fingerprint must be exactly 32 bytes"
+    );
+    fingerprint
 }
 
 /// Compute fingerprint from a certificate that is encoded in pem format
 pub fn calculate_fingerprint(certificate: &[u8]) -> Result<Vec<u8>, CertificateError> {
     let parsed_certificate = parse_pem(certificate)?;
     let fingerprint = calculate_fingerprint_from_der(&parsed_certificate.contents);
+    // POST: the result is a SHA-256 digest and recomputing it over the same
+    // DER bytes yields the same value — the fingerprint is a pure function of
+    // the parsed certificate contents, never of the surrounding PEM framing.
+    debug_assert_eq!(
+        fingerprint.len(),
+        SHA256_FINGERPRINT_LEN,
+        "PEM fingerprint must be a 32-byte SHA-256 digest"
+    );
+    debug_assert_eq!(
+        fingerprint,
+        calculate_fingerprint_from_der(&parsed_certificate.contents),
+        "fingerprint must be a deterministic function of the DER contents"
+    );
     Ok(fingerprint)
 }
 
@@ -248,9 +300,22 @@ pub fn split_certificate_chain(mut chain: String) -> Vec<String> {
     let mut v = Vec::new();
 
     let end = "-----END CERTIFICATE-----";
+    // PRE: the loop consumes exactly one END marker per iteration, so the
+    // final chain length must equal the number of markers present on entry.
+    // The leaf certificate is, by PEM convention, the first block — it lands
+    // at index 0 because we drain from the front. (`matches().count()` is
+    // overlap-free; the END marker cannot overlap itself.)
+    let expected_certs = chain.matches(end).count();
     loop {
         if let Some(sz) = chain.find(end) {
             let cert: String = chain.drain(..sz + end.len()).collect();
+            // INV: every emitted block carries exactly the END marker that
+            // terminated it — the drain range includes `end.len()` bytes past
+            // the match, so a non-terminated trailing block is impossible.
+            debug_assert!(
+                cert.contains(end),
+                "each split block must contain its END CERTIFICATE marker"
+            );
             v.push(cert.trim().to_string());
             continue;
         }
@@ -258,6 +323,12 @@ pub fn split_certificate_chain(mut chain: String) -> Vec<String> {
         break;
     }
 
+    // POST: one block per END marker, leaf at index 0.
+    debug_assert_eq!(
+        v.len(),
+        expected_certs,
+        "split must yield exactly one certificate per END marker"
+    );
     v
 }
 
@@ -272,6 +343,14 @@ pub fn get_fingerprint_from_certificate_path(
 
     let parsed_bytes = calculate_fingerprint(&bytes)?;
 
+    // POST: a computed fingerprint is always a 32-byte SHA-256 digest. (This
+    // is distinct from a *parsed* fingerprint — see `decode_fingerprint` /
+    // `Fingerprint::from_str` — which may be any operator-supplied length.)
+    debug_assert_eq!(
+        parsed_bytes.len(),
+        SHA256_FINGERPRINT_LEN,
+        "fingerprint loaded from a certificate path must be 32 bytes"
+    );
     Ok(Fingerprint(parsed_bytes))
 }
 
@@ -305,21 +384,55 @@ pub fn load_full_certificate(
         error: e,
     })?;
 
-    let versions = versions.iter().map(|v| *v as i32).collect();
+    let versions_len = versions.len();
+    let names_len = names.len();
+    let versions: Vec<i32> = versions.iter().map(|v| *v as i32).collect();
 
-    Ok(CertificateAndKey {
+    // POST: the i32-encoded TLS-version list is a 1:1 map of the input — no
+    // version is dropped or duplicated by the `as i32` projection.
+    debug_assert_eq!(
+        versions.len(),
+        versions_len,
+        "version encoding must preserve the input cardinality"
+    );
+
+    let built = CertificateAndKey {
         certificate,
         certificate_chain,
         key,
         versions,
         names,
-    })
+    };
+
+    // POST: the routing-name list is carried through verbatim — the builder
+    // does not synthesize or drop names (overriding names are derived later
+    // via `apply_overriding_names`, never here).
+    debug_assert_eq!(
+        built.names.len(),
+        names_len,
+        "names must be carried through the builder unchanged"
+    );
+    Ok(built)
 }
 
 impl CertificateAndKey {
     pub fn fingerprint(&self) -> Result<Fingerprint, CertificateError> {
         let pem = parse_pem(self.certificate.as_bytes())?;
-        let fingerprint = Fingerprint(Sha256::digest(pem.contents).iter().cloned().collect());
+        let fingerprint = Fingerprint(Sha256::digest(&pem.contents).iter().cloned().collect());
+        // POST: the certificate fingerprint is a 32-byte SHA-256 digest of the
+        // DER contents and agrees with the free-function recompute over the
+        // same bytes — the two fingerprint paths must never diverge or a cert
+        // would key into two different map slots.
+        debug_assert_eq!(
+            fingerprint.0.len(),
+            SHA256_FINGERPRINT_LEN,
+            "CertificateAndKey fingerprint must be 32 bytes"
+        );
+        debug_assert_eq!(
+            fingerprint.0,
+            calculate_fingerprint_from_der(&pem.contents),
+            "method and free-function fingerprints must agree on the same DER"
+        );
         Ok(fingerprint)
     }
 
@@ -332,12 +445,28 @@ impl CertificateAndKey {
 
             Ok(overriding_names.into_iter().collect())
         } else {
-            Ok(self.names.to_owned())
+            let names = self.names.to_owned();
+            // POST: when explicit names are set, they are returned verbatim —
+            // the cert is NOT consulted, so the operator's intent is the sole
+            // authority. (`to_owned` preserves both length and order.)
+            debug_assert_eq!(
+                names, self.names,
+                "explicit names must be returned unchanged when present"
+            );
+            Ok(names)
         }
     }
 
     pub fn apply_overriding_names(&mut self) -> Result<(), CertificateError> {
-        self.names = self.get_overriding_names()?;
+        let resolved = self.get_overriding_names()?;
+        self.names = resolved.clone();
+        // POST: after applying, the stored names are exactly the resolved set
+        // and re-resolving is idempotent — a second `apply_overriding_names`
+        // would now hit the "explicit names present" branch and be a no-op.
+        debug_assert_eq!(
+            self.names, resolved,
+            "applied names must equal the resolved set"
+        );
         Ok(())
     }
 }

--- a/command/src/channel.rs
+++ b/command/src/channel.rs
@@ -242,11 +242,28 @@ impl<Tx: Debug + ProstMessage + Default, Rx: Debug + ProstMessage + Default> Cha
         if current_capacity >= self.max_buffer_size {
             return None;
         }
+        // Precondition: we only reach here below the ceiling, so a strictly
+        // larger size always exists within [current+1, max_buffer_size].
+        debug_assert!(
+            current_capacity < self.max_buffer_size,
+            "grow_size must only grow buffers that are strictly below the max ceiling"
+        );
         // double the capacity, but don't exceed max
         let new_size = min(current_capacity.saturating_mul(2), self.max_buffer_size);
         // ensure we grow by at least something (in case current_capacity is 0)
         let new_size = new_size.max(current_capacity + 1);
-        Some(min(new_size, self.max_buffer_size))
+        let new_size = min(new_size, self.max_buffer_size);
+        // Postconditions: the new capacity strictly grows (forward progress,
+        // no spin) and never overshoots the configured ceiling.
+        debug_assert!(
+            new_size > current_capacity,
+            "grow_size must make forward progress (new capacity strictly larger)"
+        );
+        debug_assert!(
+            new_size <= self.max_buffer_size,
+            "grow_size must never exceed the configured max_buffer_size ceiling"
+        );
+        Some(new_size)
     }
 
     /// Check if a buffer has exceeded the high watermark and log a warning once
@@ -307,12 +324,26 @@ impl<Tx: Debug + ProstMessage + Default, Rx: Debug + ProstMessage + Default> Cha
                         &mut self.front_high_watermark_logged,
                     );
                     self.front_buf.grow(new_size);
+                    // The read buffer must never grow past the configured ceiling.
+                    debug_assert!(
+                        self.front_buf.capacity() <= self.max_buffer_size,
+                        "front buffer capacity must stay within the max_buffer_size ceiling"
+                    );
                 } else {
                     self.interest.remove(Ready::READABLE);
                     break;
                 }
             }
 
+            // The slice handed to `read` is exactly the free tail; the kernel
+            // can never write more than that, so a successful read of N bytes
+            // is bounded by the space we just measured (post-grow).
+            let space_before = self.front_buf.available_space();
+            debug_assert!(
+                space_before > 0,
+                "readable must only call read() with non-empty space (zero-space path grows or breaks)"
+            );
+            let data_before = self.front_buf.available_data();
             match self.sock.read(self.front_buf.space()) {
                 Ok(0) => {
                     self.interest = Ready::EMPTY;
@@ -332,8 +363,22 @@ impl<Tx: Debug + ProstMessage + Default, Rx: Debug + ProstMessage + Default> Cha
                     }
                 },
                 Ok(bytes_read) => {
+                    // A read can never deliver more bytes than the free space
+                    // it was handed; otherwise `fill` would corrupt offsets.
+                    debug_assert!(
+                        bytes_read <= space_before,
+                        "read delivered more bytes than the buffer space it was given"
+                    );
                     count += bytes_read;
                     self.front_buf.fill(bytes_read);
+                    // `fill` advances `end` by exactly the bytes read, so the
+                    // available data grows by that delta — pair-assert the
+                    // offset mutation.
+                    debug_assert_eq!(
+                        self.front_buf.available_data(),
+                        data_before + bytes_read,
+                        "front buffer available_data must increase by exactly bytes_read"
+                    );
                 }
             };
         }
@@ -357,6 +402,7 @@ impl<Tx: Debug + ProstMessage + Default, Rx: Debug + ProstMessage + Default> Cha
                 break;
             }
 
+            let data_before = self.back_buf.available_data();
             match self.sock.write(self.back_buf.data()) {
                 Ok(0) => {
                     self.interest = Ready::EMPTY;
@@ -364,8 +410,25 @@ impl<Tx: Debug + ProstMessage + Default, Rx: Debug + ProstMessage + Default> Cha
                     return Err(ChannelError::NoByteWritten);
                 }
                 Ok(bytes_written) => {
+                    // The kernel cannot accept more than the slice (`data()`)
+                    // it was handed; otherwise `consume` would underflow.
+                    debug_assert!(
+                        bytes_written <= data_before,
+                        "write reported more bytes than the buffer data it was given"
+                    );
                     count += bytes_written;
-                    self.back_buf.consume(bytes_written);
+                    let consumed = self.back_buf.consume(bytes_written);
+                    // `consume` is saturating but the bound above guarantees an
+                    // exact consume here; pair-assert the offset mutation.
+                    debug_assert_eq!(
+                        consumed, bytes_written,
+                        "back buffer must consume exactly the bytes written to the socket"
+                    );
+                    debug_assert_eq!(
+                        self.back_buf.available_data(),
+                        data_before - bytes_written,
+                        "back buffer available_data must shrink by exactly bytes_written"
+                    );
                 }
                 Err(write_error) => match write_error.kind() {
                     ErrorKind::WouldBlock => {
@@ -456,7 +519,21 @@ impl<Tx: Debug + ProstMessage + Default, Rx: Debug + ProstMessage + Default> Cha
 
     /// parse a prost message from the front buffer, grow it if necessary
     fn try_read_delimited_message(&mut self) -> Result<Option<Rx>, ChannelError> {
+        // Invariant guarding all the slice indexing below: the front buffer can
+        // never have grown past the configured ceiling. Every grow site routes
+        // through `grow_size`/`max_buffer_size`; if this ever fired the length
+        // checks would be reasoning against a stale bound.
+        debug_assert!(
+            self.front_buf.capacity() <= self.max_buffer_size,
+            "front buffer capacity must never exceed max_buffer_size"
+        );
         let buffer = self.front_buf.data();
+        // `data()` returns `memory[position..end]`, so its length is exactly the
+        // available data and can never exceed the buffer capacity.
+        debug_assert!(
+            buffer.len() <= self.front_buf.capacity(),
+            "available data slice cannot exceed buffer capacity"
+        );
         if buffer.len() >= delimiter_size() {
             let delimiter = buffer[..delimiter_size()]
                 .try_into()
@@ -499,9 +576,47 @@ impl<Tx: Debug + ProstMessage + Default, Rx: Debug + ProstMessage + Default> Cha
             }
 
             if buffer.len() >= message_len {
+                // By the time we slice, the two guards above have proven the
+                // length prefix is well-formed: it is at least the delimiter
+                // (so `delimiter_size()..message_len` runs forward) and at most
+                // the configured ceiling (so it cannot drive growth). The
+                // `buffer.len() >= message_len` branch then guarantees the whole
+                // frame is in the buffer. These are the exact invariants that
+                // keep the slice and the `consume` in bounds — never reachable
+                // from a malformed length, which already returned an error.
+                debug_assert!(
+                    message_len >= delimiter_size(),
+                    "decode path requires a frame at least as large as its delimiter"
+                );
+                debug_assert!(
+                    message_len <= self.max_buffer_size,
+                    "decode path requires the declared length within the max ceiling"
+                );
+                debug_assert!(
+                    message_len <= buffer.len(),
+                    "decode path requires the full frame to be buffered before slicing"
+                );
+                let available_before = self.front_buf.available_data();
+                debug_assert_eq!(
+                    available_before,
+                    buffer.len(),
+                    "available_data must equal the data slice length we validated against"
+                );
                 let message = Rx::decode(&buffer[delimiter_size()..message_len])
                     .map_err(ChannelError::InvalidProtobufMessage)?;
-                self.front_buf.consume(message_len);
+                let consumed = self.front_buf.consume(message_len);
+                // The whole frame (delimiter + payload) is consumed exactly:
+                // pair-assert that consume advanced by message_len and the data
+                // pointer moved forward by the same amount.
+                debug_assert_eq!(
+                    consumed, message_len,
+                    "must consume exactly the validated frame length"
+                );
+                debug_assert_eq!(
+                    self.front_buf.available_data(),
+                    available_before - message_len,
+                    "available_data must drop by exactly the consumed frame length"
+                );
                 return Ok(Some(message));
             }
         }
@@ -576,12 +691,21 @@ impl<Tx: Debug + ProstMessage + Default, Rx: Debug + ProstMessage + Default> Cha
 
         let payload_len = payload.len() + delimiter_size();
 
+        // The framed length is the payload plus a fixed delimiter, so it is by
+        // construction at least one delimiter wide — the mirror of the
+        // `MessageLengthUnderDelimiter` invariant the reader enforces.
+        debug_assert!(
+            payload_len >= delimiter_size(),
+            "framed length must include the fixed-size delimiter prefix"
+        );
+
         let delimiter = payload_len.to_le_bytes();
 
         if payload_len > self.back_buf.available_space() {
             self.back_buf.shift();
         }
 
+        let data_before = self.back_buf.available_data();
         if payload_len > self.back_buf.available_space() {
             let needed = payload_len - self.back_buf.available_space() + self.back_buf.capacity();
             if needed > self.max_buffer_size {
@@ -591,13 +715,34 @@ impl<Tx: Debug + ProstMessage + Default, Rx: Debug + ProstMessage + Default> Cha
                     max: self.max_buffer_size,
                 });
             }
+            // Past the ceiling check, the required size is within the ceiling
+            // and at least the current capacity (we only enter on shortfall).
+            debug_assert!(
+                needed <= self.max_buffer_size,
+                "grow target must be within the max ceiling once the cap check passed"
+            );
 
+            let capacity_before = self.back_buf.capacity();
             // use doubling strategy to reach at least `needed`, amortizing future writes
             let mut new_length = self.back_buf.capacity();
             while new_length < needed {
                 new_length = new_length.saturating_mul(2).max(new_length + 1);
             }
             new_length = min(new_length, self.max_buffer_size);
+            // Post-grow target: large enough to fit the frame yet capped at the
+            // configured ceiling and never below where we started.
+            debug_assert!(
+                new_length >= needed,
+                "doubling growth must reach at least the needed capacity"
+            );
+            debug_assert!(
+                new_length <= self.max_buffer_size,
+                "grown back buffer must stay within the max_buffer_size ceiling"
+            );
+            debug_assert!(
+                new_length >= capacity_before,
+                "growth must never shrink the back buffer"
+            );
             Self::check_high_watermark(
                 "back",
                 new_length,
@@ -605,6 +750,11 @@ impl<Tx: Debug + ProstMessage + Default, Rx: Debug + ProstMessage + Default> Cha
                 &mut self.back_high_watermark_logged,
             );
             self.back_buf.grow(new_length);
+            // After the grow the frame must fit in the now-available space.
+            debug_assert!(
+                payload_len <= self.back_buf.available_space(),
+                "back buffer must have room for the full frame after growth"
+            );
         }
 
         self.back_buf
@@ -613,6 +763,18 @@ impl<Tx: Debug + ProstMessage + Default, Rx: Debug + ProstMessage + Default> Cha
         self.back_buf
             .write_all(&payload)
             .map_err(ChannelError::Write)?;
+
+        // The two writes appended exactly `payload_len` bytes (delimiter +
+        // payload) to the back buffer's pending data.
+        debug_assert_eq!(
+            self.back_buf.available_data(),
+            data_before + payload_len,
+            "back buffer pending data must grow by exactly the framed length"
+        );
+        debug_assert!(
+            self.back_buf.capacity() <= self.max_buffer_size,
+            "back buffer capacity must never exceed the max_buffer_size ceiling"
+        );
 
         Ok(())
     }
@@ -624,10 +786,27 @@ impl<Tx: Debug + ProstMessage + Default, Rx: Debug + ProstMessage + Default> Cha
         if capacity <= self.initial_buffer_size {
             return;
         }
+        // Past the early return, we are strictly above the floor, so a shrink
+        // back to `initial_buffer_size` is a genuine reduction.
+        debug_assert!(
+            capacity > self.initial_buffer_size,
+            "shrink path only runs when capacity is above the initial floor"
+        );
         // only shrink when the buffer has little pending data
         if self.front_buf.available_data() * 4 < self.initial_buffer_size {
+            let data_before = self.front_buf.available_data();
             self.front_buf.shrink(self.initial_buffer_size);
             self.front_high_watermark_logged = false;
+            // Shrink preserves pending data and never drops below the floor.
+            debug_assert!(
+                self.front_buf.capacity() >= self.initial_buffer_size,
+                "front buffer must never shrink below the initial buffer size floor"
+            );
+            debug_assert_eq!(
+                self.front_buf.available_data(),
+                data_before,
+                "shrink must preserve all pending front-buffer data"
+            );
             trace!(
                 "front buffer shrunk from {} to {} bytes",
                 capacity, self.initial_buffer_size
@@ -641,9 +820,24 @@ impl<Tx: Debug + ProstMessage + Default, Rx: Debug + ProstMessage + Default> Cha
         if capacity <= self.initial_buffer_size {
             return;
         }
+        debug_assert!(
+            capacity > self.initial_buffer_size,
+            "shrink path only runs when capacity is above the initial floor"
+        );
         if self.back_buf.available_data() == 0 {
             self.back_buf.shrink(self.initial_buffer_size);
             self.back_high_watermark_logged = false;
+            // The back buffer is only shrunk once fully drained; it must end at
+            // the floor with no pending data resurrected.
+            debug_assert!(
+                self.back_buf.capacity() >= self.initial_buffer_size,
+                "back buffer must never shrink below the initial buffer size floor"
+            );
+            debug_assert_eq!(
+                self.back_buf.available_data(),
+                0,
+                "back buffer must stay empty across a drained shrink"
+            );
             trace!(
                 "back buffer shrunk from {} to {} bytes",
                 capacity, self.initial_buffer_size

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -894,6 +894,15 @@ impl ListenerBuilder {
             ..Default::default()
         };
 
+        // POST: the built listener binds exactly the address that was
+        // requested — a listener whose address drifted here would bind the
+        // wrong socket. (We reached this point only because the protocol guard
+        // at entry confirmed this is an HTTP listener.)
+        debug_assert_eq!(
+            configuration.address,
+            self.address.into(),
+            "HTTP listener must bind the requested address"
+        );
         Ok(configuration)
     }
 
@@ -1068,6 +1077,53 @@ impl ListenerBuilder {
             },
         };
 
+        // POST: the built listener binds the requested address and starts
+        // inactive (the protocol guard at entry confirmed this is an HTTPS
+        // listener).
+        debug_assert_eq!(
+            https_listener_config.address,
+            self.address.into(),
+            "HTTPS listener must bind the requested address"
+        );
+        debug_assert!(
+            !https_listener_config.active,
+            "a freshly built HTTPS listener must start inactive"
+        );
+        // POST: the resolved ALPN list is non-empty, contains only the two
+        // protocols Sōzu speaks, and is duplicate-free — the validation/dedup
+        // branches above are the sole producers, so a malformed list here would
+        // mean an unvalidated path slipped through.
+        debug_assert!(
+            !https_listener_config.alpn_protocols.is_empty(),
+            "resolved ALPN list must not be empty"
+        );
+        debug_assert!(
+            https_listener_config
+                .alpn_protocols
+                .iter()
+                .all(|p| p == "h2" || p == "http/1.1"),
+            "resolved ALPN list must contain only h2 and http/1.1"
+        );
+        debug_assert!(
+            {
+                let mut seen = std::collections::HashSet::new();
+                https_listener_config
+                    .alpn_protocols
+                    .iter()
+                    .all(|p| seen.insert(p))
+            },
+            "resolved ALPN list must be duplicate-free"
+        );
+        // POST: disable_http11 + http/1.1 in ALPN is a self-DoS that the
+        // validation above rejects — an Ok return must never carry that combo.
+        debug_assert!(
+            !(self.disable_http11.unwrap_or(false)
+                && https_listener_config
+                    .alpn_protocols
+                    .iter()
+                    .any(|p| p == "http/1.1")),
+            "disable_http11 with http/1.1 in ALPN must have been rejected"
+        );
         Ok(https_listener_config)
     }
 
@@ -1084,7 +1140,7 @@ impl ListenerBuilder {
             self.assign_config_timeouts(config);
         }
 
-        Ok(TcpListenerConfig {
+        let tcp_listener_config = TcpListenerConfig {
             address: self.address.into(),
             public_address: self.public_address.map(|a| a.into()),
             expect_proxy: self.expect_proxy.unwrap_or(false),
@@ -1092,7 +1148,20 @@ impl ListenerBuilder {
             back_timeout: self.back_timeout.unwrap_or(DEFAULT_BACK_TIMEOUT),
             connect_timeout: self.connect_timeout.unwrap_or(DEFAULT_CONNECT_TIMEOUT),
             active: false,
-        })
+        };
+
+        // POST: the built listener binds exactly the requested address and is
+        // created inactive (activation is a later, explicit step).
+        debug_assert_eq!(
+            tcp_listener_config.address,
+            self.address.into(),
+            "TCP listener must bind the requested address"
+        );
+        debug_assert!(
+            !tcp_listener_config.active,
+            "a freshly built TCP listener must start inactive"
+        );
+        Ok(tcp_listener_config)
     }
 
     /// build a UDP listener. UDP has no `expect_proxy` / `connect_timeout`;
@@ -1267,6 +1336,17 @@ pub fn load_answers(
         }
         out.insert(code.to_owned(), resolve_answer_source(value)?);
     }
+    // POST: the loaded map never invents a status code (every output key is an
+    // input key) and never grows past the input — empty-valued entries are
+    // skipped, so |out| <= |answers|.
+    debug_assert!(
+        out.len() <= answers.len(),
+        "load_answers must not synthesize entries"
+    );
+    debug_assert!(
+        out.keys().all(|k| answers.contains_key(k)),
+        "every loaded status code must come from the input map"
+    );
     Ok(out)
 }
 
@@ -1513,13 +1593,28 @@ impl FileHstsConfig {
             }
         }
 
-        Ok(HstsConfig {
+        let config = HstsConfig {
             enabled: Some(enabled),
             max_age,
             include_subdomains,
             preload,
             force_replace_backend: self.force_replace_backend,
-        })
+        };
+
+        // POST: a built HstsConfig always records an explicit `enabled` flag
+        // (the `None` case errored above), and an enabled policy always carries
+        // a max_age — defaulted to DEFAULT_HSTS_MAX_AGE when the operator left
+        // it unset, so the worker never emits an `max-age`-less STS header.
+        debug_assert_eq!(
+            config.enabled,
+            Some(enabled),
+            "built HSTS config must record the resolved enabled flag"
+        );
+        debug_assert!(
+            !enabled || config.max_age.is_some(),
+            "an enabled HSTS policy must carry a max_age"
+        );
+        Ok(config)
     }
 }
 
@@ -1547,13 +1642,29 @@ impl FileClusterFrontendConfig {
             ));
         }
 
-        Ok(TcpFrontendConfig {
+        let tcp_front = TcpFrontendConfig {
             address: self.address,
             tags: self.tags.clone(),
             // Resolved against `known_addresses` in `populate_clusters`; a
             // bare `to_tcp_front` (no listener context) defaults to TCP.
             udp: false,
-        })
+        };
+        // POST: a TCP frontend binds exactly the requested address and carries
+        // no HTTP-only attributes — the guards above reject hostname / path /
+        // certificate, so an Ok return is a witness that none leaked through
+        // (an L7 attribute on an L4 frontend is a config-shape violation).
+        debug_assert_eq!(
+            tcp_front.address, self.address,
+            "TCP frontend must bind the requested address"
+        );
+        debug_assert!(
+            self.hostname.is_none()
+                && self.path.is_none()
+                && self.certificate.is_none()
+                && self.certificate_chain.is_none(),
+            "a built TCP frontend must carry no HTTP-only attributes"
+        );
+        Ok(tcp_front)
     }
 
     pub fn to_http_front(&self, _cluster_id: &str) -> Result<HttpFrontendConfig, ConfigError> {
@@ -1714,11 +1825,25 @@ pub(crate) fn parse_header_edit(
             field: "value",
         });
     }
-    Ok(Header {
+    let header = Header {
         position: position as i32,
         key: entry.key.clone(),
         val: entry.value.clone(),
-    })
+    };
+    // POST: a Header that escapes this function carries a key that is a valid
+    // RFC 9110 token and a value free of the forbidden control bytes — the two
+    // guards above are the sole gate, so an emitted Header can never inject a
+    // CRLF or a bad token onto the H1 wire (mirrors the runtime filter in
+    // mux/converter.rs).
+    debug_assert!(
+        header_name_is_valid_token(header.key.as_bytes()),
+        "an emitted header key must be a valid token"
+    );
+    debug_assert!(
+        !header_value_contains_forbidden_controls(header.val.as_bytes()),
+        "an emitted header value must be free of forbidden control bytes"
+    );
+    Ok(header)
 }
 
 /// Field names follow the RFC 9110 §5.1 `token` grammar: non-empty,
@@ -1815,14 +1940,26 @@ pub struct FileHealthCheckConfig {
 
 impl FileHealthCheckConfig {
     pub fn to_proto(&self) -> HealthCheckConfig {
-        HealthCheckConfig {
+        let proto = HealthCheckConfig {
             uri: self.uri.to_owned(),
             interval: self.interval,
             timeout: self.timeout,
             healthy_threshold: self.healthy_threshold,
             unhealthy_threshold: self.unhealthy_threshold,
             expected_status: self.expected_status,
-        }
+        };
+        // POST: the proto mirrors the file config exactly — the URI and all
+        // timing knobs are carried through verbatim (no clamping or defaulting
+        // happens at this layer; defaults are applied by serde at parse time).
+        debug_assert_eq!(proto.uri, self.uri, "proto URI must mirror the file config");
+        debug_assert!(
+            proto.interval == self.interval
+                && proto.timeout == self.timeout
+                && proto.healthy_threshold == self.healthy_threshold
+                && proto.unhealthy_threshold == self.unhealthy_threshold,
+            "proto timing knobs must mirror the file config"
+        );
+        proto
     }
 }
 
@@ -1859,6 +1996,22 @@ pub fn validate_health_check_config(cfg: &HealthCheckConfig) -> Result<(), &'sta
     {
         return Err("health check URI must not contain CR, LF, NUL, or other C0 control bytes");
     }
+    // POST: a validated config has strictly-positive timing knobs (a zero
+    // interval/timeout/threshold would make the health-check loop spin or
+    // never converge) and a request-target the worker can splice into an HTTP
+    // probe without smuggling a second message. Every Ok return is a witness
+    // for all of these.
+    debug_assert!(
+        cfg.interval > 0
+            && cfg.timeout > 0
+            && cfg.healthy_threshold > 0
+            && cfg.unhealthy_threshold > 0,
+        "validated health-check thresholds must all be strictly positive"
+    );
+    debug_assert!(
+        cfg.uri.starts_with('/'),
+        "validated health-check URI must be an absolute path"
+    );
     Ok(())
 }
 
@@ -2015,6 +2168,9 @@ impl FileClusterConfig {
         cluster_id: &str,
         expect_proxy: &HashSet<SocketAddr>,
     ) -> Result<ClusterConfig, ConfigError> {
+        // PRE: every frontend that converts cleanly must survive into the built
+        // cluster — no frontend is silently dropped during conversion.
+        let requested_frontend_count = self.frontends.len();
         match self.protocol {
             FileClusterProtocolConfig::Tcp => {
                 let mut has_expect_proxy = None;
@@ -2064,6 +2220,26 @@ impl FileClusterConfig {
                 };
 
                 let udp = self.udp.as_ref().map(|u| u.to_proto());
+                // POST: every requested frontend converted (none dropped), and
+                // the resolved proxy-protocol mode is the documented function of
+                // the (send, expect) pair — expect-only must never resolve to a
+                // send-header mode and vice versa, which would corrupt the wire
+                // framing.
+                debug_assert_eq!(
+                    frontends.len(),
+                    requested_frontend_count,
+                    "every TCP frontend must survive conversion"
+                );
+                debug_assert_eq!(
+                    proxy_protocol,
+                    match (send_proxy, expect_proxy) {
+                        (true, true) => Some(ProxyProtocolConfig::RelayHeader),
+                        (true, false) => Some(ProxyProtocolConfig::SendHeader),
+                        (false, true) => Some(ProxyProtocolConfig::ExpectHeader),
+                        (false, false) => None,
+                    },
+                    "proxy_protocol must be the (send, expect) function"
+                );
 
                 Ok(ClusterConfig::Tcp(TcpClusterConfig {
                     cluster_id: cluster_id.to_string(),
@@ -2104,6 +2280,13 @@ impl FileClusterConfig {
                 };
 
                 let udp = self.udp.as_ref().map(|u| u.to_proto());
+                // POST: every requested HTTP frontend converted — none dropped
+                // (a dropped frontend would silently stop routing a hostname).
+                debug_assert_eq!(
+                    frontends.len(),
+                    requested_frontend_count,
+                    "every HTTP frontend must survive conversion"
+                );
 
                 Ok(ClusterConfig::Http(HttpClusterConfig {
                     cluster_id: cluster_id.to_string(),
@@ -2289,7 +2472,7 @@ pub struct HttpClusterConfig {
 
 impl HttpClusterConfig {
     pub fn generate_requests(&self) -> Result<Vec<Request>, ConfigError> {
-        let mut v = vec![
+        let mut v: Vec<Request> = vec![
             RequestType::AddCluster(Cluster {
                 cluster_id: self.cluster_id.clone(),
                 sticky_session: self.sticky_session,
@@ -2336,6 +2519,24 @@ impl HttpClusterConfig {
             );
         }
 
+        // POST: the order stream begins with exactly one AddCluster and emits
+        // exactly one AddBackend per configured backend — a missing AddCluster
+        // would orphan every backend, and a miscounted backend set would
+        // silently drop or duplicate a backend registration.
+        debug_assert!(
+            matches!(
+                v.first().and_then(|r| r.request_type.as_ref()),
+                Some(RequestType::AddCluster(_))
+            ),
+            "HTTP cluster orders must lead with an AddCluster"
+        );
+        debug_assert_eq!(
+            v.iter()
+                .filter(|r| matches!(r.request_type, Some(RequestType::AddBackend(_))))
+                .count(),
+            self.backends.len(),
+            "one AddBackend order per configured backend"
+        );
         Ok(v)
     }
 }
@@ -2396,7 +2597,7 @@ pub struct TcpClusterConfig {
 
 impl TcpClusterConfig {
     pub fn generate_requests(&self) -> Result<Vec<Request>, ConfigError> {
-        let mut v = vec![
+        let mut v: Vec<Request> = vec![
             RequestType::AddCluster(Cluster {
                 cluster_id: self.cluster_id.clone(),
                 sticky_session: false,
@@ -2464,6 +2665,33 @@ impl TcpClusterConfig {
             );
         }
 
+        // POST: the order stream leads with one AddCluster and emits exactly
+        // one AddTcpFrontend per frontend and one AddBackend per backend — the
+        // worker reconstructs the cluster topology solely from these counts.
+        debug_assert!(
+            matches!(
+                v.first().and_then(|r| r.request_type.as_ref()),
+                Some(RequestType::AddCluster(_))
+            ),
+            "TCP cluster orders must lead with an AddCluster"
+        );
+        debug_assert_eq!(
+            v.iter()
+                .filter(|r| matches!(
+                    r.request_type,
+                    Some(RequestType::AddTcpFrontend(_)) | Some(RequestType::AddUdpFrontend(_))
+                ))
+                .count(),
+            self.frontends.len(),
+            "one AddTcpFrontend or AddUdpFrontend order per configured frontend"
+        );
+        debug_assert_eq!(
+            v.iter()
+                .filter(|r| matches!(r.request_type, Some(RequestType::AddBackend(_))))
+                .count(),
+            self.backends.len(),
+            "one AddBackend order per configured backend"
+        );
         Ok(v)
     }
 }
@@ -2744,6 +2972,24 @@ impl ConfigBuilder {
             ..Default::default()
         };
 
+        // POST: the buffer free-list floor is clamped to never exceed the
+        // ceiling — the `std::cmp::min(min_buffers, max_buffers)` above is the
+        // sole guarantor of this, so assert it held.
+        debug_assert!(
+            built.min_buffers <= built.max_buffers,
+            "min_buffers must be clamped to <= max_buffers in the builder"
+        );
+        // POST: an explicit slab override, if present, was clamped into the
+        // documented [MIN, MAX] window; an absent override stays None.
+        debug_assert!(
+            built.slab_entries_per_connection.is_none_or(|n| {
+                (ServerConfig::MIN_SLAB_ENTRIES_PER_CONNECTION
+                    ..=ServerConfig::MAX_SLAB_ENTRIES_PER_CONNECTION)
+                    .contains(&n)
+            }),
+            "a set slab_entries_per_connection must be clamped into [MIN, MAX]"
+        );
+
         Self {
             file: file_config,
             known_addresses: HashMap::new(),
@@ -3006,10 +3252,34 @@ impl ConfigBuilder {
             return Err(ConfigError::Missing(MissingKind::SavedState));
         }
 
-        Ok(Config {
+        let config = Config {
             command_socket: command_socket_path,
             ..self.built.clone()
-        })
+        };
+
+        // POST: a successfully built config satisfies the buffer-pool
+        // invariants every worker relies on.
+        // 1. min_buffers <= max_buffers — guaranteed by the `std::cmp::min`
+        //    clamp in `new`; a violation would let a worker size its free-list
+        //    floor above its ceiling.
+        debug_assert!(
+            config.min_buffers <= config.max_buffers,
+            "min_buffers must not exceed max_buffers"
+        );
+        // 2. If any HTTPS listener advertises h2 in its ALPN, the global
+        //    buffer_size is at least the H2 minimum — otherwise the early
+        //    return above would have produced a BufferSizeTooSmallForH2 error
+        //    rather than this Ok. (Recomputed here so the assert is independent
+        //    of the local `h2_listeners` binding above.)
+        debug_assert!(
+            !config
+                .https_listeners
+                .iter()
+                .any(|l| l.alpn_protocols.iter().any(|p| p == "h2"))
+                || config.buffer_size >= H2_MIN_BUFFER_SIZE,
+            "an h2-advertising config must satisfy the H2 minimum buffer size"
+        );
+        Ok(config)
     }
 }
 
@@ -3475,13 +3745,22 @@ impl ServerConfig {
     /// Effective slab-entries-per-connection. Applies the [MIN, MAX] clamp
     /// and falls back to the default when the proto field is absent or 0.
     pub fn effective_slab_entries_per_connection(&self) -> u64 {
-        match self.slab_entries_per_connection {
+        let effective = match self.slab_entries_per_connection {
             Some(0) | None => Self::DEFAULT_SLAB_ENTRIES_PER_CONNECTION,
             Some(n) => n.clamp(
                 Self::MIN_SLAB_ENTRIES_PER_CONNECTION,
                 Self::MAX_SLAB_ENTRIES_PER_CONNECTION,
             ),
-        }
+        };
+        // POST: the effective value is always inside the documented clamp
+        // window [MIN, MAX], regardless of the raw config input. The default
+        // itself sits inside that window, so every branch satisfies the bound.
+        debug_assert!(
+            (Self::MIN_SLAB_ENTRIES_PER_CONNECTION..=Self::MAX_SLAB_ENTRIES_PER_CONNECTION)
+                .contains(&effective),
+            "effective slab entries per connection must stay within [MIN, MAX]"
+        );
+        effective
     }
 
     /// Size of the slab for the Session manager.
@@ -3491,7 +3770,21 @@ impl ServerConfig {
     /// [`Self::effective_slab_entries_per_connection`] entries per connection
     /// instead of the old H1-only multiplier of 2.
     pub fn slab_capacity(&self) -> u64 {
-        10 + self.effective_slab_entries_per_connection() * self.max_connections
+        let per_conn = self.effective_slab_entries_per_connection();
+        let capacity = 10 + per_conn * self.max_connections;
+        // POST: the slab always reserves the 10-entry base (listeners, command
+        // channel, etc.) plus at least MIN entries per connection, so it can
+        // never be smaller than the base. Strict `>` for any non-zero
+        // max_connections since per_conn >= MIN >= 2.
+        debug_assert!(
+            capacity >= 10,
+            "slab capacity must reserve the base entries"
+        );
+        debug_assert!(
+            self.max_connections == 0 || capacity > 10,
+            "a non-zero connection cap must reserve per-connection slab entries"
+        );
+        capacity
     }
 }
 
@@ -3504,7 +3797,7 @@ impl From<&Config> for ServerConfig {
             prefix: m.prefix,
             detail: Some(MetricDetail::from(m.detail) as i32),
         });
-        Self {
+        let server_config = Self {
             max_connections: config.max_connections as u64,
             front_timeout: config.front_timeout,
             back_timeout: config.back_timeout,
@@ -3530,7 +3823,25 @@ impl From<&Config> for ServerConfig {
             max_connections_per_ip: Some(config.max_connections_per_ip),
             retry_after: Some(config.retry_after),
             splice_pipe_capacity_bytes: config.splice_pipe_capacity_bytes,
-        }
+        };
+
+        // POST: the worker-facing config preserves the buffer-pool invariant
+        // (min <= max) and carries the sizing knobs through unchanged — a
+        // worker derives its slab and buffer pool straight from these, so any
+        // drift here would desynchronize the master's view from the worker's.
+        debug_assert!(
+            server_config.min_buffers <= server_config.max_buffers,
+            "ServerConfig must preserve min_buffers <= max_buffers"
+        );
+        debug_assert_eq!(
+            server_config.buffer_size, config.buffer_size,
+            "ServerConfig buffer_size must mirror the source config"
+        );
+        debug_assert_eq!(
+            server_config.max_connections, config.max_connections as u64,
+            "ServerConfig max_connections must mirror the source config"
+        );
+        server_config
     }
 }
 

--- a/command/src/request.rs
+++ b/command/src/request.rs
@@ -123,6 +123,41 @@ impl Request {
             | RequestType::SubscribeEvents(_)
             | RequestType::ReloadConfiguration(_) => {}
         }
+
+        // POST: HTTP-frontend orders route to the HTTP proxy ONLY, HTTPS /
+        // certificate orders to the HTTPS proxy ONLY, and TCP-frontend orders
+        // to the TCP proxy ONLY — a frontend order must never fan out across
+        // protocol planes (that would double-apply the order). Cluster-wide
+        // and broadcast orders (AddCluster, SoftStop, …) legitimately target
+        // all three, so we only assert the single-plane exclusivity here.
+        debug_assert!(
+            !(proxy_destination.to_http_proxy
+                && proxy_destination.to_https_proxy
+                && proxy_destination.to_tcp_proxy)
+                || matches!(
+                    self.request_type,
+                    Some(
+                        RequestType::AddCluster(_)
+                            | RequestType::AddBackend(_)
+                            | RequestType::RemoveCluster(_)
+                            | RequestType::RemoveBackend(_)
+                            | RequestType::SetHealthCheck(_)
+                            | RequestType::RemoveHealthCheck(_)
+                            | RequestType::SoftStop(_)
+                            | RequestType::HardStop(_)
+                            | RequestType::Status(_)
+                    )
+                ),
+            "only cluster-wide / broadcast orders may target all three proxy planes"
+        );
+        // POST: a None request_type carries no destination at all.
+        debug_assert!(
+            self.request_type.is_some()
+                || (!proxy_destination.to_http_proxy
+                    && !proxy_destination.to_https_proxy
+                    && !proxy_destination.to_tcp_proxy),
+            "a request without a request_type must have no proxy destination"
+        );
         proxy_destination
     }
 
@@ -179,7 +214,9 @@ pub struct ProxyDestinations {
 impl RequestHttpFrontend {
     /// convert a requested frontend to a usable one by parsing its address
     pub fn to_frontend(self) -> Result<HttpFrontend, RequestError> {
-        Ok(HttpFrontend {
+        let requested_hostname = self.hostname.clone();
+        let requested_cluster_id = self.cluster_id.clone();
+        let frontend = HttpFrontend {
             address: self.address.into(),
             cluster_id: self.cluster_id,
             hostname: self.hostname,
@@ -201,7 +238,21 @@ impl RequestHttpFrontend {
             required_auth: self.required_auth,
             headers: self.headers,
             hsts: self.hsts,
-        })
+        };
+
+        // POST: routing identity (hostname + cluster_id) is carried through
+        // unchanged — only the address is reparsed and the position is mapped
+        // through the proto enum. A frontend whose hostname or cluster shifted
+        // here would route traffic to the wrong place.
+        debug_assert_eq!(
+            frontend.hostname, requested_hostname,
+            "hostname must survive the frontend conversion"
+        );
+        debug_assert_eq!(
+            frontend.cluster_id, requested_cluster_id,
+            "cluster_id must survive the frontend conversion"
+        );
+        Ok(frontend)
     }
 }
 
@@ -278,17 +329,42 @@ impl From<SocketAddr> for SocketAddress {
             }
         };
 
-        SocketAddress {
+        let encoded = SocketAddress {
             port: socket_addr.port() as u32,
             ip: IpAddress {
                 inner: Some(ip_inner),
             },
-        }
+        };
+
+        // POST: the port widens losslessly (u16 → u32) and the proto address
+        // family matches the source family — a V4 SocketAddr must never encode
+        // as a V6 inner and vice versa, or the reverse `From` would synthesize
+        // the wrong address.
+        debug_assert_eq!(
+            encoded.port,
+            socket_addr.port() as u32,
+            "port must round-trip losslessly into the proto"
+        );
+        debug_assert_eq!(
+            matches!(encoded.ip.inner, Some(ip_address::Inner::V4(_))),
+            socket_addr.is_ipv4(),
+            "proto IP family must match the source SocketAddr family"
+        );
+        encoded
     }
 }
 
 impl From<SocketAddress> for SocketAddr {
     fn from(socket_address: SocketAddress) -> Self {
+        // PRE: a wire-sourced proto port may exceed u16::MAX (16-bit on the
+        // wire is carried as a 32-bit field). This is peer/config input, so we
+        // narrow rather than panic; the debug_assert only guards our *own*
+        // encoders, which never emit an out-of-range port.
+        debug_assert!(
+            socket_address.port <= u16::MAX as u32,
+            "self-encoded proto port must fit in a u16"
+        );
+        let had_inner = socket_address.ip.inner.is_some();
         let port = socket_address.port as u16;
 
         let ip = match socket_address.ip.inner {
@@ -299,13 +375,33 @@ impl From<SocketAddress> for SocketAddr {
             None => IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), // should never happen
         };
 
-        SocketAddr::new(ip, port)
+        let decoded = SocketAddr::new(ip, port);
+        // POST: a self-encoded proto address always carries an inner IP, so the
+        // unspecified-V4 fallback is only ever reached on malformed peer input.
+        debug_assert!(
+            had_inner || decoded.ip() == IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            "missing inner IP must decode to the unspecified-V4 sentinel"
+        );
+        decoded
     }
 }
 
 impl From<Uint128> for u128 {
     fn from(value: Uint128) -> Self {
-        value.low as u128 | ((value.high as u128) << 64)
+        let combined = value.low as u128 | ((value.high as u128) << 64);
+        // POST: the two 64-bit halves occupy disjoint bit ranges, so the low
+        // half is recoverable as the bottom 64 bits and the high half as the
+        // top 64 bits — the pack is bijective.
+        debug_assert_eq!(
+            combined as u64, value.low,
+            "low half must be the bottom 64 bits"
+        );
+        debug_assert_eq!(
+            (combined >> 64) as u64,
+            value.high,
+            "high half must be the top 64 bits"
+        );
+        combined
     }
 }
 
@@ -313,7 +409,19 @@ impl From<u128> for Uint128 {
     fn from(value: u128) -> Self {
         let low = value as u64;
         let high = (value >> 64) as u64;
-        Uint128 { low, high }
+        let packed = Uint128 { low, high };
+        // POST: splitting then recombining reproduces the original u128 — the
+        // split-into-halves and join-from-halves operations are mutual
+        // inverses (no bit is lost or duplicated).
+        debug_assert_eq!(
+            u128::from(Uint128 {
+                low: packed.low,
+                high: packed.high
+            }),
+            value,
+            "u128 → Uint128 → u128 must round-trip"
+        );
+        packed
     }
 }
 
@@ -326,13 +434,29 @@ impl From<i128> for Uint128 {
 impl From<Ulid> for Uint128 {
     fn from(value: Ulid) -> Self {
         let (low, high) = value.into();
-        Uint128 { low, high }
+        let packed = Uint128 { low, high };
+        // POST: the (low, high) tuple is carried verbatim into the proto, so
+        // re-reading it reconstructs the same Ulid — the encoding loses no bits.
+        debug_assert_eq!(
+            Ulid::from((packed.low, packed.high)),
+            value,
+            "Ulid → Uint128 must preserve all 128 bits"
+        );
+        packed
     }
 }
 
 impl From<Uint128> for Ulid {
     fn from(value: Uint128) -> Self {
         let Uint128 { low, high } = value;
-        Ulid::from((low, high))
+        let ulid = Ulid::from((low, high));
+        // POST: the decode is the exact inverse of the encode above — the same
+        // halves go back out, so Uint128 → Ulid → Uint128 round-trips.
+        debug_assert_eq!(
+            Uint128::from(ulid),
+            value,
+            "Uint128 → Ulid must preserve all 128 bits"
+        );
+        ulid
     }
 }

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -77,7 +77,9 @@ pub struct HttpFrontend {
 
 impl From<HttpFrontend> for RequestHttpFrontend {
     fn from(val: HttpFrontend) -> Self {
-        RequestHttpFrontend {
+        let source_address = val.address;
+        let source_hostname = val.hostname.clone();
+        let request_frontend = RequestHttpFrontend {
             cluster_id: val.cluster_id,
             address: val.address.into(),
             hostname: val.hostname,
@@ -94,20 +96,57 @@ impl From<HttpFrontend> for RequestHttpFrontend {
             required_auth: val.required_auth,
             headers: val.headers,
             hsts: val.hsts,
-        }
+        };
+
+        // POST: the proto-encoded address decodes back to the source SocketAddr
+        // and the hostname is unchanged — the in-Sōzu → wire conversion must be
+        // routing-preserving (the SocketAddress ⇔ SocketAddr round-trip is
+        // exercised in request.rs; here we tie the frontend identity to it).
+        debug_assert_eq!(
+            SocketAddr::from(request_frontend.address),
+            source_address,
+            "frontend address must round-trip through the proto encoding"
+        );
+        debug_assert_eq!(
+            request_frontend.hostname, source_hostname,
+            "frontend hostname must survive the proto conversion"
+        );
+        request_frontend
     }
 }
 
 impl From<Backend> for AddBackend {
     fn from(val: Backend) -> Self {
-        AddBackend {
+        let source_address = val.address;
+        let source_cluster_id = val.cluster_id.clone();
+        let source_backend_id = val.backend_id.clone();
+        let add_backend = AddBackend {
             cluster_id: val.cluster_id,
             backend_id: val.backend_id,
             address: val.address.into(),
             sticky_id: val.sticky_id,
             load_balancing_parameters: val.load_balancing_parameters,
             backup: val.backup,
-        }
+        };
+
+        // POST: backend identity (cluster + backend id) and the wire address
+        // are preserved — a backend that changed cluster/id/address here would
+        // be registered under the wrong key and never receive (or steal)
+        // traffic.
+        debug_assert_eq!(
+            add_backend.cluster_id, source_cluster_id,
+            "backend cluster_id must survive the proto conversion"
+        );
+        debug_assert_eq!(
+            add_backend.backend_id, source_backend_id,
+            "backend_id must survive the proto conversion"
+        );
+        debug_assert_eq!(
+            SocketAddr::from(add_backend.address),
+            source_address,
+            "backend address must round-trip through the proto encoding"
+        );
+        add_backend
     }
 }
 
@@ -116,30 +155,50 @@ impl PathRule {
     where
         S: ToString,
     {
-        Self {
+        let rule = Self {
             kind: PathRuleKind::Prefix.into(),
             value: value.to_string(),
-        }
+        };
+        // POST: the encoded kind decodes back to the Prefix variant — the proto
+        // i32 must round-trip or the router would misclassify the match type.
+        debug_assert_eq!(
+            PathRuleKind::try_from(rule.kind),
+            Ok(PathRuleKind::Prefix),
+            "prefix() must encode a Prefix-kind rule"
+        );
+        rule
     }
 
     pub fn regex<S>(value: S) -> Self
     where
         S: ToString,
     {
-        Self {
+        let rule = Self {
             kind: PathRuleKind::Regex.into(),
             value: value.to_string(),
-        }
+        };
+        debug_assert_eq!(
+            PathRuleKind::try_from(rule.kind),
+            Ok(PathRuleKind::Regex),
+            "regex() must encode a Regex-kind rule"
+        );
+        rule
     }
 
     pub fn equals<S>(value: S) -> Self
     where
         S: ToString,
     {
-        Self {
+        let rule = Self {
             kind: PathRuleKind::Equals.into(),
             value: value.to_string(),
-        }
+        };
+        debug_assert_eq!(
+            PathRuleKind::try_from(rule.kind),
+            Ok(PathRuleKind::Equals),
+            "equals() must encode an Equals-kind rule"
+        );
+        rule
     }
 
     pub fn from_cli_options(
@@ -147,7 +206,12 @@ impl PathRule {
         path_regex: Option<String>,
         path_equals: Option<String>,
     ) -> Self {
-        match (path_prefix, path_regex, path_equals) {
+        // PRE: prefix takes precedence over regex, which takes precedence over
+        // equals. Capture which arms are populated so the post-condition can
+        // assert the precedence actually fired.
+        let had_prefix = path_prefix.is_some();
+        let had_regex = path_regex.is_some();
+        let rule = match (path_prefix, path_regex, path_equals) {
             (Some(prefix), _, _) => PathRule {
                 kind: PathRuleKind::Prefix as i32,
                 value: prefix,
@@ -161,7 +225,20 @@ impl PathRule {
                 value: equals,
             },
             _ => PathRule::default(),
-        }
+        };
+
+        // POST: a present prefix wins outright; absent a prefix, a present
+        // regex wins. The resolved kind must reflect that precedence so two
+        // simultaneously-set CLI flags can never silently pick the wrong rule.
+        debug_assert!(
+            !had_prefix || rule.kind == PathRuleKind::Prefix as i32,
+            "a path prefix must produce a Prefix rule regardless of other flags"
+        );
+        debug_assert!(
+            had_prefix || !had_regex || rule.kind == PathRuleKind::Regex as i32,
+            "absent a prefix, a regex must produce a Regex rule"
+        );
+        rule
     }
 }
 
@@ -191,11 +268,26 @@ pub struct TcpFrontend {
 
 impl From<TcpFrontend> for RequestTcpFrontend {
     fn from(val: TcpFrontend) -> Self {
-        RequestTcpFrontend {
+        let source_address = val.address;
+        let source_cluster_id = val.cluster_id.clone();
+        let request_frontend = RequestTcpFrontend {
             cluster_id: val.cluster_id,
             address: val.address.into(),
             tags: val.tags,
-        }
+        };
+
+        // POST: cluster identity and the wire address are preserved across the
+        // proto conversion (same routing guarantee as the HTTP frontend path).
+        debug_assert_eq!(
+            request_frontend.cluster_id, source_cluster_id,
+            "TCP frontend cluster_id must survive the proto conversion"
+        );
+        debug_assert_eq!(
+            SocketAddr::from(request_frontend.address),
+            source_address,
+            "TCP frontend address must round-trip through the proto encoding"
+        );
+        request_frontend
     }
 }
 
@@ -237,7 +329,20 @@ pub struct Backend {
 
 impl Ord for Backend {
     fn cmp(&self, o: &Backend) -> Ordering {
-        self.cluster_id
+        // INV: Equal can only be returned when every keyed field compares
+        // Equal — the tuple of field orderings is the source of truth, and the
+        // `.then(...)` fold must not collapse two distinct backends to Equal
+        // (which would let one silently evict the other from a BTree key set).
+        // Computed inline (no recursion into `cmp`) so it stays cheap.
+        let fields_all_equal = self.cluster_id == o.cluster_id
+            && self.backend_id == o.backend_id
+            && self.sticky_id == o.sticky_id
+            && self.load_balancing_parameters == o.load_balancing_parameters
+            && self.backup == o.backup
+            && self.address == o.address;
+
+        let ordering = self
+            .cluster_id
             .cmp(&o.cluster_id)
             .then(self.backend_id.cmp(&o.backend_id))
             .then(self.sticky_id.cmp(&o.sticky_id))
@@ -246,7 +351,14 @@ impl Ord for Backend {
                     .cmp(&o.load_balancing_parameters),
             )
             .then(self.backup.cmp(&o.backup))
-            .then(socketaddr_cmp(&self.address, &o.address))
+            .then(socketaddr_cmp(&self.address, &o.address));
+
+        debug_assert_eq!(
+            ordering == Ordering::Equal,
+            fields_all_equal,
+            "Backend::cmp returns Equal iff every keyed field is equal"
+        );
+        ordering
     }
 }
 
@@ -258,14 +370,29 @@ impl PartialOrd for Backend {
 
 impl Backend {
     pub fn to_add_backend(self) -> AddBackend {
-        AddBackend {
+        let source_address = self.address;
+        let source_backend_id = self.backend_id.clone();
+        let add_backend = AddBackend {
             cluster_id: self.cluster_id,
             address: self.address.into(),
             sticky_id: self.sticky_id,
             backend_id: self.backend_id,
             load_balancing_parameters: self.load_balancing_parameters,
             backup: self.backup,
-        }
+        };
+
+        // POST: identity (backend id) and wire address are preserved — same
+        // routing guarantee as the `From<Backend>` path, kept in lockstep.
+        debug_assert_eq!(
+            add_backend.backend_id, source_backend_id,
+            "backend_id must survive to_add_backend"
+        );
+        debug_assert_eq!(
+            SocketAddr::from(add_backend.address),
+            source_address,
+            "backend address must round-trip through to_add_backend"
+        );
+        add_backend
     }
 }
 
@@ -373,5 +500,14 @@ impl fmt::Display for FilteredTimeSerie {
 }
 
 fn socketaddr_cmp(a: &SocketAddr, b: &SocketAddr) -> Ordering {
-    a.ip().cmp(&b.ip()).then(a.port().cmp(&b.port()))
+    let ordering = a.ip().cmp(&b.ip()).then(a.port().cmp(&b.port()));
+    // INV: two socket addresses compare Equal iff both IP and port match —
+    // the `.then` fold must not declare distinct (ip, port) pairs equal, which
+    // would make two different backends indistinguishable to the BTree key.
+    debug_assert_eq!(
+        ordering == Ordering::Equal,
+        a.ip() == b.ip() && a.port() == b.port(),
+        "socketaddr_cmp is Equal iff ip and port both match"
+    );
+    ordering
 }

--- a/command/src/scm_socket.rs
+++ b/command/src/scm_socket.rs
@@ -99,6 +99,12 @@ impl ScmSocket {
         if self.blocking == blocking {
             return Ok(());
         }
+        // Past the idempotent early-return the flag must actually be flipping.
+        debug_assert_ne!(
+            self.blocking, blocking,
+            "set_blocking only reaches the syscall when the state actually changes"
+        );
+        let blocking_before = self.blocking;
         // SAFETY: `self.fd` is borrowed for the duration of this block. We wrap
         // it in a `StdUnixStream` to call `set_nonblocking`, then immediately
         // release ownership with `into_raw_fd` so the descriptor is not closed
@@ -111,6 +117,15 @@ impl ScmSocket {
             let _dropped_fd = stream.into_raw_fd();
         }
         self.blocking = blocking;
+        // The flag landed on the requested value and genuinely toggled.
+        debug_assert_eq!(
+            self.blocking, blocking,
+            "blocking flag must reflect the requested state after a successful set"
+        );
+        debug_assert_ne!(
+            self.blocking, blocking_before,
+            "blocking flag must have toggled across a real state change"
+        );
         Ok(())
     }
 
@@ -123,6 +138,27 @@ impl ScmSocket {
             udp: listeners.udp.iter().map(|t| t.0.to_string()).collect(),
         };
 
+        // The manifest is built 1:1 from the listener tables; each address slot
+        // ships exactly one FD, so the per-protocol counts must agree on both
+        // sides of the wire. The receiver reconstructs (address, fd) pairs by
+        // zipping these counts against the FD array — drift here is the exact
+        // bug class `command_channel_security_tests` guards.
+        debug_assert_eq!(
+            listeners_count.http.len(),
+            listeners.http.len(),
+            "http manifest count must match the http listener table"
+        );
+        debug_assert_eq!(
+            listeners_count.tls.len(),
+            listeners.tls.len(),
+            "tls manifest count must match the tls listener table"
+        );
+        debug_assert_eq!(
+            listeners_count.tcp.len(),
+            listeners.tcp.len(),
+            "tcp manifest count must match the tcp listener table"
+        );
+
         let message = listeners_count.encode_length_delimited_to_vec();
 
         let mut file_descriptors: Vec<RawFd> = Vec::new();
@@ -131,6 +167,19 @@ impl ScmSocket {
         file_descriptors.extend(listeners.tls.iter().map(|t| t.1));
         file_descriptors.extend(listeners.tcp.iter().map(|t| t.1));
         file_descriptors.extend(listeners.udp.iter().map(|t| t.1));
+
+        // The FD vector must reconcile with the address totals: one descriptor
+        // per listener, folded http+tls+tcp+udp. If these disagree the receiver
+        // would zip mismatched (address, fd) pairs.
+        let address_total = listeners.http.len()
+            + listeners.tls.len()
+            + listeners.tcp.len()
+            + listeners.udp.len();
+        debug_assert_eq!(
+            file_descriptors.len(),
+            address_total,
+            "the FD count sent must equal the total listener-address count (one FD per address)"
+        );
 
         self.send_msg_and_fds(&message, &file_descriptors)
     }
@@ -184,36 +233,107 @@ impl ScmSocket {
             });
         }
 
+        // Past the consistency guard, the folded total reconciles with both the
+        // fixed FD-array bound and the number of FDs that actually arrived.
+        // These are the invariants that keep every `received_fds[index..index+len]`
+        // slice below in bounds — a malformed manifest already returned an error
+        // and never reaches here.
+        debug_assert_eq!(
+            total,
+            http_len + tls_len + tcp_len + udp_len,
+            "folded total must equal the sum of per-protocol counts"
+        );
+        debug_assert!(
+            total <= MAX_FDS_OUT,
+            "total FD slots must fit the fixed-size received_fds array before indexing"
+        );
+        debug_assert!(
+            total <= file_descriptor_length,
+            "manifest total must not exceed the FDs actually received"
+        );
+        debug_assert!(
+            total <= received_fds.len(),
+            "every (address, fd) zip below must stay within the received_fds array"
+        );
+
         let mut http_addresses = parse_addresses(&listeners_count.http)?;
         let mut tls_addresses = parse_addresses(&listeners_count.tls)?;
         let mut tcp_addresses = parse_addresses(&listeners_count.tcp)?;
         let mut udp_addresses = parse_addresses(&listeners_count.udp)?;
 
+        // Each parsed address list maps 1:1 onto a contiguous FD slice; the
+        // counts must survive `parse_addresses` unchanged.
+        debug_assert_eq!(
+            http_addresses.len(),
+            http_len,
+            "parsed http address count must match the manifest count"
+        );
+        debug_assert_eq!(
+            tls_addresses.len(),
+            tls_len,
+            "parsed tls address count must match the manifest count"
+        );
+        debug_assert_eq!(
+            tcp_addresses.len(),
+            tcp_len,
+            "parsed tcp address count must match the manifest count"
+        );
+
         let mut index = 0;
         let len = http_len;
+        // Each FD slice end must stay within the validated total (and thus the
+        // array); pair-assert the slice window before every zip.
+        debug_assert!(
+            index + len <= total,
+            "http FD slice must lie within the reconciled total"
+        );
         let mut http = Vec::new();
         http.extend(
             http_addresses
                 .drain(..)
                 .zip(received_fds[index..index + len].iter().cloned()),
         );
+        // Each address was wrapped with exactly one FD.
+        debug_assert_eq!(
+            http.len(),
+            http_len,
+            "every http address must be paired with exactly one FD"
+        );
 
         index += len;
         let len = tls_len;
+        debug_assert!(
+            index + len <= total,
+            "tls FD slice must lie within the reconciled total"
+        );
         let mut tls = Vec::new();
         tls.extend(
             tls_addresses
                 .drain(..)
                 .zip(received_fds[index..index + len].iter().cloned()),
         );
+        debug_assert_eq!(
+            tls.len(),
+            tls_len,
+            "every tls address must be paired with exactly one FD"
+        );
 
         index += len;
         let len = tcp_len;
+        debug_assert!(
+            index + len <= total,
+            "tcp FD slice must lie within the reconciled total"
+        );
         let mut tcp = Vec::new();
         tcp.extend(
             tcp_addresses
                 .drain(..)
                 .zip(received_fds[index..index + len].iter().cloned()),
+        );
+        debug_assert_eq!(
+            tcp.len(),
+            tcp_len,
+            "every tcp address must be paired with exactly one FD"
         );
 
         index += len;
@@ -223,6 +343,24 @@ impl ScmSocket {
             udp_addresses
                 .drain(..)
                 .zip(received_fds[index..index + len].iter().cloned()),
+        );
+        debug_assert_eq!(
+            udp.len(),
+            udp_len,
+            "every udp address must be paired with exactly one FD"
+        );
+
+        // The reconstructed tables consume every FD slot the manifest declared:
+        // the final cursor lands exactly on the folded total (http+tls+tcp+udp).
+        debug_assert_eq!(
+            index + len,
+            total,
+            "the (address, fd) zips must consume exactly the reconciled total of FD slots"
+        );
+        debug_assert_eq!(
+            http.len() + tls.len() + tcp.len() + udp.len(),
+            total,
+            "reconstructed listener count must equal the reconciled FD total"
         );
 
         Ok(Listeners {
@@ -263,6 +401,9 @@ impl ScmSocket {
         message: &mut [u8],
         fds: &mut [RawFd],
     ) -> Result<(usize, usize), ScmSocketError> {
+        // Snapshot the buffer length before `message` is borrowed mutably by
+        // `iov`; the received byte count is asserted against it below.
+        let message_capacity = message.len();
         let mut cmsg = cmsg_space!([RawFd; MAX_FDS_OUT]);
         let mut iov = [IoSliceMut::new(message)];
 
@@ -275,6 +416,13 @@ impl ScmSocket {
         let msg = socket::recvmsg::<()>(self.fd, &mut iov[..], Some(&mut cmsg), flags)
             .map_err(|error| ScmSocketError::Receive(error.to_string()))?;
 
+        // The destination slice is the receiver's fixed `[RawFd; MAX_FDS_OUT]`
+        // array; the zip below cannot write past it.
+        let fds_capacity = fds.len();
+        debug_assert!(
+            fds_capacity <= MAX_FDS_OUT,
+            "destination FD slice must not exceed the MAX_FDS_OUT cmsg space"
+        );
         let mut fd_count = 0;
         let received_fds = msg
             .cmsgs()
@@ -290,7 +438,23 @@ impl ScmSocket {
         for (fd, place) in received_fds.zip(fds.iter_mut()) {
             fd_count += 1;
             *place = fd;
+            // The zip is bounded by `fds.iter_mut()`, so each wrap stays within
+            // the destination array — never write past `fds_capacity`.
+            debug_assert!(
+                fd_count <= fds_capacity,
+                "received FD count must never exceed the destination array capacity"
+            );
         }
+        // Post-condition: the reported count reconciles with the destination
+        // bound and the byte count is within the message buffer we handed in.
+        debug_assert!(
+            fd_count <= fds_capacity,
+            "final received FD count must fit the destination array"
+        );
+        debug_assert!(
+            msg.bytes <= message_capacity,
+            "received byte count must not exceed the message buffer it was read into"
+        );
         Ok((msg.bytes, fd_count))
     }
 }
@@ -309,24 +473,53 @@ pub struct Listeners {
 
 impl Listeners {
     pub fn get_http(&mut self, addr: &SocketAddr) -> Option<RawFd> {
-        self.http
-            .iter()
-            .position(|(front, _)| front == addr)
-            .map(|pos| self.http.remove(pos).1)
+        let before = self.http.len();
+        let pos = self.http.iter().position(|(front, _)| front == addr);
+        let result = pos.map(|pos| self.http.remove(pos).1);
+        // Exactly the matched entry is removed: the length drops by one iff a
+        // match was found, and the removed address is truly gone.
+        debug_assert_eq!(
+            self.http.len(),
+            before - result.is_some() as usize,
+            "http listener table shrinks by exactly one iff an address matched"
+        );
+        debug_assert!(
+            result.is_none() || !self.http.iter().any(|(front, _)| front == addr),
+            "the matched http address must no longer be present after removal"
+        );
+        result
     }
 
     pub fn get_https(&mut self, addr: &SocketAddr) -> Option<RawFd> {
-        self.tls
-            .iter()
-            .position(|(front, _)| front == addr)
-            .map(|pos| self.tls.remove(pos).1)
+        let before = self.tls.len();
+        let pos = self.tls.iter().position(|(front, _)| front == addr);
+        let result = pos.map(|pos| self.tls.remove(pos).1);
+        debug_assert_eq!(
+            self.tls.len(),
+            before - result.is_some() as usize,
+            "tls listener table shrinks by exactly one iff an address matched"
+        );
+        debug_assert!(
+            result.is_none() || !self.tls.iter().any(|(front, _)| front == addr),
+            "the matched tls address must no longer be present after removal"
+        );
+        result
     }
 
     pub fn get_tcp(&mut self, addr: &SocketAddr) -> Option<RawFd> {
-        self.tcp
-            .iter()
-            .position(|(front, _)| front == addr)
-            .map(|pos| self.tcp.remove(pos).1)
+        let before = self.tcp.len();
+        let pos = self.tcp.iter().position(|(front, _)| front == addr);
+        let result = pos.map(|pos| self.tcp.remove(pos).1);
+        debug_assert_eq!(
+            self.tcp.len(),
+            before - result.is_some() as usize,
+            "tcp listener table shrinks by exactly one iff an address matched"
+        );
+        debug_assert!(
+            result.is_none() || !self.tcp.iter().any(|(front, _)| front == addr),
+            "the matched tcp address must no longer be present after removal"
+        );
+        result
     }
 
     pub fn get_udp(&mut self, addr: &SocketAddr) -> Option<RawFd> {

--- a/command/src/scm_socket.rs
+++ b/command/src/scm_socket.rs
@@ -171,10 +171,8 @@ impl ScmSocket {
         // The FD vector must reconcile with the address totals: one descriptor
         // per listener, folded http+tls+tcp+udp. If these disagree the receiver
         // would zip mismatched (address, fd) pairs.
-        let address_total = listeners.http.len()
-            + listeners.tls.len()
-            + listeners.tcp.len()
-            + listeners.udp.len();
+        let address_total =
+            listeners.http.len() + listeners.tls.len() + listeners.tcp.len() + listeners.udp.len();
         debug_assert_eq!(
             file_descriptors.len(),
             address_total,

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -113,7 +113,7 @@ impl ConfigState {
 
         self.increment_request_count(request);
 
-        match request_type {
+        let result = match request_type {
             RequestType::AddCluster(cluster) => self.add_cluster(cluster),
             RequestType::RemoveCluster(cluster_id) => self.remove_cluster(cluster_id),
             RequestType::AddHttpListener(listener) => self.add_http_listener(listener),
@@ -166,7 +166,137 @@ impl ConfigState {
             | RequestType::HardStop(_) => Ok(()),
 
             _other_request => Err(StateError::UndispatchableRequest),
+        };
+
+        // Run-to-completion postcondition: whatever path `dispatch` took, the
+        // cross-map invariants of the model must hold once it returns. We run
+        // the full sweep on both success and error: a failed mutating handler
+        // (e.g. a duplicate `add_*` or an absent `remove_*`) is required to be
+        // a no-op, so the invariants must be intact regardless of the result.
+        #[cfg(debug_assertions)]
+        self.check_invariants();
+
+        result
+    }
+
+    /// Full cross-map invariant sweep for the control-plane state model.
+    ///
+    /// This is the run-to-completion postcondition called via a
+    /// `#[cfg(debug_assertions)]` guard at the end of [`Self::dispatch`]. It
+    /// encodes the coherence invariants the diff/replay machinery relies on:
+    /// every map entry is self-consistent (a value's stored key/cluster_id
+    /// matches the key it is filed under), and the public accounting helpers
+    /// (`count_frontends`/`count_backends`) agree with the raw map contents.
+    ///
+    /// Compiled out entirely in release builds (no body, no callers).
+    #[cfg(debug_assertions)]
+    fn check_invariants(&self) {
+        // Listener maps: the value's `address` field must match the SocketAddr
+        // key it is filed under, or a hot-upgrade replay (which re-derives the
+        // key from the value) would land the entry under a different key.
+        for (addr, listener) in &self.http_listeners {
+            debug_assert_eq!(
+                SocketAddr::from(listener.address),
+                *addr,
+                "http_listener value address must match its map key"
+            );
         }
+        for (addr, listener) in &self.https_listeners {
+            debug_assert_eq!(
+                SocketAddr::from(listener.address),
+                *addr,
+                "https_listener value address must match its map key"
+            );
+        }
+        for (addr, listener) in &self.tcp_listeners {
+            debug_assert_eq!(
+                SocketAddr::from(listener.address),
+                *addr,
+                "tcp_listener value address must match its map key"
+            );
+        }
+
+        // Clusters: the value's `cluster_id` must match the key it is filed
+        // under (replay re-keys on `cluster.cluster_id`).
+        for (cluster_id, cluster) in &self.clusters {
+            debug_assert_eq!(
+                &cluster.cluster_id, cluster_id,
+                "cluster value cluster_id must match its map key"
+            );
+        }
+
+        // Backends: grouped by cluster_id. Every backend in a bucket must carry
+        // that bucket's cluster_id (replay groups on `backend.cluster_id`), and
+        // the per-cluster Vec must stay deduplicated on (backend_id, address) —
+        // `add_backend` upserts, so duplicates would mean lost state.
+        for (cluster_id, backends) in &self.backends {
+            for backend in backends {
+                debug_assert_eq!(
+                    &backend.cluster_id, cluster_id,
+                    "backend cluster_id must match its bucket key"
+                );
+            }
+            let unique: HashSet<(&String, &SocketAddr)> = backends
+                .iter()
+                .map(|b| (&b.backend_id, &b.address))
+                .collect();
+            debug_assert_eq!(
+                unique.len(),
+                backends.len(),
+                "backends within a cluster must be unique on (backend_id, address)"
+            );
+        }
+
+        // TCP frontends: grouped by cluster_id. Every frontend in a bucket must
+        // carry that bucket's cluster_id, and `add_tcp_frontend` rejects exact
+        // duplicates so each bucket stays a set.
+        for (cluster_id, fronts) in &self.tcp_fronts {
+            for front in fronts {
+                debug_assert_eq!(
+                    &front.cluster_id, cluster_id,
+                    "tcp_frontend cluster_id must match its bucket key"
+                );
+            }
+            let unique: HashSet<&TcpFrontend> = fronts.iter().collect();
+            debug_assert_eq!(
+                unique.len(),
+                fronts.len(),
+                "tcp frontends within a cluster must be unique"
+            );
+        }
+
+        // Certificates: nested map keyed by (address, fingerprint). The inner
+        // map's fingerprint key is the addressing identity used by diff; we do
+        // not recompute it here (expensive), but the outer/inner structure must
+        // not hold an empty inner map silently produced outside the API — an
+        // empty bucket is a benign no-op for diff/replay, so we only assert the
+        // address-key relationship is preserved by construction (trivially true
+        // for a BTree/HashMap), leaving the costly fingerprint recompute out.
+
+        // Public accounting helpers must agree with the raw maps. These are the
+        // numbers the CLI and metrics surface; a drift here is a real bug.
+        let raw_frontends = self.http_fronts.len()
+            + self.https_fronts.len()
+            + self.count_tcp_frontends_raw()
+            + self.udp_fronts.values().map(|v| v.len()).sum::<usize>();
+        debug_assert_eq!(
+            self.count_frontends(),
+            raw_frontends,
+            "count_frontends must equal the sum of all frontend map entries"
+        );
+        let raw_backends: usize = self.backends.values().map(|v| v.len()).sum();
+        debug_assert_eq!(
+            self.count_backends(),
+            raw_backends,
+            "count_backends must equal the sum of all backend Vec lengths"
+        );
+    }
+
+    /// Raw count of TCP frontends across all clusters — debug-only helper used
+    /// by [`Self::check_invariants`] to cross-check `count_frontends`.
+    #[cfg(debug_assertions)]
+    fn count_tcp_frontends_raw(&self) -> usize {
+        self.tcp_fronts.values().map(|v| v.len()).sum()
     }
 
     /// Increments the count for this request type
@@ -202,17 +332,49 @@ impl ConfigState {
             }
         }
         let cluster = cluster.clone();
-        self.clusters.insert(cluster.cluster_id.clone(), cluster);
+        // AddCluster is an upsert (replacing an existing cluster_id keeps the
+        // entry count flat), so we assert on presence/key-coherence rather than
+        // a strict +1 on len.
+        let cluster_id = cluster.cluster_id.clone();
+        self.clusters.insert(cluster_id.clone(), cluster);
+        debug_assert!(
+            self.clusters.contains_key(&cluster_id),
+            "add_cluster must leave the cluster present in the map"
+        );
+        debug_assert_eq!(
+            self.clusters.get(&cluster_id).map(|c| &c.cluster_id),
+            Some(&cluster_id),
+            "stored cluster must be keyed by its own cluster_id"
+        );
         Ok(())
     }
 
     fn remove_cluster(&mut self, cluster_id: &str) -> Result<(), StateError> {
+        let before = self.clusters.len();
         match self.clusters.remove(cluster_id) {
-            Some(_) => Ok(()),
-            None => Err(StateError::NotFound {
-                kind: ObjectKind::Cluster,
-                id: cluster_id.to_owned(),
-            }),
+            Some(_) => {
+                debug_assert!(
+                    !self.clusters.contains_key(cluster_id),
+                    "remove_cluster must evict the cluster"
+                );
+                debug_assert_eq!(
+                    self.clusters.len(),
+                    before - 1,
+                    "remove_cluster must drop exactly one entry"
+                );
+                Ok(())
+            }
+            None => {
+                debug_assert_eq!(
+                    self.clusters.len(),
+                    before,
+                    "a failed remove_cluster must not mutate the map"
+                );
+                Err(StateError::NotFound {
+                    kind: ObjectKind::Cluster,
+                    id: cluster_id.to_owned(),
+                })
+            }
         }
     }
 
@@ -271,43 +433,88 @@ impl ConfigState {
 
     fn add_http_listener(&mut self, listener: &HttpListenerConfig) -> Result<(), StateError> {
         let address: SocketAddr = listener.address.into();
+        let before = self.http_listeners.len();
         match self.http_listeners.entry(address) {
             BTreeMapEntry::Vacant(vacant_entry) => vacant_entry.insert(listener.clone()),
             BTreeMapEntry::Occupied(_) => {
+                debug_assert_eq!(
+                    self.http_listeners.len(),
+                    before,
+                    "a rejected duplicate add_http_listener must not mutate the map"
+                );
                 return Err(StateError::Exists {
                     kind: ObjectKind::HttpListener,
                     id: address.to_string(),
                 });
             }
         };
+        debug_assert!(
+            self.http_listeners.contains_key(&address),
+            "add_http_listener must insert the listener under its address"
+        );
+        debug_assert_eq!(
+            self.http_listeners.len(),
+            before + 1,
+            "add_http_listener inserts exactly one entry on the vacant path"
+        );
         Ok(())
     }
 
     fn add_https_listener(&mut self, listener: &HttpsListenerConfig) -> Result<(), StateError> {
         let address: SocketAddr = listener.address.into();
+        let before = self.https_listeners.len();
         match self.https_listeners.entry(address) {
             BTreeMapEntry::Vacant(vacant_entry) => vacant_entry.insert(listener.clone()),
             BTreeMapEntry::Occupied(_) => {
+                debug_assert_eq!(
+                    self.https_listeners.len(),
+                    before,
+                    "a rejected duplicate add_https_listener must not mutate the map"
+                );
                 return Err(StateError::Exists {
                     kind: ObjectKind::HttpsListener,
                     id: address.to_string(),
                 });
             }
         };
+        debug_assert!(
+            self.https_listeners.contains_key(&address),
+            "add_https_listener must insert the listener under its address"
+        );
+        debug_assert_eq!(
+            self.https_listeners.len(),
+            before + 1,
+            "add_https_listener inserts exactly one entry on the vacant path"
+        );
         Ok(())
     }
 
     fn add_tcp_listener(&mut self, listener: &TcpListenerConfig) -> Result<(), StateError> {
         let address: SocketAddr = listener.address.into();
+        let before = self.tcp_listeners.len();
         match self.tcp_listeners.entry(address) {
             BTreeMapEntry::Vacant(vacant_entry) => vacant_entry.insert(*listener),
             BTreeMapEntry::Occupied(_) => {
+                debug_assert_eq!(
+                    self.tcp_listeners.len(),
+                    before,
+                    "a rejected duplicate add_tcp_listener must not mutate the map"
+                );
                 return Err(StateError::Exists {
                     kind: ObjectKind::TcpListener,
                     id: address.to_string(),
                 });
             }
         };
+        debug_assert!(
+            self.tcp_listeners.contains_key(&address),
+            "add_tcp_listener must insert the listener under its address"
+        );
+        debug_assert_eq!(
+            self.tcp_listeners.len(),
+            before + 1,
+            "add_tcp_listener inserts exactly one entry on the vacant path"
+        );
         Ok(())
     }
 
@@ -335,23 +542,68 @@ impl ConfigState {
     }
 
     fn remove_http_listener(&mut self, address: &SocketAddr) -> Result<(), StateError> {
+        let before = self.http_listeners.len();
         if self.http_listeners.remove(address).is_none() {
+            debug_assert_eq!(
+                self.http_listeners.len(),
+                before,
+                "a failed remove_http_listener must not mutate the map"
+            );
             return Err(StateError::NoChange);
         }
+        debug_assert!(
+            !self.http_listeners.contains_key(address),
+            "remove_http_listener must evict the address"
+        );
+        debug_assert_eq!(
+            self.http_listeners.len(),
+            before - 1,
+            "remove_http_listener drops exactly one entry"
+        );
         Ok(())
     }
 
     fn remove_https_listener(&mut self, address: &SocketAddr) -> Result<(), StateError> {
+        let before = self.https_listeners.len();
         if self.https_listeners.remove(address).is_none() {
+            debug_assert_eq!(
+                self.https_listeners.len(),
+                before,
+                "a failed remove_https_listener must not mutate the map"
+            );
             return Err(StateError::NoChange);
         }
+        debug_assert!(
+            !self.https_listeners.contains_key(address),
+            "remove_https_listener must evict the address"
+        );
+        debug_assert_eq!(
+            self.https_listeners.len(),
+            before - 1,
+            "remove_https_listener drops exactly one entry"
+        );
         Ok(())
     }
 
     fn remove_tcp_listener(&mut self, address: &SocketAddr) -> Result<(), StateError> {
+        let before = self.tcp_listeners.len();
         if self.tcp_listeners.remove(address).is_none() {
+            debug_assert_eq!(
+                self.tcp_listeners.len(),
+                before,
+                "a failed remove_tcp_listener must not mutate the map"
+            );
             return Err(StateError::NoChange);
         }
+        debug_assert!(
+            !self.tcp_listeners.contains_key(address),
+            "remove_tcp_listener must evict the address"
+        );
+        debug_assert_eq!(
+            self.tcp_listeners.len(),
+            before - 1,
+            "remove_tcp_listener drops exactly one entry"
+        );
         Ok(())
     }
 
@@ -729,6 +981,7 @@ impl ConfigState {
 
     fn add_http_frontend(&mut self, front: &RequestHttpFrontend) -> Result<(), StateError> {
         let front_as_key = front.to_string();
+        let before = self.http_fronts.len();
 
         match self.http_fronts.entry(front.to_string()) {
             BTreeMapEntry::Vacant(e) => {
@@ -740,17 +993,34 @@ impl ConfigState {
                 })?)
             }
             BTreeMapEntry::Occupied(_) => {
+                debug_assert_eq!(
+                    self.http_fronts.len(),
+                    before,
+                    "a rejected duplicate add_http_frontend must not mutate the map"
+                );
                 return Err(StateError::Exists {
                     kind: ObjectKind::HttpFrontend,
                     id: front.to_string(),
                 });
             }
         };
+        // On the conversion-error path the `?` already returned, so reaching
+        // here means exactly one entry was inserted under the route key.
+        debug_assert!(
+            self.http_fronts.contains_key(&front.to_string()),
+            "add_http_frontend must insert the route key on success"
+        );
+        debug_assert_eq!(
+            self.http_fronts.len(),
+            before + 1,
+            "add_http_frontend inserts exactly one entry on success"
+        );
         Ok(())
     }
 
     fn add_https_frontend(&mut self, front: &RequestHttpFrontend) -> Result<(), StateError> {
         let front_as_key = front.to_string();
+        let before = self.https_fronts.len();
 
         match self.https_fronts.entry(front.to_string()) {
             BTreeMapEntry::Vacant(e) => {
@@ -762,32 +1032,64 @@ impl ConfigState {
                 })?)
             }
             BTreeMapEntry::Occupied(_) => {
+                debug_assert_eq!(
+                    self.https_fronts.len(),
+                    before,
+                    "a rejected duplicate add_https_frontend must not mutate the map"
+                );
                 return Err(StateError::Exists {
                     kind: ObjectKind::HttpsFrontend,
                     id: front.to_string(),
                 });
             }
         };
+        debug_assert!(
+            self.https_fronts.contains_key(&front.to_string()),
+            "add_https_frontend must insert the route key on success"
+        );
+        debug_assert_eq!(
+            self.https_fronts.len(),
+            before + 1,
+            "add_https_frontend inserts exactly one entry on success"
+        );
         Ok(())
     }
 
     fn remove_http_frontend(&mut self, front: &RequestHttpFrontend) -> Result<(), StateError> {
-        self.http_fronts
-            .remove(&front.to_string())
-            .ok_or(StateError::NotFound {
-                kind: ObjectKind::HttpFrontend,
-                id: front.to_string(),
-            })?;
+        let key = front.to_string();
+        let before = self.http_fronts.len();
+        self.http_fronts.remove(&key).ok_or(StateError::NotFound {
+            kind: ObjectKind::HttpFrontend,
+            id: front.to_string(),
+        })?;
+        debug_assert!(
+            !self.http_fronts.contains_key(&key),
+            "remove_http_frontend must evict the route key"
+        );
+        debug_assert_eq!(
+            self.http_fronts.len(),
+            before - 1,
+            "remove_http_frontend drops exactly one entry"
+        );
         Ok(())
     }
 
     fn remove_https_frontend(&mut self, front: &RequestHttpFrontend) -> Result<(), StateError> {
-        self.https_fronts
-            .remove(&front.to_string())
-            .ok_or(StateError::NotFound {
-                kind: ObjectKind::HttpsFrontend,
-                id: front.to_string(),
-            })?;
+        let key = front.to_string();
+        let before = self.https_fronts.len();
+        self.https_fronts.remove(&key).ok_or(StateError::NotFound {
+            kind: ObjectKind::HttpsFrontend,
+            id: front.to_string(),
+        })?;
+        debug_assert!(
+            !self.https_fronts.contains_key(&key),
+            "remove_https_frontend must evict the route key"
+        );
+        debug_assert_eq!(
+            self.https_fronts.len(),
+            before - 1,
+            "remove_https_frontend drops exactly one entry"
+        );
         Ok(())
     }
 
@@ -814,7 +1116,17 @@ impl ConfigState {
             return Ok(());
         }
 
-        entry.insert(fingerprint, add.certificate);
+        let before = entry.len();
+        entry.insert(fingerprint.clone(), add.certificate);
+        debug_assert!(
+            entry.contains_key(&fingerprint),
+            "add_certificate must insert the fingerprint under its address"
+        );
+        debug_assert_eq!(
+            entry.len(),
+            before + 1,
+            "add_certificate inserts exactly one fingerprint on the new path"
+        );
         Ok(())
     }
 
@@ -826,6 +1138,10 @@ impl ConfigState {
 
         if let Some(index) = self.certificates.get_mut(&remove.address.into()) {
             index.remove(&fingerprint);
+            debug_assert!(
+                !index.contains_key(&fingerprint),
+                "remove_certificate must evict the fingerprint when the address is known"
+            );
         }
 
         Ok(())
@@ -874,6 +1190,22 @@ impl ConfigState {
                 replace.address
             )));
         }
+        // Postcondition: the new fingerprint is keyed under the address, and
+        // (unless old and new collide, e.g. a self-replace) the old one is gone.
+        debug_assert!(
+            self.certificates
+                .get(&replace_address)
+                .is_some_and(|certs| certs.contains_key(&new_fingerprint)),
+            "replace_certificate must leave the new fingerprint present"
+        );
+        debug_assert!(
+            new_fingerprint == old_fingerprint
+                || self
+                    .certificates
+                    .get(&replace_address)
+                    .is_none_or(|certs| !certs.contains_key(&old_fingerprint)),
+            "replace_certificate must evict the old fingerprint unless it equals the new one"
+        );
         Ok(())
     }
 
@@ -885,14 +1217,29 @@ impl ConfigState {
             address: front.address.into(),
             tags: front.tags.clone(),
         };
+        let before = tcp_frontends.len();
         if tcp_frontends.contains(&tcp_frontend) {
+            debug_assert_eq!(
+                tcp_frontends.len(),
+                before,
+                "a rejected duplicate add_tcp_frontend must not grow the bucket"
+            );
             return Err(StateError::Exists {
                 kind: ObjectKind::TcpFrontend,
                 id: format!("{tcp_frontend:?}"),
             });
         }
 
+        debug_assert_eq!(
+            tcp_frontend.cluster_id, front.cluster_id,
+            "the built frontend must carry its bucket's cluster_id"
+        );
         tcp_frontends.push(tcp_frontend);
+        debug_assert_eq!(
+            tcp_frontends.len(),
+            before + 1,
+            "add_tcp_frontend appends exactly one entry"
+        );
         Ok(())
     }
 
@@ -909,10 +1256,24 @@ impl ConfigState {
                 })?;
 
         let len = tcp_frontends.len();
-        tcp_frontends.retain(|front| front.address != front_to_remove.address.into());
-        if tcp_frontends.len() == len {
+        let remove_address: SocketAddr = front_to_remove.address.into();
+        tcp_frontends.retain(|front| front.address != remove_address);
+        let after = tcp_frontends.len();
+        if after == len {
             return Err(StateError::NoChange);
         }
+        // `retain` may drop more than one entry only if duplicates on the same
+        // address ever existed; `add_tcp_frontend` forbids that, so a
+        // successful removal must drop exactly one and leave none matching.
+        debug_assert_eq!(
+            after,
+            len - 1,
+            "remove_tcp_frontend drops exactly one entry"
+        );
+        debug_assert!(
+            !tcp_frontends.iter().any(|f| f.address == remove_address),
+            "remove_tcp_frontend must leave no frontend at the removed address"
+        );
         Ok(())
     }
 
@@ -965,12 +1326,39 @@ impl ConfigState {
             backup: add_backend.backup,
         };
         let backends = self.backends.entry(backend.cluster_id.clone()).or_default();
+        let backend_id = backend.backend_id.clone();
+        let backend_address = backend.address;
+        let before = backends.len();
 
-        // we might be modifying the sticky id or load balancing parameters
+        // we might be modifying the sticky id or load balancing parameters:
+        // the retain drops at most one prior copy (the map stays deduplicated
+        // on (backend_id, address)), then we re-push the new version. So the
+        // net length grows by exactly one iff this was a brand-new backend.
+        let was_present = backends
+            .iter()
+            .any(|b| b.backend_id == backend_id && b.address == backend_address);
         backends.retain(|b| b.backend_id != backend.backend_id || b.address != backend.address);
+        debug_assert_eq!(
+            backends.len(),
+            before - was_present as usize,
+            "the upsert retain must drop exactly the prior copy iff it existed"
+        );
         backends.push(backend);
         backends.sort();
 
+        debug_assert_eq!(
+            backends.len(),
+            before + (!was_present) as usize,
+            "add_backend grows the bucket by one iff the backend was new"
+        );
+        debug_assert_eq!(
+            backends
+                .iter()
+                .filter(|b| b.backend_id == backend_id && b.address == backend_address)
+                .count(),
+            1,
+            "exactly one copy of the upserted backend must remain"
+        );
         Ok(())
     }
 
@@ -984,12 +1372,22 @@ impl ConfigState {
                 })?;
 
         let len = backend_list.len();
-        let remove_address = backend.address.into();
+        let remove_address: SocketAddr = backend.address.into();
         backend_list.retain(|b| b.backend_id != backend.backend_id || b.address != remove_address);
         backend_list.sort();
-        if backend_list.len() == len {
+        let after = backend_list.len();
+        if after == len {
             return Err(StateError::NoChange);
         }
+        // The list is deduplicated on (backend_id, address), so a matching
+        // removal drops exactly one entry and leaves nothing matching.
+        debug_assert_eq!(after, len - 1, "remove_backend drops exactly one entry");
+        debug_assert!(
+            !backend_list
+                .iter()
+                .any(|b| b.backend_id == backend.backend_id && b.address == remove_address),
+            "remove_backend must leave no backend matching (backend_id, address)"
+        );
         Ok(())
     }
 
@@ -1096,6 +1494,34 @@ impl ConfigState {
             }
         }
 
+        // Bootstrap round-trip: replaying `generate_requests` into a fresh,
+        // empty `ConfigState` must reconstruct `self`'s maps exactly. This is
+        // the property SaveState/LoadState and worker bootstrap depend on. We
+        // compare the business maps only (not `request_counts`, which is
+        // bookkeeping mutated by `dispatch`).
+        #[cfg(debug_assertions)]
+        {
+            let mut replayed = ConfigState::new();
+            for request in &v {
+                debug_assert!(
+                    replayed.dispatch(request).is_ok(),
+                    "every request from generate_requests must replay cleanly"
+                );
+            }
+            debug_assert!(
+                replayed.clusters == self.clusters
+                    && replayed.backends == self.backends
+                    && replayed.http_listeners == self.http_listeners
+                    && replayed.https_listeners == self.https_listeners
+                    && replayed.tcp_listeners == self.tcp_listeners
+                    && replayed.http_fronts == self.http_fronts
+                    && replayed.https_fronts == self.https_fronts
+                    && replayed.tcp_fronts == self.tcp_fronts
+                    && replayed.certificates == self.certificates,
+                "replaying generate_requests into a fresh state must reproduce self"
+            );
+        }
+
         v
     }
 
@@ -1160,6 +1586,25 @@ impl ConfigState {
                     from_scm: false,
                 })
                 .into(),
+            );
+        }
+
+        // Symmetry with the active-listener census: exactly one ActivateListener
+        // is emitted per active listener across the three maps, no more, no less.
+        #[cfg(debug_assertions)]
+        {
+            let active_listeners = self.http_listeners.values().filter(|l| l.active).count()
+                + self.https_listeners.values().filter(|l| l.active).count()
+                + self.tcp_listeners.values().filter(|l| l.active).count();
+            debug_assert_eq!(
+                v.len(),
+                active_listeners,
+                "generate_activate_requests emits one request per active listener"
+            );
+            debug_assert!(
+                v.iter()
+                    .all(|r| matches!(r.request_type, Some(RequestType::ActivateListener(_)))),
+                "generate_activate_requests must emit only ActivateListener requests"
             );
         }
 
@@ -1350,6 +1795,23 @@ impl ConfigState {
                 let mut listener_to_add = *their_listener;
                 listener_to_add.active = false;
                 v.push(RequestType::AddTcpListener(listener_to_add).into());
+
+                // The Remove + Add(active=false) above wipes the listener's
+                // active state. Re-emit an ActivateListener whenever the target
+                // state keeps it active, otherwise a config change on a still
+                // active listener would silently deactivate it on replay. This
+                // subsumes the newly-active (`!my.active && their.active`) case:
+                // a differing `active` flag always makes the listeners unequal.
+                if their_listener.active {
+                    v.push(
+                        RequestType::ActivateListener(ActivateListener {
+                            address: SocketAddress::from(**addr),
+                            proxy: ListenerType::Tcp.into(),
+                            from_scm: false,
+                        })
+                        .into(),
+                    );
+                }
             }
 
             if my_listener.active && !their_listener.active {
@@ -1358,17 +1820,6 @@ impl ConfigState {
                         address: SocketAddress::from(**addr),
                         proxy: ListenerType::Tcp.into(),
                         to_scm: false,
-                    })
-                    .into(),
-                );
-            }
-
-            if !my_listener.active && their_listener.active {
-                v.push(
-                    RequestType::ActivateListener(ActivateListener {
-                        address: SocketAddress::from(**addr),
-                        proxy: ListenerType::Tcp.into(),
-                        from_scm: false,
                     })
                     .into(),
                 );
@@ -1391,6 +1842,23 @@ impl ConfigState {
                 let mut listener_to_add = *their_listener;
                 listener_to_add.active = false;
                 v.push(RequestType::AddUdpListener(listener_to_add).into());
+
+                // The Remove + Add(active=false) above wipes the listener's
+                // active state. Re-emit an ActivateListener whenever the target
+                // state keeps it active, otherwise a config change on a still
+                // active listener would silently deactivate it on replay. This
+                // subsumes the newly-active (`!my.active && their.active`) case:
+                // a differing `active` flag always makes the listeners unequal.
+                if their_listener.active {
+                    v.push(
+                        RequestType::ActivateListener(ActivateListener {
+                            address: SocketAddress::from(**addr),
+                            proxy: ListenerType::Udp.into(),
+                            from_scm: false,
+                        })
+                        .into(),
+                    );
+                }
             }
 
             if my_listener.active && !their_listener.active {
@@ -1399,17 +1867,6 @@ impl ConfigState {
                         address: SocketAddress::from(**addr),
                         proxy: ListenerType::Udp.into(),
                         to_scm: false,
-                    })
-                    .into(),
-                );
-            }
-
-            if !my_listener.active && their_listener.active {
-                v.push(
-                    RequestType::ActivateListener(ActivateListener {
-                        address: SocketAddress::from(**addr),
-                        proxy: ListenerType::Udp.into(),
-                        from_scm: false,
                     })
                     .into(),
                 );
@@ -1432,6 +1889,23 @@ impl ConfigState {
                 let mut listener_to_add = their_listener.clone();
                 listener_to_add.active = false;
                 v.push(RequestType::AddHttpListener(listener_to_add).into());
+
+                // The Remove + Add(active=false) above wipes the listener's
+                // active state. Re-emit an ActivateListener whenever the target
+                // state keeps it active, otherwise a config change on a still
+                // active listener would silently deactivate it on replay. This
+                // subsumes the newly-active (`!my.active && their.active`) case:
+                // a differing `active` flag always makes the listeners unequal.
+                if their_listener.active {
+                    v.push(
+                        RequestType::ActivateListener(ActivateListener {
+                            address: SocketAddress::from(**addr),
+                            proxy: ListenerType::Http.into(),
+                            from_scm: false,
+                        })
+                        .into(),
+                    );
+                }
             }
 
             if my_listener.active && !their_listener.active {
@@ -1440,17 +1914,6 @@ impl ConfigState {
                         address: SocketAddress::from(**addr),
                         proxy: ListenerType::Http.into(),
                         to_scm: false,
-                    })
-                    .into(),
-                );
-            }
-
-            if !my_listener.active && their_listener.active {
-                v.push(
-                    RequestType::ActivateListener(ActivateListener {
-                        address: SocketAddress::from(**addr),
-                        proxy: ListenerType::Http.into(),
-                        from_scm: false,
                     })
                     .into(),
                 );
@@ -1473,6 +1936,23 @@ impl ConfigState {
                 let mut listener_to_add = their_listener.clone();
                 listener_to_add.active = false;
                 v.push(RequestType::AddHttpsListener(listener_to_add).into());
+
+                // The Remove + Add(active=false) above wipes the listener's
+                // active state. Re-emit an ActivateListener whenever the target
+                // state keeps it active, otherwise a config change on a still
+                // active listener would silently deactivate it on replay. This
+                // subsumes the newly-active (`!my.active && their.active`) case:
+                // a differing `active` flag always makes the listeners unequal.
+                if their_listener.active {
+                    v.push(
+                        RequestType::ActivateListener(ActivateListener {
+                            address: SocketAddress::from(**addr),
+                            proxy: ListenerType::Https.into(),
+                            from_scm: false,
+                        })
+                        .into(),
+                    );
+                }
             }
 
             if my_listener.active && !their_listener.active {
@@ -1481,17 +1961,6 @@ impl ConfigState {
                         address: SocketAddress::from(**addr),
                         proxy: ListenerType::Https.into(),
                         to_scm: false,
-                    })
-                    .into(),
-                );
-            }
-
-            if !my_listener.active && their_listener.active {
-                v.push(
-                    RequestType::ActivateListener(ActivateListener {
-                        address: SocketAddress::from(**addr),
-                        proxy: ListenerType::Https.into(),
-                        from_scm: false,
                     })
                     .into(),
                 );
@@ -1726,6 +2195,55 @@ impl ConfigState {
                     .into(),
                 );
             }
+        }
+
+        // Replay symmetry: the request set `diff` emits, when replayed onto a
+        // clone of `self`, must reproduce `other`'s routing-relevant maps —
+        // listeners included, with their `active` flag. This is the property the
+        // hot-reconfig fan-out relies on — a worker applies these requests and
+        // must converge on `other`. We verify it in debug by actually replaying;
+        // `dispatch`'s own invariant sweep runs on every step.
+        //
+        // One deliberate normalization: `backends`/`tcp_fronts` are compared
+        // after dropping empty buckets. `remove_backend`/`remove_tcp_frontend`
+        // leave an empty `Vec` under a cluster key, whereas `other` may have no
+        // key at all. An empty bucket emits no requests and is semantically
+        // equivalent to an absent one, so we normalize it away before comparing.
+        #[cfg(debug_assertions)]
+        {
+            let mut replayed = self.clone();
+            for request in &v {
+                // A diff request must always be dispatchable onto `self`.
+                debug_assert!(
+                    replayed.dispatch(request).is_ok(),
+                    "every request emitted by diff must replay cleanly onto self"
+                );
+            }
+            let nonempty = |m: &BTreeMap<ClusterId, Vec<Backend>>| {
+                m.iter()
+                    .filter(|(_, v)| !v.is_empty())
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect::<BTreeMap<_, _>>()
+            };
+            let nonempty_tcp = |m: &HashMap<ClusterId, Vec<TcpFrontend>>| {
+                m.iter()
+                    .filter(|(_, v)| !v.is_empty())
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect::<HashMap<_, _>>()
+            };
+            debug_assert!(
+                replayed.clusters == other.clusters
+                    && nonempty(&replayed.backends) == nonempty(&other.backends)
+                    && replayed.http_fronts == other.http_fronts
+                    && replayed.https_fronts == other.https_fronts
+                    && nonempty_tcp(&replayed.tcp_fronts) == nonempty_tcp(&other.tcp_fronts)
+                    && replayed.certificates == other.certificates
+                    && replayed.http_listeners == other.http_listeners
+                    && replayed.https_listeners == other.https_listeners
+                    && replayed.tcp_listeners == other.tcp_listeners
+                    && replayed.udp_listeners == other.udp_listeners,
+                "replaying diff(self, other) onto self must reproduce other's clusters/backends/frontends/certificates/listeners"
+            );
         }
 
         v
@@ -3015,6 +3533,17 @@ mod tests {
                 ..Default::default()
             })
             .into(),
+            // The 8443 HTTPS listener is active in both states but its content
+            // changed (custom answers). The Remove + Add(active=false) above
+            // wipes the active flag, so diff must re-emit an ActivateListener to
+            // keep the listener live across the hot reconfig. Without it the
+            // worker would silently deactivate the listener on replay.
+            RequestType::ActivateListener(ActivateListener {
+                address: SocketAddress::new_v4(0, 0, 0, 0, 8443),
+                proxy: ListenerType::Https.into(),
+                from_scm: false,
+            })
+            .into(),
         ];
 
         let diff = state.diff(&state2);
@@ -3026,6 +3555,41 @@ mod tests {
         let _hash2 = state2.hash_state();
 
         assert_eq!(diff, e);
+
+        // Round-trip: replaying diff(state -> state2) onto a clone of `state`
+        // must reproduce `state2`'s listener maps EXACTLY, active flag included.
+        // This is the hot-reconfig correctness property — a worker applies these
+        // requests and must converge on the target state. In particular the 8443
+        // HTTPS listener (active in both states, content changed) must come back
+        // ACTIVE, which is the bug the ActivateListener re-emission above fixes.
+        let mut replayed = state.clone();
+        for request in &diff {
+            replayed
+                .dispatch(request)
+                .expect("every diff request must replay cleanly onto the source state");
+        }
+        assert_eq!(
+            replayed.tcp_listeners, state2.tcp_listeners,
+            "replayed tcp_listeners must match the target state"
+        );
+        assert_eq!(
+            replayed.http_listeners, state2.http_listeners,
+            "replayed http_listeners must match the target state"
+        );
+        assert_eq!(
+            replayed.https_listeners, state2.https_listeners,
+            "replayed https_listeners must match the target state"
+        );
+        // Explicitly assert the still-active listener stays active across the
+        // config change (the core of the fixed bug).
+        let replayed_8443 = replayed
+            .https_listeners
+            .get(&SocketAddr::from(SocketAddress::new_v4(0, 0, 0, 0, 8443)))
+            .expect("8443 HTTPS listener must exist after replay");
+        assert!(
+            replayed_8443.active,
+            "the 8443 HTTPS listener must stay ACTIVE across a config change"
+        );
     }
 
     #[test]

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -1590,12 +1590,13 @@ impl ConfigState {
         }
 
         // Symmetry with the active-listener census: exactly one ActivateListener
-        // is emitted per active listener across the three maps, no more, no less.
+        // is emitted per active listener across the four maps, no more, no less.
         #[cfg(debug_assertions)]
         {
             let active_listeners = self.http_listeners.values().filter(|l| l.active).count()
                 + self.https_listeners.values().filter(|l| l.active).count()
-                + self.tcp_listeners.values().filter(|l| l.active).count();
+                + self.tcp_listeners.values().filter(|l| l.active).count()
+                + self.udp_listeners.values().filter(|l| l.active).count();
             debug_assert_eq!(
                 v.len(),
                 active_listeners,

--- a/lib/src/backends.rs
+++ b/lib/src/backends.rs
@@ -88,12 +88,31 @@ impl Default for HealthState {
 impl HealthState {
     /// Record a successful health check. Returns true if the backend transitioned to healthy.
     pub fn record_success(&mut self, healthy_threshold: u32) -> bool {
+        let was_unhealthy = self.status == HealthStatus::Unhealthy;
+        let successes_before = self.consecutive_successes;
         self.consecutive_failures = 0;
         self.consecutive_successes += 1;
 
-        if self.status == HealthStatus::Unhealthy && self.consecutive_successes >= healthy_threshold
-        {
+        // A success resets the failure streak and advances the success streak by
+        // exactly one — the two counters are never both non-zero afterwards.
+        debug_assert_eq!(
+            self.consecutive_failures, 0,
+            "a success must clear the consecutive-failure streak"
+        );
+        debug_assert_eq!(
+            self.consecutive_successes,
+            successes_before + 1,
+            "a success must advance the success streak by exactly one"
+        );
+
+        if was_unhealthy && self.consecutive_successes >= healthy_threshold {
             self.status = HealthStatus::Healthy;
+            // The transition is only reported when crossing the threshold from
+            // Unhealthy; a backend that was already Healthy never "transitions".
+            debug_assert!(
+                self.status == HealthStatus::Healthy,
+                "a reported recovery must leave the status Healthy"
+            );
             return true;
         }
         false
@@ -101,12 +120,29 @@ impl HealthState {
 
     /// Record a failed health check. Returns true if the backend transitioned to unhealthy.
     pub fn record_failure(&mut self, unhealthy_threshold: u32) -> bool {
+        let was_healthy = self.status == HealthStatus::Healthy;
+        let failures_before = self.consecutive_failures;
         self.consecutive_successes = 0;
         self.consecutive_failures += 1;
 
-        if self.status == HealthStatus::Healthy && self.consecutive_failures >= unhealthy_threshold
-        {
+        // A failure resets the success streak and advances the failure streak by
+        // exactly one — symmetric with `record_success`.
+        debug_assert_eq!(
+            self.consecutive_successes, 0,
+            "a failure must clear the consecutive-success streak"
+        );
+        debug_assert_eq!(
+            self.consecutive_failures,
+            failures_before + 1,
+            "a failure must advance the failure streak by exactly one"
+        );
+
+        if was_healthy && self.consecutive_failures >= unhealthy_threshold {
             self.status = HealthStatus::Unhealthy;
+            debug_assert!(
+                self.status == HealthStatus::Unhealthy,
+                "a reported drop must leave the status Unhealthy"
+            );
             return true;
         }
         false
@@ -194,30 +230,75 @@ impl Backend {
     }
 
     pub fn inc_connections(&mut self) -> Option<usize> {
+        let before = self.active_connections;
         if self.status == BackendStatus::Normal {
             self.active_connections += 1;
+            // A `Normal` backend always increments by exactly one and reports the
+            // post-increment count back to the caller.
+            debug_assert_eq!(
+                self.active_connections,
+                before + 1,
+                "inc_connections must add exactly one active connection"
+            );
             Some(self.active_connections)
         } else {
+            // Non-`Normal` backends refuse new connections and leave the gauge
+            // untouched (no silent increment on a Closing/Closed backend).
+            debug_assert_eq!(
+                self.active_connections, before,
+                "inc_connections must not touch the count for a non-Normal backend"
+            );
             None
         }
     }
 
     /// TODO: normalize with saturating_sub()
     pub fn dec_connections(&mut self) -> Option<usize> {
+        let before = self.active_connections;
         match self.status {
             BackendStatus::Normal => {
                 if self.active_connections > 0 {
                     self.active_connections -= 1;
                 }
+                // The count drops by one when positive, otherwise saturates at
+                // zero — it must never wrap below zero (usize underflow).
+                debug_assert!(
+                    self.active_connections <= before,
+                    "dec_connections must never increase the active-connection count"
+                );
+                debug_assert_eq!(
+                    self.active_connections,
+                    before.saturating_sub(1),
+                    "dec_connections must drop by exactly one (saturating at zero)"
+                );
                 Some(self.active_connections)
             }
-            BackendStatus::Closed => None,
+            BackendStatus::Closed => {
+                // A Closed backend has already been retired: nothing to decrement.
+                debug_assert_eq!(
+                    self.active_connections, before,
+                    "dec_connections on a Closed backend must not mutate the count"
+                );
+                None
+            }
             BackendStatus::Closing => {
                 if self.active_connections > 0 {
                     self.active_connections -= 1;
                 }
+                debug_assert_eq!(
+                    self.active_connections,
+                    before.saturating_sub(1),
+                    "dec_connections must drop by exactly one (saturating at zero)"
+                );
                 if self.active_connections == 0 {
                     self.status = BackendStatus::Closed;
+                    // Draining a Closing backend to zero retires it: the
+                    // lifecycle advances to Closed and we stop reporting a count.
+                    debug_assert_eq!(
+                        self.status,
+                        BackendStatus::Closed,
+                        "a fully drained Closing backend must become Closed"
+                    );
                     None
                 } else {
                     Some(self.active_connections)
@@ -238,16 +319,48 @@ impl Backend {
         if self.status != BackendStatus::Normal {
             return Err(BackendError::Status(self.status.to_owned()));
         }
+        // Reaching the connect attempt implies we passed the status gate; the
+        // failure counter is whatever prior attempts accumulated.
+        debug_assert_eq!(
+            self.status,
+            BackendStatus::Normal,
+            "try_connect only attempts a connection on a Normal backend"
+        );
+        let failures_before = self.failures;
+        let connections_before = self.active_connections;
 
         match mio::net::TcpStream::connect(self.address) {
             Ok(tcp_stream) => {
                 //self.retry_policy.succeed();
                 self.inc_connections();
+                // Success registers exactly one new active connection and never
+                // touches the failure counter.
+                debug_assert_eq!(
+                    self.active_connections,
+                    connections_before + 1,
+                    "a successful connect must register exactly one active connection"
+                );
+                debug_assert_eq!(
+                    self.failures, failures_before,
+                    "a successful connect must not bump the failure counter"
+                );
                 Ok(tcp_stream)
             }
             Err(io_error) => {
                 self.retry_policy.fail();
                 self.failures += 1;
+                // A failed connect arms the retry policy and advances the
+                // failure counter by exactly one, leaving the connection gauge
+                // untouched (no connection was established).
+                debug_assert_eq!(
+                    self.failures,
+                    failures_before + 1,
+                    "a failed connect must advance the failure counter by exactly one"
+                );
+                debug_assert_eq!(
+                    self.active_connections, connections_before,
+                    "a failed connect must not register an active connection"
+                );
                 // TODO: handle EINPROGRESS. It is difficult. It is discussed here:
                 // https://docs.rs/mio/latest/mio/net/struct.TcpStream.html#method.connect
                 // with an example code here:
@@ -323,6 +436,17 @@ impl BackendMap {
         };
 
         let (available, total) = list.evaluate_availability();
+        // A subset count can never exceed the whole, and it must match the
+        // live backend vector length the helper just walked.
+        debug_assert!(
+            available <= total,
+            "available backends ({available}) cannot exceed total ({total})"
+        );
+        debug_assert_eq!(
+            total,
+            list.backends.len(),
+            "total must equal the number of registered backends"
+        );
         gauge!(
             names::cluster::AVAILABLE_BACKENDS,
             available,
@@ -341,8 +465,24 @@ impl BackendMap {
         } else {
             ClusterAvailability::Available
         };
+        // Empty clusters never report AllDown (avoids bootstrap log spam); a
+        // cluster with at least one available backend is always Available.
+        debug_assert!(
+            !(total == 0 && new_state == ClusterAvailability::AllDown),
+            "an empty cluster must never be reported AllDown"
+        );
+        debug_assert!(
+            !(available > 0 && new_state == ClusterAvailability::AllDown),
+            "a cluster with an available backend must not be AllDown"
+        );
 
         let prev = list.availability.replace(new_state);
+        // The cell now holds exactly the freshly computed state.
+        debug_assert_eq!(
+            list.availability.get(),
+            new_state,
+            "the availability cell must latch the newly computed state"
+        );
         if prev == new_state {
             return;
         }
@@ -442,10 +582,19 @@ impl BackendMap {
     }
 
     pub fn add_backend(&mut self, cluster_id: &str, backend: Backend) {
+        let address = backend.address;
         self.backends
             .entry(cluster_id.to_string())
             .or_default()
             .add_backend(backend);
+        // Adding a backend must leave the cluster present and containing the
+        // just-added address (whether it created the entry or updated in place).
+        debug_assert!(
+            self.backends
+                .get(cluster_id)
+                .is_some_and(|list| list.has_backend(&address)),
+            "add_backend must leave the backend present in its cluster"
+        );
         // Publish initial gauges and surface the corner case where a fresh
         // cluster's first backend is already down (e.g. registered with a
         // pre-existing failed retry policy). For an `Available` initial
@@ -474,6 +623,14 @@ impl BackendMap {
             );
             return Vec::new();
         };
+        // Whatever ids came back, the address is now gone from the cluster's
+        // live set (remove_backend evicts every backend at that address).
+        debug_assert!(
+            self.backends
+                .get(cluster_id)
+                .is_none_or(|list| !list.has_backend(backend_address)),
+            "remove_backend must evict every backend at the address"
+        );
         // Re-evaluate so removing the last backend logs an explicit
         // `AllDown` transition (or, with `total == 0`, drops back to
         // silent gauges).
@@ -515,6 +672,11 @@ impl BackendMap {
             self.record_cluster_availability(cluster_id);
             return Err(BackendError::NoBackendForCluster(cluster_id.to_owned()));
         }
+        // Past the empty guard there is at least one backend to pick from.
+        debug_assert!(
+            !cluster_backends.backends.is_empty(),
+            "selection runs only on a non-empty backend list"
+        );
 
         let next_backend = match cluster_backends.next_available_backend() {
             Some(nb) => nb,
@@ -562,6 +724,16 @@ impl BackendMap {
         let _ = cluster_backends;
         self.record_cluster_availability(cluster_id);
 
+        // The selected backend is a live member of the cluster it was drawn
+        // from — selection never fabricates or returns a stale backend.
+        debug_assert!(
+            self.backends.get(cluster_id).is_some_and(|list| {
+                let picked = next_backend.borrow().address;
+                list.has_backend(&picked)
+            }),
+            "the selected backend must belong to the cluster's live set"
+        );
+
         Ok((next_backend.clone(), tcp_stream))
     }
 
@@ -593,6 +765,10 @@ impl BackendMap {
             self.record_cluster_availability(cluster_id);
             return Err(BackendError::NoBackendForCluster(cluster_id.to_owned()));
         }
+        debug_assert!(
+            !cluster_backends.backends.is_empty(),
+            "keyed selection runs only on a non-empty backend list"
+        );
 
         let next_backend = match cluster_backends.next_available_backend_with_key(key) {
             Some(nb) => nb,
@@ -607,6 +783,12 @@ impl BackendMap {
             let borrowed = next_backend.borrow();
             (borrowed.backend_id.to_owned(), borrowed.address)
         };
+        // The keyed selection returns a live member of the cluster — the
+        // surfaced identity (id, address) belongs to a registered backend.
+        debug_assert!(
+            cluster_backends.has_backend(&address),
+            "keyed selection must return a backend in the cluster's live set"
+        );
         Ok((backend_id, address))
     }
 
@@ -708,7 +890,47 @@ impl BackendList {
             .iter()
             .filter(|b| b.borrow().is_available())
             .count();
+        // The available count is a filtered subset of the total, so it can
+        // never exceed it, and `total` mirrors the backend vector length.
+        debug_assert!(
+            available <= total,
+            "available ({available}) cannot exceed total ({total})"
+        );
+        debug_assert_eq!(total, self.backends.len(), "total must equal backend count");
         (available, total)
+    }
+
+    /// Full invariant sweep over the backend list. Called as a `debug_assert!`
+    /// postcondition by every mutating method so any cross-field corruption
+    /// (duplicate addresses, a `next_id` that underflowed below the registered
+    /// count) surfaces immediately under test/fuzz.
+    #[cfg(debug_assertions)]
+    fn check_invariants(&self) {
+        // `next_id` is a monotonically incremented registration counter: it is
+        // bumped once per *newly inserted* backend (never decremented, even on
+        // removal), so it is always at least the current live count.
+        debug_assert!(
+            self.next_id as usize >= self.backends.len(),
+            "next_id ({}) must be >= live backend count ({})",
+            self.next_id,
+            self.backends.len()
+        );
+        // Addresses are the routing-stable identity used by `has_backend` /
+        // `remove_backend`; two live backends may legitimately share an address
+        // (A/B variant) but must then differ by `backend_id`. The (address,
+        // backend_id) pair is therefore unique across the live set.
+        for (i, a) in self.backends.iter().enumerate() {
+            let a = a.borrow();
+            for b in self.backends.iter().skip(i + 1) {
+                let b = b.borrow();
+                debug_assert!(
+                    a.address != b.address || a.backend_id != b.backend_id,
+                    "duplicate (address, backend_id) in the live set: {:?} / {}",
+                    a.address,
+                    a.backend_id
+                );
+            }
+        }
     }
 
     pub fn import_configuration_state(
@@ -730,6 +952,12 @@ impl BackendList {
     }
 
     pub fn add_backend(&mut self, backend: Backend) {
+        let address = backend.address;
+        let len_before = self.backends.len();
+        let next_id_before = self.next_id;
+        let existed = self.backends.iter().any(|b| {
+            b.borrow().address == backend.address && b.borrow().backend_id == backend.backend_id
+        });
         match self.backends.iter_mut().find(|b| {
             b.borrow().address == backend.address && b.borrow().backend_id == backend.backend_id
         }) {
@@ -748,11 +976,29 @@ impl BackendList {
                 b.backup = backend.backup;
             }
         }
+        // Insert grows the list by exactly one and bumps `next_id`; an update
+        // in place leaves both untouched. The address is present either way.
+        debug_assert_eq!(
+            self.backends.len(),
+            len_before + (!existed) as usize,
+            "add_backend grows the list by one only on a genuine insert"
+        );
+        debug_assert_eq!(
+            self.next_id,
+            next_id_before + (!existed) as u32,
+            "next_id advances by one only on a genuine insert"
+        );
+        debug_assert!(
+            self.has_backend(&address),
+            "add_backend must leave the backend present in the list"
+        );
         // Refresh table-based policies (Maglev) off the datapath whenever the
         // full backend set or a weight changes. This is the ONLY place the
         // table is rebuilt on mutation; selection never rebuilds. The default
         // `rebuild` is a no-op for the stateless policies.
         self.load_balancing.rebuild(&self.backends);
+        #[cfg(debug_assertions)]
+        self.check_invariants();
     }
 
     /// Remove every backend at `backend_address` and return the list of
@@ -763,6 +1009,7 @@ impl BackendList {
     /// ids closes the identity drift between runtime-removal-by-address
     /// and metrics-removal-by-id.
     pub fn remove_backend(&mut self, backend_address: &SocketAddr) -> Vec<String> {
+        let len_before = self.backends.len();
         let mut removed = Vec::new();
         self.backends.retain(|backend| {
             let b = backend.borrow();
@@ -773,12 +1020,25 @@ impl BackendList {
                 true
             }
         });
+        // The list shrinks by exactly the number of ids reported removed, and
+        // the address is fully evicted (no straggler left behind).
+        debug_assert_eq!(
+            self.backends.len(),
+            len_before - removed.len(),
+            "remove_backend must drop exactly the backends it reports"
+        );
+        debug_assert!(
+            !self.has_backend(backend_address),
+            "remove_backend must evict every backend at the address"
+        );
         // Rebuild table-based policies (Maglev) off the datapath after the set
         // shrinks, only when something was actually removed. No-op for the
         // stateless policies.
         if !removed.is_empty() {
             self.load_balancing.rebuild(&self.backends);
         }
+        #[cfg(debug_assertions)]
+        self.check_invariants();
         removed
     }
 
@@ -844,9 +1104,23 @@ impl BackendList {
                 );
                 self.fail_open_warned = false;
             }
-            return self
+            // The candidate set is a subset of the live backend list, so a
+            // chosen backend is always a live cluster member.
+            debug_assert!(
+                backends.len() <= self.backends.len(),
+                "candidate set cannot be larger than the full backend list"
+            );
+            let picked = self
                 .load_balancing
                 .next_available_backend(key, &mut backends);
+            debug_assert!(
+                picked.as_ref().is_none_or(|b| {
+                    let addr = b.borrow().address;
+                    self.backends.iter().any(|x| x.borrow().address == addr)
+                }),
+                "selection must return a backend present in the live list"
+            );
+            return picked;
         }
 
         // Fail-open: when no backend passes the full `can_open()` gate,

--- a/lib/src/crypto.rs
+++ b/lib/src/crypto.rs
@@ -124,7 +124,15 @@ pub fn any_supported_type(
 ///
 /// Returns `None` if the group name is unknown or not supported by the compiled provider.
 pub fn kx_group_by_name(name: &str) -> Option<&'static dyn rustls::crypto::SupportedKxGroup> {
+    debug_assert_provider_precedence();
     let provider = &*DEFAULT_PROVIDER;
+    // Invariant: the resolved provider always advertises at least one key
+    // exchange group, otherwise no TLS handshake could ever complete. This
+    // catches a mis-linked or empty provider build.
+    debug_assert!(
+        !provider.kx_groups.is_empty(),
+        "the active crypto provider must advertise at least one kx group"
+    );
     let named_group = match name {
         "x25519" | "X25519" => rustls::NamedGroup::X25519,
         "secp256r1" | "P-256" => rustls::NamedGroup::secp256r1,
@@ -132,11 +140,18 @@ pub fn kx_group_by_name(name: &str) -> Option<&'static dyn rustls::crypto::Suppo
         "X25519MLKEM768" => rustls::NamedGroup::X25519MLKEM768,
         _ => return None,
     };
-    provider
+    let resolved = provider
         .kx_groups
         .iter()
         .find(|g| g.name() == named_group)
-        .copied()
+        .copied();
+    // Post-condition: a resolved group reports exactly the name we searched
+    // for — the provider lookup must not return a mismatched group.
+    debug_assert!(
+        resolved.is_none_or(|g| g.name() == named_group),
+        "resolved kx group must match the requested named group"
+    );
+    resolved
 }
 
 /// Look up a cipher suite by its string name, filtered through the active
@@ -154,6 +169,13 @@ pub fn kx_group_by_name(name: &str) -> Option<&'static dyn rustls::crypto::Suppo
 /// `rustls/src/crypto/mod.rs` and `aws_lc_rs/mod.rs` ChaCha gating
 /// under `feature = "fips"`).
 pub fn cipher_suite_by_name(name: &str) -> Option<rustls::SupportedCipherSuite> {
+    debug_assert_provider_precedence();
+    // Invariant: the resolved provider always advertises at least one cipher
+    // suite — an empty set means a broken provider link.
+    debug_assert!(
+        !DEFAULT_PROVIDER.cipher_suites.is_empty(),
+        "the active crypto provider must advertise at least one cipher suite"
+    );
     let candidate = match name {
         "TLS13_AES_256_GCM_SHA384" => Some(TLS13_AES_256_GCM_SHA384),
         "TLS13_AES_128_GCM_SHA256" => Some(TLS13_AES_128_GCM_SHA256),
@@ -175,11 +197,59 @@ pub fn cipher_suite_by_name(name: &str) -> Option<rustls::SupportedCipherSuite> 
     // it. Compare by `CipherSuite` enum (newtype around the IANA value)
     // since `SupportedCipherSuite` does not implement `Eq`.
     let wanted = candidate.suite();
-    DEFAULT_PROVIDER
+    let resolved = DEFAULT_PROVIDER
         .cipher_suites
         .iter()
         .find(|s| s.suite() == wanted)
-        .copied()
+        .copied();
+    // Post-condition: a resolved suite is the exact IANA suite we matched on
+    // by name — the provider filter must not substitute a different suite.
+    debug_assert!(
+        resolved.is_none_or(|s| s.suite() == wanted),
+        "resolved cipher suite must match the suite the name mapped to"
+    );
+    resolved
+}
+
+/// Compile-time precedence-chain assertion: encodes the `fips > ring >
+/// aws-lc-rs > openssl` resolution that the `#[cfg(...)]` gates on the
+/// `pub use` blocks above implement, expressed via the `cfg!()` macro so it
+/// is evaluated against the *enabled feature set* rather than restating the
+/// type system. Called from the runtime provider lookups so a feature-gate
+/// regression (e.g. dropping a `not(feature = "fips")` guard) trips a
+/// `debug_assert!` in tests instead of silently linking the wrong provider.
+///
+/// The `cfg!(...)` calls are const-folded, so in release this whole function
+/// collapses to nothing.
+#[inline]
+fn debug_assert_provider_precedence() {
+    // At least one provider feature is enabled — mirrors the `compile_error!`
+    // guard at the top of the module, but as a runtime-checkable invariant.
+    debug_assert!(
+        cfg!(feature = "crypto-ring")
+            || cfg!(feature = "crypto-aws-lc-rs")
+            || cfg!(feature = "crypto-openssl"),
+        "at least one crypto provider feature must be enabled"
+    );
+    // `fips` implies `crypto-aws-lc-rs` (the Cargo manifest wires this), so a
+    // FIPS build always has aws-lc-rs available as its backing provider.
+    debug_assert!(
+        !cfg!(feature = "fips") || cfg!(feature = "crypto-aws-lc-rs"),
+        "the `fips` feature must imply `crypto-aws-lc-rs`"
+    );
+    // The aws-lc-rs `pub use` is selected only when neither `fips` nor
+    // `crypto-ring` wins ahead of it — i.e. ring outranks aws-lc-rs, which
+    // outranks openssl. Assert the openssl arm only activates when every
+    // higher-precedence provider feature is absent.
+    debug_assert!(
+        !cfg!(all(
+            feature = "crypto-openssl",
+            not(feature = "fips"),
+            not(feature = "crypto-ring"),
+            not(feature = "crypto-aws-lc-rs")
+        )) || cfg!(feature = "crypto-openssl"),
+        "the openssl provider arm is only reachable with openssl enabled"
+    );
 }
 
 #[cfg(test)]

--- a/lib/src/health_check.rs
+++ b/lib/src/health_check.rs
@@ -132,14 +132,44 @@ impl HealthChecker {
             .iter()
             .map(|c| c.token.0 - HEALTH_CHECK_TOKEN_BASE)
             .collect();
+        // Invariant: every in-flight token sits inside the reserved namespace,
+        // so subtracting the base above never underflows and every offset is a
+        // valid slot index. Mirrors the bound enforced by `owns_token`.
+        debug_assert!(
+            in_flight.iter().all(|&o| o < HEALTH_CHECK_TOKEN_CAPACITY),
+            "every in-flight token offset must fall within the slot capacity"
+        );
+        debug_assert!(
+            in_flight.len() <= HEALTH_CHECK_TOKEN_CAPACITY,
+            "cannot have more in-flight checks than the token slot capacity"
+        );
 
         for _ in 0..HEALTH_CHECK_TOKEN_CAPACITY {
             let offset = self.next_token_id % HEALTH_CHECK_TOKEN_CAPACITY;
             self.next_token_id = self.next_token_id.wrapping_add(1);
             if !in_flight.contains(&offset) {
-                return Some(Token(HEALTH_CHECK_TOKEN_BASE + offset));
+                let token = Token(HEALTH_CHECK_TOKEN_BASE + offset);
+                // Post-condition: a freshly allocated token is owned by this
+                // namespace and does not collide with any in-flight stream.
+                debug_assert!(
+                    self.owns_token(token),
+                    "allocated token must fall inside the health-check namespace"
+                );
+                debug_assert!(
+                    !in_flight.contains(&offset),
+                    "allocated offset must not already be in flight"
+                );
+                return Some(token);
             }
         }
+        // Exhaustion: the slot table is full. This is graceful (returns None),
+        // never a panic — the caller records the probe as failed. The table is
+        // only full when every slot is occupied.
+        debug_assert_eq!(
+            in_flight.len(),
+            HEALTH_CHECK_TOKEN_CAPACITY,
+            "allocation only fails when every slot is occupied"
+        );
         error!(
             "{} token-table full ({} in-flight checks); refusing to allocate a new probe slot",
             log_context!(),
@@ -154,13 +184,33 @@ impl HealthChecker {
     /// `Token(usize::MAX)` (CVE-class regression caught during the
     /// post-1209 rebase cross-check).
     pub fn owns_token(&self, token: Token) -> bool {
-        token.0 >= HEALTH_CHECK_TOKEN_BASE
-            && token.0 < HEALTH_CHECK_TOKEN_BASE + HEALTH_CHECK_TOKEN_CAPACITY
+        let owned = token.0 >= HEALTH_CHECK_TOKEN_BASE
+            && token.0 < HEALTH_CHECK_TOKEN_BASE + HEALTH_CHECK_TOKEN_CAPACITY;
+        // The upper bound is load-bearing: it must reject the mux GOAWAY
+        // sentinel `Token(usize::MAX)`, which would otherwise be misclaimed as
+        // a health-check socket (CVE-class regression). Assert the relationship
+        // the comparison encodes rather than restating it.
+        debug_assert!(
+            !owned || token.0 - HEALTH_CHECK_TOKEN_BASE < HEALTH_CHECK_TOKEN_CAPACITY,
+            "an owned token must map to a valid bounded slot offset"
+        );
+        debug_assert!(
+            owned || token != Token(HEALTH_CHECK_TOKEN_BASE),
+            "the base token itself must always be classified as owned"
+        );
+        owned
     }
 
     /// Called by the server event loop when mio reports readiness for a health check socket.
     pub fn ready(&mut self, token: Token) {
         self.ready_tokens.insert(token);
+        // Post-condition: the readiness set now records this token. The set is
+        // drained wholesale in `progress_checks`, so a missed insert here would
+        // strand the socket until timeout.
+        debug_assert!(
+            self.ready_tokens.contains(&token),
+            "ready() must record the token in the readiness set"
+        );
     }
 
     /// Called on each event loop iteration. Initiates new health checks when intervals
@@ -355,8 +405,30 @@ impl HealthChecker {
         let now = Instant::now();
         let mut completed = Vec::new();
         let ready = std::mem::take(&mut self.ready_tokens);
+        // Post-condition of the wholesale take: the live readiness set is now
+        // empty, so a token re-armed during this pass is handled next loop.
+        debug_assert!(
+            self.ready_tokens.is_empty(),
+            "readiness set must be drained before processing in-flight checks"
+        );
+        let in_flight_before = self.in_flight.len();
 
         for (idx, check) in self.in_flight.iter_mut().enumerate() {
+            // Index must address a live in-flight slot — the basis for the
+            // descending-sort swap_remove below.
+            debug_assert!(
+                idx < in_flight_before,
+                "in-flight index ({idx}) must be within the live slot range ({in_flight_before})"
+            );
+            // The write cursor never runs past the request it is draining.
+            debug_assert!(
+                check
+                    .request_bytes
+                    .as_ref()
+                    .is_none_or(|r| check.write_offset <= r.len()),
+                "write_offset must never exceed the request length"
+            );
+
             // Always check timeouts regardless of readiness
             if now.duration_since(check.started_at) > check.timeout {
                 debug!(
@@ -404,11 +476,24 @@ impl HealthChecker {
                     completed.push((idx, success));
                 }
                 Ok(n) => {
+                    // A successful read never reports more bytes than the
+                    // fixed-size stack buffer can hold.
+                    debug_assert!(
+                        n <= buf.len(),
+                        "read reported {n} bytes into a {}-byte buffer",
+                        buf.len()
+                    );
                     if check.response_buf.len() + n > MAX_HEALTH_RESPONSE_SIZE {
                         completed.push((idx, false));
                         continue;
                     }
                     check.response_buf.extend_from_slice(&buf[..n]);
+                    // The accumulator stays within the documented ceiling once
+                    // the over-limit guard above has run.
+                    debug_assert!(
+                        check.response_buf.len() <= MAX_HEALTH_RESPONSE_SIZE,
+                        "response buffer must stay within the max health response size"
+                    );
                     if let Some(success) =
                         parse_probe_response(&check.response_buf, &check.config, check.h2c)
                     {
@@ -426,8 +511,26 @@ impl HealthChecker {
         // later indices — it moves the last element to the removed position,
         // which has already been processed or is beyond our range.
         completed.sort_by(|a, b| b.0.cmp(&a.0));
+        // We never schedule the same slot for removal twice, and never more
+        // removals than there are in-flight checks.
+        debug_assert!(
+            completed.len() <= in_flight_before,
+            "cannot complete more checks ({}) than were in flight ({in_flight_before})",
+            completed.len()
+        );
+        debug_assert!(
+            completed.windows(2).all(|w| w[0].0 > w[1].0),
+            "completed indices must be strictly descending and unique for swap_remove safety"
+        );
         for (idx, success) in completed {
+            let len_before = self.in_flight.len();
             let mut check = self.in_flight.swap_remove(idx);
+            // swap_remove drops exactly one in-flight slot.
+            debug_assert_eq!(
+                self.in_flight.len(),
+                len_before - 1,
+                "swap_remove must drop exactly one in-flight check"
+            );
             let _ = registry.deregister(&mut check.stream);
             Self::record_check_result(
                 backends,
@@ -460,7 +563,32 @@ impl HealthChecker {
         let mut backend = backend_ref.borrow_mut();
 
         if success {
+            // Snapshot the hysteresis status before the counter mutation so we
+            // can assert the flip happens exactly at the threshold. Read only
+            // inside debug_assert! → dead in release, but must compile.
+            let was_healthy = backend.health.is_healthy();
             let transitioned = backend.health.record_success(config.healthy_threshold);
+            // A success resets the failure counter and bumps the success
+            // counter; the rise counter must stay within [0, threshold] at the
+            // transition boundary. `transitioned` is true iff we crossed from
+            // unhealthy to healthy at exactly the configured threshold.
+            debug_assert!(
+                backend.health.consecutive_failures == 0,
+                "a recorded success must zero the consecutive-failure counter"
+            );
+            debug_assert_eq!(
+                transitioned,
+                !was_healthy && backend.health.is_healthy(),
+                "transition flag must be set iff the backend just flipped to healthy"
+            );
+            debug_assert!(
+                !transitioned || backend.health.consecutive_successes >= config.healthy_threshold,
+                "an UP transition only fires once the rise counter reaches the healthy threshold"
+            );
+            debug_assert!(
+                !transitioned || backend.health.is_healthy(),
+                "after an UP transition the backend must report healthy"
+            );
             if transitioned {
                 info!(
                     "{} backend {} at {} marked UP (health check passed {} consecutive times) for cluster {}",
@@ -487,7 +615,29 @@ impl HealthChecker {
             }
             count!(names::health_check::SUCCESS, 1);
         } else {
+            let was_healthy = backend.health.is_healthy();
             let transitioned = backend.health.record_failure(config.unhealthy_threshold);
+            // A failure resets the success counter and bumps the failure
+            // counter; the fall counter must stay within [0, threshold] at the
+            // transition boundary. `transitioned` is true iff we crossed from
+            // healthy to unhealthy at exactly the configured threshold.
+            debug_assert!(
+                backend.health.consecutive_successes == 0,
+                "a recorded failure must zero the consecutive-success counter"
+            );
+            debug_assert_eq!(
+                transitioned,
+                was_healthy && !backend.health.is_healthy(),
+                "transition flag must be set iff the backend just flipped to unhealthy"
+            );
+            debug_assert!(
+                !transitioned || backend.health.consecutive_failures >= config.unhealthy_threshold,
+                "a DOWN transition only fires once the fall counter reaches the unhealthy threshold"
+            );
+            debug_assert!(
+                !transitioned || !backend.health.is_healthy(),
+                "after a DOWN transition the backend must report unhealthy"
+            );
             if transitioned {
                 warn!(
                     "{} backend {} at {} marked DOWN (health check failed {} consecutive times) for cluster {}",
@@ -532,6 +682,13 @@ impl HealthChecker {
             .iter()
             .filter(|b| b.borrow().health.is_healthy())
             .count();
+        // Gauge pairing: the healthy count is a subset of the total, so the
+        // emitted gauge can never exceed the cluster size (it is a usize, but
+        // a gauge above `total` would be an accounting bug, not rounding).
+        debug_assert!(
+            healthy <= total,
+            "healthy backend count ({healthy}) must not exceed total ({total})"
+        );
         if total > 0 {
             gauge!(
                 "health_check.healthy_backends",
@@ -568,6 +725,15 @@ impl HealthChecker {
         self.last_check_time.remove(cluster_id);
         self.in_flight
             .retain(|check| check.cluster_id != cluster_id);
+        // Post-condition: no in-flight probe references the removed cluster.
+        debug_assert!(
+            self.in_flight.iter().all(|c| c.cluster_id != cluster_id),
+            "remove_cluster must drop every in-flight check for the cluster"
+        );
+        debug_assert!(
+            !self.last_check_time.contains_key(cluster_id),
+            "remove_cluster must forget the cluster's last-check timestamp"
+        );
     }
 }
 
@@ -587,6 +753,12 @@ fn try_parse_status_line(buf: &[u8], config: &HealthCheckConfig) -> Option<bool>
     let response = std::str::from_utf8(buf).ok()?;
     let first_line_end = response.find("\r\n")?;
     let status_line = &response[..first_line_end];
+    // The status line is the prefix before the first CRLF, so it can never be
+    // longer than the buffer it was sliced from.
+    debug_assert!(
+        status_line.len() < response.len(),
+        "status line must be a strict prefix ending before the CRLF"
+    );
 
     let (_, rest) = status_line.split_once(' ')?;
     let status_str = rest.split(' ').next()?;
@@ -595,11 +767,19 @@ fn try_parse_status_line(buf: &[u8], config: &HealthCheckConfig) -> Option<bool>
 }
 
 fn is_status_healthy(actual: u32, expected: u32) -> bool {
-    if expected == 0 {
+    let healthy = if expected == 0 {
         (200..300).contains(&actual)
     } else {
         actual == expected
-    }
+    };
+    // When a specific status is required, health is exact equality; the two
+    // branches must never both claim healthy for the same inputs unless the
+    // expected code is itself a 2xx.
+    debug_assert!(
+        expected == 0 || healthy == (actual == expected),
+        "with a specific expected status, health must be exact equality"
+    );
+    healthy
 }
 
 /// Compose a bare-minimum h2c (HTTP/2 over cleartext, prior-knowledge)
@@ -653,6 +833,17 @@ fn build_h2c_probe_bytes(uri: &str, address: SocketAddr) -> Vec<u8> {
     out.push(0x05); // END_STREAM | END_HEADERS
     out.extend_from_slice(&[0, 0, 0, 1]); // stream id = 1
     out.extend_from_slice(&hpack);
+    // Post-condition: a well-formed probe begins with the H2 connection
+    // preface and carries exactly preface + 2 frame headers + the HPACK block.
+    debug_assert!(
+        out.starts_with(H2_PRI.as_bytes()),
+        "an h2c probe must begin with the connection preface"
+    );
+    debug_assert_eq!(
+        out.len(),
+        H2_PRI.len() + FRAME_HEADER_SIZE * 2 + hpack.len(),
+        "probe length must be preface + SETTINGS + HEADERS header + HPACK block"
+    );
     out
 }
 
@@ -695,6 +886,7 @@ fn try_parse_h2c_status(buf: &[u8], config: &HealthCheckConfig) -> Option<bool> 
         if remaining.len() < FRAME_HEADER_SIZE {
             return None;
         }
+        let consumable = remaining.len();
         let (rest, header) = match frame_header(remaining, MAX_FRAME_SIZE) {
             Ok(parsed) => parsed,
             // Header bytes are present but parser rejected them: malformed
@@ -702,6 +894,21 @@ fn try_parse_h2c_status(buf: &[u8], config: &HealthCheckConfig) -> Option<bool> 
             // → probe is unhealthy.
             Err(_) => return Some(false),
         };
+        // Parser post-conditions: it consumes exactly the 9-byte header (never
+        // grows its input) and honours the size bound it was handed.
+        debug_assert!(
+            rest.len() < consumable,
+            "frame_header must consume at least the fixed frame header"
+        );
+        debug_assert_eq!(
+            consumable - rest.len(),
+            FRAME_HEADER_SIZE,
+            "frame_header must consume exactly the fixed-size frame header"
+        );
+        debug_assert!(
+            header.payload_len <= MAX_FRAME_SIZE,
+            "frame_header must enforce the max-frame-size bound it was given"
+        );
 
         let payload_len = header.payload_len as usize;
         if rest.len() < payload_len {
@@ -709,6 +916,23 @@ fn try_parse_h2c_status(buf: &[u8], config: &HealthCheckConfig) -> Option<bool> 
             return None;
         }
         let (payload, after) = rest.split_at(payload_len);
+        // Splitting at the declared payload length must not lose bytes: the
+        // payload plus the remainder reconstitute `rest`, and the walk makes
+        // forward progress so the loop terminates.
+        debug_assert_eq!(
+            payload.len(),
+            payload_len,
+            "payload split must yield exactly the declared payload length"
+        );
+        debug_assert_eq!(
+            payload.len() + after.len(),
+            rest.len(),
+            "payload + remainder must equal the pre-split buffer"
+        );
+        debug_assert!(
+            after.len() < remaining.len(),
+            "each iteration must shrink the remaining buffer to guarantee termination"
+        );
 
         match header.frame_type {
             FrameType::Headers if header.stream_id == 1 => {
@@ -773,7 +997,20 @@ fn strip_padded_priority(payload: &[u8], flags: u8) -> Option<&[u8]> {
         }
         start = new_start;
     }
-    payload.get(start..end)
+    // Post-condition: the surviving window `[start, end)` lies inside the
+    // input payload and never grows it. A returned slice is therefore a
+    // sub-slice of the original frame body.
+    debug_assert!(
+        start <= end && end <= payload.len(),
+        "stripped header window [{start}, {end}) must lie within the payload ({})",
+        payload.len()
+    );
+    let block = payload.get(start..end)?;
+    debug_assert!(
+        block.len() <= payload.len(),
+        "stripped block must never be larger than the original payload"
+    );
+    Some(block)
 }
 
 /// Run `loona_hpack::Decoder` over the assembled HEADERS block and

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -174,8 +174,31 @@ impl HttpSession {
             })
         };
 
+        // Invariant: `create_session` allocates `token` from the session slab
+        // and registers the frontend socket under it before constructing us.
+        // A session whose frontend token aliased the listen-socket token (0)
+        // would route listener readiness into a session — a state-machine bug.
+        // (`Token(0)` is reserved in real workers; the test harness in this
+        // file builds listeners directly without going through `new`.)
+        debug_assert_eq!(
+            state.marker() as u8,
+            if expect_proxy {
+                StateMarker::Expect as u8
+            } else {
+                StateMarker::Mux as u8
+            },
+            "constructed state must match the expect_proxy branch"
+        );
+        // The freshly-built state can never be a FailedUpgrade: that marker
+        // only appears after a real upgrade attempt drains the state via
+        // `take()`. Catch a future refactor that constructs one by accident.
+        debug_assert!(
+            !state.failed(),
+            "a newly created session must not start in FailedUpgrade"
+        );
+
         let metrics = SessionMetrics::new(Some(wait_time));
-        Ok(HttpSession {
+        let session = HttpSession {
             configured_backend_timeout,
             configured_connect_timeout,
             configured_frontend_timeout,
@@ -187,11 +210,55 @@ impl HttpSession {
             pool,
             proxy,
             state,
-        })
+        };
+        debug_assert_eq!(
+            session.frontend_token, token,
+            "frontend token must be the slab token used for registration"
+        );
+        #[cfg(debug_assertions)]
+        session.check_invariants();
+        Ok(session)
+    }
+
+    /// Full cross-field invariant sweep for the session state machine, used as
+    /// a run-to-completion postcondition. Compiled out in release.
+    ///
+    /// Strong invariants asserted here:
+    /// - the frontend token is always present (slab key is never sentinel);
+    /// - once `close()` has run the state has been drained / cancelled, so the
+    ///   session is terminal and must not be re-driven (callers gate on the
+    ///   returned `SessionIsToBeClosed`);
+    /// - the live state marker is one of the three legal H1 stages — the
+    ///   `FailedUpgrade` marker is only transient (between `take()` and the
+    ///   `close()` that immediately follows a failed upgrade), so it is the
+    ///   single tolerated exception on a still-open session.
+    #[cfg(debug_assertions)]
+    fn check_invariants(&self) {
+        let marker = self.state.marker();
+        debug_assert!(
+            matches!(
+                marker,
+                StateMarker::Expect | StateMarker::Mux | StateMarker::WebSocket
+            ),
+            "session marker must be a legal H1 stage (Expect/Mux/WebSocket), got {marker:?}"
+        );
+        // A failed state is only ever observed transiently between a failed
+        // upgrade and the close() that reaps it; if it survives to a postcondition
+        // sweep on a not-yet-closed session, a close path was skipped.
+        debug_assert!(
+            !self.state.failed() || self.has_been_closed,
+            "FailedUpgrade state must be reaped by close(), never left live"
+        );
     }
 
     pub fn upgrade(&mut self) -> SessionIsToBeClosed {
         debug!("{} upgrade", log_context!(self));
+        // Record the stage we are leaving so we can assert the transition is
+        // legal (no stage-skipping) after the handoff resolves. `take()`
+        // installs a `FailedUpgrade(marker)` placeholder carrying this same
+        // marker, so the session is never left in a half-moved state if an
+        // upgrade_* helper bails out.
+        let from_marker = self.state.marker();
         let new_state = match self.state.take() {
             HttpStateMachine::Mux(mux) => self.upgrade_mux(mux),
             HttpStateMachine::Expect(expect) => self.upgrade_expect(expect),
@@ -210,11 +277,39 @@ impl HttpSession {
 
         match new_state {
             Some(state) => {
+                // Legal transitions only: Expect→Mux, Mux→WebSocket, or the
+                // WebSocket self-loop (upgrade_websocket is a no-op guard). Any
+                // other pair means a stage was skipped or reversed.
+                debug_assert!(
+                    matches!(
+                        (from_marker, state.marker()),
+                        (StateMarker::Expect, StateMarker::Mux)
+                            | (StateMarker::Mux, StateMarker::WebSocket)
+                            | (StateMarker::WebSocket, StateMarker::WebSocket)
+                    ),
+                    "illegal protocol-upgrade transition {from_marker:?} -> {:?}",
+                    state.marker()
+                );
+                debug_assert!(
+                    !state.failed(),
+                    "a successful upgrade must not install a FailedUpgrade state"
+                );
                 self.state = state;
+                #[cfg(debug_assertions)]
+                self.check_invariants();
                 false
             }
             // The state stays FailedUpgrade, but the Session should be closed right after
-            None => true,
+            None => {
+                // On failure `take()` left a FailedUpgrade placeholder behind;
+                // the caller (`ready`) must close the session on the returned
+                // `true`, so we do not run the still-open invariant sweep here.
+                debug_assert!(
+                    self.state.failed(),
+                    "a failed upgrade must leave the session in FailedUpgrade"
+                );
+                true
+            }
         }
     }
 
@@ -267,6 +362,24 @@ impl HttpSession {
                 };
                 mux.frontend.readiness_mut().event = expect.frontend_readiness.event;
 
+                // The Expect→Mux handoff must carry the session's frontend
+                // token across unchanged: the slab slot and epoll registration
+                // are keyed by it, so a mismatch would misroute readiness.
+                debug_assert_eq!(
+                    mux.frontend_token, self.frontend_token,
+                    "expect upgrade must preserve the frontend token"
+                );
+                // Fresh Mux: exactly one stream was just created above, and no
+                // backend is connected yet (back token is set iff linked).
+                debug_assert_eq!(
+                    mux.context.streams.len(),
+                    1,
+                    "a freshly upgraded Mux owns exactly the request stream"
+                );
+
+                // Gauge pairing: this connection leaves PROXY_EXPECT and enters
+                // HTTP. The two adjustments must stay together so the live-state
+                // gauges sum to the session count (no double-count, no leak).
                 gauge_add!(names::protocol::PROXY_EXPECT, -1);
                 gauge_add!(names::protocol::HTTP, 1);
                 Some(HttpStateMachine::Mux(mux))
@@ -318,6 +431,16 @@ impl HttpSession {
             );
             return None;
         };
+        // Invariant (back token set iff backend connected): a Linked stream
+        // names a backend token that must exist in the router's backend map.
+        // We assert the map is non-empty here, then prove membership by the
+        // `remove` below — a Linked token absent from the map would be a
+        // book-keeping desync between stream state and the backend map.
+        debug_assert!(
+            mux.router.backends.contains_key(&back_token),
+            "a Linked stream's back token must index a connected backend"
+        );
+        let backends_before = mux.router.backends.len();
         let Some(backend) = mux.router.backends.remove(&back_token) else {
             error!(
                 "{} upgrade_mux: backend for token {:?} is missing (already disconnected?), closing",
@@ -352,6 +475,18 @@ impl HttpSession {
                 }
             };
 
+        // Post-removal book-keeping: the backend is gone from the map and the
+        // count dropped by exactly one (the `remove` matched a present key).
+        debug_assert!(
+            !mux.router.backends.contains_key(&back_token),
+            "the upgraded backend must be evicted from the router map"
+        );
+        debug_assert_eq!(
+            mux.router.backends.len(),
+            backends_before - 1,
+            "removing the backend must drop the backend count by exactly one"
+        );
+
         let ws_context = stream.context.websocket_context();
 
         container_frontend_timeout.reset();
@@ -384,10 +519,21 @@ impl HttpSession {
 
         pipe.frontend_readiness.event = frontend_readiness.event;
         pipe.backend_readiness.event = backend_readiness.event;
+        // The WebSocket pipe inherits the live backend connection, so its back
+        // token must be set (back token present iff a backend is connected).
         pipe.set_back_token(back_token);
+        debug_assert_eq!(
+            pipe.back_token(),
+            vec![back_token],
+            "websocket pipe must carry exactly the upgraded backend token"
+        );
 
         // http.active_requests was already decremented by generate_access_log()
         // in h1.rs when the 101 response was written (before MuxResult::Upgrade).
+        //
+        // Gauge pairing (Mux→WebSocket): leave HTTP, enter WS, and start
+        // accounting one active websocket request. These three must move
+        // together so the protocol gauges stay consistent with the session set.
         gauge_add!(names::protocol::HTTP, -1);
         gauge_add!(names::protocol::WS, 1);
         gauge_add!(names::websocket::ACTIVE_REQUESTS, 1);
@@ -412,6 +558,11 @@ impl ProxySession for HttpSession {
         if self.has_been_closed {
             return;
         }
+        // Reaching here means we are about to do the one-and-only teardown.
+        debug_assert!(
+            !self.has_been_closed,
+            "close past the guard must run on a not-yet-closed session"
+        );
 
         trace!("{} closing HTTP session", log_context!(self));
         self.metrics.service_stop();
@@ -438,6 +589,10 @@ impl ProxySession for HttpSession {
             self.state.close(self.proxy.clone(), &mut self.metrics);
             self.proxy.borrow().remove_session(self.frontend_token);
             self.has_been_closed = true;
+            debug_assert!(
+                self.has_been_closed,
+                "failed-upgrade close path must mark the session closed"
+            );
             return;
         }
 
@@ -476,6 +631,10 @@ impl ProxySession for HttpSession {
         proxy.remove_session(self.frontend_token);
 
         self.has_been_closed = true;
+        debug_assert!(
+            self.has_been_closed,
+            "close must leave the session marked closed (idempotency latch)"
+        );
     }
 
     fn timeout(&mut self, token: Token) -> SessionIsToBeClosed {
@@ -516,6 +675,14 @@ impl ProxySession for HttpSession {
         };
 
         self.metrics.service_stop();
+        // Run-to-completion postcondition: a session that is being kept alive
+        // must still satisfy its cross-field invariants. When `to_be_closed`
+        // is true the state may be a transient FailedUpgrade or already torn
+        // down, so the sweep only applies to the still-open path.
+        #[cfg(debug_assertions)]
+        if !to_be_closed {
+            self.check_invariants();
+        }
         to_be_closed
     }
 
@@ -1445,8 +1612,18 @@ impl ProxyConfiguration for HttpProxy {
             );
         }
         let mut session_manager = self.sessions.borrow_mut();
+        let slab_len_before = session_manager.slab.len();
         let session_entry = session_manager.slab.vacant_entry();
         let session_token = Token(session_entry.key());
+        // The token handed to the new session, used for epoll registration and
+        // every `remove_session(frontend_token)` call, MUST be the very slab
+        // key this entry will occupy. A drift here would deregister/free the
+        // wrong slot on close.
+        debug_assert_eq!(
+            session_token.0,
+            session_entry.key(),
+            "session token must equal the slab vacant-entry key"
+        );
         let owned = listener.borrow();
 
         if let Err(register_error) = self.registry.register(
@@ -1483,8 +1660,24 @@ impl ProxyConfiguration for HttpProxy {
             wait_time,
         )?;
 
+        // The session's frontend token must be exactly the slab key we are
+        // about to fill — the registration above and all later token lookups
+        // depend on it.
+        debug_assert_eq!(
+            session.frontend_token, session_token,
+            "session must own the frontend token it was created with"
+        );
+
         let session = Rc::new(RefCell::new(session));
         session_entry.insert(session);
+        // Inserting into the previously-vacant entry grows the live session
+        // count by exactly one (gauge-like ±1 pairing against close()'s
+        // try_remove). `len()` is the count of occupied slots.
+        debug_assert_eq!(
+            session_manager.slab.len(),
+            slab_len_before + 1,
+            "creating a session must occupy exactly one new slab slot"
+        );
 
         Ok(())
     }
@@ -1510,21 +1703,52 @@ impl L7Proxy for HttpProxy {
 
     fn add_session(&self, session: Rc<RefCell<dyn ProxySession>>) -> Token {
         let mut session_manager = self.sessions.borrow_mut();
+        let len_before = session_manager.slab.len();
         let entry = session_manager.slab.vacant_entry();
         let token = Token(entry.key());
         let _entry = entry.insert(session);
+        // The returned token is the slab key callers use to later remove this
+        // session, and the insert occupied exactly one new slot.
+        debug_assert_eq!(
+            session_manager.slab.len(),
+            len_before + 1,
+            "add_session must occupy exactly one new slab slot"
+        );
+        debug_assert!(
+            session_manager.slab.contains(token.0),
+            "the returned token must index the freshly inserted session"
+        );
         token
     }
 
     fn remove_session(&self, token: Token) -> bool {
         let mut sessions = self.sessions.borrow_mut();
+        let was_present = sessions.slab.contains(token.0);
+        let len_before = sessions.slab.len();
         // Drain the session's `(cluster, ip)` accounting before the slab
         // slot is freed — once the slot is reused for a new session the
         // token would otherwise alias an unrelated set of entries. No-op
         // when the session never tracked anything (feature disabled, or
         // no request reached `Router::connect`).
         sessions.untrack_all_cluster_ip(token);
-        sessions.slab.try_remove(token.0).is_some()
+        let removed = sessions.slab.try_remove(token.0).is_some();
+        // Removal must report exactly whether the slot was occupied, and the
+        // live count drops by one iff something was actually removed (±1
+        // pairing against add_session / create_session). The slot is gone.
+        debug_assert_eq!(
+            removed, was_present,
+            "try_remove reports presence iff the slot was occupied"
+        );
+        debug_assert_eq!(
+            sessions.slab.len(),
+            len_before - removed as usize,
+            "slab len drops by exactly one iff a session was removed"
+        );
+        debug_assert!(
+            !sessions.slab.contains(token.0),
+            "the slot must be free after remove_session"
+        );
+        removed
     }
 
     fn backends(&self) -> Rc<RefCell<BackendMap>> {

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -92,6 +92,20 @@ enum AlpnProtocol {
     Http11,
 }
 
+/// Monotonic rank of an HTTPS lifecycle stage, used only by `debug_assert!`s to
+/// check that upgrades move strictly forward (Expect → Handshake → Mux →
+/// WebSocket) and never re-enter an earlier stage. Gated to debug builds so it
+/// does not register as dead code in release.
+#[cfg(debug_assertions)]
+fn https_stage_rank(marker: StateMarker) -> u8 {
+    match marker {
+        StateMarker::Expect => 0,
+        StateMarker::Handshake => 1,
+        StateMarker::Mux => 2,
+        StateMarker::WebSocket => 3,
+    }
+}
+
 /// Module-level prefix for log lines emitted from this file when no session
 /// is in scope. Produces a bold bright-white `HTTPS` label in colored mode.
 /// Used by [`HttpsProxy`] / [`HttpsListener`] callbacks (`notify`,
@@ -159,6 +173,19 @@ impl HttpsSession {
         token: Token,
         wait_time: Duration,
     ) -> HttpsSession {
+        // Timeouts are wired from the listener config and feed `TimeoutContainer`s
+        // that arm the event loop. A zero request timeout would arm a deadline that
+        // fires on the very next tick, so reaching this constructor with one signals
+        // a config-loading bug upstream rather than hostile input.
+        debug_assert!(
+            !configured_request_timeout.is_zero(),
+            "HTTPS session request timeout must be non-zero (would arm an immediate deadline)"
+        );
+        debug_assert!(
+            !configured_frontend_timeout.is_zero() && !configured_backend_timeout.is_zero(),
+            "HTTPS session front/back timeouts must be non-zero"
+        );
+
         let peer_address = if expect_proxy {
             // Will be defined later once the expect proxy header has been received and parsed
             None
@@ -188,6 +215,24 @@ impl HttpsSession {
             ))
         };
 
+        // The freshly built state must reflect the entry-protocol choice exactly:
+        // `expect_proxy` enters via PROXY-protocol parsing, otherwise straight into
+        // the TLS handshake. No other entry state is legal, and `peer_address` is
+        // unknown until the PROXY header is parsed (mirror of the `if` above).
+        debug_assert_eq!(
+            matches!(state, HttpsStateMachine::Expect(..)),
+            expect_proxy,
+            "fresh HTTPS session must start in Expect iff expect_proxy is set"
+        );
+        debug_assert!(
+            expect_proxy || matches!(state, HttpsStateMachine::Handshake(_)),
+            "non-expect-proxy HTTPS session must start in the TLS Handshake state"
+        );
+        debug_assert!(
+            !expect_proxy || peer_address.is_none(),
+            "expect-proxy peer address is only known after the PROXY header is parsed"
+        );
+
         let metrics = SessionMetrics::new(Some(wait_time));
         HttpsSession {
             configured_backend_timeout,
@@ -208,6 +253,13 @@ impl HttpsSession {
 
     pub fn upgrade(&mut self) -> SessionIsToBeClosed {
         debug!("{} upgrade", log_context!(self));
+        // `take()` swaps in a FailedUpgrade carrying the marker of the state we
+        // are leaving, so the marker observed here is the *origin* of this
+        // upgrade. Capture it to check the transition is forward-only below.
+        // Read only by debug-only asserts → cfg-gated so release has no unused
+        // binding.
+        #[cfg(debug_assertions)]
+        let from_marker = self.state.marker();
         let new_state = match self.state.take() {
             HttpsStateMachine::Expect(expect, ssl) => self.upgrade_expect(expect, ssl),
             HttpsStateMachine::Handshake(handshake) => self.upgrade_handshake(handshake),
@@ -227,11 +279,47 @@ impl HttpsSession {
 
         match new_state {
             Some(state) => {
+                // The HTTPS lifecycle is strictly forward: Expect → Handshake →
+                // Mux → WebSocket. A successful upgrade must move to a strictly
+                // later stage and never re-enter the one it came from (no
+                // re-handshake mid-stream, no fall-back to Expect). `WebSocket`
+                // is terminal: `upgrade_websocket` returns the same state, so we
+                // exempt the self-loop there. The whole assert is cfg-gated (not
+                // just `debug_assert!`'s runtime guard) because its argument calls
+                // the debug-only `https_stage_rank`; leaving the call to compile
+                // in release would be an E0425 (HARD RULE #2).
+                #[cfg(debug_assertions)]
+                debug_assert!(
+                    https_stage_rank(state.marker()) > https_stage_rank(from_marker)
+                        || matches!(from_marker, StateMarker::WebSocket),
+                    "HTTPS upgrade must advance the lifecycle (from {:?} to {:?})",
+                    from_marker,
+                    state.marker()
+                );
+                debug_assert!(
+                    !state.failed(),
+                    "a successful HTTPS upgrade must not yield a FailedUpgrade state"
+                );
                 self.state = state;
                 false
             }
             // The state stays FailedUpgrade, but the Session should be closed right after
-            None => true,
+            None => {
+                // On a refused upgrade `take()` left a FailedUpgrade behind that
+                // still remembers the origin stage, so `close()` can restore the
+                // right gauge. Guard that the marker survived the failed attempt.
+                debug_assert!(
+                    self.state.failed(),
+                    "a refused HTTPS upgrade must leave the state in FailedUpgrade"
+                );
+                // cfg-gated for the same E0425 reason as the success arm above.
+                #[cfg(debug_assertions)]
+                debug_assert!(
+                    https_stage_rank(self.state.marker()) == https_stage_rank(from_marker),
+                    "FailedUpgrade must retain the origin stage marker for gauge restoration"
+                );
+                true
+            }
         }
     }
 
@@ -267,6 +355,19 @@ impl HttpsSession {
                 // so the event loop properly monitors the socket after the transition.
                 handshake.frontend_readiness = readiness;
                 handshake.frontend_readiness.event.insert(Ready::READABLE);
+
+                // The PROXY header just resolved both endpoints; the session now
+                // knows its true peer, and the handshake must watch for readable
+                // bytes or the TLS ClientHello will never be serviced.
+                debug_assert_eq!(
+                    self.peer_address,
+                    Some(session_address),
+                    "expect upgrade must adopt the PROXY-advertised source as the peer address"
+                );
+                debug_assert!(
+                    handshake.frontend_readiness.event.is_readable(),
+                    "handshake handed off from expect must be armed for READABLE"
+                );
 
                 gauge_add!(names::protocol::PROXY_EXPECT, -1);
                 gauge_add!(names::protocol::TLS_HANDSHAKE, 1);
@@ -368,6 +469,26 @@ impl HttpsSession {
                 (AlpnProtocol::Http11, None)
             }
         };
+
+        // Post-decision invariant: every refusal path above already returned, so
+        // reaching here means the negotiated protocol is one Sōzu serves. An
+        // H2-only listener must therefore have landed on H2 — never on the H1
+        // dispatch — or the `disable_http11` guard leaked a downgrade. The label,
+        // when present, must name exactly the protocol we are about to build.
+        debug_assert!(
+            !disable_http11 || matches!(alpn, AlpnProtocol::H2),
+            "H2-only listener must not dispatch an HTTP/1.1 session past ALPN"
+        );
+        debug_assert!(
+            match (&alpn, alpn_label) {
+                (AlpnProtocol::H2, Some(l)) => l == "h2",
+                (AlpnProtocol::Http11, Some(l)) => l == "http/1.1",
+                // Absent label only for ALPN-less HTTP/1.1 downgrade.
+                (AlpnProtocol::Http11, None) => true,
+                (AlpnProtocol::H2, None) => false,
+            },
+            "negotiated ALPN protocol and its wire label must agree"
+        );
 
         // Capture the negotiated TLS metadata as `&'static str` labels for the
         // access log alongside the existing metric counters. Both calls are
@@ -490,6 +611,24 @@ impl HttpsSession {
                 }),
             None => None,
         };
+        // Structural postcondition of the SAN-snapshot builder above: a cert-name
+        // snapshot only exists when the client sent an SNI (the `None => None`
+        // arm), and when present it is non-empty (empty collapses to `None`) and
+        // sorted+deduped (so the H2 router's coalescing check sees a canonical
+        // set). These hold regardless of `strict_sni_binding`; the binding policy
+        // is *enforced* later at routing, but the snapshot feeding it must be
+        // well-formed here.
+        debug_assert!(
+            tls_cert_names.is_none() || sni_owned.is_some(),
+            "cert-name snapshot must not exist without an SNI to key it"
+        );
+        debug_assert!(
+            tls_cert_names
+                .as_ref()
+                .is_none_or(|names| { !names.is_empty() && names.windows(2).all(|w| w[0] < w[1]) }),
+            "cert-name snapshot must be non-empty and strictly sorted (sorted + deduped)"
+        );
+
         // Bind the TLS SNI to this session so the routing layer can reject any
         // H2 stream whose `:authority` crosses the TLS trust boundary (see
         // `route_from_request`).
@@ -542,6 +681,22 @@ impl HttpsSession {
             .readiness_mut()
             .event
             .insert(Ready::READABLE | Ready::WRITABLE);
+
+        // Post-handoff: the mux frontend MUST be armed for both directions or the
+        // H2 preface→SETTINGS exchange deadlocks (see the comment above). This is
+        // the structural guarantee the insert just made — assert it survived.
+        debug_assert!(
+            frontend.readiness_mut().event.is_readable()
+                && frontend.readiness_mut().event.is_writable(),
+            "post-handshake mux frontend must be armed for READABLE and WRITABLE"
+        );
+        // The two crate halves of the H2/H1 session reference streams by a shared
+        // ulid; the handshake-derived ulid must thread through both the connection
+        // and its context unchanged, otherwise per-stream lookups cross sessions.
+        debug_assert_eq!(
+            context.session_ulid, session_ulid,
+            "mux context and connection must share the handshake-derived session ulid"
+        );
 
         gauge_add!(names::protocol::HTTPS, 1);
         Some(HttpsStateMachine::Mux(Mux {
@@ -655,6 +810,14 @@ impl HttpsSession {
         pipe.frontend_readiness.event = frontend_readiness.event;
         pipe.backend_readiness.event = backend_readiness.event;
         pipe.set_back_token(back_token);
+        // The WSS pipe is a frontend↔backend bridge: it only exists because the
+        // upgrading stream was `Linked(back_token)` to a *connected* backend (the
+        // guard arms above already rejected `!Connected` and missing backends).
+        // So the back token must be set, and set to exactly the token we routed.
+        debug_assert!(
+            pipe.back_token().contains(&back_token),
+            "WSS pipe back token must be the connected backend token carried from the mux"
+        );
         // Carry the connection-scoped TLS metadata captured at handshake time
         // into the post-upgrade WSS pipe so its access log records the same
         // version/cipher/sni/alpn the H1 request log already emitted. `clone`
@@ -665,6 +828,20 @@ impl HttpsSession {
             stream.context.tls_cipher,
             stream.context.tls_server_name.clone(),
             stream.context.tls_alpn,
+        );
+
+        // Gauge accounting for the Mux→WebSocket transition is a balanced
+        // hand-off: exactly one HTTPS gauge leaves and one WSS gauge arrives, so
+        // the live-session total is conserved. The readiness events captured from
+        // the mux frontend/backend must survive the transfer into the pipe — a
+        // lost event would silently park the bridge with no epoll wake-up.
+        debug_assert_eq!(
+            pipe.frontend_readiness.event, frontend_readiness.event,
+            "WSS pipe must inherit the mux frontend readiness event verbatim"
+        );
+        debug_assert_eq!(
+            pipe.backend_readiness.event, backend_readiness.event,
+            "WSS pipe must inherit the mux backend readiness event verbatim"
         );
 
         // http.active_requests was already decremented by generate_access_log()
@@ -686,6 +863,56 @@ impl HttpsSession {
         );
         Some(HttpsStateMachine::WebSocket(wss))
     }
+
+    /// Full cross-field invariant sweep for the session state machine, run as a
+    /// run-to-completion postcondition at the end of `ready()` (the public
+    /// mutating entry point). Encodes only relationships that must hold for any
+    /// live HTTPS session regardless of network input; a violation here is a
+    /// Sōzu logic bug, never a property of hostile traffic.
+    #[cfg(debug_assertions)]
+    fn check_invariants(&self) {
+        // Timeouts are immutable for the session's lifetime and were validated as
+        // non-zero at construction; they must never drift to zero (which would
+        // arm an immediate-firing deadline on the next state hand-off).
+        debug_assert!(
+            !self.configured_frontend_timeout.is_zero()
+                && !self.configured_backend_timeout.is_zero()
+                && !self.configured_connect_timeout.is_zero(),
+            "HTTPS session timeouts must stay non-zero for the session lifetime"
+        );
+        // The marker is total over the four live stages plus FailedUpgrade; a
+        // FailedUpgrade session is awaiting close and must report `failed()`,
+        // while any of the four live stages must not. This is the structural
+        // bridge the gauge-restore logic in `close()` relies on.
+        if self.state.failed() {
+            debug_assert!(
+                matches!(
+                    self.state.marker(),
+                    StateMarker::Expect
+                        | StateMarker::Handshake
+                        | StateMarker::Mux
+                        | StateMarker::WebSocket
+                ),
+                "FailedUpgrade must retain a valid origin-stage marker"
+            );
+        } else {
+            debug_assert!(
+                !self.state.failed(),
+                "a non-failed session must not also report FailedUpgrade"
+            );
+        }
+        // Before the PROXY header resolves, the Expect stage has no peer address;
+        // once any later stage is reached the address is either the real peer
+        // (direct TLS) or the PROXY-advertised source. We only assert the Expect
+        // direction, since direct-TLS `peer_addr()` may legitimately fail and
+        // leave `None` at handshake time.
+        debug_assert!(
+            !matches!(self.state.marker(), StateMarker::Expect)
+                || self.peer_address.is_none()
+                || self.state.failed(),
+            "a live Expect-stage session has no resolved peer address yet"
+        );
+    }
 }
 
 impl ProxySession for HttpsSession {
@@ -693,6 +920,14 @@ impl ProxySession for HttpsSession {
         if self.has_been_closed {
             return;
         }
+        // Reaching past the idempotency guard means this is the *first* close.
+        // Every exit below sets `has_been_closed = true`, so a clear flag here is
+        // a real precondition (the gauge restore that follows must run exactly
+        // once or the per-protocol gauge underflows / over-counts).
+        debug_assert!(
+            !self.has_been_closed,
+            "close() body must run only on a not-yet-closed session"
+        );
 
         trace!("{} closing HTTPS session", log_context!(self));
         self.metrics.service_stop();
@@ -762,6 +997,13 @@ impl ProxySession for HttpsSession {
         proxy.remove_session(self.frontend_token);
 
         self.has_been_closed = true;
+        // Postcondition: a session that completed `close()` is sealed — any later
+        // `close()` short-circuits on the guard above, keeping the gauge restore
+        // single-shot.
+        debug_assert!(
+            self.has_been_closed,
+            "close() must leave the session marked closed"
+        );
     }
 
     fn timeout(&mut self, token: Token) -> SessionIsToBeClosed {
@@ -815,6 +1057,12 @@ impl ProxySession for HttpsSession {
                 self.state.marker()
             );
         }
+
+        // Run-to-completion postcondition: whatever state `ready()` (and any
+        // nested upgrade) left the session in must satisfy the full cross-field
+        // invariant set before we yield back to the event loop.
+        #[cfg(debug_assertions)]
+        self.check_invariants();
 
         self.metrics.service_stop();
         to_be_closed
@@ -1151,6 +1399,15 @@ impl HttpsListener {
 
         self.listener = Some(listener);
         self.active = true;
+        // Post: an activated listener owns a bound socket and is flagged active,
+        // so a later `activate()` short-circuits on the `self.active` guard and
+        // `give_back_listener*` find a socket to hand back. The two must move in
+        // lockstep — an active listener with no socket would silently accept
+        // nothing.
+        debug_assert!(
+            self.active && self.listener.is_some(),
+            "an activated HTTPS listener must hold a bound socket and be flagged active"
+        );
         Ok(self.token)
     }
 
@@ -1384,6 +1641,14 @@ impl HttpsListener {
             // Build succeeded — commit.
             self.config.alpn_protocols = alpn_wrapper.values.clone();
             self.rustls_details = new_rustls;
+            // Post: the commit is atomic — the live config must now name exactly
+            // the patched ALPN set. New handshakes negotiate against this set, so
+            // the `upgrade_handshake` "protocol ∈ configured ALPN" property is
+            // anchored to what we just stored.
+            debug_assert_eq!(
+                self.config.alpn_protocols, alpn_wrapper.values,
+                "committed ALPN config must match the patch values exactly"
+            );
         }
 
         // HTTP answers: merge legacy `http_answers` and the new `answers`
@@ -2010,6 +2275,15 @@ impl ProxyConfiguration for HttpsProxy {
         let mut session_manager = self.sessions.borrow_mut();
         let entry = session_manager.slab.vacant_entry();
         let session_token = Token(entry.key());
+        // The session token IS the slab key: the event loop later indexes the
+        // slab directly by the mio `Token` it receives, so any divergence here
+        // would route readiness to the wrong session slot. Snapshot the key to
+        // re-check after `entry.insert` consumes the entry.
+        debug_assert_eq!(
+            session_token.0,
+            entry.key(),
+            "HTTPS session token must equal its slab key"
+        );
 
         self.registry
             .register(
@@ -2047,6 +2321,14 @@ impl ProxyConfiguration for HttpsProxy {
             session_token,
             wait_time,
         )));
+        // The freshly built session must own exactly the token it is filed under,
+        // so event-loop dispatch (slab key → session) and self-removal
+        // (`frontend_token()` → slab key) agree.
+        debug_assert_eq!(
+            session.borrow().frontend_token(),
+            session_token,
+            "stored HTTPS session must report the slab token as its frontend token"
+        );
         entry.insert(session);
 
         Ok(())

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1067,6 +1067,14 @@ impl Default for Readiness {
 }
 
 impl Readiness {
+    /// Mask of every bit `Ready` defines (READABLE | WRITABLE | ERROR | HUP).
+    /// Any bit outside this set in `event` or `interest` is a corrupted
+    /// readiness word — checked by [`Self::check_invariants`]. Not
+    /// `#[cfg(debug_assertions)]`-gated: it is read from inside `debug_assert!`s
+    /// whose arguments must still compile in release (HARD RULE 2 / E0425).
+    const KNOWN_BITS: Ready =
+        Ready(Ready::READABLE.0 | Ready::WRITABLE.0 | Ready::ERROR.0 | Ready::HUP.0);
+
     pub const fn new() -> Readiness {
         Readiness {
             event: Ready::EMPTY,
@@ -1074,26 +1082,96 @@ impl Readiness {
         }
     }
 
+    /// Cross-field invariant sweep: neither `event` nor `interest` may carry a
+    /// bit `Ready` does not define. A stray bit would silently widen
+    /// `filter_interest`'s mask and wake (or starve) a session on a phantom
+    /// readiness. Cheap enough to call as a postcondition from every mutator.
+    #[cfg(debug_assertions)]
+    fn check_invariants(&self) {
+        debug_assert_eq!(
+            self.event & Self::KNOWN_BITS,
+            self.event,
+            "Readiness.event carries a bit outside READABLE|WRITABLE|ERROR|HUP"
+        );
+        debug_assert_eq!(
+            self.interest & Self::KNOWN_BITS,
+            self.interest,
+            "Readiness.interest carries a bit outside READABLE|WRITABLE|ERROR|HUP"
+        );
+    }
+
     pub fn reset(&mut self) {
         self.event = Ready::EMPTY;
         self.interest = Ready::EMPTY;
+        // Post-condition: a reset clears *both* words — a half-reset leaves a
+        // session armed on stale interest after teardown.
+        debug_assert!(
+            self.event.is_empty() && self.interest.is_empty(),
+            "reset must clear both event and interest"
+        );
+        #[cfg(debug_assertions)]
+        self.check_invariants();
     }
 
     /// filters the readiness we actually want
     pub fn filter_interest(&self) -> Ready {
-        self.event & self.interest
+        // Pre-condition: both source words must be well-formed before we mask —
+        // a stray bit upstream would leak through the intersection and wake (or
+        // starve) a session on a phantom readiness.
+        #[cfg(debug_assertions)]
+        self.check_invariants();
+        let filtered = self.event & self.interest;
+        // Post-condition: the result is a subset of the recognized bits and can
+        // only contain bits the session both saw AND asked for.
+        debug_assert_eq!(
+            filtered & Self::KNOWN_BITS,
+            filtered,
+            "filter_interest must not yield an unknown bit"
+        );
+        debug_assert!(
+            self.interest.contains(filtered) && self.event.contains(filtered),
+            "filtered readiness must be present in both interest and event"
+        );
+        filtered
     }
 
     /// Signal that the socket has buffered data to write (e.g., TLS internal
     /// buffers) that won't generate a new epoll WRITABLE event.
     pub fn signal_pending_write(&mut self) {
+        // Snapshot the unrelated bits (everything but WRITABLE) so we can prove
+        // we flipped exactly the WRITABLE bit. `Ready` exposes no `!`, so mask on
+        // the public `.0` word.
+        let other_event_before = Ready(self.event.0 & !Ready::WRITABLE.0);
         self.event.insert(Ready::WRITABLE);
+        debug_assert!(
+            self.event.is_writable(),
+            "signal_pending_write must set the WRITABLE event bit"
+        );
+        debug_assert_eq!(
+            Ready(self.event.0 & !Ready::WRITABLE.0),
+            other_event_before,
+            "signal_pending_write must touch only the WRITABLE bit"
+        );
+        #[cfg(debug_assertions)]
+        self.check_invariants();
     }
 
     /// Signal that the socket has buffered data to read (e.g., TLS plaintext
     /// buffer after a 1xx clear) that won't generate a new epoll READABLE event.
     pub fn signal_pending_read(&mut self) {
+        let other_event_before = Ready(self.event.0 & !Ready::READABLE.0);
         self.event.insert(Ready::READABLE);
+        debug_assert!(
+            self.event.is_readable(),
+            "signal_pending_read must set the READABLE event bit"
+        );
+        debug_assert_eq!(
+            Ready(self.event.0 & !Ready::READABLE.0),
+            other_event_before,
+            "signal_pending_read must touch only the READABLE bit"
+        );
+        #[cfg(debug_assertions)]
+        self.check_invariants();
     }
 
     /// Pair `Ready::WRITABLE` insert with `signal_pending_write` — the canonical
@@ -1101,8 +1179,28 @@ impl Readiness {
     /// under edge-triggered epoll. See `lib/src/protocol/mux/LIFECYCLE.md`.
     #[inline]
     pub fn arm_writable(&mut self) {
+        // Snapshot the non-WRITABLE bits of both words: arm_writable must set the
+        // WRITABLE bit in *both* interest and event and leave everything else as-is.
+        let other_interest_before = Ready(self.interest.0 & !Ready::WRITABLE.0);
+        let other_event_before = Ready(self.event.0 & !Ready::WRITABLE.0);
         self.interest.insert(Ready::WRITABLE);
         self.signal_pending_write();
+        debug_assert!(
+            self.interest.is_writable() && self.event.is_writable(),
+            "arm_writable must set WRITABLE in both interest and event"
+        );
+        debug_assert_eq!(
+            Ready(self.interest.0 & !Ready::WRITABLE.0),
+            other_interest_before,
+            "arm_writable must touch only the WRITABLE interest bit"
+        );
+        debug_assert_eq!(
+            Ready(self.event.0 & !Ready::WRITABLE.0),
+            other_event_before,
+            "arm_writable must touch only the WRITABLE event bit"
+        );
+        #[cfg(debug_assertions)]
+        self.check_invariants();
     }
 }
 

--- a/lib/src/load_balancing.rs
+++ b/lib/src/load_balancing.rs
@@ -265,7 +265,9 @@ impl LoadBalancingAlgorithm for Random {
         } else {
             // `WeightedIndex::new` fails only when the set is empty or every
             // weight is zero; the uniform `choose` then selects iff non-empty.
-            let chosen = (*backends).choose(&mut rng).map(|backend| (*backend).clone());
+            let chosen = (*backends)
+                .choose(&mut rng)
+                .map(|backend| (*backend).clone());
             debug_assert_eq!(
                 chosen.is_some(),
                 len > 0,
@@ -666,7 +668,10 @@ impl Maglev {
         // guarantee for the population loop below — it writes one slot per unit
         // of target budget and stops at `count == m`, so an under/over sum would
         // either leave holes (`usize::MAX` entries) or loop forever.
-        debug_assert_eq!(assigned, m, "Maglev target budget must sum to the table size");
+        debug_assert_eq!(
+            assigned, m,
+            "Maglev target budget must sum to the table size"
+        );
         debug_assert_eq!(
             targets.iter().sum::<usize>(),
             m,

--- a/lib/src/load_balancing.rs
+++ b/lib/src/load_balancing.rs
@@ -24,12 +24,17 @@ pub const DEFAULT_HASH_SEED: u64 = 0x9E37_79B9_7F4A_7C15;
 /// is clamped to at least `1` so a `0`/negative configured weight never zeroes
 /// out a backend's share (which would make weighted hashing degenerate).
 fn backend_weight(backend: &Backend) -> u32 {
-    backend
+    let weight = backend
         .load_balancing_parameters
         .as_ref()
         .map(|p| p.weight)
         .unwrap_or(DEFAULT_WEIGHT)
-        .max(1) as u32
+        .max(1) as u32;
+    // The clamp guarantees every backend carries a strictly positive weight,
+    // otherwise weighted hashing (HRW score, Maglev slot share) would zero out
+    // the backend's share and skew or divide-by-zero the distribution.
+    debug_assert!(weight >= 1, "backend weight must be clamped to at least 1");
+    weight
 }
 
 /// Deterministic, seedable 64-bit hash over the backend's STABLE identifier.
@@ -85,6 +90,14 @@ fn next_prime(n: usize) -> usize {
     while !is_prime(candidate) {
         candidate += 1;
     }
+    // The result is the smallest prime not below `max(n, 2)`: it is prime, it
+    // is at least 2, and it never went below the requested floor.
+    debug_assert!(is_prime(candidate), "next_prime must return a prime");
+    debug_assert!(candidate >= 2, "next_prime must return at least 2");
+    debug_assert!(
+        candidate >= n,
+        "next_prime ({candidate}) must be >= the requested floor ({n})"
+    );
     candidate
 }
 
@@ -176,12 +189,28 @@ impl LoadBalancingAlgorithm for RoundRobin {
         if backends.is_empty() {
             return None;
         }
+        debug_assert!(
+            !backends.is_empty(),
+            "round-robin index math runs only on a non-empty set"
+        );
 
-        let res = backends
-            .get(self.next_backend as usize % backends.len())
-            .map(|backend| (*backend).clone());
+        let index = self.next_backend as usize % backends.len();
+        // The reduced index always addresses a real slot, so the lookup yields
+        // a backend (never the `None` arm of `get`).
+        debug_assert!(index < backends.len(), "round-robin index out of bounds");
+        let res = backends.get(index).map(|backend| (*backend).clone());
+        debug_assert!(
+            res.is_some(),
+            "round-robin must select a backend from a non-empty set"
+        );
 
         self.next_backend = (self.next_backend + 1) % backends.len() as u32;
+        // The cursor stays a valid index into the current set after advancing,
+        // so the next call never starts out of range.
+        debug_assert!(
+            (self.next_backend as usize) < backends.len(),
+            "round-robin cursor must stay within bounds"
+        );
         res
     }
 }
@@ -208,6 +237,7 @@ impl LoadBalancingAlgorithm for Random {
         backends: &mut Vec<Rc<RefCell<Backend>>>,
     ) -> Option<Rc<RefCell<Backend>>> {
         let mut rng = rng();
+        let len = backends.len();
         let weights: Vec<i32> = backends
             .iter()
             .map(|b| {
@@ -218,14 +248,30 @@ impl LoadBalancingAlgorithm for Random {
                     .unwrap_or(100)
             })
             .collect();
+        // One weight per backend feeds the weighted distribution; a mismatch
+        // would make `dist.sample` index a backend that does not exist.
+        debug_assert_eq!(
+            weights.len(),
+            len,
+            "Random must derive exactly one weight per backend"
+        );
 
         if let Ok(dist) = WeightedIndex::new(weights) {
             let index = dist.sample(&mut rng);
+            // `WeightedIndex` only samples valid indices into the weight vector,
+            // which is the same length as `backends`, so the lookup hits.
+            debug_assert!(index < len, "Random sampled an out-of-range index");
             backends.get(index).cloned()
         } else {
-            (*backends)
-                .choose(&mut rng)
-                .map(|backend| (*backend).clone())
+            // `WeightedIndex::new` fails only when the set is empty or every
+            // weight is zero; the uniform `choose` then selects iff non-empty.
+            let chosen = (*backends).choose(&mut rng).map(|backend| (*backend).clone());
+            debug_assert_eq!(
+                chosen.is_some(),
+                len > 0,
+                "Random fallback selects iff the set is non-empty"
+            );
+            chosen
         }
     }
 }
@@ -241,6 +287,7 @@ impl LoadBalancingAlgorithm for LeastLoaded {
         _key: Option<u64>,
         backends: &mut Vec<Rc<RefCell<Backend>>>,
     ) -> Option<Rc<RefCell<Backend>>> {
+        let was_empty = backends.is_empty();
         let opt_b = match self.metric {
             LoadMetric::Connections => backends
                 .iter_mut()
@@ -268,6 +315,14 @@ impl LoadBalancingAlgorithm for LeastLoaded {
                 b.map(|(_cost, backend)| backend)
             }
         };
+        // Least-loaded over a non-empty set always finds a minimum; an empty
+        // set yields nothing. (`min_by_key` / the manual fold both have this
+        // shape.)
+        debug_assert_eq!(
+            opt_b.is_some(),
+            !was_empty,
+            "LeastLoaded selects iff the candidate set is non-empty"
+        );
         opt_b.map(|backend| (*backend).clone())
     }
 }
@@ -283,6 +338,7 @@ impl LoadBalancingAlgorithm for PowerOfTwo {
         _key: Option<u64>,
         backends: &mut Vec<Rc<RefCell<Backend>>>,
     ) -> Option<Rc<RefCell<Backend>>> {
+        let len = backends.len();
         let mut first = None;
         let mut second = None;
 
@@ -310,6 +366,28 @@ impl LoadBalancingAlgorithm for PowerOfTwo {
                 first = Some((measure, backend));
             }
         }
+
+        // `first` holds the lighter of the two tracked candidates and `second`
+        // the heavier — the running fold keeps `first.measure <= second.measure`
+        // — and the candidates populate in step with the set size (none for an
+        // empty set, only `first` for a singleton, both for >= 2 backends).
+        debug_assert!(
+            match (&first, &second) {
+                (Some((f, _)), Some((s, _))) => f <= s,
+                _ => true,
+            },
+            "power-of-two: first candidate must be no heavier than second"
+        );
+        debug_assert_eq!(
+            first.is_some(),
+            len > 0,
+            "power-of-two must hold a primary candidate iff the set is non-empty"
+        );
+        debug_assert_eq!(
+            second.is_some(),
+            len > 1,
+            "power-of-two holds a second candidate iff the set has >= 2 backends"
+        );
 
         match (first, second) {
             (None, None) => None,
@@ -382,7 +460,19 @@ impl Rendezvous {
         let h = hash_backend(self.seed, key, &backend.address);
         // (h + 0.5) / 2^64 keeps the value strictly inside (0, 1).
         let unit = (h as f64 + 0.5) / (u64::MAX as f64 + 1.0);
-        -weight / unit.ln()
+        // `unit` must land strictly inside (0, 1) so `ln(unit) < 0` and the
+        // score stays a positive, finite number — the whole HRW ordering relies
+        // on a well-defined comparable score for every backend.
+        debug_assert!(
+            unit > 0.0 && unit < 1.0,
+            "HRW unit must lie strictly inside (0, 1), got {unit}"
+        );
+        let score = -weight / unit.ln();
+        debug_assert!(
+            score.is_finite() && score > 0.0,
+            "HRW score must be finite and positive, got {score}"
+        );
+        score
     }
 }
 
@@ -407,6 +497,21 @@ impl LoadBalancingAlgorithm for Rendezvous {
             match best {
                 Some((best_score, _)) if best_score >= score => {}
                 _ => best = Some((score, backend)),
+            }
+        }
+        // A non-empty set always yields a winner, and that winner's score is the
+        // maximum over the whole set (HRW = highest random weight).
+        debug_assert!(
+            best.is_some(),
+            "HRW must select a winner from a non-empty set"
+        );
+        #[cfg(debug_assertions)]
+        if let Some((best_score, _)) = best {
+            for backend in backends.iter() {
+                debug_assert!(
+                    best_score >= self.score(key, &backend.borrow()),
+                    "HRW winner does not maximize the score over the set"
+                );
             }
         }
         best.map(|(_, backend)| backend.clone())
@@ -518,12 +623,28 @@ impl Maglev {
             // so `offset` and `skip` are uncorrelated.
             let h1 = hash_backend(self.seed, 0x6F66_6673_6574, &addr); // "offset"
             let h2 = hash_backend(self.seed, 0x736B_6970_5F5F, &addr); // "skip__"
-            offsets.push((h1 % m as u64) as usize);
-            skips.push((h2 % (m as u64 - 1)) as usize + 1);
+            let offset = (h1 % m as u64) as usize;
+            let skip = (h2 % (m as u64 - 1)) as usize + 1;
+            // The permutation parameters must address valid slots and keep a
+            // non-zero stride; `skip ∈ [1, m-1]` is coprime with the prime `m`,
+            // which is what guarantees the population loop visits every slot.
+            debug_assert!(offset < m, "Maglev offset must be a valid slot");
+            debug_assert!(
+                (1..m).contains(&skip),
+                "Maglev skip must lie in [1, m-1] to stay coprime with the prime table"
+            );
+            offsets.push(offset);
+            skips.push(skip);
             let w = backend_weight(&b) as u64;
             weights.push(w);
             total_weight += w;
         }
+        // Every backend contributes weight >= 1, so a non-empty set has a
+        // strictly positive total — the proportional target math divides by it.
+        debug_assert!(
+            total_weight > 0,
+            "Maglev total weight must be positive for a non-empty backend set"
+        );
 
         // Target slot count per backend, proportional to weight. The sum of
         // targets equals `m` (remainder handed to the heaviest/first backends).
@@ -541,6 +662,16 @@ impl Maglev {
             assigned += 1;
             i += 1;
         }
+        // The targets must sum to exactly `m`: this is the termination
+        // guarantee for the population loop below — it writes one slot per unit
+        // of target budget and stops at `count == m`, so an under/over sum would
+        // either leave holes (`usize::MAX` entries) or loop forever.
+        debug_assert_eq!(assigned, m, "Maglev target budget must sum to the table size");
+        debug_assert_eq!(
+            targets.iter().sum::<usize>(),
+            m,
+            "Maglev per-backend targets must sum to the table size"
+        );
 
         // Standard Maglev population loop, capped per backend by `targets`.
         let mut table = vec![usize::MAX; m];
@@ -567,6 +698,18 @@ impl Maglev {
                 }
             }
         }
+        // The loop terminates with every slot claimed exactly once: `count`
+        // reached `m`, no slot still holds the `usize::MAX` sentinel, and each
+        // backend filled precisely its target budget.
+        debug_assert_eq!(count, m, "Maglev population loop must fill exactly m slots");
+        debug_assert!(
+            table.iter().all(|&slot| slot != usize::MAX),
+            "Maglev population loop left an unfilled slot"
+        );
+        debug_assert!(
+            filled == targets,
+            "Maglev filled counts must match the per-backend targets"
+        );
 
         self.table = table;
 
@@ -657,11 +800,27 @@ impl LoadBalancingAlgorithm for Maglev {
         );
         for i in 0..self.size {
             let slot = (start + i) % self.size;
+            // Both the running slot and the index it stores are in range: the
+            // table is `size` long and every entry is a valid `backend_addrs`
+            // index (rebuild post-condition), so the resolution below is total.
+            debug_assert!(slot < self.size, "Maglev probe slot out of range");
             let idx = self.table[slot];
+            debug_assert!(
+                idx < self.backend_addrs.len(),
+                "Maglev table entry indexes outside the captured address set"
+            );
             // Resolve the table's backend index back to an address captured at
             // the last rebuild, then look it up in the live healthy subset.
             if let Some(addr) = self.backend_addrs.get(idx) {
                 if let Some(backend) = backends.iter().find(|b| b.borrow().address == *addr) {
+                    // The chosen backend is, by construction, a member of the
+                    // healthy subset we were handed.
+                    debug_assert!(
+                        backends
+                            .iter()
+                            .any(|b| b.borrow().address == backend.borrow().address),
+                        "Maglev must return a backend from the healthy subset"
+                    );
                     return Some(backend.clone());
                 }
             }

--- a/lib/src/metrics/local_drain.rs
+++ b/lib/src/metrics/local_drain.rs
@@ -55,15 +55,23 @@ impl AggregatedMetric {
         match metric {
             MetricValue::Gauge(value) => Ok(AggregatedMetric::Gauge(value)),
             MetricValue::GaugeAdd(value) => {
-                if value >= 0 {
-                    Ok(AggregatedMetric::Gauge(value as usize))
+                // First emission via a relative add: a negative seed clamps
+                // to 0 (never wraps through `value as usize`). Post-state is
+                // always a `Gauge` with the clamped magnitude.
+                let aggregated = if value >= 0 {
+                    AggregatedMetric::Gauge(value as usize)
                 } else {
                     error!(
                         "local drain metric created with negative GaugeAdd({}), clamping to 0",
                         value
                     );
-                    Ok(AggregatedMetric::Gauge(0))
-                }
+                    AggregatedMetric::Gauge(0)
+                };
+                debug_assert!(
+                    matches!(&aggregated, AggregatedMetric::Gauge(v) if *v as i64 == value.max(0)),
+                    "GaugeAdd seed must clamp negatives to 0 and keep non-negatives verbatim"
+                );
+                Ok(aggregated)
             }
             MetricValue::Count(value) => Ok(AggregatedMetric::Count(value)),
             MetricValue::Time(value) => {
@@ -81,6 +89,18 @@ impl AggregatedMetric {
                     }
                 })?;
 
+                // A freshly-seeded histogram holds exactly the one sample we
+                // just recorded; min/max collapse to that single value.
+                debug_assert_eq!(
+                    histogram.len(),
+                    1,
+                    "fresh time histogram must hold exactly one sample"
+                );
+                debug_assert!(
+                    histogram.min() <= histogram.max(),
+                    "histogram min must never exceed max"
+                );
+
                 Ok(AggregatedMetric::Time(histogram))
             }
         }
@@ -90,25 +110,69 @@ impl AggregatedMetric {
         match (self, m) {
             (&mut AggregatedMetric::Gauge(ref mut v1), MetricValue::Gauge(v2)) => {
                 *v1 = v2;
+                debug_assert_eq!(*v1, v2, "gauge set must store exactly the requested value");
             }
             (&mut AggregatedMetric::Gauge(ref mut v1), MetricValue::GaugeAdd(v2)) => {
-                let res = *v1 as i64 + v2;
+                // Canonical gauge-underflow guard (CLAUDE.md: "Gauge
+                // underflow is a correctness bug, not a rounding issue"). We
+                // saturate + log rather than panic because a clear()/remove
+                // during live traffic can legitimately drive a paired
+                // decrement below a fresh-zero baseline — a recovery path,
+                // not a logic bug. The post-condition asserts the clamp is
+                // exact (to 0, never wrapped) and that the non-underflow
+                // path equals `before + v2`.
+                let before = *v1;
+                let res = before as i64 + v2;
                 *v1 = if res >= 0 {
                     res as usize
                 } else {
                     error!(
                         "local drain metric {} underflow: previous value: {}, adding: {}",
-                        key, *v1, v2
+                        key, before, v2
                     );
                     0
                 };
+                debug_assert!(
+                    res >= 0 || *v1 == 0,
+                    "gauge underflow must clamp to exactly 0 (never wrap to usize::MAX)"
+                );
+                debug_assert!(
+                    res < 0 || *v1 as i64 == before as i64 + v2,
+                    "non-underflow gauge add must equal before + v2 exactly"
+                );
             }
             (&mut AggregatedMetric::Count(ref mut v1), MetricValue::Count(v2)) => {
+                // Counters advance by exactly the delta between resets.
+                let before = *v1;
                 *v1 += v2;
+                debug_assert_eq!(*v1, before + v2, "count update must advance by exactly v2");
             }
             (&mut AggregatedMetric::Time(ref mut v1), MetricValue::Time(v2)) => {
-                if let Err(e) = (*v1).record(v2 as u64) {
-                    error!("could not record time metric: {:?}", e.to_string());
+                // A successful record grows the cumulative sample count by
+                // exactly one and keeps min ≤ max consistent. On the
+                // hdrhistogram error path (value out of range) nothing is
+                // recorded — assert only on success.
+                let before_len = v1.len();
+                match v1.record(v2 as u64) {
+                    Ok(()) => {
+                        debug_assert_eq!(
+                            v1.len(),
+                            before_len + 1,
+                            "a recorded time sample must grow the histogram by exactly one"
+                        );
+                        debug_assert!(
+                            v1.min() <= v1.max(),
+                            "histogram min must never exceed max after record"
+                        );
+                    }
+                    Err(e) => {
+                        error!("could not record time metric: {:?}", e.to_string());
+                        debug_assert_eq!(
+                            v1.len(),
+                            before_len,
+                            "a rejected time sample must not change the histogram count"
+                        );
+                    }
                 }
             }
             (s, m) => {
@@ -139,7 +203,7 @@ impl AggregatedMetric {
 
 pub fn histogram_to_percentiles(hist: &Histogram<u64>) -> Percentiles {
     let sum = hist.len() as f64 * hist.mean();
-    Percentiles {
+    let percentiles = Percentiles {
         samples: hist.len(),
         p_50: hist.value_at_percentile(50.0),
         p_90: hist.value_at_percentile(90.0),
@@ -149,7 +213,25 @@ pub fn histogram_to_percentiles(hist: &Histogram<u64>) -> Percentiles {
         p_99_999: hist.value_at_percentile(99.999),
         p_100: hist.value_at_percentile(100.0),
         sum: sum as u64,
-    }
+    };
+    // Percentiles over a single distribution are monotonic non-decreasing,
+    // and the reported sample count must match the histogram length. p_100
+    // is the maximum recorded value, so it bounds every lower percentile.
+    debug_assert_eq!(
+        percentiles.samples,
+        hist.len(),
+        "reported sample count must equal the histogram length"
+    );
+    debug_assert!(
+        percentiles.p_50 <= percentiles.p_90
+            && percentiles.p_90 <= percentiles.p_99
+            && percentiles.p_99 <= percentiles.p_99_9
+            && percentiles.p_99_9 <= percentiles.p_99_99
+            && percentiles.p_99_99 <= percentiles.p_99_999
+            && percentiles.p_99_999 <= percentiles.p_100,
+        "percentiles must be monotonic non-decreasing (p50 ≤ … ≤ p100)"
+    );
+    percentiles
 }
 
 /// convert a collected histogram to a prometheus-compatible format
@@ -160,16 +242,42 @@ pub fn filter_histogram(hist: &Histogram<u64>) -> FilteredMetrics {
         .sum();
 
     let mut count = 0;
-    let buckets = hist
+    let mut prev_le = 0u64;
+    let mut prev_count = 0u64;
+    let buckets: Vec<Bucket> = hist
         .iter_log(1, 2.0)
         .map(|value| {
             count += value.count_since_last_iteration();
+            // Cumulative prometheus buckets: upper bounds (`le`) strictly
+            // increase and the running count is monotonic non-decreasing.
+            debug_assert!(
+                value.value_iterated_to() >= prev_le,
+                "prometheus bucket upper bounds must be non-decreasing"
+            );
+            debug_assert!(
+                count >= prev_count,
+                "cumulative bucket count must be monotonic non-decreasing"
+            );
+            prev_le = value.value_iterated_to();
+            prev_count = count;
             Bucket {
                 le: value.value_iterated_to(),
                 count,
             }
         })
         .collect();
+
+    // The final cumulative bucket count is the total recorded sample count,
+    // and an empty histogram yields no buckets / zero count.
+    debug_assert_eq!(
+        count,
+        hist.len(),
+        "final cumulative bucket count must equal the total sample count"
+    );
+    debug_assert!(
+        !hist.is_empty() || buckets.is_empty(),
+        "an empty histogram must yield no buckets"
+    );
 
     FilteredMetrics {
         inner: Some(filtered_metrics::Inner::Histogram(FilteredHistogram {
@@ -223,6 +331,8 @@ impl MetricsMap {
         metric_name: &str,
         new_value: MetricValue,
     ) -> Result<(), MetricError> {
+        let before_len = self.map.len();
+        let existed = self.map.contains_key(metric_name);
         match self.map.get_mut(metric_name) {
             Some(old_value) => old_value.update(metric_name, new_value),
             None => {
@@ -230,6 +340,18 @@ impl MetricsMap {
                 self.map.insert(metric_name.to_owned(), aggregated_metric);
             }
         }
+        // Map-accounting invariant: an update of an existing key keeps the
+        // size; a fresh insert grows it by exactly one. The key is always
+        // present afterwards (we either updated it or inserted it).
+        debug_assert_eq!(
+            self.map.len(),
+            before_len + (!existed) as usize,
+            "receive_metric grows the map by exactly one iff the key was absent"
+        );
+        debug_assert!(
+            self.map.contains_key(metric_name),
+            "the metric key must be present after receive_metric"
+        );
         Ok(())
     }
 
@@ -260,6 +382,8 @@ impl LocalClusterMetrics {
         backend_id: &str,
         new_value: MetricValue,
     ) -> Result<(), MetricError> {
+        let existed = self.contains_backend(backend_id);
+        let before_len = self.backends.len();
         let backend = self
             .backends
             .iter_mut()
@@ -267,6 +391,11 @@ impl LocalClusterMetrics {
 
         if let Some(backend) = backend {
             backend.metrics.receive_metric(metric_name, new_value)?;
+            debug_assert_eq!(
+                self.backends.len(),
+                before_len,
+                "updating an existing backend must not change the backend count"
+            );
             return Ok(());
         }
 
@@ -277,6 +406,22 @@ impl LocalClusterMetrics {
             backend_id: backend_id.to_owned(),
             metrics,
         });
+        // A fresh backend grows the vec by exactly one, and the
+        // backend_id must now be present. We also uphold the single-entry-
+        // per-backend invariant: a brand-new id was absent before.
+        debug_assert!(
+            !existed,
+            "fresh backend insert path must only run for an absent backend_id"
+        );
+        debug_assert_eq!(
+            self.backends.len(),
+            before_len + 1,
+            "a fresh backend must grow the vec by exactly one"
+        );
+        debug_assert!(
+            self.contains_backend(backend_id),
+            "the backend_id must be present after a fresh insert"
+        );
         Ok(())
     }
 
@@ -399,6 +544,20 @@ impl LocalDrain {
         self.proxy_metrics = MetricsMap::new();
         self.cluster_metrics.clear();
         self.removed_clusters.clear();
+        // A full reset must leave every map empty — proxy-wide, per-cluster
+        // (and therefore per-backend), and the tombstone set.
+        debug_assert!(
+            self.proxy_metrics.map.is_empty(),
+            "clear must empty the proxy-wide metric map"
+        );
+        debug_assert!(
+            self.cluster_metrics.is_empty(),
+            "clear must empty every cluster (and backend) row"
+        );
+        debug_assert!(
+            self.removed_clusters.is_empty(),
+            "clear must wipe the removed-cluster tombstones"
+        );
     }
 
     /// Drop all metrics for a cluster from the local drain and mark the
@@ -425,6 +584,16 @@ impl LocalDrain {
     pub fn remove_cluster(&mut self, cluster_id: &str) {
         self.cluster_metrics.remove(cluster_id);
         self.removed_clusters.insert(cluster_id.to_owned());
+        // Post-condition: the cluster row is gone AND the tombstone is armed
+        // so late session emissions for the id are dropped on the floor.
+        debug_assert!(
+            !self.cluster_metrics.contains_key(cluster_id),
+            "remove_cluster must drop the cluster row"
+        );
+        debug_assert!(
+            self.removed_clusters.contains(cluster_id),
+            "remove_cluster must arm the tombstone for the id"
+        );
     }
 
     /// Re-arm a previously-removed cluster id so its metrics flow again.
@@ -433,6 +602,12 @@ impl LocalDrain {
     /// removed.
     pub fn add_cluster(&mut self, cluster_id: &str) {
         self.removed_clusters.remove(cluster_id);
+        // Post-condition: the tombstone for the id is gone so fresh
+        // emissions are recorded again. Idempotent on never-removed ids.
+        debug_assert!(
+            !self.removed_clusters.contains(cluster_id),
+            "add_cluster must clear the tombstone for the id"
+        );
     }
 
     /// Drop all metrics for one backend within a cluster. Called from the
@@ -446,7 +621,18 @@ impl LocalDrain {
     /// the tombstone.
     pub fn remove_backend(&mut self, cluster_id: &str, backend_id: &str) {
         let drop_cluster = if let Some(cluster) = self.cluster_metrics.get_mut(cluster_id) {
+            let before = cluster.backends.len();
             cluster.backends.retain(|b| b.backend_id != backend_id);
+            // The targeted backend is gone, and `retain` removes at most one
+            // entry (backend_ids are unique within a cluster).
+            debug_assert!(
+                !cluster.contains_backend(backend_id),
+                "remove_backend must evict the targeted backend"
+            );
+            debug_assert!(
+                cluster.backends.len() == before || cluster.backends.len() == before - 1,
+                "remove_backend drops at most one backend (ids are unique per cluster)"
+            );
             cluster.cluster.map.is_empty() && cluster.backends.is_empty()
         } else {
             false
@@ -454,6 +640,19 @@ impl LocalDrain {
         if drop_cluster {
             self.cluster_metrics.remove(cluster_id);
         }
+        // Post-condition: the cluster row survives iff it still holds
+        // cluster-level metrics or at least one other backend.
+        debug_assert!(
+            !drop_cluster || !self.cluster_metrics.contains_key(cluster_id),
+            "an emptied cluster row must be dropped to avoid phantom keyspace"
+        );
+        debug_assert!(
+            self.cluster_metrics
+                .get(cluster_id)
+                .map(|c| !c.contains_backend(backend_id))
+                .unwrap_or(true),
+            "no surviving cluster row may still contain the removed backend"
+        );
     }
 
     pub fn query(&mut self, options: &QueryMetricsOptions) -> Result<ResponseContent, MetricError> {
@@ -662,6 +861,12 @@ impl LocalDrain {
         if self.removed_clusters.contains(cluster_id) {
             return Ok(());
         }
+        // We only reach the insert with a non-tombstoned id: a row for a
+        // removed cluster must never be (re)created here.
+        debug_assert!(
+            !self.removed_clusters.contains(cluster_id),
+            "a tombstoned cluster must not reach the entry().or_default() insert"
+        );
 
         let local_cluster_metric = self
             .cluster_metrics
@@ -685,6 +890,10 @@ impl LocalDrain {
         if self.removed_clusters.contains(cluster_id) {
             return Ok(());
         }
+        debug_assert!(
+            !self.removed_clusters.contains(cluster_id),
+            "a tombstoned cluster must not reach the backend insert"
+        );
 
         let local_cluster_metric = self
             .cluster_metrics
@@ -699,6 +908,8 @@ impl LocalDrain {
         metric_name: &str,
         metric: MetricValue,
     ) -> Result<(), MetricError> {
+        let before_len = self.proxy_metrics.map.len();
+        let existed = self.proxy_metrics.map.contains_key(metric_name);
         match self.proxy_metrics.map.get_mut(metric_name) {
             Some(stored_metric) => stored_metric.update(metric_name, metric),
             None => {
@@ -709,6 +920,17 @@ impl LocalDrain {
                     .insert(String::from(metric_name), aggregated_metric);
             }
         }
+        // Proxy-wide map accounting: an update keeps the size, a fresh
+        // insert grows it by exactly one, and the key is present afterwards.
+        debug_assert_eq!(
+            self.proxy_metrics.map.len(),
+            before_len + (!existed) as usize,
+            "receive_proxy_metric grows the map by exactly one iff the key was absent"
+        );
+        debug_assert!(
+            self.proxy_metrics.map.contains_key(metric_name),
+            "the proxy metric key must be present after receive_proxy_metric"
+        );
         Ok(())
     }
 }

--- a/lib/src/metrics/mod.rs
+++ b/lib/src/metrics/mod.rs
@@ -46,11 +46,28 @@ fn filter_labels_for_detail<'a>(
     cluster_id: Option<&'a str>,
     backend_id: Option<&'a str>,
 ) -> (Option<&'a str>, Option<&'a str>) {
-    match detail {
+    let (out_cluster, out_backend) = match detail {
         MetricDetailLevel::Process | MetricDetailLevel::Frontend => (None, None),
         MetricDetailLevel::Cluster => (cluster_id, None),
         MetricDetailLevel::Backend => (cluster_id, backend_id),
-    }
+    };
+    // The filter only ever DROPS labels: an absent input can never become a
+    // present output, and a kept output must be the exact same borrow we
+    // were handed (no synthesised label). This is the cardinality-safety
+    // post-condition that keeps the local CLI view and the wire consistent.
+    debug_assert!(
+        cluster_id.is_some() || out_cluster.is_none(),
+        "filter must never invent a cluster_id"
+    );
+    debug_assert!(
+        backend_id.is_some() || out_backend.is_none(),
+        "filter must never invent a backend_id"
+    );
+    debug_assert!(
+        out_backend.is_none() || out_cluster.is_some(),
+        "a kept backend label implies a kept cluster label (no orphan backend)"
+    );
+    (out_cluster, out_backend)
 }
 
 /// Map a numeric HTTP status code to its dedicated counter name, if any.
@@ -129,8 +146,19 @@ impl MetricValue {
     fn update(&mut self, key: &'static str, m: MetricValue) -> bool {
         match (self, m) {
             (&mut MetricValue::Gauge(ref mut v1), MetricValue::Gauge(v2)) => {
+                // `changed` reflects the absolute set: true iff the stored
+                // value actually moves. Pair-assert the post-state matches
+                // the requested value and that `changed` is the equality
+                // relationship between before and after.
+                let before = *v1;
                 let changed = *v1 != v2;
                 *v1 = v2;
+                debug_assert_eq!(*v1, v2, "gauge set must store exactly the requested value");
+                debug_assert_eq!(
+                    changed,
+                    before != v2,
+                    "`changed` must report whether the gauge actually moved"
+                );
                 changed
             }
             (&mut MetricValue::Gauge(ref mut v1), MetricValue::GaugeAdd(v2)) => {
@@ -142,23 +170,45 @@ impl MetricValue {
                 // make underflow structurally impossible from live code,
                 // and a panic on a metric mismatch is too aggressive — the
                 // log line names the offending key for observability.
+                //
+                // INVARIANT (the canonical gauge-underflow guard): the post
+                // value is non-negative, equals `before + v2` on the
+                // non-underflow path, and is exactly the `0` floor whenever
+                // `before + v2` would have gone negative. We assert the
+                // *post-condition* (never panic the recovery path) rather
+                // than a `before >= -v2` pre-condition, because a real
+                // underflow is recovered (clamp + log) by design.
+                let before = *v1;
                 let changed = v2 != 0;
-                let res = *v1 as i64 + v2;
+                let res = before as i64 + v2;
                 *v1 = if res >= 0 {
                     res as usize
                 } else {
                     error!(
                         "metric {} underflow: previous value: {}, adding: {}",
-                        key, v1, v2
+                        key, before, v2
                     );
                     0
                 };
+                debug_assert!(
+                    res >= 0 || *v1 == 0,
+                    "gauge underflow must clamp to exactly 0 (never wrap)"
+                );
+                debug_assert!(
+                    res < 0 || *v1 as i64 == before as i64 + v2,
+                    "non-underflow gauge add must equal before + v2 exactly"
+                );
 
                 changed
             }
             (&mut MetricValue::Count(ref mut v1), MetricValue::Count(v2)) => {
+                // Counter delta: `v2` may be negative (e.g. `decr!`), so the
+                // monotonic-between-resets invariant is encoded as the exact
+                // delta — the post value equals the pre value plus `v2`.
+                let before = *v1;
                 let changed = v2 != 0;
                 *v1 += v2;
+                debug_assert_eq!(*v1, before + v2, "count update must advance by exactly v2");
                 changed
             }
             (s, m) => {
@@ -206,6 +256,13 @@ impl StoredMetricValue {
         } else {
             data
         };
+        // Post-conditions: a `GaugeAdd` seed never survives as `GaugeAdd`
+        // (it is normalised to a non-negative `Gauge`), and a fresh stored
+        // value is always flagged `updated` so the next drain emits it.
+        debug_assert!(
+            !matches!(data, MetricValue::GaugeAdd(_)),
+            "GaugeAdd must be normalised to a non-negative Gauge at construction"
+        );
         StoredMetricValue {
             last_sent,
             updated: true,
@@ -214,10 +271,23 @@ impl StoredMetricValue {
     }
 
     pub fn update(&mut self, key: &'static str, m: MetricValue) {
+        // The `updated` flag is a monotone latch within one drain cycle: it
+        // may only go from false→true here (the drain resets it to false on
+        // emit). So once set, it stays set; and if this update reports a
+        // change, the flag must be set afterwards.
+        let was_updated = self.updated;
         let updated = self.data.update(key, m);
         if !self.updated {
             self.updated = updated;
         }
+        debug_assert!(
+            self.updated || (!was_updated && !updated),
+            "`updated` must stay set once latched; a reported change must latch it"
+        );
+        debug_assert!(
+            !was_updated || self.updated,
+            "`updated` is a monotone latch within a drain cycle (never cleared here)"
+        );
     }
 }
 
@@ -457,6 +527,14 @@ impl Aggregator {
     pub fn set_up_detail(&mut self, detail: MetricDetailLevel) {
         self.configured = detail;
         self.recompute_effective();
+        // Raising the configured floor can only raise/hold the effective
+        // level; the full invariant set must hold afterwards.
+        debug_assert!(
+            self.effective >= self.configured,
+            "effective must dominate the freshly-set configured floor"
+        );
+        #[cfg(debug_assertions)]
+        self.check_lease_invariants();
     }
 
     /// Returns the static (configured) cardinality floor. Independent of
@@ -528,6 +606,7 @@ impl Aggregator {
             return LeaseApplyOutcome::Unauthorized;
         }
         let expires_at = Instant::now() + ttl;
+        let before_len = self.leases.len();
         self.leases.insert(
             client_id,
             LeaseEntry {
@@ -536,8 +615,34 @@ impl Aggregator {
                 binding,
             },
         );
+        // Map-accounting invariant: a renewal REPLACES in place (count
+        // stable) while a fresh insert grows the table by exactly one. The
+        // table must never exceed the cap on the insert path because the
+        // fresh-insert branch was gated by the `>= LEASE_TABLE_CAP` check
+        // above.
+        debug_assert_eq!(
+            self.leases.len(),
+            before_len + (!is_renewal) as usize,
+            "lease_apply grows the table by exactly one iff this is a fresh insert"
+        );
+        debug_assert!(
+            self.leases.len() <= LEASE_TABLE_CAP,
+            "lease table must never exceed LEASE_TABLE_CAP after an accepted apply"
+        );
         let previous_effective = self.effective;
         self.recompute_effective();
+        // An apply can only ELEVATE the effective level (a fresh/renewed
+        // lease adds to the max), never lower it below the prior effective.
+        debug_assert!(
+            self.effective >= previous_effective,
+            "lease_apply must not lower the effective detail level"
+        );
+        debug_assert!(
+            self.effective >= self.configured,
+            "effective must never drop below the configured floor"
+        );
+        #[cfg(debug_assertions)]
+        self.check_lease_invariants();
         LeaseApplyOutcome::Applied {
             previous_effective,
             new_effective: self.effective,
@@ -563,9 +668,33 @@ impl Aggregator {
         if entry.binding.is_known() && !entry.binding.matches(&presented) {
             return LeaseClearOutcome::Unauthorized;
         }
+        // We only reach here after the `get` above proved the key is
+        // present, so the removal evicts exactly one entry.
+        let before_len = self.leases.len();
         self.leases.remove(client_id);
+        debug_assert!(
+            !self.leases.contains_key(client_id),
+            "lease_clear must evict the cleared client_id"
+        );
+        debug_assert_eq!(
+            self.leases.len(),
+            before_len - 1,
+            "lease_clear removes exactly one entry on the authorised path"
+        );
         let previous = self.effective;
         self.recompute_effective();
+        // Clearing a lease can only LOWER or hold the effective level (one
+        // contributor to the max is gone), never raise it.
+        debug_assert!(
+            self.effective <= previous,
+            "lease_clear must not raise the effective detail level"
+        );
+        debug_assert!(
+            self.effective >= self.configured,
+            "effective must never drop below the configured floor"
+        );
+        #[cfg(debug_assertions)]
+        self.check_lease_invariants();
         LeaseClearOutcome::Cleared {
             previous_effective: previous,
         }
@@ -590,11 +719,33 @@ impl Aggregator {
         self.last_lease_tick = now;
         let before = self.leases.len();
         self.leases.retain(|_, entry| entry.expires_at > now);
+        // Expiry is a pure shrink: `retain` can only drop entries, never
+        // add them, and every surviving lease must be strictly in the
+        // future relative to `now`.
+        debug_assert!(
+            self.leases.len() <= before,
+            "lease_tick (expiry) can only shrink the table, never grow it"
+        );
+        debug_assert!(
+            self.leases.values().all(|entry| entry.expires_at > now),
+            "every surviving lease must expire strictly after `now`"
+        );
         if self.leases.len() == before {
             return None;
         }
         let previous = self.effective;
         self.recompute_effective();
+        // Losing leases can only lower or hold the effective level.
+        debug_assert!(
+            self.effective <= previous,
+            "lease expiry must not raise the effective detail level"
+        );
+        debug_assert!(
+            self.effective >= self.configured,
+            "effective must never drop below the configured floor"
+        );
+        #[cfg(debug_assertions)]
+        self.check_lease_invariants();
         if previous != self.effective {
             Some(previous)
         } else {
@@ -620,6 +771,53 @@ impl Aggregator {
             }
         }
         self.effective = max_lease;
+        // Post-condition: effective is the floor AND every active lease's
+        // ceiling — i.e. it is at least `configured` and at least each
+        // lease level, and it equals one of those contributors (max).
+        debug_assert!(
+            self.effective >= self.configured,
+            "effective is bounded below by the configured floor"
+        );
+        debug_assert!(
+            self.leases.values().all(|e| self.effective >= e.level),
+            "effective dominates every active lease level"
+        );
+        debug_assert!(
+            self.effective == self.configured
+                || self.leases.values().any(|e| e.level == self.effective),
+            "effective must equal the configured floor or one active lease level"
+        );
+    }
+
+    /// Debug-only full invariant sweep for the lease table, called as a
+    /// run-to-completion post-condition from every lease-mutating method.
+    /// Gathers the cross-field relationships that the individual delta
+    /// assertions cannot express on their own.
+    #[cfg(debug_assertions)]
+    fn check_lease_invariants(&self) {
+        debug_assert!(
+            self.leases.len() <= LEASE_TABLE_CAP,
+            "lease table size must stay within LEASE_TABLE_CAP"
+        );
+        debug_assert!(
+            self.leases
+                .keys()
+                .all(|id| id.len() <= LEASE_CLIENT_ID_MAX_BYTES),
+            "every stored client_id must respect LEASE_CLIENT_ID_MAX_BYTES"
+        );
+        debug_assert!(
+            self.effective >= self.configured,
+            "effective is at least the configured floor"
+        );
+        debug_assert!(
+            self.leases.values().all(|e| self.effective >= e.level),
+            "effective dominates every active lease level"
+        );
+        debug_assert!(
+            self.effective == self.configured
+                || self.leases.values().any(|e| e.level == self.effective),
+            "effective equals the configured floor or some active lease level"
+        );
     }
 
     pub fn socket(&self) -> Option<&UdpSocket> {

--- a/lib/src/metrics/network_drain.rs
+++ b/lib/src/metrics/network_drain.rs
@@ -95,6 +95,27 @@ impl NetworkDrain {
         self.queue
             .retain(|m| m.cluster_id.as_deref() != Some(cluster_id));
         self.removed_clusters.insert(cluster_id.to_owned());
+        // Post-condition: no stored counter, backend counter, or queued line
+        // for the cluster survives, and the tombstone is armed so live
+        // sessions cannot re-insert (see `receive_metric`).
+        debug_assert!(
+            self.cluster_metrics.keys().all(|(c, _)| c != cluster_id),
+            "no cluster-level counter for the removed cluster may survive"
+        );
+        debug_assert!(
+            self.backend_metrics.keys().all(|(c, _, _)| c != cluster_id),
+            "no backend counter under the removed cluster may survive"
+        );
+        debug_assert!(
+            self.queue
+                .iter()
+                .all(|m| m.cluster_id.as_deref() != Some(cluster_id)),
+            "no queued line for the removed cluster may survive"
+        );
+        debug_assert!(
+            self.removed_clusters.contains(cluster_id),
+            "remove_cluster must arm the tombstone for the id"
+        );
     }
 
     /// Re-arm a previously-removed cluster id so its metrics can flow on
@@ -103,6 +124,12 @@ impl NetworkDrain {
     /// removed.
     pub fn add_cluster(&mut self, cluster_id: &str) {
         self.removed_clusters.remove(cluster_id);
+        // Post-condition: the tombstone for the id is gone so metrics flow
+        // on the wire again. Idempotent on never-removed ids.
+        debug_assert!(
+            !self.removed_clusters.contains(cluster_id),
+            "add_cluster must clear the tombstone for the id"
+        );
     }
 
     /// Operator-issued reset triggered by `MetricsConfiguration::Clear`.
@@ -115,6 +142,22 @@ impl NetworkDrain {
         self.backend_metrics.clear();
         self.queue.clear();
         self.removed_clusters.clear();
+        // A full reset empties every wire-side map, the pending queue, and
+        // the tombstone set so any cluster id can resume emitting.
+        debug_assert!(
+            self.proxy_metrics.is_empty()
+                && self.cluster_metrics.is_empty()
+                && self.backend_metrics.is_empty(),
+            "clear must empty every wire-side metric map"
+        );
+        debug_assert!(
+            self.queue.is_empty(),
+            "clear must drop every queued timing line"
+        );
+        debug_assert!(
+            self.removed_clusters.is_empty(),
+            "clear must wipe the removed-cluster tombstones"
+        );
     }
 
     /// Drop all wire-side metric storage for one backend: stored counters
@@ -130,6 +173,22 @@ impl NetworkDrain {
             !(m.cluster_id.as_deref() == Some(cluster_id)
                 && m.backend_id.as_deref() == Some(backend_id))
         });
+        // Post-condition: no stored counter or queued line for exactly this
+        // (cluster, backend) pair survives. Other backends and the
+        // cluster-level entries are untouched (this does NOT tombstone).
+        debug_assert!(
+            self.backend_metrics
+                .keys()
+                .all(|(c, b, _)| !(c == cluster_id && b == backend_id)),
+            "no backend counter for the removed (cluster, backend) pair may survive"
+        );
+        debug_assert!(
+            self.queue
+                .iter()
+                .all(|m| !(m.cluster_id.as_deref() == Some(cluster_id)
+                    && m.backend_id.as_deref() == Some(backend_id))),
+            "no queued line for the removed (cluster, backend) pair may survive"
+        );
     }
 
     pub fn send_metrics(&mut self) {
@@ -138,12 +197,32 @@ impl NetworkDrain {
         let mut send_count = 0;
 
         // remove metrics that were not touched in the last 10mn
+        let cluster_before = self.cluster_metrics.len();
+        let backend_before = self.backend_metrics.len();
         self.cluster_metrics.retain(|_, ref value| {
             value.updated || now.duration_since(value.last_sent) < Duration::new(600, 00)
         });
         self.backend_metrics.retain(|_, ref value| {
             value.updated || now.duration_since(value.last_sent) < Duration::new(600, 00)
         });
+        // Staleness pruning is a pure shrink: `retain` only drops entries.
+        // Every surviving entry is either freshly updated or within the
+        // 10-minute window — never both stale AND not updated.
+        debug_assert!(
+            self.cluster_metrics.len() <= cluster_before
+                && self.backend_metrics.len() <= backend_before,
+            "staleness retain can only shrink the metric maps, never grow them"
+        );
+        debug_assert!(
+            self.cluster_metrics
+                .values()
+                .all(|v| v.updated || now.duration_since(v.last_sent) < Duration::new(600, 0))
+                && self
+                    .backend_metrics
+                    .values()
+                    .all(|v| v.updated || now.duration_since(v.last_sent) < Duration::new(600, 0)),
+            "every surviving entry must be updated or within the 10-minute window"
+        );
 
         if !self.is_writable {
             return;
@@ -198,8 +277,20 @@ impl NetworkDrain {
 
                 match res {
                     Ok(()) => {
+                        // A counter that was successfully emitted is consumed
+                        // to 0 (delta semantics on the statsd wire); a gauge
+                        // keeps its absolute value. Either way the stored
+                        // value must never be a negative count after emit.
+                        debug_assert!(
+                            !matches!(stored_metric.data, MetricValue::Count(c) if c < 0),
+                            "an emitted counter must reset to a non-negative value"
+                        );
                         stored_metric.last_sent = now;
                         stored_metric.updated = false;
+                        debug_assert!(
+                            !stored_metric.updated,
+                            "a successfully-sent metric must clear its updated flag"
+                        );
 
                         send_count += 1;
                         if send_count >= 10 {
@@ -208,6 +299,10 @@ impl NetworkDrain {
                             }*/
                             send_count = 0;
                         }
+                        debug_assert!(
+                            send_count < 10,
+                            "send_count must wrap back below the flush threshold"
+                        );
                     }
                     Err(e) => match e.kind() {
                         ErrorKind::WriteZero => {
@@ -282,8 +377,16 @@ impl NetworkDrain {
 
                 match res {
                     Ok(()) => {
+                        debug_assert!(
+                            !matches!(stored_metric.data, MetricValue::Count(c) if c < 0),
+                            "an emitted cluster counter must reset to a non-negative value"
+                        );
                         stored_metric.last_sent = now;
                         stored_metric.updated = false;
+                        debug_assert!(
+                            !stored_metric.updated,
+                            "a successfully-sent cluster metric must clear its updated flag"
+                        );
 
                         send_count += 1;
                         if send_count >= 10 {
@@ -292,6 +395,10 @@ impl NetworkDrain {
                             }*/
                             send_count = 0;
                         }
+                        debug_assert!(
+                            send_count < 10,
+                            "send_count must wrap back below the flush threshold"
+                        );
                     }
                     Err(e) => match e.kind() {
                         ErrorKind::WriteZero => {
@@ -366,8 +473,16 @@ impl NetworkDrain {
 
                 match res {
                     Ok(()) => {
+                        debug_assert!(
+                            !matches!(stored_metric.data, MetricValue::Count(c) if c < 0),
+                            "an emitted backend counter must reset to a non-negative value"
+                        );
                         stored_metric.last_sent = now;
                         stored_metric.updated = false;
+                        debug_assert!(
+                            !stored_metric.updated,
+                            "a successfully-sent backend metric must clear its updated flag"
+                        );
 
                         send_count += 1;
                         if send_count >= 10 {
@@ -376,6 +491,10 @@ impl NetworkDrain {
                             }*/
                             send_count = 0;
                         }
+                        debug_assert!(
+                            send_count < 10,
+                            "send_count must wrap back below the flush threshold"
+                        );
                     }
                     Err(e) => match e.kind() {
                         ErrorKind::WriteZero => {
@@ -507,16 +626,29 @@ impl Subscriber for NetworkDrain {
             if self.removed_clusters.contains(cid) {
                 return;
             }
+            // Past this point the cluster is NOT tombstoned, so any insert
+            // below is legitimate (a tombstoned cluster can never reach the
+            // map mutations).
+            debug_assert!(
+                !self.removed_clusters.contains(cid),
+                "a tombstoned cluster must not reach the wire-side map insert"
+            );
         }
 
         if metric.is_time() {
             if let MetricValue::Time(millis) = metric {
+                let before = self.queue.len();
                 self.queue.push_back(MetricLine {
                     label: key,
                     cluster_id: cluster_id.map(|s| s.to_string()),
                     backend_id: backend_id.map(|s| s.to_string()),
                     duration: millis,
                 });
+                debug_assert_eq!(
+                    self.queue.len(),
+                    before + 1,
+                    "a timing metric must enqueue exactly one line"
+                );
             }
             return;
         }
@@ -525,20 +657,44 @@ impl Subscriber for NetworkDrain {
             (None, _) => {}
             (Some(cid), None) => {
                 let k = (String::from(cid), String::from(key));
+                let existed = self.cluster_metrics.contains_key(&k);
+                let before_len = self.cluster_metrics.len();
                 if let Entry::Vacant(e) = self.cluster_metrics.entry(k.to_owned()) {
                     e.insert(StoredMetricValue::new(self.created, metric));
                 } else if let Some(stored_metric) = self.cluster_metrics.get_mut(&k) {
                     stored_metric.update(key, metric);
                 }
+                // Fresh key grows the map by one; an existing key is updated
+                // in place. The key is present either way.
+                debug_assert_eq!(
+                    self.cluster_metrics.len(),
+                    before_len + (!existed) as usize,
+                    "cluster metric insert grows the map by one iff the key was absent"
+                );
+                debug_assert!(
+                    self.cluster_metrics.contains_key(&k),
+                    "the cluster metric key must be present after receive_metric"
+                );
                 return;
             }
             (Some(cid), Some(bid)) => {
                 let k = (String::from(cid), String::from(bid), String::from(key));
+                let existed = self.backend_metrics.contains_key(&k);
+                let before_len = self.backend_metrics.len();
                 if let Entry::Vacant(e) = self.backend_metrics.entry(k.to_owned()) {
                     e.insert(StoredMetricValue::new(self.created, metric));
                 } else if let Some(stored_metric) = self.backend_metrics.get_mut(&k) {
                     stored_metric.update(key, metric);
                 }
+                debug_assert_eq!(
+                    self.backend_metrics.len(),
+                    before_len + (!existed) as usize,
+                    "backend metric insert grows the map by one iff the key was absent"
+                );
+                debug_assert!(
+                    self.backend_metrics.contains_key(&k),
+                    "the backend metric key must be present after receive_metric"
+                );
                 return;
             }
         }
@@ -567,9 +723,19 @@ impl Subscriber for NetworkDrain {
         */
 
         if !self.proxy_metrics.contains_key(key) {
+            let before_len = self.proxy_metrics.len();
             self.proxy_metrics.insert(
                 String::from(key),
                 StoredMetricValue::new(self.created, metric),
+            );
+            debug_assert_eq!(
+                self.proxy_metrics.len(),
+                before_len + 1,
+                "a fresh proxy metric must grow the map by exactly one"
+            );
+            debug_assert!(
+                self.proxy_metrics.contains_key(key),
+                "the proxy metric key must be present after a fresh insert"
             );
             return;
         }

--- a/lib/src/pool.rs
+++ b/lib/src/pool.rs
@@ -24,12 +24,35 @@ pub struct Pool {
 
 impl Pool {
     pub fn with_capacity(minimum: usize, maximum: usize, buffer_size: usize) -> Pool {
+        debug_assert!(
+            minimum <= maximum,
+            "pool minimum ({minimum}) must not exceed maximum ({maximum})"
+        );
         let mut inner = poule::Pool::with_extra(maximum, buffer_size);
         inner.grow_to(minimum);
-        Pool { inner, buffer_size }
+        let pool = Pool { inner, buffer_size };
+        // Post-condition: a fresh pool hands out nothing and respects its
+        // capacity ceiling. `grow_to(minimum)` may pre-allocate, but never
+        // beyond `maximum`, and nothing is checked out yet.
+        debug_assert_eq!(pool.inner.used(), 0, "a fresh pool has nothing checked out");
+        debug_assert!(
+            pool.inner.capacity() <= maximum,
+            "grown capacity must never exceed the configured maximum"
+        );
+        #[cfg(debug_assertions)]
+        pool.check_invariants();
+        pool
     }
 
     pub fn checkout(&mut self) -> Option<Checkout> {
+        // Pre-condition: the accounting invariant holds on entry.
+        #[cfg(debug_assertions)]
+        self.check_invariants();
+        // Snapshot used-count before any growth or checkout so the
+        // post-conditions can assert the exact delta. Read only inside
+        // `debug_assert!` → dead code in release, but it must still compile.
+        let used_before = self.inner.used();
+
         if self.inner.used() == self.inner.capacity()
             && self.inner.capacity() < self.inner.maximum_capacity()
         {
@@ -44,7 +67,9 @@ impl Pool {
             );
         }
         let capacity = self.buffer_size;
-        self.inner
+        let buffer_size = self.buffer_size;
+        let result = self
+            .inner
             .checkout(|| {
                 trace!("initializing a buffer with capacity {}", capacity);
                 BufferMetadata::new()
@@ -53,7 +78,90 @@ impl Pool {
                 let old_buffer_count = BUFFER_COUNT.fetch_add(1, Ordering::SeqCst);
                 gauge!(names::buffer::IN_USE, old_buffer_count + 1);
                 Checkout { inner: c }
-            })
+            });
+
+        match &result {
+            Some(checkout) => {
+                // A successful checkout consumes exactly one slot: the pool's
+                // used-count rose by one and never exceeded the live capacity.
+                debug_assert_eq!(
+                    self.inner.used(),
+                    used_before + 1,
+                    "a successful checkout must increment used-count by exactly 1"
+                );
+                debug_assert!(
+                    self.inner.used() <= self.inner.capacity(),
+                    "used-count must never exceed the pool capacity"
+                );
+                // The handed-out buffer must carry at least the configured size
+                // (poule rounds the per-entry extra up to `align_of::<Entry>`, so
+                // capacity equals buffer_size only when it is already aligned —
+                // the default 16393 rounds to 16400) and start empty
+                // (position == end == 0 from `BufferMetadata::new`).
+                debug_assert!(
+                    checkout.capacity() >= buffer_size,
+                    "a checked-out buffer must hold at least the configured buffer size"
+                );
+                debug_assert_eq!(
+                    checkout.available_data(),
+                    0,
+                    "a freshly checked-out buffer must hold no data"
+                );
+            }
+            None => {
+                // Exhaustion is graceful (never a panic): the used-count must
+                // be unchanged on the failure path. The pool was at its hard
+                // ceiling, so capacity equals maximum_capacity.
+                debug_assert_eq!(
+                    self.inner.used(),
+                    used_before,
+                    "a failed checkout must not change the used-count"
+                );
+                debug_assert_eq!(
+                    self.inner.capacity(),
+                    self.inner.maximum_capacity(),
+                    "checkout only fails once the pool is grown to its maximum"
+                );
+            }
+        }
+
+        // Post-condition: the accounting invariant still holds on exit.
+        #[cfg(debug_assertions)]
+        self.check_invariants();
+        result
+    }
+
+    /// Full accounting-invariant sweep for the buffer pool, used as a
+    /// `debug_assert!`-guarded pre/post-condition on every public mutating
+    /// method. Encodes the `available + checked_out == capacity` contract in
+    /// terms of `poule`'s accounting: the number of checked-out buffers
+    /// (`used`) plus the number still available equals the live capacity, and
+    /// capacity stays bounded by the configured hard maximum. Compiled out
+    /// entirely in release.
+    #[cfg(debug_assertions)]
+    fn check_invariants(&self) {
+        let used = self.inner.used();
+        let capacity = self.inner.capacity();
+        let maximum = self.inner.maximum_capacity();
+
+        // `available + checked_out == capacity`: every slot in the live
+        // capacity is either checked out or available, never both, never lost.
+        debug_assert!(
+            used <= capacity,
+            "checked-out buffers ({used}) must never exceed live capacity ({capacity})"
+        );
+        let available = capacity - used;
+        debug_assert_eq!(
+            available + used,
+            capacity,
+            "available ({available}) + checked_out ({used}) must equal capacity ({capacity})"
+        );
+
+        // Capacity grows lazily but is hard-bounded by the configured maximum.
+        debug_assert!(
+            capacity <= maximum,
+            "live capacity ({capacity}) must never exceed maximum_capacity ({maximum})"
+        );
     }
 }
 
@@ -115,6 +223,16 @@ impl ops::DerefMut for Checkout {
 impl Drop for Checkout {
     fn drop(&mut self) {
         let old_buffer_count = BUFFER_COUNT.fetch_sub(1, Ordering::SeqCst);
+        // Gauge-underflow guard: every live `Checkout` was paired with a
+        // `fetch_add(1)` at checkout time, so the global in-use counter must
+        // be strictly positive when one is dropped. A zero here means a
+        // double-checkin or an unbalanced add/sub — a real accounting bug, not
+        // a rounding issue. `fetch_sub` wraps in release; the assert makes the
+        // violation loud in debug/test/fuzz.
+        debug_assert!(
+            old_buffer_count >= 1,
+            "buffer in-use gauge underflow on checkin: count was {old_buffer_count} before decrement"
+        );
         gauge!(names::buffer::IN_USE, old_buffer_count - 1);
     }
 }
@@ -136,35 +254,128 @@ impl Checkout {
         self.inner.position == self.inner.end
     }
 
+    /// Internal buffer-window invariant: `position <= end <= capacity`. The
+    /// occupied window `[position, end)` is the live data; everything outside
+    /// it is free space. Used as a `debug_assert!`-guarded pre/post-condition
+    /// on the slice-mutating methods. Compiled out in release.
+    #[cfg(debug_assertions)]
+    fn check_invariants(&self) {
+        let position = self.inner.position;
+        let end = self.inner.end;
+        let capacity = self.capacity();
+        debug_assert!(
+            position <= end,
+            "buffer position ({position}) must not pass end ({end})"
+        );
+        debug_assert!(
+            end <= capacity,
+            "buffer end ({end}) must not exceed capacity ({capacity})"
+        );
+        // consumed-prefix + available_data + available_space == capacity:
+        // the three regions partition the buffer with no overlap or loss.
+        debug_assert_eq!(
+            position + self.available_data() + self.available_space(),
+            capacity,
+            "consumed prefix + available data + free space must tile the whole buffer"
+        );
+    }
+
     pub fn consume(&mut self, count: usize) -> usize {
-        let cnt = cmp::min(count, self.available_data());
+        #[cfg(debug_assertions)]
+        self.check_invariants();
+        let available_before = self.available_data();
+        let cnt = cmp::min(count, available_before);
+        // `consume` can never advance past the available data — `cnt` is
+        // clamped above, so this read can never underflow `available_data`.
+        debug_assert!(
+            cnt <= available_before,
+            "consume count ({cnt}) must not exceed available data ({available_before})"
+        );
         self.inner.position += cnt;
         if self.inner.position > self.capacity() / 2 {
             //trace!("consume shift: pos {}, end {}", self.position, self.end);
             self.shift();
         }
+        // Post-condition: exactly `cnt` bytes left the readable window (a
+        // shift relocates but does not change `available_data`).
+        debug_assert_eq!(
+            self.available_data(),
+            available_before - cnt,
+            "consume must shrink available data by exactly the consumed count"
+        );
+        #[cfg(debug_assertions)]
+        self.check_invariants();
         cnt
     }
 
     pub fn fill(&mut self, count: usize) -> usize {
-        let cnt = cmp::min(count, self.available_space());
+        #[cfg(debug_assertions)]
+        self.check_invariants();
+        let data_before = self.available_data();
+        let space_before = self.available_space();
+        let cnt = cmp::min(count, space_before);
+        // `fill` can never claim more than the free space — `cnt` is clamped,
+        // so advancing `end` by `cnt` can never overrun the buffer.
+        debug_assert!(
+            cnt <= space_before,
+            "fill count ({cnt}) must not exceed available space ({space_before})"
+        );
         self.inner.end += cnt;
         if self.available_space() < self.available_data() + cnt {
             //trace!("fill shift: pos {}, end {}", self.position, self.end);
             self.shift();
         }
-
+        // Post-condition: exactly `cnt` bytes entered the readable window (a
+        // shift relocates but does not change `available_data`).
+        debug_assert_eq!(
+            self.available_data(),
+            data_before + cnt,
+            "fill must grow available data by exactly the filled count"
+        );
+        #[cfg(debug_assertions)]
+        self.check_invariants();
         cnt
     }
 
     pub fn reset(&mut self) {
         self.inner.position = 0;
         self.inner.end = 0;
+        // Post-condition: a reset buffer is empty and offers its full
+        // capacity as free space.
+        debug_assert_eq!(self.available_data(), 0, "reset must empty the buffer");
+        debug_assert_eq!(
+            self.available_space(),
+            self.capacity(),
+            "reset must restore the full capacity as free space"
+        );
+        #[cfg(debug_assertions)]
+        self.check_invariants();
     }
 
     pub fn sync(&mut self, end: usize, position: usize) {
+        // Pre-condition: the caller must supply a coherent window —
+        // `position <= end <= capacity`. `sync` restores a previously valid
+        // window (e.g. after a `Vec`-backed parse), so a violation here is a
+        // caller logic bug, not network input.
+        debug_assert!(
+            position <= end,
+            "sync position ({position}) must not pass end ({end})"
+        );
+        debug_assert!(
+            end <= self.capacity(),
+            "sync end ({end}) must not exceed capacity ({})",
+            self.capacity()
+        );
         self.inner.position = position;
         self.inner.end = end;
+        // Post-condition: the readable window matches the requested span.
+        debug_assert_eq!(
+            self.available_data(),
+            end - position,
+            "sync must expose exactly end - position readable bytes"
+        );
+        #[cfg(debug_assertions)]
+        self.check_invariants();
     }
 
     pub fn data(&self) -> &[u8] {
@@ -177,8 +388,11 @@ impl Checkout {
     }
 
     pub fn shift(&mut self) {
+        #[cfg(debug_assertions)]
+        self.check_invariants();
         let pos = self.inner.position;
         let end = self.inner.end;
+        let data_before = self.available_data();
         if pos > 0 {
             // SAFETY: src and dst point into the same checkout buffer
             // (`self.inner.extra`); the slice indexing above bounds-checks
@@ -195,10 +409,28 @@ impl Checkout {
                 self.inner.end = length;
             }
         }
+        // Post-condition: shift relocates the readable window to the front but
+        // never changes how many bytes are readable.
+        debug_assert_eq!(
+            self.available_data(),
+            data_before,
+            "shift must preserve the amount of readable data"
+        );
+        #[cfg(debug_assertions)]
+        self.check_invariants();
     }
 
     pub fn delete_slice(&mut self, start: usize, length: usize) -> Option<usize> {
+        #[cfg(debug_assertions)]
+        self.check_invariants();
+        let data_before = self.available_data();
         if start + length >= self.available_data() {
+            // Out-of-range deletes are a graceful no-op: nothing changed.
+            debug_assert_eq!(
+                self.available_data(),
+                data_before,
+                "rejected delete_slice must not mutate the buffer"
+            );
             return None;
         }
 
@@ -217,16 +449,42 @@ impl Checkout {
             );
             self.inner.end = next_end;
         }
+        // Post-condition: removing `length` bytes from the middle shrinks the
+        // readable window by exactly `length`.
+        debug_assert_eq!(
+            self.available_data(),
+            data_before - length,
+            "delete_slice must shrink available data by exactly the deleted length"
+        );
+        #[cfg(debug_assertions)]
+        self.check_invariants();
         Some(self.available_data())
     }
 
     pub fn replace_slice(&mut self, data: &[u8], start: usize, length: usize) -> Option<usize> {
+        #[cfg(debug_assertions)]
+        self.check_invariants();
+        let data_before = self.available_data();
         let data_len = data.len();
         if start + length > self.available_data()
             || self.inner.position + start + data_len > self.capacity()
         {
+            // Rejected replace is a graceful no-op.
+            debug_assert_eq!(
+                self.available_data(),
+                data_before,
+                "rejected replace_slice must not mutate the buffer"
+            );
             return None;
         }
+        // Pre-condition: the replacement window lies within the readable data
+        // (guaranteed by the early-return above). The net length change is
+        // `data_len - length`.
+        debug_assert!(
+            start + length <= data_before,
+            "replace_slice window [{start}, {}) must lie within available data ({data_before})",
+            start + length
+        );
 
         // SAFETY: every `ptr::copy` below moves bytes inside the same
         // checkout buffer (`self.inner.extra`) or copies from the caller's
@@ -267,16 +525,42 @@ impl Checkout {
                 self.inner.end += data_len - length;
             }
         }
+        // Post-condition: the readable window grew/shrank by exactly the net
+        // difference between the inserted data and the replaced span. Compare
+        // as i64 to keep the arithmetic signed and avoid usize underflow in
+        // the assertion itself.
+        debug_assert_eq!(
+            self.available_data() as i64,
+            data_before as i64 + data_len as i64 - length as i64,
+            "replace_slice must change available data by exactly data_len - length"
+        );
+        #[cfg(debug_assertions)]
+        self.check_invariants();
         Some(self.available_data())
     }
 
     pub fn insert_slice(&mut self, data: &[u8], start: usize) -> Option<usize> {
+        #[cfg(debug_assertions)]
+        self.check_invariants();
+        let data_before = self.available_data();
         let data_len = data.len();
         if start > self.available_data()
             || self.inner.position + self.inner.end + data_len > self.capacity()
         {
+            // Rejected insert is a graceful no-op.
+            debug_assert_eq!(
+                self.available_data(),
+                data_before,
+                "rejected insert_slice must not mutate the buffer"
+            );
             return None;
         }
+        // Pre-condition: the insertion point lies within the readable data and
+        // the resulting buffer stays within capacity (guaranteed above).
+        debug_assert!(
+            start <= data_before,
+            "insert_slice start ({start}) must lie within available data ({data_before})"
+        );
 
         // SAFETY: both `ptr::copy` calls touch `self.inner.extra` (same
         // allocation) or copy from `data` into it. The early-return checks
@@ -298,6 +582,15 @@ impl Checkout {
             );
             self.inner.end += data_len;
         }
+        // Post-condition: inserting `data_len` bytes grows the readable window
+        // by exactly `data_len`.
+        debug_assert_eq!(
+            self.available_data(),
+            data_before + data_len,
+            "insert_slice must grow available data by exactly the inserted length"
+        );
+        #[cfg(debug_assertions)]
+        self.check_invariants();
         Some(self.available_data())
     }
 }

--- a/lib/src/protocol/kawa_h1/answers.rs
+++ b/lib/src/protocol/kawa_h1/answers.rs
@@ -183,6 +183,16 @@ impl Template {
         } else {
             return Err(TemplateError::InvalidType);
         };
+        // Post (status validity): a template that reached `is_main_phase()`
+        // above carries a syntactically valid response status line. HTTP
+        // status codes are exactly 3 digits (RFC 9110 §15), so the parsed
+        // code is bounded to `100..=999`. Downstream `save_http_status_metric`
+        // buckets on this range; an out-of-band code would silently fall into
+        // the `STATUS_OTHER` bucket.
+        debug_assert!(
+            (100..=999).contains(&resolved_status),
+            "parsed template status must be a 3-digit HTTP code, got {resolved_status}"
+        );
         let buf = kawa.storage.buffer();
         let mut blocks = VecDeque::new();
         let mut header_replacements = Vec::new();
@@ -292,6 +302,19 @@ impl Template {
                                             data: Store::new_slice(buf, &data[start..i]),
                                         }));
                                     }
+                                    // Pre (no underflow): the `%NAME` literal we
+                                    // are about to remove from the running
+                                    // body-size total (`%` + the variable name)
+                                    // was counted into `body_size` when this
+                                    // chunk's bytes were added above, so the
+                                    // subtraction cannot underflow.
+                                    debug_assert!(
+                                        body_size > variable.name.len(),
+                                        "body_size accounting underflow: {} < %{} ({} bytes)",
+                                        body_size,
+                                        variable.name,
+                                        variable.name.len() + 1
+                                    );
                                     body_size -= variable.name.len() + 1;
                                     start = i + variable.name.len() + 1;
                                     i += variable.name.len();
@@ -330,6 +353,31 @@ impl Template {
             }
         }
         kawa.blocks = blocks;
+        // Post (replacement bookkeeping): every replacement we recorded points
+        // at a block index that exists in the pre-baked sequence — `fill`
+        // indexes `blocks[replacement.block_index]` directly, so a stale index
+        // would be an out-of-bounds panic on the hot path. Both replacement
+        // lists are bounded by the block count.
+        debug_assert!(
+            header_replacements
+                .iter()
+                .chain(body_replacements.iter())
+                .all(|r| r.block_index < kawa.blocks.len()),
+            "every replacement index must address a block within the pre-baked sequence"
+        );
+        // Post (one ContentLength): at most one block is wired to the
+        // auto-computed `Content-Length` placeholder — duplicate
+        // `Content-Length` is a CWE-444 request-smuggling primitive and is
+        // rejected via `AlreadyConsumed` above, so the rendered response must
+        // never carry two.
+        debug_assert!(
+            header_replacements
+                .iter()
+                .filter(|r| matches!(r.typ, ReplacementType::ContentLength))
+                .count()
+                <= 1,
+            "at most one Content-Length placeholder may survive template compilation"
+        );
         Ok(Self {
             status: resolved_status,
             keep_alive,
@@ -347,6 +395,33 @@ impl Template {
         variables: &[Vec<u8>],
         variables_once: &mut [Vec<u8>],
     ) -> DefaultAnswerStream {
+        // Pre (slot coverage): every `Variable(i)` / `VariableOnce(i)` recorded
+        // at compile time must have a runtime slot supplied by the caller.
+        // `Template::new` re-indexes the variables into contiguous slots, so
+        // the caller's vectors must be at least as long as the highest index
+        // referenced. A short vector would be an out-of-bounds index panic on
+        // the hot path; this surfaces the caller/template mismatch loudly in
+        // debug while staying a plain index in release.
+        #[cfg(debug_assertions)]
+        for replacement in self
+            .body_replacements
+            .iter()
+            .chain(&self.header_replacements)
+        {
+            match replacement.typ {
+                ReplacementType::Variable(i) => debug_assert!(
+                    i < variables.len(),
+                    "Variable({i}) has no runtime slot (only {} supplied)",
+                    variables.len()
+                ),
+                ReplacementType::VariableOnce(i) => debug_assert!(
+                    i < variables_once.len(),
+                    "VariableOnce({i}) has no runtime slot (only {} supplied)",
+                    variables_once.len()
+                ),
+                ReplacementType::ContentLength => {}
+            }
+        }
         let mut blocks = self.kawa.blocks.clone();
         let mut body_size = self.body_size;
         for replacement in &self.body_replacements {
@@ -391,6 +466,17 @@ impl Template {
                 }
             }
         }
+        // Post (body-size monotonicity): substituting runtime values only ever
+        // adds bytes on top of the template's literal body, so the rendered
+        // total cannot be smaller than the compile-time `body_size` of the
+        // literal-only body. A regression that subtracted here would render a
+        // short `Content-Length` and truncate the answer on the wire.
+        debug_assert!(
+            body_size >= self.body_size,
+            "rendered body_size {} must not be below the template's literal body_size {}",
+            body_size,
+            self.body_size
+        );
         Kawa {
             storage: Buffer::new(self.kawa.storage.buffer.clone()),
             blocks,
@@ -1188,6 +1274,15 @@ impl HttpAnswers {
             _ => return None,
         };
         let template = Self::template(name, answer_str).ok()?;
+        // The redirect template name (`"301"`/`"302"`/`"308"`) pins the
+        // expected status at compile time (`Template::new(Some(code), …)`), so
+        // a successfully compiled template's status must equal the requested
+        // redirect code. The doc comment promises callers `template.status ==
+        // code`; this guards that contract against a future name/code skew.
+        debug_assert_eq!(
+            template.status, code,
+            "inline redirect template status must match the requested redirect code"
+        );
         // Variable order must match the matching `DefaultAnswer::Answer{301,302,308}`
         // arm of `HttpAnswers::get`: `(ROUTE, REQUEST_ID)` are persistent
         // `Variable` slots, `REDIRECT_LOCATION` is the once slot.
@@ -1358,6 +1453,16 @@ impl HttpAnswers {
             .and_then(|answers| answers.get(name))
             .or_else(|| self.listener_answers.get(name))
             .unwrap_or(&self.fallback);
+        // Post (resolved status validity): the template we selected was
+        // validated to carry a 3-digit status at `Template::new` time; the
+        // lookup chain (per-cluster → listener → fallback) can never produce a
+        // template with an out-of-range status. The returned code feeds
+        // `self.context.status` and `save_http_status_metric`.
+        debug_assert!(
+            (100..=999).contains(&template.status),
+            "resolved answer status must be a 3-digit HTTP code, got {}",
+            template.status
+        );
         (
             template.status,
             template.keep_alive,

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -70,13 +70,44 @@ fn random_id<const N: usize>() -> [u8; N] {
 
 #[cfg(feature = "opentelemetry")]
 fn build_traceparent(trace_id: &[u8; 32], parent_id: &[u8; 16]) -> [u8; 55] {
+    // Pre: the ids are hex (they come from a parsed traceparent or our own
+    // hex `random_id`). Hex digits are inherently CR/LF-free, so this also
+    // upholds the anti-injection guarantee for the value we splice into the
+    // `traceparent` header. Inline (not via `is_crlf_free`) so the release
+    // build under `--features opentelemetry` still compiles (HARD RULE 2).
+    debug_assert!(
+        trace_id.iter().all(u8::is_ascii_hexdigit) && parent_id.iter().all(u8::is_ascii_hexdigit),
+        "traceparent ids must be hex (CR/LF-free header value)"
+    );
     let mut buf = [0; 55];
     buf[..3].copy_from_slice(b"00-");
     buf[3..35].copy_from_slice(trace_id);
     buf[35] = b'-';
     buf[36..52].copy_from_slice(parent_id);
     buf[52..55].copy_from_slice(b"-01");
+    // Post: the value is exactly the `00-<trace>-<parent>-01` shape with the
+    // dash separators at the fixed offsets the parser expects.
+    debug_assert!(
+        buf[2] == b'-' && buf[35] == b'-' && buf[52] == b'-',
+        "traceparent must carry dash separators at fixed offsets"
+    );
     buf
+}
+
+/// `true` when `bytes` contains no CR or LF — the anti-injection
+/// invariant for any header value Sōzu serialises onto the wire. A value
+/// carrying a raw CR/LF could split one header into two (request/response
+/// smuggling, CWE-93/CWE-113).
+///
+/// Compiled in EVERY profile (HARD RULE 2): it is referenced inside plain
+/// `debug_assert!` calls whose arguments still compile with
+/// `debug_assertions` OFF, so a `#[cfg(debug_assertions)]` gate would break
+/// the release build with E0425. In release it is only reached from
+/// optimised-out `debug_assert!` bodies, so the optimiser drops it — hence
+/// `#[allow(dead_code)]` to keep `-D warnings` clean.
+#[allow(dead_code)]
+fn is_crlf_free(bytes: &[u8]) -> bool {
+    !bytes.iter().any(|b| *b == b'\r' || *b == b'\n')
 }
 
 /// Write the ";for=..;by=.." portion of a Forwarded header into `buf`
@@ -90,6 +121,7 @@ fn build_traceparent(trace_id: &[u8; 32], parent_id: &[u8; 16]) -> [u8; 55] {
 /// (`_7239_print_ip6` in `src/http_ext.c`), which is the de-facto reference
 /// implementation of RFC 7239 in the proxy world. See sozu issue #1254.
 fn write_forwarded_for_by(buf: &mut Vec<u8>, peer_ip: IpAddr, peer_port: u16, public_ip: IpAddr) {
+    let before = buf.len();
     buf.extend_from_slice(b";for=\"");
     write_ip_literal(buf, peer_ip);
     buf.push(b':');
@@ -106,12 +138,27 @@ fn write_forwarded_for_by(buf: &mut Vec<u8>, peer_ip: IpAddr, peer_port: u16, pu
             buf.push(b'"');
         }
     }
+    // Post: the fragment grew the buffer and the whole appended span is
+    // CR/LF-free — it is spliced verbatim into a `Forwarded` header value,
+    // so a stray CR/LF would let an attacker-influenced peer address split
+    // the header (CWE-93). `peer_ip`/`public_ip` are `IpAddr` and the port
+    // is a `u16`, so no untrusted bytes reach here, but the guard pins the
+    // anti-injection contract against future edits to this fragment.
+    debug_assert!(
+        buf.len() > before,
+        "the Forwarded ;for=;by= fragment must emit bytes"
+    );
+    debug_assert!(
+        is_crlf_free(&buf[before..]),
+        "the Forwarded fragment must be CR/LF-free (anti-injection)"
+    );
 }
 
 /// Write an `IP-literal` per RFC 3986 §3.2.2 / RFC 7239 §6: IPv4 verbatim,
 /// IPv6 wrapped in `[...]`. Caller is responsible for any surrounding quotes
 /// required by the embedding syntax (RFC 7239 mandates them for IPv6).
 fn write_ip_literal(buf: &mut Vec<u8>, ip: IpAddr) {
+    let before = buf.len();
     match ip {
         IpAddr::V4(_) => {
             let _ = write!(buf, "{ip}");
@@ -122,6 +169,21 @@ fn write_ip_literal(buf: &mut Vec<u8>, ip: IpAddr) {
             buf.push(b']');
         }
     }
+    // Post: a non-empty literal was appended (every IpAddr renders to at
+    // least one byte) and the emitted bytes carry no CR/LF — an IpAddr can
+    // only render `[0-9a-fA-F:.]` plus the brackets we add, so this is a
+    // belt-and-suspenders guard on the value we splice into a header.
+    debug_assert!(buf.len() > before, "write_ip_literal must emit bytes");
+    debug_assert!(
+        is_crlf_free(&buf[before..]),
+        "an IP literal spliced into a header must be CR/LF-free"
+    );
+    // IPv6 is bracketed on both ends; IPv4 is bare (RFC 3986 §3.2.2).
+    debug_assert_eq!(
+        matches!(ip, IpAddr::V6(_)),
+        buf[before] == b'[' && buf[buf.len() - 1] == b']',
+        "IPv6 literals are bracketed, IPv4 literals are not"
+    );
 }
 
 /// Write ", proto=<proto>;for=..;by=.." (the suffix appended to an existing Forwarded value).
@@ -132,9 +194,32 @@ fn write_forwarded_suffix(
     peer_port: u16,
     public_ip: IpAddr,
 ) {
+    // Pre: `proto` is the proxy-chosen scheme label ("http"/"https"), never
+    // attacker-controlled — assert it carries no CR/LF before it is spliced
+    // into the `Forwarded` value (anti-injection, CWE-93).
+    debug_assert!(
+        is_crlf_free(proto.as_bytes()),
+        "the proto label spliced into Forwarded must be CR/LF-free"
+    );
+    let before = buf.len();
     buf.extend_from_slice(b", proto=");
     buf.extend_from_slice(proto.as_bytes());
     write_forwarded_for_by(buf, peer_ip, peer_port, public_ip);
+    // Post: the suffix grew the buffer, begins with the `, proto=`
+    // separator (so it appends cleanly to an existing value), and the whole
+    // appended span is CR/LF-free.
+    debug_assert!(
+        buf.len() > before + b", proto=".len(),
+        "the Forwarded suffix must emit the separator plus a value"
+    );
+    debug_assert!(
+        buf[before..].starts_with(b", proto="),
+        "the Forwarded suffix must start with the `, proto=` separator"
+    );
+    debug_assert!(
+        is_crlf_free(&buf[before..]),
+        "the Forwarded suffix must be CR/LF-free (anti-injection)"
+    );
 }
 
 /// This is the container used to store and use information about the session from within a Kawa parser callback
@@ -471,6 +556,11 @@ impl HttpContext {
     ///   - user-agent
     ///   - x-request-id (preserved if present, else derived from `self.id`)
     fn on_request_headers(&mut self, request: &mut GenericHttpStream) {
+        // Editing never drops a block — it only elides in place (key set to
+        // Empty, length preserved) or pushes new headers. Snapshot the count
+        // so the postcondition can pin "blocks only grow" for the whole edit.
+        let blocks_at_entry = request.blocks.len();
+
         let buf = request.storage.mut_buffer();
 
         // Captures the request line
@@ -504,6 +594,15 @@ impl HttpContext {
             _ => unreachable!(),
         };
 
+        // `proto` is the proxy-resolved scheme label, sourced from the
+        // listener protocol (never from request bytes). The match above
+        // already rejects anything but HTTP/HTTPS; pin that it is one of the
+        // two CR/LF-free literals we splice into forwarding headers.
+        debug_assert!(
+            proto == "http" || proto == "https",
+            "proto must be the http/https scheme label"
+        );
+
         // Find and remove the sticky_name cookie
         // if found its value is stored in sticky_session_found
         for cookie in &mut request.detached.jar {
@@ -512,6 +611,12 @@ impl HttpContext {
                 let val = cookie.val.data(buf);
                 self.sticky_session_found = from_utf8(val).ok().map(ToOwned::to_owned);
                 cookie.elide();
+                // Post: the matched sticky cookie is gone from the forwarded
+                // jar so the backend never sees Sōzu's own session cookie.
+                debug_assert!(
+                    cookie.is_elided(),
+                    "the matched sticky cookie must be elided after capture"
+                );
             }
         }
 
@@ -596,7 +701,17 @@ impl HttpContext {
                         // HEADERS frames bypass this callback; they are
                         // covered by the matching elision in
                         // `pkawa::handle_trailer`.
+                        debug_assert!(
+                            self.elide_x_real_ip,
+                            "X-Real-IP is only elided when anti-spoofing is enabled"
+                        );
                         header.elide();
+                        // Post: the spoofable client value is stripped before
+                        // forwarding (anti-spoofing invariant, CWE-348).
+                        debug_assert!(
+                            header.is_elided(),
+                            "client X-Real-IP must be elided when elide_x_real_ip is set"
+                        );
                     } else if compare_no_case(key, b"Forwarded") {
                         forwarded = Some(header);
                     } else if compare_no_case(key, b"User-Agent") {
@@ -672,31 +787,77 @@ impl HttpContext {
             let mut hdr_buf = Vec::with_capacity(128);
 
             if let Some(header) = x_for {
+                let prior_len = header.val.data(buf).len();
                 hdr_buf.extend_from_slice(header.val.data(buf));
                 let _ = write!(hdr_buf, ", {peer_ip}");
+                // Pre: we only ever extend the client-attested chain — the
+                // existing value stays a prefix and we appended the `, ip`
+                // separator, so the rewritten value is strictly longer and
+                // CR/LF-free (else the appended peer would split the header).
+                debug_assert!(
+                    hdr_buf.len() > prior_len,
+                    "X-Forwarded-For append must grow the value"
+                );
+                debug_assert!(
+                    is_crlf_free(&hdr_buf[prior_len..]),
+                    "the X-Forwarded-For hop we append must be CR/LF-free (anti-injection)"
+                );
                 header.val = kawa::Store::from_vec(std::mem::take(&mut hdr_buf));
             }
             if let Some(header) = &mut forwarded {
+                let prior_len = header.val.data(buf).len();
                 hdr_buf.extend_from_slice(header.val.data(buf));
                 write_forwarded_suffix(&mut hdr_buf, proto, peer_ip, peer_port, public_ip);
+                // Pre: same contract for the structured `Forwarded` chain —
+                // the existing value is preserved as a prefix and our suffix
+                // is CR/LF-free (`write_forwarded_suffix` asserts the suffix
+                // span too; this pins it relative to the prior value).
+                debug_assert!(
+                    hdr_buf.len() > prior_len,
+                    "Forwarded append must grow the value"
+                );
+                debug_assert!(
+                    is_crlf_free(&hdr_buf[prior_len..]),
+                    "the Forwarded element we append must be CR/LF-free (anti-injection)"
+                );
                 header.val = kawa::Store::from_vec(std::mem::take(&mut hdr_buf));
             }
 
             if !has_x_for {
+                let blocks_before = request.blocks.len();
                 let _ = write!(hdr_buf, "{peer_ip}");
+                debug_assert!(
+                    is_crlf_free(&hdr_buf),
+                    "a synthesised X-Forwarded-For value must be CR/LF-free"
+                );
                 request.push_block(kawa::Block::Header(kawa::Pair {
                     key: kawa::Store::Static(b"X-Forwarded-For"),
                     val: kawa::Store::from_vec(std::mem::take(&mut hdr_buf)),
                 }));
+                debug_assert_eq!(
+                    request.blocks.len(),
+                    blocks_before + 1,
+                    "creating X-Forwarded-For must push exactly one block"
+                );
             }
             if !has_forwarded {
+                let blocks_before = request.blocks.len();
                 hdr_buf.extend_from_slice(b"proto=");
                 hdr_buf.extend_from_slice(proto.as_bytes());
                 write_forwarded_for_by(&mut hdr_buf, peer_ip, peer_port, public_ip);
+                debug_assert!(
+                    is_crlf_free(&hdr_buf),
+                    "a synthesised Forwarded value must be CR/LF-free"
+                );
                 request.push_block(kawa::Block::Header(kawa::Pair {
                     key: kawa::Store::Static(b"Forwarded"),
                     val: kawa::Store::from_vec(std::mem::take(&mut hdr_buf)),
                 }));
+                debug_assert_eq!(
+                    request.blocks.len(),
+                    blocks_before + 1,
+                    "creating Forwarded must push exactly one block"
+                );
             }
 
             // Inject a proxy-generated `X-Real-IP` header carrying the
@@ -710,11 +871,27 @@ impl HttpContext {
             // header is appended last so order in the resulting block
             // list is deterministic for tests.
             if self.send_x_real_ip {
+                let blocks_before = request.blocks.len();
+                debug_assert!(
+                    hdr_buf.is_empty(),
+                    "the header scratch buffer was taken before reuse"
+                );
                 let _ = write!(hdr_buf, "{peer_ip}");
+                // The proxy-generated value is a rendered IpAddr — non-empty
+                // and CR/LF-free, so it cannot inject a second header.
+                debug_assert!(
+                    !hdr_buf.is_empty() && is_crlf_free(&hdr_buf),
+                    "the injected X-Real-IP value must be a CR/LF-free IP"
+                );
                 request.push_block(kawa::Block::Header(kawa::Pair {
                     key: kawa::Store::Static(b"X-Real-IP"),
                     val: kawa::Store::from_vec(std::mem::take(&mut hdr_buf)),
                 }));
+                debug_assert_eq!(
+                    request.blocks.len(),
+                    blocks_before + 1,
+                    "injecting X-Real-IP must push exactly one block"
+                );
             }
         }
 
@@ -761,6 +938,12 @@ impl HttpContext {
             incr!(names::http::X_REQUEST_ID_PROPAGATED);
         } else {
             let value = self.id.to_string();
+            // The generated id is a ULID rendering — Crockford base-32, so
+            // CR/LF-free by construction.
+            debug_assert!(
+                is_crlf_free(value.as_bytes()),
+                "the generated X-Request-Id must be CR/LF-free"
+            );
             request.push_block(kawa::Block::Header(kawa::Pair {
                 key: kawa::Store::Static(b"X-Request-Id"),
                 val: kawa::Store::from_string(value.clone()),
@@ -768,13 +951,34 @@ impl HttpContext {
             self.x_request_id = Some(value);
             incr!(names::http::X_REQUEST_ID_GENERATED);
         }
+        // Either branch leaves the forwarded value recorded for the access
+        // log so it matches exactly what the backend receives.
+        debug_assert!(
+            self.x_request_id.is_some(),
+            "on_request_headers must record the forwarded X-Request-Id"
+        );
 
         // Create a custom correlation header (defaults to "Sozu-Id", can be
         // renamed via the `sozu_id_header` listener config knob).
+        let blocks_before_sozu_id = request.blocks.len();
         request.push_block(kawa::Block::Header(kawa::Pair {
             key: kawa::Store::from_string(self.sozu_id_header.clone()),
             val: kawa::Store::from_string(self.id.to_string()),
         }));
+        debug_assert_eq!(
+            request.blocks.len(),
+            blocks_before_sozu_id + 1,
+            "the Sozu-Id correlation header must be pushed exactly once"
+        );
+
+        // Postcondition: the whole edit only ever added or elided headers —
+        // the block count is monotonically non-decreasing (a removed header
+        // is elided in place, never popped), so the backend never loses a
+        // header it should have seen.
+        debug_assert!(
+            request.blocks.len() >= blocks_at_entry,
+            "header editing must never drop a block from the request"
+        );
     }
 
     /// Callback for response:
@@ -785,6 +989,10 @@ impl HttpContext {
     ///   - reason
     ///   - back keep-alive
     fn on_response_headers(&mut self, response: &mut GenericHttpStream) {
+        // Like the request path, response editing only adds or elides — pin
+        // the entry count so the postcondition can assert "blocks only grow".
+        let blocks_at_entry = response.blocks.len();
+
         let buf = &mut response.storage.mut_buffer();
 
         // Captures the response line
@@ -824,28 +1032,77 @@ impl HttpContext {
         // create a "Set-Cookie" header to update the sticky_name value
         if let Some(sticky_session) = &self.sticky_session {
             if self.sticky_session != self.sticky_session_found {
+                let blocks_before = response.blocks.len();
                 let mut cookie_buf =
                     Vec::with_capacity(self.sticky_name.len() + 1 + sticky_session.len() + 8);
                 cookie_buf.extend_from_slice(self.sticky_name.as_bytes());
                 cookie_buf.push(b'=');
                 cookie_buf.extend_from_slice(sticky_session.as_bytes());
                 cookie_buf.extend_from_slice(b"; Path=/");
+                // The cookie value is `name=session; Path=/`, built from the
+                // proxy-controlled sticky name + session id — assert it is
+                // well-formed (contains the `=` separator, ends with the
+                // attribute suffix) and CR/LF-free so it cannot inject an
+                // extra Set-Cookie / split the response (CWE-113).
+                debug_assert!(
+                    cookie_buf.contains(&b'='),
+                    "the Set-Cookie value must carry the name=value separator"
+                );
+                debug_assert!(
+                    cookie_buf.ends_with(b"; Path=/"),
+                    "the Set-Cookie value must end with the Path attribute"
+                );
+                debug_assert!(
+                    is_crlf_free(&cookie_buf),
+                    "the synthesised Set-Cookie value must be CR/LF-free (anti-injection)"
+                );
                 response.push_block(kawa::Block::Header(kawa::Pair {
                     key: kawa::Store::Static(b"Set-Cookie"),
                     val: kawa::Store::from_vec(cookie_buf),
                 }));
+                debug_assert_eq!(
+                    response.blocks.len(),
+                    blocks_before + 1,
+                    "synthesising Set-Cookie must push exactly one block"
+                );
             }
         }
 
         // Create a custom correlation header (defaults to "Sozu-Id", can be
         // renamed via the `sozu_id_header` listener config knob).
+        let blocks_before_sozu_id = response.blocks.len();
         response.push_block(kawa::Block::Header(kawa::Pair {
             key: kawa::Store::from_string(self.sozu_id_header.clone()),
             val: kawa::Store::from_string(self.id.to_string()),
         }));
+        debug_assert_eq!(
+            response.blocks.len(),
+            blocks_before_sozu_id + 1,
+            "the Sozu-Id correlation header must be pushed exactly once"
+        );
+
+        // Postcondition: response editing only added or elided headers, so
+        // the block count never decreased.
+        debug_assert!(
+            response.blocks.len() >= blocks_at_entry,
+            "header editing must never drop a block from the response"
+        );
     }
 
     pub fn reset(&mut self) {
+        // Snapshot the connection-scoped identity + TLS/listener fields that
+        // reset() must NOT touch (set once at handshake, reused across every
+        // keep-alive request). Cheap to copy — all `Copy`. Read only inside
+        // the postcondition `debug_assert!`s below, so dead code in release.
+        let session_id_before = self.session_id;
+        let id_before = self.id;
+        let strict_sni_before = self.strict_sni_binding;
+        let elide_before = self.elide_x_real_ip;
+        let send_before = self.send_x_real_ip;
+        let tls_version_before = self.tls_version;
+        let tls_cipher_before = self.tls_cipher;
+        let tls_alpn_before = self.tls_alpn;
+
         self.keep_alive_backend = true;
         self.keep_alive_frontend = true;
         self.sticky_session_found = None;
@@ -866,6 +1123,37 @@ impl HttpContext {
         // connection-scoped — set once at handshake completion and reused
         // across every keep-alive request, so reset() intentionally leaves
         // them in place.
+
+        // Post: request-scoped state is fully cleared (a stale value here
+        // would leak across pipelined requests on the same connection).
+        debug_assert!(
+            self.method.is_none()
+                && self.authority.is_none()
+                && self.path.is_none()
+                && self.status.is_none()
+                && self.x_request_id.is_none()
+                && self.headers_response.is_empty(),
+            "reset() must clear all request-scoped state"
+        );
+        debug_assert!(
+            self.keep_alive_backend && self.keep_alive_frontend,
+            "reset() must restore keep-alive to its optimistic default"
+        );
+        // Post: connection-scoped identity + TLS/listener knobs are untouched.
+        debug_assert_eq!(
+            self.session_id, session_id_before,
+            "reset() must preserve the connection session id"
+        );
+        debug_assert_eq!(self.id, id_before, "reset() must preserve the request id");
+        debug_assert!(
+            self.strict_sni_binding == strict_sni_before
+                && self.elide_x_real_ip == elide_before
+                && self.send_x_real_ip == send_before
+                && self.tls_version == tls_version_before
+                && self.tls_cipher == tls_cipher_before
+                && self.tls_alpn == tls_alpn_before,
+            "reset() must preserve connection-scoped TLS/listener knobs"
+        );
     }
 
     pub fn extract_route(&self) -> Result<(&str, &str, &Method), RetrieveClusterError> {
@@ -876,6 +1164,15 @@ impl HttpContext {
             .ok_or(RetrieveClusterError::NoHost)?;
         let given_path = self.path.as_deref().ok_or(RetrieveClusterError::NoPath)?;
 
+        // Post: the triple is returned in (authority, path, method) order —
+        // pin it against a future field-swap regression that would route to
+        // the wrong cluster. (Both fields can be empty strings on the wire,
+        // so we assert the mapping, not non-emptiness.)
+        debug_assert!(
+            std::ptr::eq(given_authority, self.authority.as_deref().unwrap())
+                && std::ptr::eq(given_path, self.path.as_deref().unwrap()),
+            "extract_route must return (authority, path, method) in order"
+        );
         Ok((given_authority, given_path, given_method))
     }
 
@@ -903,12 +1200,21 @@ impl HttpContext {
     }
 
     pub fn log_context(&self) -> LogContext<'_> {
-        LogContext {
+        let ctx = LogContext {
             session_id: self.session_id,
             request_id: Some(self.id),
             cluster_id: self.cluster_id.as_deref(),
             backend_id: self.backend_id.as_deref(),
-        }
+        };
+        // The access-log bracket `[session req cluster backend]` is keyed on
+        // session + request id; both must always be present so the log line
+        // is correlatable. cluster/backend are legitimately absent before
+        // routing, so they are not asserted here.
+        debug_assert!(
+            ctx.request_id.is_some(),
+            "log_context must always carry the request id for correlation"
+        );
+        ctx
     }
 }
 

--- a/lib/src/protocol/kawa_h1/mod.rs
+++ b/lib/src/protocol/kawa_h1/mod.rs
@@ -340,7 +340,24 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
 
         self.request_stream.clear();
         response_stream.clear();
+        // Pair-assert the keep-alive counter advances by exactly one per
+        // completed request: it gates the `WaitingForNewRequest` timeout-status
+        // branch and the keepalive-vs-error accounting in `readable`. A
+        // double-increment or stall would mis-attribute the next idle close.
+        let keepalive_before = self.keepalive_count;
         self.keepalive_count += 1;
+        debug_assert_eq!(
+            self.keepalive_count,
+            keepalive_before + 1,
+            "reset() must advance keepalive_count by exactly one"
+        );
+        // The response side has just been cleared, so it is back to its
+        // initial parsing phase — `writable` must not see a half-consumed
+        // response when the next request starts.
+        debug_assert!(
+            response_stream.is_initial(),
+            "response stream must be reset to initial on keep-alive"
+        );
         gauge_add!(names::http::ACTIVE_REQUESTS, -1);
 
         if let Some(backend) = &mut self.backend {
@@ -423,6 +440,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             return StateResult::Continue;
         }
 
+        let available_space = self.request_stream.storage.available_space();
         let (size, socket_state) = self
             .frontend_socket
             .socket_read(self.request_stream.storage.space());
@@ -433,8 +451,23 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             size
         );
 
+        // A read can never deliver more bytes than the buffer slice we handed
+        // it; `storage.fill(size)` below trusts this to advance the write
+        // cursor, and an over-long `size` would push the cursor past the
+        // buffer end (OOB on the next parse).
+        debug_assert!(
+            size <= available_space,
+            "socket_read returned {size} bytes for a {available_space}-byte buffer slice"
+        );
+
         if size > 0 {
+            let used_before = self.request_stream.storage.used().len();
             self.request_stream.storage.fill(size);
+            debug_assert_eq!(
+                self.request_stream.storage.used().len(),
+                used_before + size,
+                "storage.fill(size) must grow the used region by exactly the bytes read"
+            );
             count!(names::backend::BYTES_IN, size as i64);
             metrics.bin += size;
             // if self.kawa_request.storage.is_full() {
@@ -573,6 +606,16 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         );
 
         if size > 0 {
+            // A vectored write can only have flushed bytes that were actually
+            // queued in `bufs`; consuming more than we sent would advance the
+            // kawa output cursor past the data the peer received and truncate
+            // the next chunk. (`as_io_slice` is built from the same stream we
+            // now consume from.)
+            let queued = bufs.iter().map(|b| b.len()).sum::<usize>();
+            debug_assert!(
+                size <= queued,
+                "socket_write_vectored reported {size} bytes for {queued} queued"
+            );
             response_stream.consume(size);
             count!(names::backend::BYTES_OUT, size as i64);
             metrics.bout += size;
@@ -702,6 +745,14 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         let bufs = response_stream.as_io_slice();
         let (size, socket_state) = self.frontend_socket.socket_write_vectored(&bufs);
 
+        // Never consume more of the rendered default answer than the socket
+        // actually accepted, or the next flush would skip bytes and ship a
+        // truncated error page.
+        let queued = bufs.iter().map(|b| b.len()).sum::<usize>();
+        debug_assert!(
+            size <= queued,
+            "default-answer write reported {size} bytes for {queued} queued"
+        );
         count!(names::backend::BYTES_OUT, size as i64);
         metrics.bout += size;
         response_stream.consume(size);
@@ -761,6 +812,14 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         debug!("{} Wrote {} bytes", log_context!(self), size);
 
         if size > 0 {
+            // Consume only what the backend socket actually accepted from the
+            // queued request slices — over-consuming would drop request bytes
+            // the backend never saw (silent request truncation / smuggling).
+            let queued = bufs.iter().map(|b| b.len()).sum::<usize>();
+            debug_assert!(
+                size <= queued,
+                "backend socket_write_vectored reported {size} bytes for {queued} queued"
+            );
             self.request_stream.consume(size);
             count!(names::backend::BACK_BYTES_OUT, size as i64);
             metrics.backend_bout += size;
@@ -852,6 +911,7 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             return SessionResult::Continue;
         }
 
+        let available_space = response_stream.storage.available_space();
         let (size, socket_state) = backend_socket.socket_read(response_stream.storage.space());
         debug!(
             "{} Read {} bytes",
@@ -859,8 +919,22 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             size
         );
 
+        // Same buffer-slice bound as the frontend read path: a backend read
+        // can never exceed the space slice we handed it, or `fill(size)` would
+        // push the response write cursor past the buffer end.
+        debug_assert!(
+            size <= available_space,
+            "backend socket_read returned {size} bytes for a {available_space}-byte slice"
+        );
+
         if size > 0 {
+            let used_before = response_stream.storage.used().len();
             response_stream.storage.fill(size);
+            debug_assert_eq!(
+                response_stream.storage.used().len(),
+                used_before + size,
+                "response storage.fill(size) must grow the used region by exactly the bytes read"
+            );
             count!(names::backend::BACK_BYTES_IN, size as i64);
             metrics.backend_bin += size;
             // if self.kawa_response.storage.is_full() {
@@ -1180,6 +1254,14 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             self.context.backend_id.as_deref(),
             self.get_route(),
         );
+        // The answer engine only ever resolves to a template whose status line
+        // parsed as a 3-digit HTTP code (`Template::new` enforces it); a value
+        // outside `100..=999` here would mean a malformed template slipped
+        // through and the bytes on the wire would carry a bogus status.
+        debug_assert!(
+            (100..=999).contains(&resolved_status),
+            "default answer must resolve to a 3-digit HTTP status, got {resolved_status}"
+        );
         kawa.prepare(&mut kawa::h1::BlockConverter);
         // The template's resolved status may differ from the requested
         // code when a fallback template is selected (e.g. unknown status).
@@ -1195,6 +1277,19 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         self.response_stream = ResponseStream::DefaultAnswer(status, kawa);
         self.frontend_readiness.interest = Ready::WRITABLE | Ready::HUP | Ready::ERROR;
         self.backend_readiness.interest = Ready::HUP | Ready::ERROR;
+        // Post: the session is now in the default-answer regime —
+        // `writable_default_answer` flushes the queued bytes and the frontend
+        // is steered to WRITABLE (never READABLE) while the backend is parked.
+        // This mirrors the `DefaultAnswer` arm of `check_invariants`.
+        debug_assert!(
+            matches!(self.response_stream, ResponseStream::DefaultAnswer(s, _) if s == status),
+            "set_answer must leave the response stream as the queued DefaultAnswer"
+        );
+        debug_assert!(
+            self.frontend_readiness.interest.is_writable()
+                && !self.frontend_readiness.interest.is_readable(),
+            "default answer must steer the frontend to WRITABLE only"
+        );
     }
 
     pub fn test_backend_socket(&self) -> bool {
@@ -1328,6 +1423,19 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
                 backend.borrow_mut().dec_connections();
             }
         }
+        // Post: the backend token is fully released — `close_backend` is the
+        // sole site that decrements the `CONNECTIONS` gauge, paired with the
+        // `+1` in `set_backend_connected`. Leaving a token behind would orphan
+        // the slab entry and skip the next session's gauge decrement.
+        debug_assert!(
+            self.backend_token.is_none(),
+            "close_backend must release the backend token"
+        );
+        debug_assert_ne!(
+            self.backend_connection_status,
+            BackendConnectionStatus::Connected,
+            "close_backend must leave the backend out of the Connected state"
+        );
     }
 
     /// Check the number of connection attempts against authorized connection retries
@@ -1352,6 +1460,13 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             });
             return Err(BackendConnectionError::MaxConnectionRetries(None));
         }
+        // Post (Ok branch): we only fall through when there is still budget for
+        // another connect attempt. `connect_to_backend` relies on this — it
+        // proceeds straight to the dial after a clean breaker check.
+        debug_assert!(
+            self.connection_attempts < CONN_RETRIES,
+            "check_circuit_breaker must only return Ok with retry budget remaining"
+        );
         Ok(())
     }
 
@@ -1685,6 +1800,17 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         self.backend_connection_status = connected;
 
         if connected == BackendConnectionStatus::Connected {
+            // Gauge ±1 pairing: the `CONNECTIONS` gauge is incremented here and
+            // decremented exactly once in `close_backend`. Transitioning into
+            // `Connected` from an already-`Connected` state would double-count
+            // and leave the gauge permanently inflated (it never underflows,
+            // but it would never return to zero either). The only legitimate
+            // predecessors are `NotConnected` and `Connecting(_)`.
+            debug_assert_ne!(
+                last,
+                BackendConnectionStatus::Connected,
+                "set_backend_connected(Connected) must not run twice without a close in between"
+            );
             gauge_add!(names::backend::CONNECTIONS, 1);
             gauge_add!(
                 names::backend::CONNECTIONS_PER_BACKEND,
@@ -1807,6 +1933,15 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
         if response_stream.is_terminated() {
             return StateResult::CloseBackend;
         }
+        // Reaching the match means the response is neither fully readable nor
+        // already terminated — the early returns above peeled those cases off.
+        // The `(_, false)` arm relies on this when it force-terminates a
+        // length-less response: terminating an already-terminated stream would
+        // be a no-op masking a real double-close.
+        debug_assert!(
+            !response_stream.is_terminated(),
+            "backend_hup reached its decision match with an already-terminated response"
+        );
         match (
             self.request_stream.is_initial(),
             response_stream.is_initial(),
@@ -1826,9 +1961,22 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
 
                 response_stream.parsing_phase = kawa::ParsingPhase::Terminated;
 
+                // Post: the forced termination took — required for the
+                // length-less / truncated-response close path to make progress.
+                debug_assert!(
+                    response_stream.is_terminated(),
+                    "forced backend-hup termination must mark the response terminated"
+                );
+
                 // writable() will be called again and finish the session properly
                 // for this reason, writable must not short cut
                 self.frontend_readiness.interest.insert(Ready::WRITABLE);
+                // Post: the frontend is now armed to write so `writable` can
+                // flush whatever the backend already sent and then close.
+                debug_assert!(
+                    self.frontend_readiness.interest.is_writable(),
+                    "backend-hup termination must arm the frontend for the final flush"
+                );
                 StateResult::Continue
             }
             // probably backend hup between keep alive request, change backend
@@ -1886,7 +2034,24 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
                     self.connection_attempts
                 );
 
+                // Each backend HUP-retry bumps the attempt counter by exactly
+                // one; the very next `connect_to_backend` runs the circuit
+                // breaker, which converts the `== CONN_RETRIES` case into a 503
+                // instead of dialling again — so the counter is never observed
+                // above `CONN_RETRIES` once the loop settles (see
+                // `check_invariants`).
+                let attempts_before = self.connection_attempts;
                 self.connection_attempts += 1;
+                debug_assert_eq!(
+                    self.connection_attempts,
+                    attempts_before + 1,
+                    "a backend retry must bump connection_attempts by exactly one"
+                );
+                debug_assert!(
+                    self.connection_attempts <= CONN_RETRIES,
+                    "connection_attempts ({}) must not exceed the breaker budget on retry",
+                    self.connection_attempts
+                );
                 self.fail_backend_connection(metrics);
 
                 self.backend_connection_status =
@@ -2073,6 +2238,13 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             return SessionResult::Close;
         }
 
+        // Post: a `Continue` exit means the loop drained all pending interest
+        // within the iteration budget (the `>= MAX_LOOP_ITERATIONS` arm above
+        // returns `Close` otherwise). This pins the no-infinite-loop contract.
+        debug_assert!(
+            counter < MAX_LOOP_ITERATIONS,
+            "ready_inner must only Continue when the loop settled within the iteration budget"
+        );
         SessionResult::Continue
     }
 
@@ -2088,6 +2260,64 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Http<Front, L
             TimeoutStatus::WaitingForNewRequest
         } else {
             TimeoutStatus::Request
+        }
+    }
+
+    /// Cross-field invariant sweep for the H1 session state machine.
+    ///
+    /// Run-to-completion postcondition: called via a `#[cfg(debug_assertions)]`
+    /// guard at the end of the [`SessionState::ready`] entry point, after the
+    /// inner loop has settled the session into a stable, between-events state.
+    /// It encodes relationships that must hold for ANY `Http` regardless of the
+    /// path (request, response, default answer, backend retry) that drove the
+    /// loop:
+    ///
+    /// - the circuit-breaker counter never exceeds the configured retry budget
+    ///   (`check_circuit_breaker` short-circuits at `CONN_RETRIES`, so a higher
+    ///   value would mean a retry slipped past the breaker);
+    /// - a `Connected` backend always names a live socket — `close_backend`
+    ///   takes the socket and drops back to `NotConnected` atomically, so any
+    ///   `Connected`-without-socket state is a teardown-ordering bug that would
+    ///   make `backend_writable`/`backend_readable` log "back socket not found";
+    /// - while a default answer is queued the frontend is steered toward
+    ///   WRITABLE and never asked to read more request bytes (the read path
+    ///   `error!`s and bails if it sees a `DefaultAnswer`), and the backend is
+    ///   never asked to read or write (we have nothing left to proxy);
+    /// - `context.status` agrees with the queued default-answer status, so the
+    ///   access-log / `save_http_status_metric` code never reports a different
+    ///   code than the bytes on the wire.
+    ///
+    /// Network input never reaches a hard `assert!` here — invalid traffic is
+    /// turned into a default answer or a close upstream; these `debug_assert!`s
+    /// fire only on our own logic bugs and compile out in release.
+    #[cfg(debug_assertions)]
+    fn check_invariants(&self) {
+        debug_assert!(
+            self.connection_attempts <= CONN_RETRIES,
+            "connection_attempts ({}) must stay within the circuit-breaker budget ({CONN_RETRIES})",
+            self.connection_attempts
+        );
+        if self.backend_connection_status == BackendConnectionStatus::Connected {
+            debug_assert!(
+                self.backend_socket.is_some(),
+                "a Connected backend must own a live socket (teardown-ordering bug)"
+            );
+        }
+        if let ResponseStream::DefaultAnswer(status, _) = &self.response_stream {
+            debug_assert!(
+                !self.frontend_readiness.interest.is_readable(),
+                "frontend must not be asked to read more request bytes while a default answer is queued"
+            );
+            debug_assert!(
+                !self.backend_readiness.interest.is_readable()
+                    && !self.backend_readiness.interest.is_writable(),
+                "backend must be idle (no read/write interest) while a default answer is queued"
+            );
+            debug_assert_eq!(
+                self.context.status,
+                Some(*status),
+                "context.status must match the queued default-answer status"
+            );
         }
     }
 }
@@ -2116,6 +2346,10 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> SessionState 
                 .buffer
                 .sync(response_storage.end, response_storage.head);
         }
+        // Run-to-completion postcondition: the session has settled into a
+        // stable between-events state. Compiled out in release.
+        #[cfg(debug_assertions)]
+        self.check_invariants();
         session_result
     }
 
@@ -2289,6 +2523,15 @@ fn handle_connection_result(
 /// only carries `Some(status)` so the `else` branch is unnecessary here.
 fn save_http_status_metric(status: Option<u16>, context: LogContext) {
     if let Some(status) = status {
+        // Every status reaching this bucketer originates either from a parsed
+        // backend response status line or a validated answer template, both of
+        // which are 3-digit HTTP codes. A value outside `100..=999` would fall
+        // into the `STATUS_OTHER` catch-all below and signal a status that was
+        // never a real HTTP code — a logic bug upstream, not hostile traffic.
+        debug_assert!(
+            (100..=999).contains(&status),
+            "save_http_status_metric got a non-3-digit status: {status}"
+        );
         match status {
             100..=199 => {
                 incr!(

--- a/lib/src/protocol/mux/connection.rs
+++ b/lib/src/protocol/mux/connection.rs
@@ -304,7 +304,20 @@ impl<Front: SocketHandler> Connection<Front> {
                         "{} H1 try_resume_reading: re-arming READABLE",
                         log_module_context!()
                     );
+                    // Pre: we only reach here because the connection parked on
+                    // buffer pressure AND the kawa now has room. Pair the
+                    // synthetic READABLE event with that drained-space fact:
+                    // edge-triggered epoll won't re-fire on its own, so this is
+                    // the sole re-arm path.
+                    debug_assert!(
+                        c.parked_on_buffer_pressure,
+                        "re-arm only fires for a connection parked on buffer pressure"
+                    );
                     c.readiness.signal_pending_read();
+                    debug_assert!(
+                        c.readiness.event.is_readable(),
+                        "signal_pending_read must leave a READABLE event queued"
+                    );
                     true
                 } else {
                     false
@@ -371,7 +384,17 @@ impl<Front: SocketHandler> Connection<Front> {
     fn pre_close_client_bookkeeping(&self) {
         if let Position::Client(cluster_id, backend, _) = self.position() {
             let mut backend_borrow = backend.borrow_mut();
+            // Pair the `dec_connections` with its prior value: the close path
+            // releases exactly one slot. `dec_connections` floors at 0 (a
+            // double-close from a desynced peer must not panic), so the
+            // post-relation is "decreased by one, unless already at zero".
+            let before = backend_borrow.active_connections;
             backend_borrow.dec_connections();
+            debug_assert_eq!(
+                backend_borrow.active_connections,
+                before.saturating_sub(1),
+                "close must release exactly one backend connection (saturating at 0)"
+            );
             gauge_add!(names::backend::CONNECTIONS, -1);
             // Pair with the `+1` at `router.rs::connect` (new-dial path).
             // This is the graceful-close decrement, used both by the dead
@@ -395,7 +418,21 @@ impl<Front: SocketHandler> Connection<Front> {
     fn pre_end_stream_client_bookkeeping(&self) {
         if let Position::Client(_, backend, BackendStatus::Connected) = self.position() {
             let mut backend_borrow = backend.borrow_mut();
+            // Pairs with the `+1` in `pre_start_stream_client_bookkeeping`.
+            // `saturating_sub` is the network-safe floor (a desync from the
+            // peer must not panic), so we can only assert the post-relation,
+            // not that `before > 0`.
+            let before = backend_borrow.active_requests;
             backend_borrow.active_requests = backend_borrow.active_requests.saturating_sub(1);
+            debug_assert_eq!(
+                backend_borrow.active_requests,
+                before.saturating_sub(1),
+                "end_stream bookkeeping must decrement active_requests by one (saturating)"
+            );
+            debug_assert!(
+                backend_borrow.active_requests <= before,
+                "active_requests must not grow on stream end"
+            );
             trace!(
                 "{} connection end stream: {:#?}",
                 log_module_context!(),
@@ -407,7 +444,15 @@ impl<Front: SocketHandler> Connection<Front> {
     fn pre_start_stream_client_bookkeeping(&self) {
         if let Position::Client(_, backend, BackendStatus::Connected) = self.position() {
             let mut backend_borrow = backend.borrow_mut();
+            // Pairs with the `saturating_sub(1)` in the end path. Snapshot the
+            // counter so we can assert it advanced by exactly one.
+            let before = backend_borrow.active_requests;
             backend_borrow.active_requests += 1;
+            debug_assert_eq!(
+                backend_borrow.active_requests,
+                before + 1,
+                "start_stream bookkeeping must increment active_requests by exactly one"
+            );
             trace!(
                 "{} connection start stream: {:#?}",
                 log_module_context!(),
@@ -441,13 +486,42 @@ impl<Front: SocketHandler> Connection<Front> {
     where
         L: ListenerHandler + L7ListenerHandler,
     {
+        // Snapshot the backend's in-flight counter so we can assert the
+        // increment/rollback is net-zero on the failure path: a refused
+        // `start_stream` must NOT leak an `active_requests` charge onto the
+        // backend (it would skew least-loaded balancing forever). The snapshot
+        // and its assert are both cfg'd so the `RefCell` borrow never exists in
+        // release (the helper is `#[cfg(debug_assertions)]` too).
+        #[cfg(debug_assertions)]
+        let before = self.backend_active_requests();
         self.pre_start_stream_client_bookkeeping();
         let started = forward!(self, start_stream(stream, context));
         if !started {
             // Undo active_requests increment on failure
             self.pre_end_stream_client_bookkeeping();
+            #[cfg(debug_assertions)]
+            debug_assert_eq!(
+                self.backend_active_requests(),
+                before,
+                "a refused start_stream must roll active_requests back to its prior value"
+            );
         }
         started
+    }
+
+    /// Snapshot the backend's in-flight request counter, or `None` when this
+    /// connection has no `Connected` backend (server position, or a client
+    /// that is still connecting / already keep-alive). Used by `start_stream`
+    /// to pair-assert the increment/rollback is net-zero on refusal. Cheap
+    /// `RefCell` borrow, compiled only with `debug_assertions`.
+    #[cfg(debug_assertions)]
+    fn backend_active_requests(&self) -> Option<usize> {
+        match self.position() {
+            Position::Client(_, backend, BackendStatus::Connected) => {
+                Some(backend.borrow().active_requests)
+            }
+            _ => None,
+        }
     }
 }
 

--- a/lib/src/protocol/mux/h1.rs
+++ b/lib/src/protocol/mux/h1.rs
@@ -166,6 +166,13 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
     /// RST_STREAM(InternalError) rather than a silent END_STREAM with a
     /// truncated body — RFC 9112 §7.1 requires the zero-chunk terminator.
     fn terminate_close_delimited(kawa: &mut super::GenericHttpStream, stream_id: GlobalStreamId) {
+        // Pre: we only synthesize an end-of-body for a response still in its
+        // body phase. A kawa already Terminated/Error must not be re-terminated
+        // (it would double-push an END_STREAM flag onto the converter).
+        debug_assert!(
+            !kawa.is_terminated(),
+            "terminate_close_delimited must not run on an already-terminated kawa"
+        );
         if kawa.body_size == kawa::BodySize::Chunked {
             warn!(
                 "{} H1 backend EOF mid-chunked response on stream {}: emitting RST_STREAM",
@@ -177,6 +184,12 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
                 .error(kawa::ParsingErrorKind::Processing {
                     message: "INTERNAL_ERROR",
                 });
+            // Post: a truncated chunked body is demoted to Error so the
+            // converter emits RST_STREAM, never a silent END_STREAM.
+            debug_assert!(
+                kawa.is_error(),
+                "truncated chunked response must end in the Error phase"
+            );
             return;
         }
         debug!(
@@ -191,6 +204,12 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
             end_stream: true,
         }));
         kawa.parsing_phase = kawa::ParsingPhase::Terminated;
+        // Post: a close-delimited body is now Terminated so the converter
+        // emits DATA with END_STREAM on the last frame.
+        debug_assert!(
+            kawa.is_terminated(),
+            "close-delimited body must end in the Terminated phase"
+        );
     }
 
     pub fn readable<E, L>(&mut self, context: &mut Context<L>, mut endpoint: E) -> MuxResult
@@ -228,13 +247,38 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         if kawa.storage.available_space() == 0 {
             self.readiness.event.remove(Ready::READABLE);
             self.parked_on_buffer_pressure = true;
+            // Pair the park flag with the cleared READABLE event: only
+            // `try_resume_reading` may re-arm it once the peer drains space.
+            debug_assert!(
+                self.parked_on_buffer_pressure && !self.readiness.event.is_readable(),
+                "parking on buffer pressure must clear the READABLE event"
+            );
             return MuxResult::Continue;
         }
 
         self.parked_on_buffer_pressure = false;
+        // Pre: we never ask the socket to read into a full buffer (that path
+        // returned above) — `socket_read` requires a non-empty target slice.
+        let space_before = kawa.storage.available_space();
+        debug_assert!(
+            space_before > 0,
+            "socket_read must target a buffer with free space"
+        );
         let (size, status) = self.socket.socket_read(kawa.storage.space());
+        // A read cannot deliver more bytes than the buffer had room for.
+        // `debug_assert!` only — `size` is socket-derived, never trusted to
+        // panic, but a violation here is a SocketHandler contract bug.
+        debug_assert!(
+            size <= space_before,
+            "socket_read returned more bytes than the buffer could hold"
+        );
         context.debug.push(DebugEvent::StreamEvent(0, size));
         kawa.storage.fill(size);
+        debug_assert_eq!(
+            kawa.storage.available_space(),
+            space_before - size,
+            "fill must consume exactly `size` bytes of free space"
+        );
         self.position.count_bytes_in_counter(size);
         self.position.count_bytes_in(parts.metrics, size);
         if update_readiness_after_read(size, status, &mut self.readiness) {
@@ -355,7 +399,19 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
                     set_default_answer(stream, &mut self.readiness, 400, &answers);
                     return MuxResult::Continue;
                 }
+                // First-seen request on this (server) connection: the keep-alive
+                // request counter advances by exactly one and the matching
+                // `http.active_requests` gauge `+1` is paired with flipping
+                // `request_counted` true (the `generate_access_log` `-1` is
+                // gated on that flag, so they must stay balanced).
+                let requests_before = self.requests;
+                let links_before = context.pending_links.len();
                 self.requests += 1;
+                debug_assert_eq!(
+                    self.requests,
+                    requests_before + 1,
+                    "server keep-alive request counter must advance by exactly one"
+                );
                 trace!("{} REQUESTS: {}", log_context!(self), self.requests);
                 incr!(names::http::REQUESTS);
                 gauge_add!(names::http::ACTIVE_REQUESTS, 1);
@@ -364,6 +420,22 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
                 stream.request_counted = true;
                 stream.state = StreamState::Link;
                 context.pending_links.push_back(stream_id);
+                // Post: the stream is queued for backend linking exactly once
+                // and is now in the Link state the ready loop expects.
+                debug_assert!(
+                    stream.request_counted,
+                    "request_counted must be set when the active-requests gauge is incremented"
+                );
+                debug_assert_eq!(
+                    stream.state,
+                    StreamState::Link,
+                    "a first-seen request must transition the stream to Link"
+                );
+                debug_assert_eq!(
+                    context.pending_links.len(),
+                    links_before + 1,
+                    "a first-seen request must enqueue exactly one pending link"
+                );
             }
             if let StreamState::Linked(token) = stream.state {
                 // Signal pending write alongside the WRITABLE interest flip: the
@@ -462,7 +534,14 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
             return MuxResult::Continue;
         }
         let tls_only_flush = io_slices.is_empty();
+        // Total bytes we offered the socket across the gathered slices; a
+        // vectored write can never report more consumed than we handed it.
+        let queued: usize = io_slices.iter().map(|s| s.len()).sum();
         let (size, status) = self.socket.socket_write_vectored(&io_slices);
+        debug_assert!(
+            size <= queued,
+            "socket_write_vectored reported more bytes written than were queued"
+        );
         context.debug.push(DebugEvent::StreamEvent(1, size));
         kawa.consume(size);
         self.position.count_bytes_out_counter(size);
@@ -470,6 +549,13 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         let should_yield = update_readiness_after_write(size, status, &mut self.readiness);
         if self.socket.socket_wants_write() {
             self.readiness.signal_pending_write();
+            // Pair the queued-write signal with the socket's own report: we
+            // only synthesize a WRITABLE event when the socket still has bytes
+            // buffered (edge-triggered epoll won't re-fire on its own).
+            debug_assert!(
+                self.readiness.event.is_writable(),
+                "signal_pending_write must leave a WRITABLE event queued"
+            );
             return MuxResult::Continue;
         }
         if !tls_only_flush && should_yield {
@@ -588,6 +674,24 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
                         // Transition back to Idle so buffered pipelined requests
                         // trigger a phase transition on the next readable() call.
                         stream.state = StreamState::Idle;
+                        // Post: the keep-alive reset leaves a clean, closed slot
+                        // ready for the next pipelined request. `request_counted`
+                        // was already cleared by `generate_access_log` above, so
+                        // the slot carries no pending active-requests charge.
+                        debug_assert_eq!(
+                            stream.state,
+                            StreamState::Idle,
+                            "keep-alive reset must return the stream to Idle"
+                        );
+                        debug_assert_eq!(stream.attempts, 0, "keep-alive reset must zero attempts");
+                        debug_assert!(
+                            !stream.request_counted,
+                            "keep-alive reset must leave no counted request (active-requests leak)"
+                        );
+                        debug_assert!(
+                            stream.back.storage.is_empty(),
+                            "keep-alive reset must drain the response storage"
+                        );
                         // HTTP/1.1 pipelining: if there's still data in the frontend
                         // storage (pipelined requests already read from the socket),
                         // parse it now. We can't rely on a new READABLE event because
@@ -671,13 +775,31 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         if !self.position.is_server() {
             return false;
         }
+        // Past the guard we are always server-side; close_notify is a
+        // frontend-only TLS concern.
+        debug_assert!(
+            self.position.is_server(),
+            "initiate_close_notify past the guard must be server-side"
+        );
         if !self.close_notify_sent {
             trace!("{} H1 initiating CLOSE_NOTIFY", log_context!(self));
             self.socket.socket_close();
             self.close_notify_sent = true;
         }
+        // `close_notify` is monotone: once requested it stays sent for the
+        // connection's lifetime (a second send would corrupt the TLS stream).
+        debug_assert!(
+            self.close_notify_sent,
+            "close_notify_sent must be set once initiate_close_notify has run"
+        );
         if self.socket.socket_wants_write() {
             self.readiness.arm_writable();
+            // arm_writable pairs interest + event so the deferred TLS flush is
+            // actually scheduled under edge-triggered epoll.
+            debug_assert!(
+                self.readiness.interest.is_writable() && self.readiness.event.is_writable(),
+                "arm_writable must set both WRITABLE interest and event"
+            );
             true
         } else {
             false
@@ -756,7 +878,28 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
             );
             return;
         }
+        // Reached only on the matched-stream path: the connection's active
+        // stream is exactly the one being ended.
+        debug_assert_eq!(
+            self.stream,
+            Some(stream),
+            "end_stream past the guard must target the active stream"
+        );
         context.unlink_stream(stream);
+        // Post: whatever backend token this stream was Linked to no longer
+        // lists it in the reverse index — `unlink_stream` is the single
+        // eviction point, so a subsequent end/close cannot double-remove it.
+        // (The `state` field is still `Linked` here; the arms below retire it.)
+        #[cfg(debug_assertions)]
+        if let StreamState::Linked(token) = context.streams[stream].state {
+            debug_assert!(
+                context
+                    .backend_streams
+                    .get(&token)
+                    .is_none_or(|ids| !ids.contains(&stream)),
+                "unlink_stream must evict the stream from the backend reverse index"
+            );
+        }
         let answers_rc = context.listener.borrow().get_answers().clone();
         let stream_id = stream;
         let stream = &mut context.streams[stream_id];
@@ -773,6 +916,17 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
                 if stream.state != StreamState::Recycle {
                     stream.state = StreamState::Unlinked;
                 }
+                // Post: the client connection detaches from its stream and the
+                // slot is retired (Unlinked) unless already marked for reuse —
+                // never left dangling in an open/Linked state.
+                debug_assert!(
+                    self.stream.is_none(),
+                    "client end_stream must detach the stream"
+                );
+                debug_assert!(
+                    !matches!(stream.state, StreamState::Linked(_)),
+                    "detached stream must not remain Linked"
+                );
                 self.readiness.interest.remove(Ready::ALL);
                 self.force_disconnect();
             }
@@ -781,6 +935,14 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
                 if stream.state != StreamState::Recycle {
                     stream.state = StreamState::Unlinked;
                 }
+                debug_assert!(
+                    self.stream.is_none(),
+                    "client end_stream must detach the stream"
+                );
+                debug_assert!(
+                    !matches!(stream.state, StreamState::Linked(_)),
+                    "detached stream must not remain Linked"
+                );
                 self.readiness.interest.remove(Ready::ALL);
                 // keep alive should probably be used only if the http context is fully reset
                 // in case end_stream occurs due to an error the connection state is probably
@@ -845,9 +1007,23 @@ impl<Front: SocketHandler> ConnectionH1<Front> {
         );
         self.readiness.interest.insert(Ready::ALL);
         self.stream = Some(stream);
+        debug_assert_eq!(
+            self.stream,
+            Some(stream),
+            "start_stream must pin the connection's active stream"
+        );
         match &mut self.position {
             Position::Client(_, _, status @ BackendStatus::KeepAlive) => {
                 *status = BackendStatus::Connected;
+                // A keep-alive client transitions to Connected when it picks up
+                // a new stream; it must not stay parked in KeepAlive.
+                debug_assert!(
+                    matches!(
+                        self.position,
+                        Position::Client(_, _, BackendStatus::Connected)
+                    ),
+                    "a reused keep-alive client must become Connected on start_stream"
+                );
             }
             Position::Client(_, _, BackendStatus::Disconnecting) => {
                 error!(

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -212,6 +212,29 @@ pub(super) fn next_stream_id(
     if issued > STREAM_ID_MAX {
         return None;
     }
+    // Post-conditions (RFC 9113 §5.1.1):
+    // - the issued id fits the 31-bit space;
+    // - the returned watermark is strictly greater than the id we issued, so a
+    //   subsequent call cannot re-issue or regress;
+    // - role-parity: client ids are odd, server ids even. This holds ONLY when
+    //   `last_stream_id` is an even watermark, which is the helper's documented
+    //   contract and what production always maintains (`create_stream` rounds to
+    //   `(stream_id + 2) & !1`; the connection initialises it to 0). The unit
+    //   tests deliberately feed odd `last` values at the saturation boundary, so
+    //   the parity check is gated on the watermark being even — a parity slip
+    //   from an *even* watermark would let two roles collide on one id.
+    debug_assert!(
+        issued <= STREAM_ID_MAX,
+        "issued stream id must fit the 31-bit space"
+    );
+    debug_assert!(
+        next > issued,
+        "the next watermark must advance strictly past the issued id"
+    );
+    debug_assert!(
+        last_stream_id & 1 != 0 || (issued & 1 == 1) == is_client,
+        "from an even watermark, client ids must be odd and server ids even (RFC 9113 §5.1.1)"
+    );
     Some((issued, next))
 }
 
@@ -418,7 +441,7 @@ impl H2FloodConfig {
         max_header_table_size: u32,
         max_header_fields: u32,
     ) -> Self {
-        Self {
+        let config = Self {
             max_rst_stream_per_window: max_rst_stream_per_window.max(1),
             max_ping_per_window: max_ping_per_window.max(1),
             max_settings_per_window: max_settings_per_window.max(1),
@@ -432,7 +455,33 @@ impl H2FloodConfig {
             max_header_list_size: max_header_list_size.max(1),
             max_header_table_size: max_header_table_size.max(1),
             max_header_fields: max_header_fields.max(1),
-        }
+        };
+        // Post-condition: every threshold is clamped to at least 1. A zero
+        // threshold would make `check_flood`/`record_rst_*` trip on the very
+        // first frame (count > 0 > threshold), turning a legitimate connection
+        // into an immediate GOAWAY. This is the central invariant the clamps
+        // above exist to enforce — assert it rather than trusting the `.max(1)`
+        // chain stays correct under future edits.
+        debug_assert!(
+            config.max_rst_stream_per_window >= 1
+                && config.max_ping_per_window >= 1
+                && config.max_settings_per_window >= 1
+                && config.max_empty_data_per_window >= 1
+                && config.max_window_update_stream0_per_window >= 1
+                && config.max_continuation_frames >= 1
+                && config.max_glitch_count >= 1,
+            "every u32 flood threshold must be clamped to >= 1"
+        );
+        debug_assert!(
+            config.max_rst_stream_lifetime >= 1
+                && config.max_rst_stream_abusive_lifetime >= 1
+                && config.max_rst_stream_emitted_lifetime >= 1
+                && config.max_header_list_size >= 1
+                && config.max_header_table_size >= 1
+                && config.max_header_fields >= 1,
+            "every lifetime/size flood threshold must be clamped to >= 1"
+        );
+        config
     }
 }
 
@@ -512,11 +561,30 @@ impl H2ConnectionConfig {
                 stream_shrink_ratio
             );
         }
-        Self {
+        let config = Self {
             initial_connection_window: clamped_window,
             max_concurrent_streams: clamped_streams,
             stream_shrink_ratio: clamped_ratio,
-        }
+        };
+        // Post-conditions matching the documented clamp ranges. The window must
+        // stay within RFC 9113 §6.9's [65535, 2^31-1] (a window outside this
+        // band desynchronises flow control with the peer); max_concurrent_streams
+        // must be >= 1 (zero would refuse every stream); shrink_ratio must be
+        // >= 2 (1 defeats slot recycling, the whole point of the knob).
+        debug_assert!(
+            (DEFAULT_INITIAL_WINDOW_SIZE..=FLOW_CONTROL_MAX_WINDOW)
+                .contains(&config.initial_connection_window),
+            "clamped connection window must lie within RFC 9113 §6.9 bounds"
+        );
+        debug_assert!(
+            config.max_concurrent_streams >= 1,
+            "clamped max_concurrent_streams must be >= 1"
+        );
+        debug_assert!(
+            config.stream_shrink_ratio >= 2,
+            "clamped stream_shrink_ratio must be >= 2 to keep slot recycling effective"
+        );
+        config
     }
 
     /// Create from optional config values, falling back to compile-time defaults.
@@ -607,10 +675,41 @@ fn distribute_overhead(
         // No stream has transferred any outbound bytes — fall back to even split.
         *overhead_bout / active_streams.max(1)
     };
+    // Pre-condition: a stream can never be credited more overhead than remains
+    // in the pool — otherwise the `*overhead_b* -= share_*` below underflows
+    // (usize wraps to a huge value, corrupting connection-overhead accounting).
+    // Every branch above either takes the whole pool (last stream) or `.min`s
+    // against it, so this must hold.
+    debug_assert!(
+        share_in <= *overhead_bin,
+        "overhead-in share must not exceed the remaining overhead pool"
+    );
+    debug_assert!(
+        share_out <= *overhead_bout,
+        "overhead-out share must not exceed the remaining overhead pool"
+    );
+    let before_bin = *overhead_bin;
+    let before_bout = *overhead_bout;
     metrics.bin += share_in;
     metrics.bout += share_out;
     *overhead_bin -= share_in;
     *overhead_bout -= share_out;
+    // Post-condition: the pool shrinks by exactly the credited share (overhead
+    // is conserved, neither created nor lost). The last stream drains it to 0.
+    debug_assert_eq!(
+        *overhead_bin,
+        before_bin - share_in,
+        "overhead-in pool must decrease by exactly the credited share"
+    );
+    debug_assert_eq!(
+        *overhead_bout,
+        before_bout - share_out,
+        "overhead-out pool must decrease by exactly the credited share"
+    );
+    debug_assert!(
+        !is_last_stream || (*overhead_bin == 0 && *overhead_bout == 0),
+        "the last stream must drain the overhead pool to zero (no lost remainder)"
+    );
 }
 
 /// LIFECYCLE §9 invariant 16 probe: returns `true` if any open stream still
@@ -773,12 +872,52 @@ fn enqueue_rst_into(
     wire_stream_id: StreamId,
     error: H2Error,
 ) -> bool {
+    let pending_before = pending.len();
+    let total_before = *total;
     if !rst_sent.insert(wire_stream_id) {
+        // Dedupe short-circuit: the id was already queued/flushed. We must NOT
+        // touch any of the wire-count state, otherwise duplicate calls inflate
+        // the MadeYouReset (CVE-2025-8671) lifetime cap with frames that never
+        // reach the wire.
+        debug_assert!(
+            rst_sent.contains(&wire_stream_id),
+            "dedupe path requires the id to already be present in rst_sent"
+        );
+        debug_assert_eq!(
+            pending.len(),
+            pending_before,
+            "dedupe path must not enqueue a new pending RST"
+        );
+        debug_assert_eq!(
+            *total, total_before,
+            "dedupe path must not bump the queued-RST lifetime counter"
+        );
         return false;
     }
     pending.push((wire_stream_id, error));
     *total += 1;
     readiness.arm_writable();
+    // Post-condition: a freshly-queued RST advances both the pending Vec and the
+    // lifetime counter by exactly one, and the id is now tracked for dedupe.
+    debug_assert!(
+        rst_sent.contains(&wire_stream_id),
+        "freshly-queued RST must be recorded in rst_sent for future dedupe"
+    );
+    debug_assert_eq!(
+        pending.len(),
+        pending_before + 1,
+        "a freshly-queued RST must push exactly one pending entry"
+    );
+    debug_assert_eq!(
+        *total,
+        total_before + 1,
+        "a freshly-queued RST must bump the queued-RST lifetime counter by one"
+    );
+    debug_assert_eq!(
+        pending.last().map(|(id, _)| *id),
+        Some(wire_stream_id),
+        "the just-pushed entry must be the requested wire stream id"
+    );
     true
 }
 
@@ -880,6 +1019,18 @@ impl Default for H2FloodDetector {
 
 impl H2FloodDetector {
     pub fn new(config: H2FloodConfig) -> Self {
+        // Pre-condition: thresholds are already validated (clamped to >= 1 by
+        // `H2FloodConfig::new`). A zero per-window threshold would trip on the
+        // first counted frame; assert it here so a config that bypassed `new`
+        // (raw struct literal in a future caller) is caught in debug.
+        debug_assert!(
+            config.max_rst_stream_per_window >= 1
+                && config.max_ping_per_window >= 1
+                && config.max_settings_per_window >= 1
+                && config.max_continuation_frames >= 1
+                && config.max_glitch_count >= 1,
+            "flood detector must be constructed with validated (>= 1) thresholds"
+        );
         Self {
             rst_stream_count: 0,
             total_rst_received_lifetime: 0,
@@ -907,11 +1058,30 @@ impl H2FloodDetector {
     /// begun when the RST arrived; `false` is the cheap-for-client /
     /// expensive-for-us Rapid Reset signature (CVE-2023-44487).
     pub fn record_rst_lifetime(&mut self, response_started: bool) -> Option<H2FloodViolation> {
+        let total_before = self.total_rst_received_lifetime;
+        let abusive_before = self.total_abusive_rst_received_lifetime;
         self.total_rst_received_lifetime = self.total_rst_received_lifetime.saturating_add(1);
         if !response_started {
             self.total_abusive_rst_received_lifetime =
                 self.total_abusive_rst_received_lifetime.saturating_add(1);
         }
+        // Monotonicity: the global lifetime counter advances by one per call
+        // (until saturation), and the abusive sub-counter advances iff the RST
+        // arrived before the backend response started. The abusive counter can
+        // never exceed the global one — every abusive RST is also a received RST.
+        debug_assert!(
+            self.total_rst_received_lifetime >= total_before,
+            "lifetime RST counter must be monotonic non-decreasing"
+        );
+        debug_assert_eq!(
+            self.total_abusive_rst_received_lifetime > abusive_before,
+            !response_started,
+            "abusive RST counter advances iff the RST is pre-response-start"
+        );
+        debug_assert!(
+            self.total_abusive_rst_received_lifetime <= self.total_rst_received_lifetime,
+            "abusive RST count is a subset of total received RST count"
+        );
         if self.total_rst_received_lifetime > self.config.max_rst_stream_lifetime {
             return Some(H2FloodViolation {
                 error: H2Error::EnhanceYourCalm,
@@ -941,8 +1111,16 @@ impl H2FloodDetector {
     /// RST_STREAM (CVE-2025-8671 "MadeYouReset"). Only non-`NoError` resets
     /// are reported — callers must exclude graceful cancels.
     pub fn record_rst_emitted(&mut self) -> Option<H2FloodViolation> {
+        let before = self.total_rst_streams_emitted_lifetime;
         self.total_rst_streams_emitted_lifetime =
             self.total_rst_streams_emitted_lifetime.saturating_add(1);
+        // Monotonic: the emitted-RST counter never decays (it is the absolute
+        // MadeYouReset ceiling, CVE-2025-8671), so each call strictly advances
+        // it until u64 saturation.
+        debug_assert!(
+            self.total_rst_streams_emitted_lifetime > before || before == u64::MAX,
+            "emitted-RST lifetime counter must advance (or already be saturated)"
+        );
         if self.total_rst_streams_emitted_lifetime > self.config.max_rst_stream_emitted_lifetime {
             return Some(H2FloodViolation {
                 error: H2Error::EnhanceYourCalm,
@@ -959,6 +1137,13 @@ impl H2FloodDetector {
     /// Uses half-window decay instead of full reset to catch burst-then-wait attacks.
     fn maybe_reset_window(&mut self) {
         if self.window_start.elapsed() >= FLOOD_WINDOW_DURATION {
+            let (rst_before, ping_before, settings_before) =
+                (self.rst_stream_count, self.ping_count, self.settings_count);
+            let (empty_before, wu0_before, glitch_before) = (
+                self.empty_data_count,
+                self.window_update_stream0_count,
+                self.glitch_count,
+            );
             self.rst_stream_count /= 2;
             self.ping_count /= 2;
             self.settings_count /= 2;
@@ -966,6 +1151,35 @@ impl H2FloodDetector {
             self.window_update_stream0_count /= 2;
             self.glitch_count /= 2;
             self.window_start = Instant::now();
+            // Half-decay invariant: each rate-based counter is exactly halved
+            // (integer division), never increased. Catching burst-then-wait
+            // attacks relies on the counter shrinking but not vanishing — a
+            // full reset would let a patient attacker reset to zero each window.
+            debug_assert_eq!(self.rst_stream_count, rst_before / 2, "RST count halves");
+            debug_assert_eq!(self.ping_count, ping_before / 2, "PING count halves");
+            debug_assert_eq!(
+                self.settings_count,
+                settings_before / 2,
+                "SETTINGS count halves"
+            );
+            debug_assert_eq!(
+                self.empty_data_count,
+                empty_before / 2,
+                "empty-DATA count halves"
+            );
+            debug_assert_eq!(
+                self.window_update_stream0_count,
+                wu0_before / 2,
+                "stream-0 WINDOW_UPDATE count halves"
+            );
+            debug_assert_eq!(self.glitch_count, glitch_before / 2, "glitch count halves");
+            // The lifetime counters are deliberately NOT touched here — they are
+            // the never-decaying ceilings. Guard against a future edit decaying
+            // them by accident.
+            debug_assert!(
+                self.window_start.elapsed() < FLOOD_WINDOW_DURATION,
+                "window_start must be refreshed to (approximately) now after decay"
+            );
         }
     }
 
@@ -994,7 +1208,7 @@ impl H2FloodDetector {
             }
         }
 
-        flag(
+        let violation = flag(
             "RST_STREAM",
             "h2.flood.violation.rst_stream_window",
             self.rst_stream_count,
@@ -1071,13 +1285,37 @@ impl H2FloodDetector {
                 self.glitch_count,
                 self.config.max_glitch_count,
             )
-        })
+        });
+        // Post-condition: any reported violation is well-formed — every H2
+        // flood escalation is an ENHANCE_YOUR_CALM connection error, and the
+        // observed count strictly exceeds the threshold it tripped (the `flag`
+        // helper and the lifetime checks all use strict `>`). A violation whose
+        // count <= threshold would be a false positive terminating a healthy
+        // connection.
+        debug_assert!(
+            violation
+                .as_ref()
+                .is_none_or(|v| v.error == H2Error::EnhanceYourCalm && v.count > v.threshold),
+            "a flood violation must be EnhanceYourCalm with count strictly above threshold"
+        );
+        violation
     }
 
     /// Reset CONTINUATION-specific counters when a header block is complete.
     pub fn reset_continuation(&mut self) {
         self.continuation_count = 0;
         self.accumulated_header_size = 0;
+        // Post-condition: both CONTINUATION-block accumulators are cleared so
+        // the next header block starts from zero (CVE-2024-27316 per-block
+        // accounting must not leak across blocks).
+        debug_assert_eq!(
+            self.continuation_count, 0,
+            "continuation_count must be zero after a block completes"
+        );
+        debug_assert_eq!(
+            self.accumulated_header_size, 0,
+            "accumulated_header_size must be zero after a block completes"
+        );
     }
 }
 
@@ -1180,6 +1418,14 @@ impl Prioriser {
             stream_id,
             priority
         );
+        // Pre-condition: the priority map never grows past MAX_PRIORITIES.
+        // The cap is the only thing standing between a PRIORITY flood and
+        // unbounded memory; assert it holds on entry (each insert path below
+        // either updates an existing key or is gated by this check).
+        debug_assert!(
+            self.priorities.len() <= MAX_PRIORITIES,
+            "priority map must never exceed MAX_PRIORITIES entries"
+        );
         // Cap the priority map to prevent flooding via PRIORITY frames
         if !self.priorities.contains_key(&stream_id) && self.priorities.len() >= MAX_PRIORITIES {
             return false;
@@ -1206,6 +1452,20 @@ impl Prioriser {
                 // allowed range [0..=7]. Intentionally not PROTOCOL_ERROR.
                 self.priorities
                     .insert(stream_id, (urgency.min(7), incremental));
+                // Post-conditions: the entry now exists with a clamped urgency
+                // in [0, 7] (the writable scheduler buckets by urgency and would
+                // mis-order on a value above 7), and the map stays within its
+                // memory cap.
+                debug_assert!(
+                    self.priorities
+                        .get(&stream_id)
+                        .is_some_and(|(u, _)| *u <= 7),
+                    "stored RFC 9218 urgency must be clamped to [0, 7]"
+                );
+                debug_assert!(
+                    self.priorities.len() <= MAX_PRIORITIES,
+                    "priority map must stay within MAX_PRIORITIES after insert"
+                );
                 false
             }
         }
@@ -1264,7 +1524,21 @@ impl Prioriser {
 
     /// Remove a stream's priority entry (called when the stream is recycled).
     pub fn remove(&mut self, stream_id: &StreamId) {
+        let had = self.priorities.contains_key(stream_id);
+        let before = self.priorities.len();
         self.priorities.remove(stream_id);
+        // Post-conditions: the entry is truly gone, and the map shrinks by
+        // exactly one iff it was present. A leak here re-introduces the
+        // PRIORITY-flood memory exposure the cap defends against.
+        debug_assert!(
+            !self.priorities.contains_key(stream_id),
+            "remove must evict the priority entry"
+        );
+        debug_assert_eq!(
+            self.priorities.len(),
+            before - had as usize,
+            "priority map length drops by exactly one iff the id was present"
+        );
     }
 
     /// Look up the priority for a stream, returning RFC 9218 defaults if absent.
@@ -1289,6 +1563,21 @@ impl Prioriser {
     /// need to update the cursor at the end of the write pass can early-exit
     /// when the count is zero.
     pub fn apply_incremental_rotation(&self, buf: &mut [StreamId]) -> usize {
+        // Pre-condition: callers must hand a slice already sorted by urgency so
+        // same-urgency runs are contiguous (this routine only partitions/rotates
+        // within a run, it does not re-sort across urgencies). A non-monotonic
+        // urgency sequence would split one logical bucket into several and
+        // mis-schedule the round-robin. `windows(2)` over a slice of size N is
+        // dead code in release.
+        #[cfg(debug_assertions)]
+        debug_assert!(
+            buf.windows(2)
+                .all(|w| self.get(&w[0]).0 <= self.get(&w[1]).0),
+            "apply_incremental_rotation requires input pre-sorted by urgency"
+        );
+        let len_before = buf.len();
+        #[cfg(debug_assertions)]
+        let expected_incremental = buf.iter().filter(|id| self.get(id).1).count();
         let mut total_incremental = 0usize;
         let mut i = 0;
         while i < buf.len() {
@@ -1324,6 +1613,20 @@ impl Prioriser {
             }
             i = j;
         }
+        // Post-conditions: the routine is a permutation — it reorders in place
+        // and never drops a stream id (len unchanged), and the returned count is
+        // exactly the number of incremental streams present (the cursor-advance
+        // callers rely on this being the true incremental-tail size).
+        debug_assert_eq!(
+            buf.len(),
+            len_before,
+            "rotation must preserve the slice (no streams dropped or added)"
+        );
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(
+            total_incremental, expected_incremental,
+            "reported incremental count must equal the incremental streams in buf"
+        );
         total_incremental
     }
 
@@ -2008,11 +2311,27 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                     return self.goaway(H2Error::ProtocolError);
                 }
                 // CVE-2024-27316: track CONTINUATION frame count and accumulated size
+                let cont_count_before = self.flood_detector.continuation_count;
+                let acc_size_before = self.flood_detector.accumulated_header_size;
                 self.flood_detector.continuation_count += 1;
                 self.flood_detector.accumulated_header_size = self
                     .flood_detector
                     .accumulated_header_size
                     .saturating_add(payload_len);
+                // Per-block CONTINUATION accounting must grow monotonically
+                // within a header block: each frame bumps the count by one and
+                // the accumulated size by the frame's payload (never shrinks
+                // mid-block). `reset_continuation` is the only thing allowed to
+                // zero these — and only once the block is complete.
+                debug_assert_eq!(
+                    self.flood_detector.continuation_count,
+                    cont_count_before + 1,
+                    "CONTINUATION per-block counter must advance by one per frame"
+                );
+                debug_assert!(
+                    self.flood_detector.accumulated_header_size >= acc_size_before,
+                    "accumulated header size must not shrink within a header block"
+                );
                 check_flood_or_return!(self);
                 // RFC 9113 §10.5.1: reject header blocks that cannot be
                 // buffered. Previously we silently removed READABLE interest
@@ -3734,6 +4053,18 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         if let Some(existing) = self.flow_control.pending_window_updates.get_mut(&stream_id) {
             let old = *existing;
             *existing = existing.saturating_add(increment).min(max_increment);
+            // Coalescing invariant: the accumulated increment never decreases
+            // and never exceeds i32::MAX (RFC 9113 §6.9 caps a WINDOW_UPDATE
+            // increment at 2^31-1; emitting a larger value would be a protocol
+            // error on the wire).
+            debug_assert!(
+                *existing >= old,
+                "coalesced WINDOW_UPDATE increment must be monotonic non-decreasing"
+            );
+            debug_assert!(
+                *existing <= max_increment,
+                "coalesced WINDOW_UPDATE increment must stay within i32::MAX"
+            );
             trace!(
                 "{} WINDOW_UPDATE coalesced: stream={} old={} new={}",
                 log_context!(self),
@@ -4485,11 +4816,20 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             );
             return None;
         }
+        let highest_before = self.highest_peer_stream_id;
+        let streams_before = self.streams.len();
         // Track the highest peer-initiated stream ID for GoAway frames
         // before any early return, so GoAway always reports the correct last stream.
         if stream_id > self.highest_peer_stream_id {
             self.highest_peer_stream_id = stream_id;
         }
+        // highest_peer_stream_id is monotonic non-decreasing — it only ever
+        // climbs to the largest id we have accepted (RFC 9113 §6.8 last-stream
+        // reporting depends on this).
+        debug_assert!(
+            self.highest_peer_stream_id >= highest_before,
+            "highest_peer_stream_id must never regress"
+        );
         let global_stream_id = context.create_stream(
             Ulid::generate(),
             self.peer_settings.settings_initial_window_size,
@@ -4498,12 +4838,48 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         self.streams.insert(stream_id, global_stream_id);
         self.stream_last_activity_at
             .insert(stream_id, Instant::now());
+        // Post-conditions: the stream is now reachable in both indices, the
+        // active count grew by exactly one (the id was not already present —
+        // `handle_header_state` rejects re-used ids), and `last_stream_id` is
+        // the even watermark just past this id so `new_stream_id` never collides.
+        debug_assert_eq!(
+            self.streams.get(&stream_id).copied(),
+            Some(global_stream_id),
+            "create_stream must register the wire->global mapping"
+        );
+        debug_assert!(
+            self.stream_last_activity_at.contains_key(&stream_id),
+            "create_stream must arm the per-stream idle timer"
+        );
+        debug_assert_eq!(
+            self.streams.len(),
+            streams_before + 1,
+            "create_stream must add exactly one stream (id must not pre-exist)"
+        );
+        debug_assert!(
+            self.last_stream_id > stream_id && self.last_stream_id & 1 == 0,
+            "last_stream_id watermark must be the even value strictly above stream_id"
+        );
         Some(global_stream_id)
     }
 
     pub fn new_stream_id(&mut self) -> Option<StreamId> {
+        let watermark_before = self.last_stream_id;
         let (issued, next) = next_stream_id(self.last_stream_id, self.position.is_client())?;
         self.last_stream_id = next;
+        // Post-conditions: the locally-issued id has the parity of our role and
+        // the watermark advanced strictly (so the next allocation cannot reuse
+        // this id). `next_stream_id` already asserts parity vs `is_client`; here
+        // we re-assert against `self.position` and the watermark monotonicity.
+        debug_assert_eq!(
+            issued & 1 == 1,
+            self.position.is_client(),
+            "locally-issued stream id parity must match our role"
+        );
+        debug_assert!(
+            self.last_stream_id > watermark_before,
+            "issuing a stream id must advance the watermark"
+        );
         Some(issued)
     }
 
@@ -4516,6 +4892,87 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
     #[cfg(any(test, feature = "e2e-hooks"))]
     pub fn __test_set_last_stream_id(&mut self, id: StreamId) {
         self.last_stream_id = id;
+    }
+
+    /// Cross-field invariant sweep for the H2 connection state machine,
+    /// asserted as a run-to-completion post-condition at the end of every
+    /// frame-handling pass (see the call in [`Self::handle_frame`]).
+    ///
+    /// These are relationships between *separate* fields that no single setter
+    /// can guarantee on its own — exactly the class of bug TigerStyle's
+    /// `check_invariants` targets. Each one is cheap (counter compares + a few
+    /// `HashMap` membership probes); the whole function is `#[cfg(debug_assertions)]`
+    /// and compiles out of release entirely.
+    ///
+    /// Encoded invariants:
+    /// 1. **Stream-id watermark parity**: locally-issued ids never exceed
+    ///    `STREAM_ID_MAX`; `last_stream_id` stays the even watermark (it is
+    ///    rounded to `(id + 2) & !1` and initialised to 0).
+    /// 2. **Per-stream caches are subsets of the live stream set**:
+    ///    `stream_last_activity_at` is keyed only by currently-tracked stream
+    ///    ids — a leak here would let a removed stream keep an idle timer and
+    ///    mis-fire `cancel_timed_out_streams`. (`rst_sent` is intentionally NOT
+    ///    a subset: a queued RST for an already-removed stream is legal.)
+    /// 3. **RST queue accounting**: the never-decaying `total_rst_streams_queued`
+    ///    lifetime counter is always `>=` the currently-pending queue length
+    ///    (CVE-2025-8671 MadeYouReset cap relies on the lifetime counter never
+    ///    under-counting), and the pending queue stays within its hard cap +1
+    ///    (the escalation tripwire fires at the cap).
+    /// 4. **Pending WINDOW_UPDATE bound**: the coalescing map never exceeds the
+    ///    per-connection cap derived from `max_concurrent_streams`.
+    /// 5. **Drain/state coupling**: a terminal `GoAway`/`Error` state implies the
+    ///    connection is draining (`goaway()` sets both); the converse need not
+    ///    hold (graceful drain stays in a live state).
+    #[cfg(debug_assertions)]
+    fn check_invariants<L>(&self, context: &Context<L>)
+    where
+        L: ListenerHandler + L7ListenerHandler,
+    {
+        // (1) Watermark parity and bound.
+        debug_assert!(
+            self.last_stream_id & 1 == 0,
+            "last_stream_id must stay an even watermark, got {}",
+            self.last_stream_id
+        );
+
+        // (2) Per-stream caches are subsets of the live stream set, and every
+        // mapping points at a valid context slot.
+        debug_assert!(
+            self.stream_last_activity_at
+                .keys()
+                .all(|id| self.streams.contains_key(id)),
+            "stream_last_activity_at must only track currently-open stream ids"
+        );
+        debug_assert!(
+            self.streams
+                .values()
+                .all(|&gid| gid < context.streams.len()),
+            "every stream mapping must point at a valid context slot"
+        );
+
+        // (3) RST queue accounting.
+        debug_assert!(
+            self.total_rst_streams_queued >= self.pending_rst_streams.len(),
+            "queued-RST lifetime counter ({}) must be >= currently-pending queue ({})",
+            self.total_rst_streams_queued,
+            self.pending_rst_streams.len()
+        );
+        debug_assert!(
+            self.pending_rst_streams.len() <= MAX_PENDING_RST_STREAMS + 1,
+            "pending RST queue must stay within its hard cap (escalates at the cap)"
+        );
+
+        // (4) Pending WINDOW_UPDATE coalescing map bound.
+        debug_assert!(
+            self.flow_control.pending_window_updates.len() <= self.max_pending_window_updates,
+            "pending WINDOW_UPDATE map must stay within its per-connection cap"
+        );
+
+        // (5) Drain/state coupling: terminal states imply draining.
+        debug_assert!(
+            !matches!(self.state, H2State::GoAway | H2State::Error) || self.drain.draining,
+            "GoAway/Error state must imply the connection is draining"
+        );
     }
 
     fn handle_frame<E, L>(
@@ -4534,7 +4991,7 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         // type — adding a new `Frame::*` variant fails the build inside the
         // helper, keeping the metric breakdown in lock-step with RFC 9113 §6.
         count!(h2_frame_rx_metric_key(&frame), 1);
-        match frame {
+        let result = match frame {
             Frame::Data(data) => self.handle_data_frame(data, wire_payload_len, context, endpoint),
             Frame::Headers(headers) => self.handle_headers_frame(headers, context, endpoint),
             Frame::PushPromise(_) => self.handle_push_promise_frame(),
@@ -4572,7 +5029,13 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
                 self.attribute_bytes_to_overhead();
                 MuxResult::Continue
             }
-        }
+        };
+        // Run-to-completion post-condition: the connection-level cross-field
+        // invariants must hold after every frame is dispatched, on success and
+        // on the protocol-error paths alike.
+        #[cfg(debug_assertions)]
+        self.check_invariants(context);
+        result
     }
 
     /// RFC 9110 §8.6: Content-Length validation must be skipped for responses
@@ -4612,7 +5075,13 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
     {
         // CVE-2019-9518: track empty DATA frames (no payload, no END_STREAM)
         if data.payload.is_empty() && !data.end_stream {
+            let empty_before = self.flood_detector.empty_data_count;
             self.flood_detector.empty_data_count += 1;
+            debug_assert_eq!(
+                self.flood_detector.empty_data_count,
+                empty_before + 1,
+                "empty-DATA flood counter must advance by exactly one per empty frame"
+            );
             check_flood_or_return!(self);
         }
         let Some(global_stream_id) = self.streams.get(&data.stream_id).copied() else {
@@ -5104,7 +5573,13 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         // mitigation event itself).
         count!(metric_for_rst_stream_received(rst_stream.error_code), 1);
         // CVE-2023-44487 Rapid Reset + CVE-2019-9514: track RST_STREAM rate.
+        let rst_count_before = self.flood_detector.rst_stream_count;
         self.flood_detector.rst_stream_count += 1;
+        debug_assert_eq!(
+            self.flood_detector.rst_stream_count,
+            rst_count_before + 1,
+            "per-window RST_STREAM counter must advance by exactly one per inbound RST"
+        );
         check_flood_or_return!(self);
         // Additional CVE-2023-44487 mitigation: lifetime cap on RST_STREAM
         // frames received. The per-window counter above half-decays, so a
@@ -5222,11 +5697,23 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             return MuxResult::Continue;
         }
         // CVE-2019-9515: track SETTINGS frame rate
+        let settings_count_before = self.flood_detector.settings_count;
+        let settings_lifetime_before = self.flood_detector.total_settings_received_lifetime;
         self.flood_detector.settings_count += 1;
         self.flood_detector.total_settings_received_lifetime = self
             .flood_detector
             .total_settings_received_lifetime
             .saturating_add(1);
+        debug_assert_eq!(
+            self.flood_detector.settings_count,
+            settings_count_before + 1,
+            "per-window SETTINGS counter must advance by one per non-ACK SETTINGS"
+        );
+        debug_assert!(
+            self.flood_detector.total_settings_received_lifetime > settings_lifetime_before
+                || settings_lifetime_before == u32::MAX,
+            "lifetime SETTINGS counter must advance (or already be saturated)"
+        );
         check_flood_or_return!(self);
         for setting in settings.settings {
             let v = setting.value;
@@ -5312,11 +5799,23 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
             return MuxResult::Continue;
         }
         // CVE-2019-9512: track non-ACK PING frame rate
+        let ping_count_before = self.flood_detector.ping_count;
+        let ping_lifetime_before = self.flood_detector.total_ping_received_lifetime;
         self.flood_detector.ping_count += 1;
         self.flood_detector.total_ping_received_lifetime = self
             .flood_detector
             .total_ping_received_lifetime
             .saturating_add(1);
+        debug_assert_eq!(
+            self.flood_detector.ping_count,
+            ping_count_before + 1,
+            "per-window PING counter must advance by one per non-ACK PING"
+        );
+        debug_assert!(
+            self.flood_detector.total_ping_received_lifetime > ping_lifetime_before
+                || ping_lifetime_before == u32::MAX,
+            "lifetime PING counter must advance (or already be saturated)"
+        );
         check_flood_or_return!(self);
         self.attribute_bytes_to_overhead();
         let kawa = &mut self.zero;
@@ -5505,22 +6004,51 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         // 2^31-1 and try_from always succeeds. Use try_from rather than `as` to
         // guard against a future parser change that drops the mask.
         let increment = i32::try_from(increment).unwrap_or(i32::MAX);
+        // RFC 9113 §6.9: a non-zero WINDOW_UPDATE increment is in [1, 2^31-1].
+        // Zero was short-circuited above; this asserts the masked value is a
+        // legal positive increment before we add it to a window.
+        debug_assert!(
+            increment > 0,
+            "WINDOW_UPDATE increment must be strictly positive at this point (zero handled above)"
+        );
         if stream_id == 0 {
             // Count connection-level WINDOW_UPDATEs before touching the window
             // so a per-window flood stops us before we pay the arithmetic cost
             // on a million-frame burst. Zero-increment frames short-circuited
             // above, so every increment here is a legal-looking rate consumer.
+            let wu0_before = self.flood_detector.window_update_stream0_count;
             self.flood_detector.window_update_stream0_count = self
                 .flood_detector
                 .window_update_stream0_count
                 .saturating_add(1);
+            debug_assert!(
+                self.flood_detector.window_update_stream0_count > wu0_before
+                    || wu0_before == u32::MAX,
+                "stream-0 WINDOW_UPDATE flood counter must advance before the flood check"
+            );
             check_flood_or_return!(self);
             self.attribute_bytes_to_overhead();
+            let window_before = self.flow_control.window;
             if let Some(window) = self.flow_control.window.checked_add(increment) {
                 if self.flow_control.window <= 0 && window > 0 {
                     self.readiness.arm_writable();
                 }
                 self.flow_control.window = window;
+                // Flow-control replenish invariant (RFC 9113 §6.9): the
+                // connection send window grows by exactly `increment` and stays
+                // within i32 (the `checked_add` already rejected overflow, which
+                // is a FLOW_CONTROL_ERROR on the wire). The window may legally
+                // be negative (a SETTINGS change can shrink it below zero) but
+                // a WINDOW_UPDATE only ever increases it.
+                debug_assert_eq!(
+                    self.flow_control.window,
+                    window_before + increment,
+                    "connection window must increase by exactly the increment"
+                );
+                debug_assert!(
+                    self.flow_control.window > window_before,
+                    "a positive WINDOW_UPDATE must strictly grow the connection window"
+                );
                 debug!(
                     "{} WINDOW_UPDATE received: stream=0 increment={} new_connection_window={}",
                     log_context!(self),
@@ -5534,11 +6062,25 @@ impl<Front: SocketHandler> ConnectionH2<Front> {
         } else if let Some(global_stream_id) = self.streams.get(&stream_id).copied() {
             let stream = &mut context.streams[global_stream_id];
             self.attribute_bytes_to_stream(&mut stream.metrics);
+            let stream_window_before = stream.window;
             if let Some(window) = stream.window.checked_add(increment) {
                 if stream.window <= 0 && window > 0 {
                     self.readiness.arm_writable();
                 }
                 stream.window = window;
+                // Same replenish invariant as the connection window, applied to
+                // the per-stream send window (RFC 9113 §6.9.1). Overflow past
+                // 2^31-1 is rejected by `checked_add` and handled as a
+                // FLOW_CONTROL_ERROR RST_STREAM below.
+                debug_assert_eq!(
+                    stream.window,
+                    stream_window_before + increment,
+                    "stream window must increase by exactly the increment"
+                );
+                debug_assert!(
+                    stream.window > stream_window_before,
+                    "a positive WINDOW_UPDATE must strictly grow the stream window"
+                );
                 debug!(
                     "{} WINDOW_UPDATE received: stream={} increment={} new_stream_window={}",
                     log_context!(self),

--- a/lib/src/protocol/mux/parser.rs
+++ b/lib/src/protocol/mux/parser.rs
@@ -285,6 +285,7 @@ macro_rules! ensure_frame_size {
 // `DEFAULT_MAX_FRAME_SIZE` freely because they construct isolated frame
 // buffers that never flow through a real peer handshake.
 pub fn frame_header(input: &[u8], max_frame_size: u32) -> IResult<&[u8], FrameHeader, ParserError> {
+    let in_len = input.len();
     let (i, payload_len) = be_u24(input)?;
     if payload_len > max_frame_size {
         return Err(Err::Failure(ParserError::new_h2(
@@ -296,8 +297,27 @@ pub fn frame_header(input: &[u8], max_frame_size: u32) -> IResult<&[u8], FrameHe
     let (i, t) = be_u8(i)?;
     let frame_type = convert_frame_type(t);
     let (i, flags) = be_u8(i)?;
-    let (i, stream_id) = be_u32(i)?;
-    let stream_id = stream_id & STREAM_ID_MASK;
+    let (i, raw_stream_id) = be_u32(i)?;
+    let stream_id = raw_stream_id & STREAM_ID_MASK;
+    // Post-conditions of the fixed 9-byte header decode: the parser never grows
+    // its input, it consumes exactly the header it just read, the size bound
+    // this function is contracted to enforce holds, and the reserved high bit is
+    // masked off the stream id.
+    debug_assert!(i.len() <= in_len, "parser must not grow its input");
+    debug_assert_eq!(
+        i.len(),
+        in_len - FRAME_HEADER_SIZE,
+        "frame_header must consume exactly the 9-byte header"
+    );
+    debug_assert!(
+        payload_len <= max_frame_size,
+        "frame_header must enforce the size bound it was given"
+    );
+    debug_assert_eq!(
+        stream_id & !STREAM_ID_MASK,
+        0,
+        "reserved high bit must be masked off the stream id"
+    );
 
     // RFC 9113 §5.5: unknown frame types MUST be silently discarded. Skip
     // stream-id parity validation for them — the spec places no constraints on
@@ -395,6 +415,7 @@ pub fn frame_body<'a>(
     i: &'a [u8],
     header: &FrameHeader,
 ) -> IResult<&'a [u8], Frame, ParserError<'a>> {
+    let in_len = i.len();
     let f = match header.frame_type {
         FrameType::Data => data_frame(i, header)?,
         FrameType::Headers => headers_frame(i, header)?,
@@ -437,6 +458,16 @@ pub fn frame_body<'a>(
         FrameType::Unknown(_) => unknown_frame(i, header)?,
     };
 
+    // Whatever the frame type, decoding the body never grows the input and
+    // never leaves more bytes than there are payload bytes to consume.
+    debug_assert!(
+        f.0.len() <= in_len,
+        "frame body parser must not grow its input"
+    );
+    debug_assert!(
+        f.0.len() <= in_len.saturating_sub(header.payload_len as usize),
+        "frame body must consume at least the declared payload_len bytes"
+    );
     Ok(f)
 }
 
@@ -465,12 +496,20 @@ fn strip_padding<'a>(
     flags: u8,
     error_input: &'a [u8],
 ) -> IResult<&'a [u8], u8, ParserError<'a>> {
+    let in_len = i.len();
     let (i, pad_length) = if flags & FLAG_PADDED != 0 {
         let (i, pad_length) = be_u8(i)?;
         (i, pad_length)
     } else {
         (i, 0)
     };
+    // Reading the pad-length byte (PADDED set) shrinks the slice by exactly one;
+    // the unpadded path leaves it untouched.
+    debug_assert_eq!(
+        i.len(),
+        in_len - (flags & FLAG_PADDED != 0) as usize,
+        "strip_padding consumes the pad-length byte iff PADDED is set"
+    );
 
     if (pad_length as usize) > i.len() {
         return Err(Err::Failure(ParserError::new_h2(
@@ -479,6 +518,12 @@ fn strip_padding<'a>(
         )));
     }
 
+    // Post-condition this function is contracted to enforce (RFC 9113 §6.1):
+    // the returned pad length never exceeds the bytes that remain for it to trim.
+    debug_assert!(
+        pad_length as usize <= i.len(),
+        "strip_padding must reject pad_length larger than the remaining payload"
+    );
     Ok((i, pad_length))
 }
 
@@ -492,10 +537,22 @@ fn unpad<'a>(
     pad_length: u8,
     error_input: &'a [u8],
 ) -> Result<&'a [u8], Err<ParserError<'a>>> {
+    let in_len = i.len();
     let content_len = i
         .len()
         .checked_sub(pad_length as usize)
         .ok_or_else(|| Err::Failure(ParserError::new_h2(error_input, H2Error::ProtocolError)))?;
+    // Trimming padding only ever removes bytes, and removes exactly the declared
+    // padding (content + padding partition the input with no overlap or gap).
+    debug_assert!(
+        content_len <= in_len,
+        "unpad must not grow the content slice"
+    );
+    debug_assert_eq!(
+        content_len + pad_length as usize,
+        in_len,
+        "content and padding must exactly partition the input"
+    );
     Ok(&i[..content_len])
 }
 
@@ -503,10 +560,28 @@ pub fn data_frame<'a>(
     input: &'a [u8],
     header: &FrameHeader,
 ) -> IResult<&'a [u8], Frame, ParserError<'a>> {
+    let in_len = input.len();
     let (remaining, i) = take(header.payload_len)(input)?;
 
     let (i, pad_length) = strip_padding(i, header.flags, input)?;
     let payload = unpad(i, pad_length, input)?;
+
+    // `take` consumed exactly the declared payload; the visible content (after
+    // stripping the optional pad-length byte and the trailing padding) can never
+    // exceed it.
+    debug_assert_eq!(
+        remaining.len(),
+        in_len - header.payload_len as usize,
+        "data_frame must consume exactly payload_len bytes"
+    );
+    debug_assert!(
+        payload.len() <= header.payload_len as usize,
+        "data payload must fit within the declared frame payload"
+    );
+    debug_assert!(
+        pad_length as usize <= header.payload_len as usize,
+        "padding must not exceed the frame payload"
+    );
 
     Ok((
         remaining,
@@ -546,6 +621,7 @@ pub fn headers_frame<'a>(
     input: &'a [u8],
     header: &FrameHeader,
 ) -> IResult<&'a [u8], Frame, ParserError<'a>> {
+    let in_len = input.len();
     let (remaining, i) = take(header.payload_len)(input)?;
 
     let (i, pad_length) = strip_padding(i, header.flags, input)?;
@@ -565,6 +641,19 @@ pub fn headers_frame<'a>(
     };
 
     let header_block_fragment = unpad(i, pad_length, input)?;
+
+    // `take` consumed exactly the declared payload, and the header block fragment
+    // that survives after stripping pad-length, the optional 5-byte priority
+    // prefix, and trailing padding is necessarily a subslice of it.
+    debug_assert_eq!(
+        remaining.len(),
+        in_len - header.payload_len as usize,
+        "headers_frame must consume exactly payload_len bytes"
+    );
+    debug_assert!(
+        header_block_fragment.len() <= header.payload_len as usize,
+        "header block fragment must fit within the declared frame payload"
+    );
 
     Ok((
         remaining,
@@ -605,7 +694,20 @@ pub fn priority_frame<'a>(
     // symmetric with variable-size ones: if the upstream length invariant is
     // ever weakened we still consume exactly the declared payload and the
     // inner parse fails cleanly instead of reading random trailing bytes.
+    let in_len = input.len();
     let (i, data) = take(header.payload_len)(input)?;
+    // PRIORITY is a fixed 5-byte frame (RFC 9113 §6.3); the framing layer
+    // rejected mismatches, so the scoped payload is exactly that wide.
+    debug_assert_eq!(
+        i.len(),
+        in_len - header.payload_len as usize,
+        "priority_frame must consume exactly payload_len bytes"
+    );
+    debug_assert_eq!(
+        data.len(),
+        PRIORITY_PAYLOAD_SIZE as usize,
+        "PRIORITY payload must be exactly 5 bytes"
+    );
     let (_, (stream_dependency, weight)) = tuple((stream_dependency, be_u8))(data)?;
     Ok((
         i,
@@ -633,7 +735,20 @@ pub fn rst_stream_frame<'a>(
     // variable-size ones (see `priority_frame`). The framing layer already
     // enforced `payload_len == RST_STREAM_PAYLOAD_SIZE == 4`, so this
     // consumes exactly the 32-bit error-code field.
+    let in_len = input.len();
     let (i, data) = take(header.payload_len)(input)?;
+    // RST_STREAM is a fixed 4-byte frame (RFC 9113 §6.4); the framing layer
+    // enforced the size, so the scoped payload holds exactly the error code.
+    debug_assert_eq!(
+        i.len(),
+        in_len - header.payload_len as usize,
+        "rst_stream_frame must consume exactly payload_len bytes"
+    );
+    debug_assert_eq!(
+        data.len(),
+        RST_STREAM_PAYLOAD_SIZE as usize,
+        "RST_STREAM payload must be exactly 4 bytes"
+    );
     let (_, error_code) = be_u32(data)?;
     Ok((
         i,
@@ -681,12 +796,31 @@ pub fn settings_frame<'a>(
         )));
     }
 
+    let in_len = input.len();
     let (i, data) = take(header.payload_len)(input)?;
 
     let (_, settings) = many0(map(
         complete(tuple((be_u16, be_u32))),
         |(identifier, value)| Setting { identifier, value },
     ))(data)?;
+
+    // The framing layer guaranteed `payload_len % 6 == 0` and the cap above
+    // bounded the entry count; the decoded vector must reflect exactly that —
+    // one entry per 6-byte pair, never more than the allocation cap.
+    debug_assert_eq!(
+        i.len(),
+        in_len - header.payload_len as usize,
+        "settings_frame must consume exactly payload_len bytes"
+    );
+    debug_assert_eq!(
+        settings.len(),
+        header.payload_len as usize / SETTINGS_ENTRY_SIZE as usize,
+        "one SETTINGS entry decodes per 6 payload bytes"
+    );
+    debug_assert!(
+        settings.len() <= MAX_SETTINGS_ENTRIES,
+        "settings_frame must honour the MAX_SETTINGS_ENTRIES allocation cap"
+    );
 
     Ok((
         i,
@@ -734,7 +868,23 @@ pub fn ping_frame<'a>(
     // `take(header.payload_len)` (rather than `take(8usize)`) keeps the
     // fixed-size parsers symmetric with variable-size ones. The framing
     // layer already enforced `payload_len == PING_PAYLOAD_SIZE == 8`.
+    let in_len = input.len();
     let (i, data) = take(header.payload_len)(input)?;
+
+    // PING is a fixed 8-byte frame (RFC 9113 §6.7). The framing layer enforced
+    // the size, which is the invariant the unchecked `copy_from_slice(&data[..8])`
+    // below relies on — assert it before the copy so a weakened size check would
+    // fire here rather than panic on the slice index.
+    debug_assert_eq!(
+        i.len(),
+        in_len - header.payload_len as usize,
+        "ping_frame must consume exactly payload_len bytes"
+    );
+    debug_assert_eq!(
+        data.len(),
+        PING_PAYLOAD_SIZE as usize,
+        "PING payload must be exactly 8 bytes for the opaque-data copy"
+    );
 
     let mut p = Ping {
         payload: [0; 8],
@@ -756,11 +906,30 @@ pub fn goaway_frame<'a>(
     input: &'a [u8],
     header: &FrameHeader,
 ) -> IResult<&'a [u8], Frame, ParserError<'a>> {
+    let in_len = input.len();
     let (remaining, i) = take(header.payload_len)(input)?;
     let (i, raw_last_stream_id) = be_u32(i)?;
     // RFC 9113 §6.8: reserved bit must be masked (same as frame_header stream_id)
     let last_stream_id = raw_last_stream_id & STREAM_ID_MASK;
     let (additional_debug_data, error_code) = be_u32(i)?;
+    // The framing layer guaranteed `payload_len >= 8`; after the two fixed u32
+    // fields the remainder is the optional debug data, exactly `payload_len - 8`
+    // bytes, and the reserved high bit of Last-Stream-ID is cleared.
+    debug_assert_eq!(
+        remaining.len(),
+        in_len - header.payload_len as usize,
+        "goaway_frame must consume exactly payload_len bytes"
+    );
+    debug_assert_eq!(
+        additional_debug_data.len(),
+        header.payload_len as usize - GOAWAY_PAYLOAD_SIZE as usize,
+        "GOAWAY debug data is payload_len minus the 8-byte fixed prefix"
+    );
+    debug_assert_eq!(
+        last_stream_id & !STREAM_ID_MASK,
+        0,
+        "GOAWAY last_stream_id reserved high bit must be masked"
+    );
     Ok((
         remaining,
         Frame::GoAway(GoAway {
@@ -784,9 +953,27 @@ pub fn window_update_frame<'a>(
     // Scope input to payload_len like other fixed-size parsers (rst_stream_frame,
     // ping_frame). The caller enforces payload_len == 4; the take() ensures a
     // future relaxation doesn't desynchronize the frame stream.
+    let in_len = input.len();
     let (i, data) = take(header.payload_len)(input)?;
+    // WINDOW_UPDATE is a fixed 4-byte frame (RFC 9113 §6.9); the framing layer
+    // enforced the size so the scoped payload holds exactly the increment.
+    debug_assert_eq!(
+        i.len(),
+        in_len - header.payload_len as usize,
+        "window_update_frame must consume exactly payload_len bytes"
+    );
+    debug_assert_eq!(
+        data.len(),
+        WINDOW_UPDATE_PAYLOAD_SIZE as usize,
+        "WINDOW_UPDATE payload must be exactly 4 bytes"
+    );
     let (_, increment) = be_u32(data)?;
     let increment = increment & STREAM_ID_MASK;
+    // The reserved high bit is masked: the increment is a 31-bit value (§6.9).
+    debug_assert!(
+        increment <= STREAM_ID_MASK,
+        "window-size increment must be a 31-bit value"
+    );
 
     // NOTE: zero-increment validation is intentionally NOT performed here.
     // RFC 9113 §6.9 requires different error handling depending on whether the
@@ -819,7 +1006,13 @@ pub fn continuation_frame<'a>(
     header: &FrameHeader,
 ) -> IResult<&'a [u8], Frame, ParserError<'a>> {
     // Consume the entire frame payload without storing fields
+    let in_len = input.len();
     let (remaining, _) = take(header.payload_len)(input)?;
+    debug_assert_eq!(
+        remaining.len(),
+        in_len - header.payload_len as usize,
+        "continuation_frame must consume exactly payload_len bytes"
+    );
     Ok((remaining, Frame::Continuation(Continuation)))
 }
 
@@ -831,7 +1024,13 @@ pub fn unknown_frame<'a>(
     input: &'a [u8],
     header: &FrameHeader,
 ) -> IResult<&'a [u8], Frame, ParserError<'a>> {
+    let in_len = input.len();
     let (remaining, _payload) = take(header.payload_len)(input)?;
+    debug_assert_eq!(
+        remaining.len(),
+        in_len - header.payload_len as usize,
+        "unknown_frame must consume exactly payload_len bytes"
+    );
     let raw = match header.frame_type {
         FrameType::Unknown(t) => t,
         _ => 0,
@@ -880,14 +1079,37 @@ pub fn priority_update_frame<'a>(
             H2Error::ProtocolError,
         )));
     }
+    let in_len = input.len();
     let (remaining, payload) = take(header.payload_len)(input)?;
     let (raw_id_bytes, value_bytes) = payload.split_at(PRIORITY_UPDATE_MIN_PAYLOAD as usize);
+    // The two checks above bound the value length; `split_at` partitions the
+    // payload into the 4-byte stream-id prefix and the SF-Item value with no
+    // overlap. Assert the bound this function is contracted to enforce.
+    debug_assert_eq!(
+        remaining.len(),
+        in_len - header.payload_len as usize,
+        "priority_update_frame must consume exactly payload_len bytes"
+    );
+    debug_assert_eq!(
+        raw_id_bytes.len(),
+        PRIORITY_UPDATE_MIN_PAYLOAD as usize,
+        "PRIORITY_UPDATE stream-id prefix must be exactly 4 bytes"
+    );
+    debug_assert!(
+        value_bytes.len() <= PRIORITY_UPDATE_MAX_VALUE,
+        "priority field value must respect the PRIORITY_UPDATE_MAX_VALUE cap"
+    );
     let prioritized_stream_id = u32::from_be_bytes([
         raw_id_bytes[0],
         raw_id_bytes[1],
         raw_id_bytes[2],
         raw_id_bytes[3],
     ]) & STREAM_ID_MASK;
+    debug_assert_eq!(
+        prioritized_stream_id & !STREAM_ID_MASK,
+        0,
+        "prioritized_stream_id reserved high bit must be masked"
+    );
     Ok((
         remaining,
         Frame::PriorityUpdate(PriorityUpdate {

--- a/lib/src/protocol/mux/pkawa.rs
+++ b/lib/src/protocol/mux/pkawa.rs
@@ -138,10 +138,11 @@ fn is_invalid_te_value(value: &[u8]) -> bool {
 /// used for the RFC 9113 §8.3.1 equivalence check between a literal ``host``
 /// header and the ``:authority`` pseudo-header when both are present.
 fn strip_port(value: &[u8]) -> &[u8] {
+    let in_len = value.len();
     // Do not strip port from IPv6 literals (e.g., [::1]:8080)
     if value.contains(&b'[') {
         // Bracketed IPv6: look for "]:port"
-        return match value.iter().rposition(|&b| b == b']') {
+        let stripped = match value.iter().rposition(|&b| b == b']') {
             Some(bracket) => {
                 if value.get(bracket + 1) == Some(&b':')
                     && bracket + 2 < value.len()
@@ -154,13 +155,35 @@ fn strip_port(value: &[u8]) -> &[u8] {
             }
             None => value,
         };
+        // Stripping only ever removes a trailing `:port` suffix — the result
+        // is a prefix of the input and never longer than what we started with.
+        debug_assert!(
+            stripped.len() <= in_len,
+            "strip_port must not grow its input (IPv6 path)"
+        );
+        debug_assert!(
+            stripped.as_ptr() == value.as_ptr(),
+            "strip_port returns a prefix of value (shares its start)"
+        );
+        return stripped;
     }
-    match value.iter().rposition(|&b| b == b':') {
+    let stripped = match value.iter().rposition(|&b| b == b':') {
         Some(i) if i + 1 < value.len() && value[i + 1..].iter().all(|b| b.is_ascii_digit()) => {
             &value[..i]
         }
         _ => value,
-    }
+    };
+    // A stripped value is strictly shorter (we dropped at least `:` + 1 digit);
+    // an unstripped value is byte-identical. Either way it is a prefix.
+    debug_assert!(
+        stripped.len() <= in_len,
+        "strip_port must not grow its input"
+    );
+    debug_assert!(
+        stripped.len() == in_len || stripped.len() + 2 <= in_len,
+        "a real port strip removes at least a colon and one digit"
+    );
+    stripped
 }
 
 /// Case-insensitively compare a literal ``host`` header value to an
@@ -177,6 +200,16 @@ fn host_matches_authority(host: &[u8], authority: &[u8]) -> bool {
     // If both have explicit ports but differ, the origins differ.
     let host_stripped = strip_port(host);
     let auth_stripped = strip_port(authority);
+    // strip_port only ever drops a trailing `:port` suffix, so the stripped
+    // forms are no longer than their inputs; len inequality is the port flag.
+    debug_assert!(
+        host_stripped.len() <= host.len(),
+        "stripped host cannot grow"
+    );
+    debug_assert!(
+        auth_stripped.len() <= authority.len(),
+        "stripped authority cannot grow"
+    );
     let host_has_port = host_stripped.len() != host.len();
     let auth_has_port = auth_stripped.len() != authority.len();
     if host_has_port && auth_has_port {
@@ -365,13 +398,25 @@ fn classify_invalid_value_byte(value: &[u8]) -> Option<RejectReason> {
             _ => {}
         }
     }
-    if saw_crlf {
+    // CR/LF takes precedence over NUL when both are present (more dangerous
+    // smuggling vector), but the result is non-None iff at least one forbidden
+    // byte was seen — never the other way around.
+    let result = if saw_crlf {
         Some(RejectReason::CrlfInValue)
     } else if saw_nul {
         Some(RejectReason::NulInValue)
     } else {
         None
-    }
+    };
+    debug_assert!(
+        result.is_some() == (saw_crlf || saw_nul),
+        "classify must reject iff a CR/LF or NUL byte was observed"
+    );
+    debug_assert!(
+        !(saw_crlf && result != Some(RejectReason::CrlfInValue)),
+        "CR/LF must classify as CrlfInValue even when NUL is also present"
+    );
+    result
 }
 
 /// Thin wrapper kept for tests and any code path that just needs the boolean.
@@ -385,13 +430,26 @@ fn is_invalid_h2_header(name: &[u8], value: &[u8]) -> bool {
 /// Validate and set Content-Length, returning false if it conflicts with a prior value
 /// (RFC 9110 §8.6: multiple disagreeing Content-Length values are malformed).
 fn set_content_length(body_size: &mut BodySize, length: usize) -> bool {
-    match *body_size {
+    let before = *body_size;
+    let accepted = match *body_size {
         BodySize::Length(existing) if existing != length => false,
         _ => {
             *body_size = BodySize::Length(length);
             true
         }
-    }
+    };
+    // On rejection the prior framing must be untouched; on acceptance the body
+    // size must now equal the value we were asked to record (RFC 9110 §8.6
+    // forbids a second, disagreeing Content-Length).
+    debug_assert!(
+        accepted || *body_size == before,
+        "rejected content-length must leave body_size unchanged"
+    );
+    debug_assert!(
+        !accepted || *body_size == BodySize::Length(length),
+        "accepted content-length must set body_size to exactly Length(length)"
+    );
+    accepted
 }
 
 /// Store a pseudo-header value into kawa storage.
@@ -427,6 +485,7 @@ fn store_pseudo_header(
         return Err(RejectReason::OversizedPseudoValue);
     }
     let start = kawa.storage.end as u32;
+    let end_before = kawa.storage.end;
     if kawa.storage.write_all(value).is_err() {
         // Storage exhaustion: report as `oversized_pseudo_value` since a
         // pseudo whose bytes don't fit is functionally an oversized payload
@@ -434,6 +493,23 @@ fn store_pseudo_header(
         // bounded without inventing a transport-failure reason.
         return Err(RejectReason::OversizedPseudoValue);
     }
+    // A successful write_all is all-or-nothing: storage advanced by exactly the
+    // value length, so the slice we are about to mint lies fully inside the
+    // written region (start..end). Reaching here also means the value is
+    // non-empty (the guard above rejected `value.is_empty()`).
+    debug_assert_eq!(
+        kawa.storage.end,
+        end_before + value.len(),
+        "pseudo store must advance storage.end by exactly value.len()"
+    );
+    debug_assert!(
+        start as usize + value.len() <= kawa.storage.end,
+        "pseudo slice must stay within the written storage region"
+    );
+    debug_assert!(
+        !value.is_empty(),
+        "empty pseudo value must already be rejected"
+    );
     Ok(Store::Slice(Slice {
         start,
         len: value.len() as u32,
@@ -460,9 +536,16 @@ fn write_regular_header(
     let len_key = key.len() as u32;
     let len_val = value.len() as u32;
     let start = kawa.storage.end as u32;
+    let end_before_val = kawa.storage.end;
     if kawa.storage.write_all(value).is_err() {
         return Err(RejectReason::OversizedPseudoValue);
     }
+    // All-or-nothing write_all: storage.end advanced by exactly the value length.
+    debug_assert_eq!(
+        kawa.storage.end,
+        end_before_val + value.len(),
+        "regular header value write must advance storage.end by value.len()"
+    );
     let val = Store::Slice(Slice {
         start,
         len: len_val,
@@ -483,13 +566,31 @@ fn write_regular_header(
             return Err(RejectReason::DuplicateCl);
         }
     }
+    let end_before_key = kawa.storage.end;
     if kawa.storage.write_all(key).is_err() {
         return Err(RejectReason::OversizedPseudoValue);
     }
+    // The key was appended immediately after the value, so it starts at
+    // `start + len_val` and the two slices tile [start, end) contiguously
+    // with no gap and no overlap.
+    debug_assert_eq!(
+        kawa.storage.end,
+        end_before_key + key.len(),
+        "regular header key write must advance storage.end by key.len()"
+    );
+    debug_assert_eq!(
+        end_before_key as u32,
+        start + len_val,
+        "key must begin exactly where the value ended (contiguous, no gap)"
+    );
     let key = Store::Slice(Slice {
         start: start + len_val,
         len: len_key,
     });
+    debug_assert!(
+        (start + len_val + len_key) as usize <= kawa.storage.end,
+        "key+val slices must stay within the written storage region"
+    );
     kawa.push_block(Block::Header(Pair { key, val }));
     Ok(())
 }
@@ -533,6 +634,9 @@ pub(super) fn parse_rfc9218_priority(value: &[u8]) -> (u8, bool) {
             if let Ok(s) = std::str::from_utf8(&token[2..]) {
                 if let Ok(n) = s.parse::<u8>() {
                     urgency = n.min(7);
+                    // The `.min(7)` clamp is the only writer of `urgency` after
+                    // the default; it can never leave the RFC 9218 §4 range.
+                    debug_assert!(urgency <= 7, "clamped urgency must stay within 0..=7");
                 }
             }
         } else if token == b"i" || token == b"i=?1" {
@@ -542,6 +646,13 @@ pub(super) fn parse_rfc9218_priority(value: &[u8]) -> (u8, bool) {
         }
     }
 
+    // RFC 9218 §4: urgency is a 3-bit field (0..=7). The default (3) and the
+    // clamped parse path are the only writers, so this always holds — the
+    // Prioriser downstream relies on it for its urgency-bucket array indexing.
+    debug_assert!(
+        urgency <= 7,
+        "parse_rfc9218_priority must yield an urgency within the RFC 9218 range"
+    );
     (urgency, incremental)
 }
 
@@ -575,6 +686,7 @@ where
         if invalid_headers || budget_exceeded || field_limit_exceeded {
             return;
         }
+        let bytes_before = decoded_bytes;
         // RFC 9113 §6.5.2: the size accounted against SETTINGS_MAX_HEADER_LIST_SIZE
         // is the name + value octets PLUS a 32-octet per-field overhead. The
         // overhead is what bounds the field count under a fixed byte budget;
@@ -584,10 +696,22 @@ where
             .saturating_add(k.len())
             .saturating_add(v.len())
             .saturating_add(crate::protocol::mux::h2::HEADER_FIELD_SIZE_OVERHEAD);
+        // The running header-list size only ever grows as pairs are admitted;
+        // it must never shrink between callbacks (RFC 9113 §6.5.2 accounting).
+        debug_assert!(
+            decoded_bytes >= bytes_before,
+            "decoded header-list size must be monotonic non-decreasing"
+        );
         if decoded_bytes > max_decoded_bytes {
             budget_exceeded = true;
             return;
         }
+        // We only reach per_header for pairs that fit the budget; the running
+        // total stays at or below the negotiated MAX_HEADER_LIST_SIZE here.
+        debug_assert!(
+            decoded_bytes <= max_decoded_bytes,
+            "admitted pairs must keep the running size within the budget"
+        );
         // Cap the COUNT of materialized header fields (cf. nginx `max_headers`,
         // Apache `LimitRequestFields`): the bomb's real cost is one `Pair` of
         // per-entry bookkeeping per field, not the decoded byte size.
@@ -615,6 +739,12 @@ where
         error!("{} INVALID FRAGMENT: {:?}", log_module_context!(), error);
         return Err((H2Error::CompressionError, true));
     }
+    // budget_exceeded is set exactly when the running total crossed the cap; if
+    // it stayed clear the whole decode fit inside MAX_HEADER_LIST_SIZE.
+    debug_assert!(
+        budget_exceeded || decoded_bytes <= max_decoded_bytes,
+        "a non-overflowing decode must end at or below the budget"
+    );
     if budget_exceeded {
         metric_reject(RejectReason::HeaderListOverBudget);
         error!(
@@ -635,6 +765,12 @@ where
         );
         return Err((H2Error::EnhanceYourCalm, false));
     }
+    // Reaching the Ok branch means we neither errored nor overflowed the budget,
+    // so the final accounted size is within the negotiated cap.
+    debug_assert!(
+        decoded_bytes <= max_decoded_bytes,
+        "successful decode must report a header-list size within the budget"
+    );
     Ok(invalid_headers)
 }
 
@@ -919,6 +1055,18 @@ where
                 // Match — drop it. kawa's H1 serializer emits Host: from
                 // :authority on its own.
             }
+            // All four mandatory request pseudo-headers passed the presence gate
+            // above (RFC 9113 §8.3.1); none may be Store::Empty at this point.
+            // `store_pseudo_header` already enforced uniqueness and the
+            // pseudo-before-regular ordering, so a populated quartet here is the
+            // proof the request line is well-formed before we mint it.
+            debug_assert!(
+                !method.is_empty()
+                    && !authority.is_empty()
+                    && !path.is_empty()
+                    && !scheme.is_empty(),
+                "all four request pseudo-headers must be present after validation"
+            );
             StatusLine::Request {
                 version: Version::V20,
                 method,
@@ -950,9 +1098,21 @@ where
                         match store_pseudo_header(&status, regular_headers, kawa, &v) {
                             Ok(s) => {
                                 status = s;
+                                // The three-digit ASCII guard above proves each
+                                // byte is in b'0'..=b'9', so this hand-rolled
+                                // base-10 decode lands in 100..=999 with no
+                                // overflow of the u16 accumulator.
+                                debug_assert!(
+                                    v.len() == 3 && v.iter().all(|b| b.is_ascii_digit()),
+                                    ":status reaching the decode must be three ASCII digits"
+                                );
                                 code = (v[0] - b'0') as u16 * 100
                                     + (v[1] - b'0') as u16 * 10
                                     + (v[2] - b'0') as u16;
+                                debug_assert!(
+                                    (100..=999).contains(&code),
+                                    "decoded :status code must be in 100..=999"
+                                );
                             }
                             Err(reason) => {
                                 metric_reject(reason);
@@ -975,6 +1135,17 @@ where
                 error!("{} INVALID HEADERS", log_module_context!());
                 return Err((H2Error::ProtocolError, false));
             }
+            // Past the validity gate, :status was exactly three ASCII digits
+            // (the in-loop guard rejected anything else), so the decimal `code`
+            // is in 100..=999 and `status` is a stored, non-empty slice.
+            debug_assert!(
+                (100..=999).contains(&code),
+                "response :status code must be a three-digit value in 100..=999"
+            );
+            debug_assert!(
+                !status.is_empty(),
+                "validated response must carry a non-empty :status pseudo"
+            );
             StatusLine::Response {
                 version: Version::V20,
                 code,
@@ -1068,12 +1239,27 @@ where
         return Ok(());
     }
 
+    // A stream that still expects a body (`!end_stream`) must have had its
+    // framing resolved to a concrete length or chunked encoding above — the
+    // `BodySize::Empty` upgrade-to-chunked branch guarantees we never enter the
+    // phase mapping with an unframed body when more bytes are coming.
+    debug_assert!(
+        end_stream || kawa.body_size != BodySize::Empty,
+        "a continuing stream must have a resolved body framing before phasing"
+    );
     kawa.parsing_phase = match kawa.body_size {
         BodySize::Chunked => ParsingPhase::Chunks { first: true },
         BodySize::Length(0) => ParsingPhase::Terminated,
         BodySize::Length(_) => ParsingPhase::Body,
         BodySize::Empty => ParsingPhase::Chunks { first: true },
     };
+    // The phase we just selected must be consistent with the framing: a
+    // length-framed body lands in Body/Terminated, never mid-chunk.
+    debug_assert!(
+        !matches!(kawa.body_size, BodySize::Length(n) if n > 0)
+            || kawa.parsing_phase == ParsingPhase::Body,
+        "a non-empty Content-Length body must transition to ParsingPhase::Body"
+    );
     Ok(())
 }
 
@@ -1145,20 +1331,36 @@ pub fn handle_trailer(
     // wild, RFC 9110 §6.5 imposes no minimum) and an order of magnitude
     // tighter than the HEADERS cap.
     let max_decoded = (max_header_list_size as usize).min(MAX_TRAILER_BYTES);
+    // The trailer carve-out can only tighten the budget, never relax it below
+    // the negotiated MAX_HEADER_LIST_SIZE.
+    debug_assert!(
+        max_decoded <= max_header_list_size as usize && max_decoded <= MAX_TRAILER_BYTES,
+        "trailer budget is the min of MAX_HEADER_LIST_SIZE and the carve-out cap"
+    );
     let decode_status = decoder.decode_with_cb(input, |k, v| {
         if invalid_trailers || budget_exceeded || field_limit_exceeded {
             return;
         }
+        let bytes_before = decoded_bytes;
         // RFC 9113 §6.5.2: count name + value octets plus the 32-octet
         // per-field overhead, matching the HEADERS path.
         decoded_bytes = decoded_bytes
             .saturating_add(k.len())
             .saturating_add(v.len())
             .saturating_add(crate::protocol::mux::h2::HEADER_FIELD_SIZE_OVERHEAD);
+        debug_assert!(
+            decoded_bytes >= bytes_before,
+            "decoded trailer size must be monotonic non-decreasing"
+        );
         if decoded_bytes > max_decoded {
             budget_exceeded = true;
             return;
         }
+        // Admitted trailers keep the running total within the carve-out cap.
+        debug_assert!(
+            decoded_bytes <= max_decoded,
+            "admitted trailers must stay within the trailer budget"
+        );
         field_count += 1;
         if field_count > max_header_fields {
             field_limit_exceeded = true;
@@ -1200,13 +1402,26 @@ pub fn handle_trailer(
             return;
         }
         let start = kawa.storage.end as u32;
+        let end_before = kawa.storage.end;
         if kawa.storage.write_all(&k).is_err() || kawa.storage.write_all(&v).is_err() {
             metric_reject(RejectReason::OversizedPseudoValue);
             invalid_trailers = true;
             return;
         }
+        // Both writes succeeded, so storage.end advanced by exactly key+value
+        // and the two slices tile [start, end) contiguously (key first, then
+        // value at `start + len_key`).
+        debug_assert_eq!(
+            kawa.storage.end,
+            end_before + k.len() + v.len(),
+            "trailer write must advance storage.end by key.len() + value.len()"
+        );
         let len_key = k.len() as u32;
         let len_val = v.len() as u32;
+        debug_assert!(
+            (start + len_key + len_val) as usize <= kawa.storage.end,
+            "trailer key+val slices must stay within the written storage region"
+        );
         let key = Store::Slice(Slice {
             start,
             len: len_key,
@@ -1246,6 +1461,13 @@ pub fn handle_trailer(
         error!("{} INVALID TRAILERS", log_module_context!());
         return Err((H2Error::ProtocolError, false));
     }
+    // Reaching here means the trailer block decoded cleanly, never overflowed
+    // the carve-out budget, and carried no invalid field — the three rejection
+    // gates above already returned on the negative space.
+    debug_assert!(
+        !budget_exceeded && !invalid_trailers && decoded_bytes <= max_decoded,
+        "an accepted trailer block must fit the budget and pass validation"
+    );
 
     // RFC 9110 §6.5: if the request/response was framed with a
     // fixed Content-Length (not chunked), the H1-side serializer cannot emit

--- a/lib/src/protocol/mux/serializer.rs
+++ b/lib/src/protocol/mux/serializer.rs
@@ -40,7 +40,17 @@ pub fn gen_frame_header<'a>(
         be_u32(frame.stream_id & parser::STREAM_ID_MASK),
     ));
 
-    r#gen(serializer, buf).map(|(buf, size)| (buf, size as usize))
+    r#gen(serializer, buf).map(|(buf, size)| {
+        // The header is the RFC 9113 §4.1 fixed-size envelope: on success it is
+        // always exactly 9 bytes, never more. (Failure short-circuits via the
+        // `Err` arm of `r#gen` and never reaches here.)
+        debug_assert_eq!(
+            size as usize,
+            parser::FRAME_HEADER_SIZE,
+            "a serialized H2 frame header is always exactly 9 bytes"
+        );
+        (buf, size as usize)
+    })
 }
 
 pub fn serialize_frame_type(f: &FrameType) -> u8 {
@@ -70,21 +80,33 @@ pub fn gen_ping_acknowledgement<'a>(
     buf: &'a mut [u8],
     payload: &[u8],
 ) -> Result<(&'a mut [u8], usize), GenError> {
+    let payload_len = payload.len();
     r#gen(
         tuple((slice(PING_ACKNOWLEDGEMENT_HEADER), slice(payload))),
         buf,
     )
-    .map(|(buf, size)| (buf, size as usize))
+    .map(|(buf, size)| {
+        // A PING ACK is the 9-byte canned header (whose length field encodes 8)
+        // followed by the opaque 8-byte payload echoed back verbatim. On success
+        // the emitted byte count is exactly header + payload.
+        debug_assert_eq!(
+            size as usize,
+            PING_ACKNOWLEDGEMENT_HEADER.len() + payload_len,
+            "PING ACK emits the 9-byte header plus the echoed payload"
+        );
+        (buf, size as usize)
+    })
 }
 
 pub fn gen_settings<'a>(
     buf: &'a mut [u8],
     settings: &H2Settings,
 ) -> Result<(&'a mut [u8], usize), GenError> {
+    let payload_len = parser::SETTINGS_ENTRY_SIZE * parser::SETTINGS_COUNT;
     gen_frame_header(
         buf,
         &FrameHeader {
-            payload_len: parser::SETTINGS_ENTRY_SIZE * parser::SETTINGS_COUNT,
+            payload_len,
             frame_type: FrameType::Settings,
             flags: 0,
             stream_id: 0,
@@ -112,7 +134,18 @@ pub fn gen_settings<'a>(
             )),
             buf,
         )
-        .map(|(buf, size)| (buf, (old_size + size as usize)))
+        .map(|(buf, size)| {
+            // The body we just emitted must be exactly the `payload_len` the
+            // header advertised — SETTINGS_COUNT (8) entries × 6 bytes each.
+            // A mismatch here would put a length on the wire that disagrees
+            // with the bytes that follow it, desynchronizing the peer parser.
+            debug_assert_eq!(old_size, parser::FRAME_HEADER_SIZE, "header is 9 bytes");
+            debug_assert_eq!(
+                size as usize, payload_len as usize,
+                "SETTINGS body length must match the advertised payload_len"
+            );
+            (buf, (old_size + size as usize))
+        })
     })
 }
 
@@ -131,8 +164,25 @@ fn gen_control_frame<F>(
 where
     F: FnOnce(&mut [u8]) -> Result<(&mut [u8], u64), GenError>,
 {
-    gen_frame_header(buf, &header)
-        .and_then(|(buf, old_size)| payload(buf).map(|(buf, size)| (buf, old_size + size as usize)))
+    let declared_payload_len = header.payload_len as usize;
+    gen_frame_header(buf, &header).and_then(|(buf, old_size)| {
+        // The header is the fixed 9-byte envelope; the body the closure writes
+        // must be exactly the `payload_len` that header advertised. This is the
+        // load-bearing serializer invariant: the length field on the wire and
+        // the bytes that follow it must agree, or the peer desyncs.
+        debug_assert_eq!(
+            old_size,
+            parser::FRAME_HEADER_SIZE,
+            "control frame header is always 9 bytes"
+        );
+        payload(buf).map(|(buf, size)| {
+            debug_assert_eq!(
+                size as usize, declared_payload_len,
+                "emitted control-frame body must match the header's payload_len"
+            );
+            (buf, old_size + size as usize)
+        })
+    })
 }
 
 pub fn gen_rst_stream(

--- a/lib/src/protocol/mux/stream.rs
+++ b/lib/src/protocol/mux/stream.rs
@@ -143,7 +143,7 @@ impl Stream {
             }
             None => return None,
         };
-        Some(Self {
+        let stream = Self {
             state: StreamState::Idle,
             attempts: 0,
             window: i32::try_from(window).unwrap_or(i32::MAX),
@@ -156,7 +156,68 @@ impl Stream {
             back: GenericHttpStream::new(kawa::Kind::Response, kawa::Buffer::new(back_buffer)),
             context,
             metrics: SessionMetrics::new(None),
-        })
+        };
+        // Post: a freshly checked-out stream is a clean, closed slot — no
+        // request has been counted yet (so `generate_access_log` won't
+        // gauge-underflow `http.active_requests`) and no DATA has been seen on
+        // either half (the content-length reconciliation counters start at 0).
+        debug_assert_eq!(stream.state, StreamState::Idle, "new stream must be Idle");
+        debug_assert!(
+            !stream.state.is_open(),
+            "an Idle stream slot must not report as open"
+        );
+        debug_assert!(
+            !stream.request_counted,
+            "new stream must not have a counted request (gauge-underflow guard)"
+        );
+        debug_assert_eq!(
+            (stream.front_data_received, stream.back_data_received),
+            (0, 0),
+            "new stream DATA counters must start at 0"
+        );
+        #[cfg(debug_assertions)]
+        stream.check_invariants();
+        Some(stream)
+    }
+
+    /// Cross-field invariant sweep for the per-request stream state machine.
+    ///
+    /// Encodes the relationships that must hold for ANY `Stream` regardless of
+    /// the mux path (H1 or H2) that drives it:
+    /// - `state.is_open()` agrees with the `Idle`/`Recycle` discriminants
+    ///   (the open/closed split is the load-bearing predicate for shutdown and
+    ///   slot reuse).
+    /// - a `Recycle` slot is fully reset — no counted request can be left
+    ///   pending on a slot advertised as reusable, or `create_stream` would
+    ///   resurrect a stale `http.active_requests` charge.
+    /// - a `Linked` stream names a backend token; the `Linked(token)`
+    ///   discriminant and `linked_token()` must agree (the access-log and
+    ///   reverse-index lookups both depend on this equivalence).
+    ///
+    /// Compiled only with `debug_assertions`; the optimizer drops every call
+    /// in release. Network input never reaches a hard `assert!` here — these
+    /// fire only on our own logic bugs.
+    #[cfg(debug_assertions)]
+    pub(super) fn check_invariants(&self) {
+        debug_assert_eq!(
+            self.state.is_open(),
+            !matches!(self.state, StreamState::Idle | StreamState::Recycle),
+            "is_open() must agree with the Idle/Recycle discriminants"
+        );
+        if self.state == StreamState::Recycle {
+            debug_assert!(
+                !self.request_counted,
+                "a Recycle slot must not carry a counted request (active-requests leak)"
+            );
+        }
+        // `linked_token()` is the canonical accessor for the backend token; it
+        // must return Some iff the slot is `Linked`, since the reverse index
+        // and the access-log RTT lookup both branch on it.
+        debug_assert_eq!(
+            self.linked_token().is_some(),
+            matches!(self.state, StreamState::Linked(_)),
+            "linked_token() must be Some iff the stream is Linked"
+        );
     }
     /// Convenience accessor for the backend token when the stream is `Linked`.
     /// Used by access-log emission sites to look up the backend socket on the
@@ -182,6 +243,19 @@ impl Stream {
     }
 
     pub fn split(&mut self, position: &Position) -> StreamParts<'_> {
+        // Pre: the front buffer always parses requests and the back buffer
+        // always parses responses. `split` only re-labels them as read/write
+        // for the caller's position — it must never swap their kawa kinds.
+        debug_assert_eq!(
+            self.front.kind,
+            kawa::Kind::Request,
+            "front buffer must hold a Request kawa"
+        );
+        debug_assert_eq!(
+            self.back.kind,
+            kawa::Kind::Response,
+            "back buffer must hold a Response kawa"
+        );
         match position {
             Position::Client(..) => StreamParts {
                 window: &mut self.window,
@@ -231,10 +305,26 @@ impl Stream {
         // backend-error 504. Caller-supplied `message` (e.g. parsing
         // errors) takes precedence when both are present.
         let message = message.or(context.access_log_message);
+        // Pair the `http.active_requests` gauge `-1` with `request_counted`:
+        // it must transition true -> false exactly once so a re-entry (H1
+        // keep-alive, double access-log on the same stream) cannot
+        // double-decrement the gauge into underflow. `request_counted` is set
+        // true at the matching `gauge_add!(.., 1)` in the H1/H2 readable paths.
+        let was_counted = self.request_counted;
         if self.request_counted {
             gauge_add!(names::http::ACTIVE_REQUESTS, -1);
             self.request_counted = false;
         }
+        debug_assert!(
+            !self.request_counted,
+            "generate_access_log must leave request_counted false (gauge-underflow guard)"
+        );
+        // The flag may only move true->false here (one `-1`); it must never be
+        // observed flipping back on within this call.
+        debug_assert!(
+            was_counted >= self.request_counted,
+            "request_counted must only clear here, never spontaneously set"
+        );
         if error {
             // Labelled with `(cluster_id, backend_id)`; see the matching
             // emission in `kawa_h1::log_request_error` for the cardinality

--- a/lib/src/protocol/pipe.rs
+++ b/lib/src/protocol/pipe.rs
@@ -408,21 +408,6 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
         self.splice_pipe.as_ref().map(|p| p.capacity).unwrap_or(0)
     }
 
-    /// Upper bound used by `debug_assert!`s on the splice pending counters.
-    /// On splice builds it is the realised kernel-pipe capacity; on builds
-    /// without splice the pending counters are hard-coded `0`, so any finite
-    /// bound holds — we return `usize::MAX` to keep the assertion a no-op
-    /// while still compiling in every profile. Invariant-only; not on a hot
-    /// path.
-    #[cfg(all(target_os = "linux", feature = "splice"))]
-    fn splice_capacity_or_max(&self) -> usize {
-        self.splice_capacity()
-    }
-    #[cfg(not(all(target_os = "linux", feature = "splice")))]
-    fn splice_capacity_or_max(&self) -> usize {
-        usize::MAX
-    }
-
     /// Tear down both readiness trackers ahead of a `SessionResult::Close`.
     ///
     /// This is the *write-only-shutdown discipline* (CLAUDE.md gotcha: never
@@ -448,11 +433,13 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
     /// Wether the session should be kept open, depending on endpoints status
     /// and buffer usage (both in memory and in kernel)
     pub fn check_connections(&self) -> bool {
-        // In-flight accounting must never see more bytes queued than the
-        // backing storage can hold: buffered data ≤ buffer capacity and
-        // splice-pending ≤ realised kernel-pipe capacity. A violation here
-        // means a `fill`/`consume`/splice-delta elsewhere desynced the
-        // counters, which would corrupt the keep-alive decision below.
+        // In-flight accounting must never see more *buffered* bytes than the
+        // backing Checkout buffer can hold. We intentionally do NOT bound the
+        // splice-pending counters by the pipe `capacity`: a kernel pipe buffers
+        // well beyond its nominal `F_GETPIPE_SZ` when `splice(2)` moves
+        // skb-backed GRO segments, so `splice_*_pending` legitimately exceeds it
+        // (see `splice_readable`). A violation here means a `fill`/`consume`
+        // elsewhere desynced the counters, corrupting the keep-alive decision.
         debug_assert!(
             self.frontend_buffer.available_data() <= self.frontend_buffer.capacity(),
             "frontend buffered data exceeds its capacity"
@@ -460,14 +447,6 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
         debug_assert!(
             self.backend_buffer.available_data() <= self.backend_buffer.capacity(),
             "backend buffered data exceeds its capacity"
-        );
-        debug_assert!(
-            self.splice_in_pending() <= self.splice_capacity_or_max(),
-            "frontend→backend splice pending exceeds kernel-pipe capacity"
-        );
-        debug_assert!(
-            self.splice_out_pending() <= self.splice_capacity_or_max(),
-            "backend→frontend splice pending exceeds kernel-pipe capacity"
         );
 
         let request_is_inflight = self.frontend_buffer.available_data() > 0
@@ -963,19 +942,24 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
         let bin_before = metrics.bin;
         let pipe_write_end = self.splice_pipe.as_ref().unwrap().in_pipe[1];
         let (sz, res) = splice::splice_in(self.frontend.socket_ref(), pipe_write_end, capacity);
-        // The kernel pipe physically holds at most `capacity` bytes, so a
-        // splice into a pipe already holding `pending_before` can add no more
-        // than the remaining headroom.
+        // `splice_in` is asked for at most `capacity` bytes, so the kernel can
+        // never report moving more than that in one call. We deliberately do
+        // NOT assert `in_pipe_pending <= capacity`: a kernel pipe buffers well
+        // beyond its nominal `F_GETPIPE_SZ` when `splice(2)` moves skb-backed
+        // segments — a GRO super-packet on loopback hands a single ring slot far
+        // more than a page — so byte-occupancy legitimately exceeds `capacity`.
+        // `capacity` is the per-call `len` and a soft backpressure threshold,
+        // not a hard occupancy bound.
         debug_assert!(
-            pending_before + sz <= capacity,
-            "splice_in moved {sz} bytes into a pipe with only {} headroom (capacity {capacity})",
-            capacity - pending_before
+            sz <= capacity,
+            "splice_in reported {sz} bytes but was capped at len {capacity}"
         );
         debug!("{} Spliced {} bytes from frontend", log_context!(self), sz);
 
         if sz > 0 {
             self.splice_pipe.as_mut().unwrap().in_pipe_pending += sz;
-            // Pending advanced by exactly the spliced bytes and stays bounded.
+            // Pending advanced by exactly the spliced bytes (tracks real
+            // kernel-pipe occupancy; see the capacity note above).
             debug_assert_eq!(
                 self.splice_in_pending(),
                 pending_before + sz,
@@ -1249,13 +1233,15 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             Some(b) => splice::splice_in(b, pipe_write_end, capacity),
             None => return SessionResult::Continue,
         };
-        // The out_pipe physically holds at most `capacity` bytes; a splice into
-        // a pipe already holding `pending_before` can add no more than the
-        // remaining headroom.
+        // `splice_in` is capped at `len = capacity`, so the kernel never reports
+        // moving more than that per call. As in `splice_readable`, we do NOT
+        // assert `out_pipe_pending <= capacity`: a kernel pipe holds well beyond
+        // its nominal `F_GETPIPE_SZ` when `splice(2)` moves skb-backed (GRO)
+        // segments, so byte-occupancy legitimately exceeds `capacity` — it is
+        // only the per-call `len` and a soft backpressure threshold.
         debug_assert!(
-            pending_before + size <= capacity,
-            "splice_in moved {size} bytes into a pipe with only {} headroom (capacity {capacity})",
-            capacity - pending_before
+            size <= capacity,
+            "splice_in reported {size} bytes but was capped at len {capacity}"
         );
 
         debug!("{} Spliced {} bytes from backend", log_context!(self), size);

--- a/lib/src/protocol/pipe.rs
+++ b/lib/src/protocol/pipe.rs
@@ -408,9 +408,68 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
         self.splice_pipe.as_ref().map(|p| p.capacity).unwrap_or(0)
     }
 
+    /// Upper bound used by `debug_assert!`s on the splice pending counters.
+    /// On splice builds it is the realised kernel-pipe capacity; on builds
+    /// without splice the pending counters are hard-coded `0`, so any finite
+    /// bound holds — we return `usize::MAX` to keep the assertion a no-op
+    /// while still compiling in every profile. Invariant-only; not on a hot
+    /// path.
+    #[cfg(all(target_os = "linux", feature = "splice"))]
+    fn splice_capacity_or_max(&self) -> usize {
+        self.splice_capacity()
+    }
+    #[cfg(not(all(target_os = "linux", feature = "splice")))]
+    fn splice_capacity_or_max(&self) -> usize {
+        usize::MAX
+    }
+
+    /// Tear down both readiness trackers ahead of a `SessionResult::Close`.
+    ///
+    /// This is the *write-only-shutdown discipline* (CLAUDE.md gotcha: never
+    /// `shutdown(Shutdown::Both)` on a TLS frontend — it emits a TCP RST that
+    /// truncates the already-queued response). `Pipe` never issues an explicit
+    /// `shutdown`; it closes purely by clearing interest+event so the event
+    /// loop stops driving I/O and lets the kernel flush queued bytes, with the
+    /// peer close arriving via the normal read path. The post-condition
+    /// asserts both trackers are fully cleared.
+    fn reset_readiness_for_close(&mut self) {
+        self.frontend_readiness.reset();
+        self.backend_readiness.reset();
+        debug_assert!(
+            self.frontend_readiness.interest.is_empty() && self.frontend_readiness.event.is_empty(),
+            "frontend readiness must be fully cleared on close (write-only-shutdown discipline)"
+        );
+        debug_assert!(
+            self.backend_readiness.interest.is_empty() && self.backend_readiness.event.is_empty(),
+            "backend readiness must be fully cleared on close (write-only-shutdown discipline)"
+        );
+    }
+
     /// Wether the session should be kept open, depending on endpoints status
     /// and buffer usage (both in memory and in kernel)
     pub fn check_connections(&self) -> bool {
+        // In-flight accounting must never see more bytes queued than the
+        // backing storage can hold: buffered data ≤ buffer capacity and
+        // splice-pending ≤ realised kernel-pipe capacity. A violation here
+        // means a `fill`/`consume`/splice-delta elsewhere desynced the
+        // counters, which would corrupt the keep-alive decision below.
+        debug_assert!(
+            self.frontend_buffer.available_data() <= self.frontend_buffer.capacity(),
+            "frontend buffered data exceeds its capacity"
+        );
+        debug_assert!(
+            self.backend_buffer.available_data() <= self.backend_buffer.capacity(),
+            "backend buffered data exceeds its capacity"
+        );
+        debug_assert!(
+            self.splice_in_pending() <= self.splice_capacity_or_max(),
+            "frontend→backend splice pending exceeds kernel-pipe capacity"
+        );
+        debug_assert!(
+            self.splice_out_pending() <= self.splice_capacity_or_max(),
+            "backend→frontend splice pending exceeds kernel-pipe capacity"
+        );
+
         let request_is_inflight = self.frontend_buffer.available_data() > 0
             || self.frontend_readiness.event.is_readable()
             || self.splice_in_pending() > 0;
@@ -460,8 +519,21 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
 
     pub fn backend_hup(&mut self, metrics: &mut SessionMetrics) -> SessionResult {
         self.backend_status = ConnectionStatus::Closed;
+        // The backend hung up: its status is now terminal regardless of which
+        // keep-alive branch we take below.
+        debug_assert!(
+            matches!(self.backend_status, ConnectionStatus::Closed),
+            "backend_hup must mark the backend Closed"
+        );
         let pipe_has_data = self.splice_out_pending() > 0;
         if self.backend_buffer.available_data() == 0 && !pipe_has_data {
+            // No buffered or in-kernel response data: there is nothing left to
+            // drain toward the frontend on this no-data branch.
+            debug_assert_eq!(
+                self.backend_buffer.available_data(),
+                0,
+                "no-data branch entered with response bytes still buffered"
+            );
             if self.backend_readiness.event.is_readable() {
                 self.backend_readiness.interest.insert(Ready::READABLE);
                 debug!(
@@ -502,15 +574,37 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             return SessionResult::Continue;
         }
 
+        let space_before = self.frontend_buffer.available_space();
+        let data_before = self.frontend_buffer.available_data();
+        let bin_before = metrics.bin;
         let (sz, res) = self.frontend.socket_read(self.frontend_buffer.space());
+        // `socket_read` fills `buf[..]` and returns `min(read, buf.len())`; it
+        // can never report more bytes than the space slice it was handed.
+        debug_assert!(
+            sz <= space_before,
+            "frontend socket_read reported more bytes ({sz}) than the buffer space offered ({space_before})"
+        );
         debug!("{} Read {} bytes", log_context!(self), sz);
 
         if sz > 0 {
             //FIXME: replace with copy()
             self.frontend_buffer.fill(sz);
+            // `fill(sz)` with `sz <= available_space` moves exactly `sz` bytes
+            // from free space into readable data — no truncation, no growth.
+            debug_assert_eq!(
+                self.frontend_buffer.available_data(),
+                data_before + sz,
+                "fill must grow readable data by exactly the bytes read"
+            );
 
             count!(names::backend::BYTES_IN, sz as i64);
             metrics.bin += sz;
+            // Front→proxy ingress metric advances by exactly the bytes read.
+            debug_assert_eq!(
+                metrics.bin,
+                bin_before + sz,
+                "metrics.bin must advance by exactly the bytes read"
+            );
 
             if self.frontend_buffer.available_space() == 0 {
                 self.frontend_readiness.interest.remove(Ready::READABLE);
@@ -529,22 +623,19 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
         }
 
         if !self.check_connections() {
-            self.frontend_readiness.reset();
-            self.backend_readiness.reset();
+            self.reset_readiness_for_close();
             self.log_request_success(metrics);
             return SessionResult::Close;
         }
 
         match res {
             SocketResult::Error => {
-                self.frontend_readiness.reset();
-                self.backend_readiness.reset();
+                self.reset_readiness_for_close();
                 self.log_request_error(metrics, "front socket read error");
                 return SessionResult::Close;
             }
             SocketResult::Closed => {
-                self.frontend_readiness.reset();
-                self.backend_readiness.reset();
+                self.reset_readiness_for_close();
                 self.log_request_success(metrics);
                 return SessionResult::Close;
             }
@@ -572,6 +663,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             return SessionResult::Continue;
         }
 
+        let queued_total = self.backend_buffer.available_data();
         let mut sz = 0usize;
         let mut res = SocketResult::Continue;
         while res == SocketResult::Continue {
@@ -583,10 +675,28 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
                 self.frontend_readiness.interest.remove(Ready::WRITABLE);
                 return SessionResult::Continue;
             }
+            let queued = self.backend_buffer.available_data();
             let (current_sz, current_res) = self.frontend.socket_write(self.backend_buffer.data());
+            // A partial write can never report more than was queued: the
+            // socket writes from `data()` and returns `min(written, data.len())`.
+            debug_assert!(
+                current_sz <= queued,
+                "frontend socket_write reported {current_sz} bytes but only {queued} were queued"
+            );
             res = current_res;
-            self.backend_buffer.consume(current_sz);
+            let consumed = self.backend_buffer.consume(current_sz);
+            // `consume` drops exactly the written bytes (we already proved
+            // `current_sz <= available_data`, so no clamping occurs).
+            debug_assert_eq!(
+                consumed, current_sz,
+                "consume must drop exactly the bytes written to the frontend"
+            );
             sz += current_sz;
+            // Cumulative transfer never overruns what was queued at entry.
+            debug_assert!(
+                sz <= queued_total,
+                "cumulative frontend write ({sz}) exceeded the queued backend data ({queued_total})"
+            );
 
             if current_sz == 0 && res == SocketResult::Continue {
                 self.frontend_status = match self.frontend_status {
@@ -599,8 +709,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             if !self.check_connections() {
                 metrics.bout += sz;
                 count!(names::backend::BYTES_OUT, sz as i64);
-                self.frontend_readiness.reset();
-                self.backend_readiness.reset();
+                self.reset_readiness_for_close();
                 self.log_request_success(metrics);
                 return SessionResult::Close;
             }
@@ -621,14 +730,12 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
 
         match res {
             SocketResult::Error => {
-                self.frontend_readiness.reset();
-                self.backend_readiness.reset();
+                self.reset_readiness_for_close();
                 self.log_request_error(metrics, "front socket write error");
                 return SessionResult::Close;
             }
             SocketResult::Closed => {
-                self.frontend_readiness.reset();
-                self.backend_readiness.reset();
+                self.reset_readiness_for_close();
                 self.log_request_success(metrics);
                 return SessionResult::Close;
             }
@@ -672,10 +779,25 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
                     return SessionResult::Continue;
                 }
 
+                let queued = self.frontend_buffer.available_data();
                 let (current_sz, current_res) = backend.socket_write(self.frontend_buffer.data());
+                // A partial write can never report more than was queued.
+                debug_assert!(
+                    current_sz <= queued,
+                    "backend socket_write reported {current_sz} bytes but only {queued} were queued"
+                );
                 socket_res = current_res;
-                self.frontend_buffer.consume(current_sz);
+                let consumed = self.frontend_buffer.consume(current_sz);
+                debug_assert_eq!(
+                    consumed, current_sz,
+                    "consume must drop exactly the bytes written to the backend"
+                );
                 sz += current_sz;
+                // Cumulative transfer never overruns the data queued at entry.
+                debug_assert!(
+                    sz <= output_size,
+                    "cumulative backend write ({sz}) exceeded the queued frontend data ({output_size})"
+                );
 
                 if current_sz == 0 && current_res == SocketResult::Continue {
                     self.backend_status = match self.backend_status {
@@ -687,12 +809,18 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             }
         }
 
+        let backend_bout_before = metrics.backend_bout;
         count!(names::backend::BACK_BYTES_OUT, sz as i64);
         metrics.backend_bout += sz;
+        // Proxy→backend egress metric advances by exactly the bytes written.
+        debug_assert_eq!(
+            metrics.backend_bout,
+            backend_bout_before + sz,
+            "metrics.backend_bout must advance by exactly the bytes written"
+        );
 
         if !self.check_connections() {
-            self.frontend_readiness.reset();
-            self.backend_readiness.reset();
+            self.reset_readiness_for_close();
             self.log_request_success(metrics);
             return SessionResult::Close;
         }
@@ -706,14 +834,12 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
 
         match socket_res {
             SocketResult::Error => {
-                self.frontend_readiness.reset();
-                self.backend_readiness.reset();
+                self.reset_readiness_for_close();
                 self.log_request_error(metrics, "back socket write error");
                 return SessionResult::Close;
             }
             SocketResult::Closed => {
-                self.frontend_readiness.reset();
-                self.backend_readiness.reset();
+                self.reset_readiness_for_close();
                 self.log_request_success(metrics);
                 return SessionResult::Close;
             }
@@ -740,9 +866,24 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             return SessionResult::Continue;
         }
 
+        let space_before = self.backend_buffer.available_space();
+        let data_before = self.backend_buffer.available_data();
+        let backend_bin_before = metrics.backend_bin;
         if let Some(ref mut backend) = self.backend_socket {
             let (size, remaining) = backend.socket_read(self.backend_buffer.space());
+            // `socket_read` reports at most the space slice it was handed.
+            debug_assert!(
+                size <= space_before,
+                "backend socket_read reported more bytes ({size}) than the buffer space offered ({space_before})"
+            );
             self.backend_buffer.fill(size);
+            // `fill(size)` with `size <= available_space` moves exactly `size`
+            // bytes from free space into readable data.
+            debug_assert_eq!(
+                self.backend_buffer.available_data(),
+                data_before + size,
+                "fill must grow readable data by exactly the bytes read"
+            );
 
             debug!("{} Read {} bytes", log_context!(self), size);
 
@@ -753,6 +894,12 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
                 self.frontend_readiness.interest.insert(Ready::WRITABLE);
                 count!(names::backend::BACK_BYTES_IN, size as i64);
                 metrics.backend_bin += size;
+                // Backend→proxy ingress metric advances by exactly bytes read.
+                debug_assert_eq!(
+                    metrics.backend_bin,
+                    backend_bin_before + size,
+                    "metrics.backend_bin must advance by exactly the bytes read"
+                );
             }
 
             if size == 0 && remaining == SocketResult::Closed {
@@ -763,8 +910,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
                 };
 
                 if !self.check_connections() {
-                    self.frontend_readiness.reset();
-                    self.backend_readiness.reset();
+                    self.reset_readiness_for_close();
                     self.log_request_success(metrics);
                     return SessionResult::Close;
                 }
@@ -772,15 +918,13 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
 
             match remaining {
                 SocketResult::Error => {
-                    self.frontend_readiness.reset();
-                    self.backend_readiness.reset();
+                    self.reset_readiness_for_close();
                     self.log_request_error(metrics, "back socket read error");
                     return SessionResult::Close;
                 }
                 SocketResult::Closed => {
                     if !self.check_connections() {
-                        self.frontend_readiness.reset();
-                        self.backend_readiness.reset();
+                        self.reset_readiness_for_close();
                         self.log_request_success(metrics);
                         return SessionResult::Close;
                     }
@@ -815,14 +959,35 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             return SessionResult::Continue;
         }
 
+        let pending_before = self.splice_in_pending();
+        let bin_before = metrics.bin;
         let pipe_write_end = self.splice_pipe.as_ref().unwrap().in_pipe[1];
         let (sz, res) = splice::splice_in(self.frontend.socket_ref(), pipe_write_end, capacity);
+        // The kernel pipe physically holds at most `capacity` bytes, so a
+        // splice into a pipe already holding `pending_before` can add no more
+        // than the remaining headroom.
+        debug_assert!(
+            pending_before + sz <= capacity,
+            "splice_in moved {sz} bytes into a pipe with only {} headroom (capacity {capacity})",
+            capacity - pending_before
+        );
         debug!("{} Spliced {} bytes from frontend", log_context!(self), sz);
 
         if sz > 0 {
             self.splice_pipe.as_mut().unwrap().in_pipe_pending += sz;
+            // Pending advanced by exactly the spliced bytes and stays bounded.
+            debug_assert_eq!(
+                self.splice_in_pending(),
+                pending_before + sz,
+                "in_pipe_pending must grow by exactly the spliced bytes"
+            );
             count!(names::backend::BYTES_IN, sz as i64);
             metrics.bin += sz;
+            debug_assert_eq!(
+                metrics.bin,
+                bin_before + sz,
+                "metrics.bin must advance by exactly the spliced bytes"
+            );
             self.backend_readiness.interest.insert(Ready::WRITABLE);
         } else {
             self.frontend_readiness.event.remove(Ready::READABLE);
@@ -837,22 +1002,19 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
         }
 
         if !self.check_connections() {
-            self.frontend_readiness.reset();
-            self.backend_readiness.reset();
+            self.reset_readiness_for_close();
             self.log_request_success(metrics);
             return SessionResult::Close;
         }
 
         match res {
             SocketResult::Error => {
-                self.frontend_readiness.reset();
-                self.backend_readiness.reset();
+                self.reset_readiness_for_close();
                 self.log_request_error(metrics, "splice front socket read error");
                 return SessionResult::Close;
             }
             SocketResult::Closed => {
-                self.frontend_readiness.reset();
-                self.backend_readiness.reset();
+                self.reset_readiness_for_close();
                 self.log_request_success(metrics);
                 return SessionResult::Close;
             }
@@ -895,9 +1057,21 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             let pipe_read_end = self.splice_pipe.as_ref().unwrap().out_pipe[0];
             let (current_sz, current_res) =
                 splice::splice_out(pipe_read_end, self.frontend.socket_ref(), pending);
+            // `splice_out` was asked for `pending` bytes and can drain no more
+            // than the pipe holds; draining more than `pending` would underflow
+            // `out_pipe_pending` below.
+            debug_assert!(
+                current_sz <= pending,
+                "splice_out drained {current_sz} bytes but only {pending} were pending (would underflow)"
+            );
             res = current_res;
             if current_sz > 0 {
                 self.splice_pipe.as_mut().unwrap().out_pipe_pending -= current_sz;
+                debug_assert_eq!(
+                    self.splice_out_pending(),
+                    pending - current_sz,
+                    "out_pipe_pending must shrink by exactly the drained bytes"
+                );
             }
             sz += current_sz;
 
@@ -912,8 +1086,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             if !self.check_connections() {
                 metrics.bout += sz;
                 count!(names::backend::BYTES_OUT, sz as i64);
-                self.frontend_readiness.reset();
-                self.backend_readiness.reset();
+                self.reset_readiness_for_close();
                 self.log_request_success(metrics);
                 return SessionResult::Close;
             }
@@ -934,14 +1107,12 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
 
         match res {
             SocketResult::Error => {
-                self.frontend_readiness.reset();
-                self.backend_readiness.reset();
+                self.reset_readiness_for_close();
                 self.log_request_error(metrics, "splice front socket write error");
                 return SessionResult::Close;
             }
             SocketResult::Closed => {
-                self.frontend_readiness.reset();
-                self.backend_readiness.reset();
+                self.reset_readiness_for_close();
                 self.log_request_success(metrics);
                 return SessionResult::Close;
             }
@@ -988,11 +1159,26 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
                 Some(b) => splice::splice_out(pipe_read_end, b, pending),
                 None => break,
             };
+            // Draining more than `pending` would underflow `in_pipe_pending`.
+            debug_assert!(
+                current_sz <= pending,
+                "splice_out drained {current_sz} bytes but only {pending} were pending (would underflow)"
+            );
             socket_res = current_res;
             if current_sz > 0 {
                 self.splice_pipe.as_mut().unwrap().in_pipe_pending -= current_sz;
+                debug_assert_eq!(
+                    self.splice_in_pending(),
+                    pending - current_sz,
+                    "in_pipe_pending must shrink by exactly the drained bytes"
+                );
             }
             sz += current_sz;
+            // Cumulative drain never exceeds what was pending at entry.
+            debug_assert!(
+                sz <= output_size,
+                "cumulative splice drain ({sz}) exceeded the bytes pending at entry ({output_size})"
+            );
 
             if current_sz == 0 && current_res == SocketResult::Continue {
                 self.backend_status = match self.backend_status {
@@ -1007,8 +1193,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
         metrics.backend_bout += sz;
 
         if !self.check_connections() {
-            self.frontend_readiness.reset();
-            self.backend_readiness.reset();
+            self.reset_readiness_for_close();
             self.log_request_success(metrics);
             return SessionResult::Close;
         }
@@ -1022,14 +1207,12 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
 
         match socket_res {
             SocketResult::Error => {
-                self.frontend_readiness.reset();
-                self.backend_readiness.reset();
+                self.reset_readiness_for_close();
                 self.log_request_error(metrics, "splice back socket write error");
                 return SessionResult::Close;
             }
             SocketResult::Closed => {
-                self.frontend_readiness.reset();
-                self.backend_readiness.reset();
+                self.reset_readiness_for_close();
                 self.log_request_success(metrics);
                 return SessionResult::Close;
             }
@@ -1059,11 +1242,21 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             return SessionResult::Continue;
         }
 
+        let pending_before = self.splice_out_pending();
+        let backend_bin_before = metrics.backend_bin;
         let pipe_write_end = self.splice_pipe.as_ref().unwrap().out_pipe[1];
         let (size, remaining) = match self.backend_socket.as_ref() {
             Some(b) => splice::splice_in(b, pipe_write_end, capacity),
             None => return SessionResult::Continue,
         };
+        // The out_pipe physically holds at most `capacity` bytes; a splice into
+        // a pipe already holding `pending_before` can add no more than the
+        // remaining headroom.
+        debug_assert!(
+            pending_before + size <= capacity,
+            "splice_in moved {size} bytes into a pipe with only {} headroom (capacity {capacity})",
+            capacity - pending_before
+        );
 
         debug!("{} Spliced {} bytes from backend", log_context!(self), size);
 
@@ -1072,9 +1265,19 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
         }
         if size > 0 {
             self.splice_pipe.as_mut().unwrap().out_pipe_pending += size;
+            debug_assert_eq!(
+                self.splice_out_pending(),
+                pending_before + size,
+                "out_pipe_pending must grow by exactly the spliced bytes"
+            );
             self.frontend_readiness.interest.insert(Ready::WRITABLE);
             count!(names::backend::BACK_BYTES_IN, size as i64);
             metrics.backend_bin += size;
+            debug_assert_eq!(
+                metrics.backend_bin,
+                backend_bin_before + size,
+                "metrics.backend_bin must advance by exactly the spliced bytes"
+            );
         }
 
         if size == 0 && remaining == SocketResult::Closed {
@@ -1085,8 +1288,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             };
 
             if !self.check_connections() {
-                self.frontend_readiness.reset();
-                self.backend_readiness.reset();
+                self.reset_readiness_for_close();
                 self.log_request_success(metrics);
                 return SessionResult::Close;
             }
@@ -1094,15 +1296,13 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
 
         match remaining {
             SocketResult::Error => {
-                self.frontend_readiness.reset();
-                self.backend_readiness.reset();
+                self.reset_readiness_for_close();
                 self.log_request_error(metrics, "splice back socket read error");
                 return SessionResult::Close;
             }
             SocketResult::Closed => {
                 if !self.check_connections() {
-                    self.frontend_readiness.reset();
-                    self.backend_readiness.reset();
+                    self.reset_readiness_for_close();
                     self.log_request_success(metrics);
                     return SessionResult::Close;
                 }

--- a/lib/src/protocol/proxy_protocol/expect.rs
+++ b/lib/src/protocol/proxy_protocol/expect.rs
@@ -122,9 +122,30 @@ impl<Front: SocketHandler> ExpectProxyProtocol<Front> {
             HeaderLen::Unix => 232,
         };
 
+        // Anti-oversized-header / partial-read invariant: the accumulation
+        // cursor never runs past the staging window, and the per-stage target
+        // never exceeds the fixed 232-byte buffer (the absolute upper bound on
+        // a PROXY-v2 header). A violation here would slice-panic on the read
+        // below; the asserts name it as a logic bug.
+        debug_assert!(
+            self.index <= total_len,
+            "read cursor must not exceed the current stage target"
+        );
+        debug_assert!(
+            total_len <= self.frontend_buffer.len(),
+            "stage target must fit the fixed proxy-protocol buffer"
+        );
+
+        let index_before = self.index;
         let (sz, socket_result) = self
             .frontend
             .socket_read(&mut self.frontend_buffer[self.index..total_len]);
+        // The socket may only fill the slice it was handed, so a successful
+        // read advances the cursor by at most the remaining stage capacity.
+        debug_assert!(
+            sz <= total_len - index_before,
+            "socket_read cannot return more bytes than the slice it was given"
+        );
         trace!(
             "{} read {} bytes and res={:?}, total_len = {}",
             log_context!(self),
@@ -135,6 +156,18 @@ impl<Front: SocketHandler> ExpectProxyProtocol<Front> {
 
         if sz > 0 {
             self.index += sz;
+            // Partial-read accumulation is strictly monotonic and stays within
+            // the bounded buffer: bytes-consumed advances by exactly `sz` and
+            // never exceeds the buffer length (anti-oversized-header bound).
+            debug_assert_eq!(
+                self.index,
+                index_before + sz,
+                "read cursor advances by exactly the bytes just read"
+            );
+            debug_assert!(
+                self.index <= self.frontend_buffer.len(),
+                "accumulated bytes must never exceed the fixed buffer bound"
+            );
 
             count!(names::backend::BYTES_IN, sz as i64);
             metrics.bin += sz;
@@ -143,6 +176,10 @@ impl<Front: SocketHandler> ExpectProxyProtocol<Front> {
                 self.frontend_readiness.interest.remove(Ready::READABLE);
             }
         } else {
+            debug_assert_eq!(
+                self.index, index_before,
+                "a non-positive read must leave the cursor unchanged"
+            );
             self.frontend_readiness.event.remove(Ready::READABLE);
         }
 
@@ -180,6 +217,14 @@ impl<Front: SocketHandler> ExpectProxyProtocol<Front> {
 
         match parse_v2_header(&self.frontend_buffer[..self.index]) {
             Ok((rest, header)) => {
+                // Completion postcondition: the parser consumed a prefix of the
+                // accumulated bytes, so the unparsed remainder is no larger than
+                // what we fed it (a complete header was recognized within the
+                // bound).
+                debug_assert!(
+                    rest.len() <= self.index,
+                    "parser remainder cannot exceed the accumulated input"
+                );
                 trace!(
                     "{} got expect header: {:?}, rest.len() = {}",
                     log_context!(self),
@@ -331,7 +376,16 @@ impl<Front: SocketHandler> SessionState for ExpectProxyProtocol<Front> {
                 return SessionResult::Close;
             }
 
+            let counter_before = counter;
             counter += 1;
+            // The readiness loop is bounded by MAX_LOOP_ITERATIONS; the counter
+            // advances by exactly one per turn and stays within the cap, so the
+            // loop cannot spin unbounded on a stuck readiness state.
+            debug_assert_eq!(counter, counter_before + 1, "loop counter advances by one");
+            debug_assert!(
+                counter <= MAX_LOOP_ITERATIONS,
+                "loop counter must stay within the iteration cap"
+            );
         }
 
         if counter >= MAX_LOOP_ITERATIONS {

--- a/lib/src/protocol/proxy_protocol/header.rs
+++ b/lib/src/protocol/proxy_protocol/header.rs
@@ -79,7 +79,7 @@ impl HeaderV1 {
     }
 
     pub fn into_bytes(&self) -> Vec<u8> {
-        if self.protocol.eq(&ProtocolSupportedV1::UNKNOWN) {
+        let bytes = if self.protocol.eq(&ProtocolSupportedV1::UNKNOWN) {
             format!("{} {}\r\n", PROXY_PROTO_IDENTIFIER, self.protocol,).into_bytes()
         } else {
             format!(
@@ -92,7 +92,18 @@ impl HeaderV1 {
                 self.addr_dst.port(),
             )
             .into_bytes()
-        }
+        };
+        // The v1 text header is framed `PROXY ...\r\n`; both the identifier
+        // prefix and the CRLF terminator are load-bearing for the peer parser.
+        debug_assert!(
+            bytes.starts_with(PROXY_PROTO_IDENTIFIER.as_bytes()),
+            "v1 header must start with the PROXY identifier"
+        );
+        debug_assert!(
+            bytes.ends_with(b"\r\n"),
+            "v1 header must be CRLF-terminated"
+        );
+        bytes
     }
 }
 
@@ -145,21 +156,42 @@ pub struct HeaderV2 {
 impl HeaderV2 {
     pub fn new(command: Command, addr_src: SocketAddr, addr_dst: SocketAddr) -> Self {
         let addr = ProxyAddr::from(addr_src, addr_dst);
+        let family = get_family(&addr);
+
+        // Invariant: the cached `family` byte is exactly the one derived from
+        // `addr`. Serialization writes both independently, so they must agree
+        // or the wire header would self-contradict (family vs. address block).
+        debug_assert_eq!(
+            family,
+            get_family(&addr),
+            "cached family must match the address it describes"
+        );
+        debug_assert!(
+            matches!(addr, ProxyAddr::AfUnspec) == (family == 0x00),
+            "AfUnspec iff zero family byte"
+        );
 
         HeaderV2 {
             command,
-            family: get_family(&addr),
+            family,
             addr,
         }
     }
 
     pub fn into_bytes(&self) -> Vec<u8> {
-        let mut header = Vec::with_capacity(self.len());
+        let expected_len = self.len();
+        let addr_len = self.addr.len() as usize;
+        let mut header = Vec::with_capacity(expected_len);
 
         let signature = [
             0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A,
         ];
         header.extend_from_slice(&signature);
+        debug_assert_eq!(
+            header.len(),
+            signature.len(),
+            "v2 header must open with exactly the 12-byte signature"
+        );
 
         let command = match self.command {
             Command::Local => 0,
@@ -170,13 +202,43 @@ impl HeaderV2 {
 
         header.push(self.family);
         header.extend_from_slice(&u16_to_array_of_u8(self.addr.len()));
+        // Fixed 12-byte signature + 1 (ver/cmd) + 1 (family) + 2 (length) = 16
+        // bytes precede the variable address block.
+        debug_assert_eq!(
+            header.len(),
+            16,
+            "v2 fixed prefix (signature + ver/cmd + family + length) must be 16 bytes"
+        );
         self.addr.write_bytes_to(&mut header);
+        // Postcondition: the serialized header length reconciles with the
+        // declared `len()` and with the 16-byte prefix plus the address block.
+        debug_assert_eq!(
+            header.len(),
+            expected_len,
+            "serialized v2 header length must match HeaderV2::len()"
+        );
+        debug_assert_eq!(
+            header.len(),
+            16 + addr_len,
+            "serialized v2 header must be the 16-byte prefix plus the address block"
+        );
         header
     }
 
     pub fn len(&self) -> usize {
         // signature + ver_and_cmd + family + len + addr
-        12 + 1 + 1 + 2 + self.addr.len() as usize
+        let total = 12 + 1 + 1 + 2 + self.addr.len() as usize;
+        // The fixed prefix is always 16 bytes; the only variable part is the
+        // address block, whose size is one of the enumerated ProxyAddr lengths.
+        debug_assert!(
+            total >= 16,
+            "v2 header is at least its 16-byte fixed prefix"
+        );
+        debug_assert!(
+            total <= 16 + 216,
+            "v2 header never exceeds the 16-byte prefix plus the largest (unix) address block"
+        );
+        total
     }
 
     pub fn is_empty(&self) -> bool {
@@ -202,7 +264,7 @@ pub enum ProxyAddr {
 
 impl ProxyAddr {
     pub fn from(addr_src: SocketAddr, addr_dst: SocketAddr) -> Self {
-        match (addr_src, addr_dst) {
+        let addr = match (addr_src, addr_dst) {
             (SocketAddr::V4(addr_ipv4_src), SocketAddr::V4(addr_ipv4_dst)) => ProxyAddr::Ipv4Addr {
                 src_addr: addr_ipv4_src,
                 dst_addr: addr_ipv4_dst,
@@ -212,7 +274,21 @@ impl ProxyAddr {
                 dst_addr: addr_ipv6_dst,
             },
             _ => ProxyAddr::AfUnspec,
-        }
+        };
+        // Postcondition: a same-family pair maps to a concrete variant, a
+        // mixed v4/v6 pair collapses to AfUnspec (PROXY-v2 has no cross-family
+        // encoding). The chosen variant must agree with both inputs' family.
+        debug_assert_eq!(
+            matches!(addr, ProxyAddr::Ipv4Addr { .. }),
+            addr_src.is_ipv4() && addr_dst.is_ipv4(),
+            "Ipv4Addr variant iff both endpoints are IPv4"
+        );
+        debug_assert_eq!(
+            matches!(addr, ProxyAddr::Ipv6Addr { .. }),
+            addr_src.is_ipv6() && addr_dst.is_ipv6(),
+            "Ipv6Addr variant iff both endpoints are IPv6"
+        );
+        addr
     }
 
     fn len(&self) -> u16 {
@@ -242,6 +318,8 @@ impl ProxyAddr {
 
     // TODO: rename to a less ambiguous name, like "write bytes to buffer"
     fn write_bytes_to(&self, buf: &mut Vec<u8>) {
+        let before = buf.len();
+        let declared = self.len() as usize;
         match *self {
             ProxyAddr::Ipv4Addr { src_addr, dst_addr } => {
                 buf.extend_from_slice(&src_addr.ip().octets());
@@ -261,6 +339,19 @@ impl ProxyAddr {
             }
             ProxyAddr::AfUnspec => {}
         };
+        // Postcondition: the bytes appended must be exactly the address
+        // block size advertised by `len()` — the wire length field is
+        // derived from `len()`, so any divergence would desynchronize the
+        // serialized header from its declared length.
+        debug_assert!(
+            buf.len() >= before,
+            "write_bytes_to must never shrink the buffer"
+        );
+        debug_assert_eq!(
+            buf.len() - before,
+            declared,
+            "appended address bytes must equal the declared ProxyAddr::len()"
+        );
     }
 }
 
@@ -318,18 +409,43 @@ impl PartialEq for ProxyAddr {
 }
 
 fn get_family(addr: &ProxyAddr) -> u8 {
-    match *addr {
+    let family = match *addr {
         ProxyAddr::Ipv4Addr { .. } => 0x10 | 0x01, // AF_INET  = 1 + STREAM = 1
         ProxyAddr::Ipv6Addr { .. } => 0x20 | 0x01, // AF_INET6 = 2 + STREAM = 1
         ProxyAddr::UnixAddr { .. } => 0x30 | 0x01, // AF_UNIX  = 3 + STREAM = 1
         ProxyAddr::AfUnspec => 0x00,               // AF_UNSPEC + UNSPEC
-    }
+    };
+    // Postcondition: the high nibble (address family) is within the
+    // enumerated set the parser accepts (0..=3), and the low nibble
+    // (transport) is STREAM for the concrete families, UNSPEC for AfUnspec.
+    debug_assert!(
+        (family >> 4) <= 0x03,
+        "address family nibble must be one of AF_UNSPEC/INET/INET6/UNIX"
+    );
+    debug_assert!(
+        matches!(addr, ProxyAddr::AfUnspec) == (family == 0x00),
+        "only AfUnspec maps to the all-zero family byte"
+    );
+    debug_assert!(
+        matches!(addr, ProxyAddr::AfUnspec) || (family & 0x0f) == 0x01,
+        "concrete address families must advertise the STREAM transport"
+    );
+    family
 }
 
 fn u16_to_array_of_u8(x: u16) -> [u8; 2] {
     let b1: u8 = ((x >> 8) & 0xff) as u8;
     let b2: u8 = (x & 0xff) as u8;
-    [b1, b2]
+    let out = [b1, b2];
+    // Postcondition: this is a pure big-endian split — reassembling the two
+    // bytes must round-trip to the input exactly. Port/length fields on the
+    // wire depend on this being byte-exact.
+    debug_assert_eq!(
+        u16::from_be_bytes(out),
+        x,
+        "big-endian split must round-trip the input u16"
+    );
+    out
 }
 
 #[cfg(test)]

--- a/lib/src/protocol/proxy_protocol/parser.rs
+++ b/lib/src/protocol/proxy_protocol/parser.rs
@@ -23,6 +23,13 @@ const PROTOCOL_SIGNATURE_V2: [u8; 12] = [
 fn parse_command(i: &[u8]) -> IResult<&[u8], Command> {
     let i2 = i;
     let (i, cmd) = be_u8(i)?;
+    // `be_u8` consumes exactly one byte on success; the remainder must be one
+    // shorter than the input we were given.
+    debug_assert_eq!(
+        i.len() + 1,
+        i2.len(),
+        "command byte parse consumes exactly one byte"
+    );
     match cmd {
         0x20 => Ok((i, Command::Local)),
         0x21 => Ok((i, Command::Proxy)),
@@ -31,12 +38,44 @@ fn parse_command(i: &[u8]) -> IResult<&[u8], Command> {
 }
 
 pub fn parse_v2_header(i: &[u8]) -> IResult<&[u8], HeaderV2> {
+    let input_len = i.len();
     let (i, _) = tag(&PROTOCOL_SIGNATURE_V2)(i)?;
     let (i, command) = parse_command(i)?;
     let (i, family) = be_u8(i)?;
     let (i, len) = be_u16(i)?;
     let (i, data) = take(len)(i)?;
-    let (_, addr) = parse_addr_v2(family)(data)?;
+    // The length field gates exactly `len` address bytes; `take` already
+    // enforces availability, so `data` is precisely that many bytes.
+    debug_assert_eq!(
+        data.len(),
+        len as usize,
+        "address block must be exactly the declared length"
+    );
+    let (data_rest, addr) = parse_addr_v2(family)(data)?;
+    // The address parser may not consume every advertised byte (TLVs / over-
+    // long length fields are tolerated by leaving a tail), but it must never
+    // read past the block it was handed.
+    debug_assert!(
+        data_rest.len() <= data.len(),
+        "address parser cannot grow its input"
+    );
+
+    // Postcondition: a parser never grows its input — the unconsumed remainder
+    // is no longer than the original, and the consumed prefix (the full v2
+    // header) is the 16-byte fixed part plus the declared address length.
+    debug_assert!(i.len() <= input_len, "parser cannot grow its input");
+    debug_assert_eq!(
+        input_len - i.len(),
+        PROTOCOL_SIGNATURE_V2.len() + 1 + 1 + 2 + len as usize,
+        "consumed header length must reconcile with the signature, fixed fields, and declared address length"
+    );
+    // The family byte is in the enumerated set the address parser accepts: a
+    // rejected family would have short-circuited via `?` above, so on this
+    // success path the high nibble is AF_UNSPEC/INET/INET6.
+    debug_assert!(
+        matches!((family >> 4) & 0x0f, 0x00..=0x02),
+        "accepted family nibble must be AF_UNSPEC, AF_INET, or AF_INET6"
+    );
 
     Ok((
         i,
@@ -58,10 +97,21 @@ fn parse_addr_v2(family: u8) -> impl Fn(&[u8]) -> IResult<&[u8], ProxyAddr> {
 }
 
 fn parse_ipv4_on_v2(i: &[u8]) -> IResult<&[u8], ProxyAddr> {
+    let in_len = i.len();
     let (i, src_ip) = take(4u8)(i)?;
     let (i, dest_ip) = take(4u8)(i)?;
     let (i, src_port) = be_u16(i)?;
     let (i, dest_port) = be_u16(i)?;
+    // An IPv4 v2 address block is fixed at 4 + 4 + 2 + 2 = 12 bytes; the parser
+    // must have consumed exactly that on success and never grown its input.
+    debug_assert_eq!(src_ip.len(), 4, "IPv4 source address is 4 bytes");
+    debug_assert_eq!(dest_ip.len(), 4, "IPv4 destination address is 4 bytes");
+    debug_assert!(i.len() <= in_len, "parser cannot grow its input");
+    debug_assert_eq!(
+        in_len - i.len(),
+        12,
+        "IPv4 v2 address block is exactly 12 bytes"
+    );
 
     Ok((
         i,
@@ -79,10 +129,22 @@ fn parse_ipv4_on_v2(i: &[u8]) -> IResult<&[u8], ProxyAddr> {
 }
 
 fn parse_ipv6_on_v2(i: &[u8]) -> IResult<&[u8], ProxyAddr> {
+    let in_len = i.len();
     let (i, src_ip) = take(16u8)(i)?;
     let (i, dest_ip) = take(16u8)(i)?;
     let (i, src_port) = be_u16(i)?;
     let (i, dest_port) = be_u16(i)?;
+    // An IPv6 v2 address block is fixed at 16 + 16 + 2 + 2 = 36 bytes; `take`
+    // guarantees the slice widths fed to `slice_to_ipv6`, so its 16-byte
+    // precondition holds on this path.
+    debug_assert_eq!(src_ip.len(), 16, "IPv6 source address is 16 bytes");
+    debug_assert_eq!(dest_ip.len(), 16, "IPv6 destination address is 16 bytes");
+    debug_assert!(i.len() <= in_len, "parser cannot grow its input");
+    debug_assert_eq!(
+        in_len - i.len(),
+        36,
+        "IPv6 v2 address block is exactly 36 bytes"
+    );
 
     Ok((
         i,
@@ -95,6 +157,11 @@ fn parse_ipv6_on_v2(i: &[u8]) -> IResult<&[u8], ProxyAddr> {
 
 // assumes the slice has 16 bytes
 pub fn slice_to_ipv6(sl: &[u8]) -> Ipv6Addr {
+    // Precondition (internal invariant): every caller hands a slice sized by a
+    // `take(16)`, so a wrong length here is a logic bug, not attacker input.
+    // `clone_from_slice` below would itself panic on a mismatch; the
+    // debug_assert names the contract loudly in debug/test/fuzz builds.
+    debug_assert_eq!(sl.len(), 16, "slice_to_ipv6 requires exactly 16 bytes");
     let mut arr: [u8; 16] = [0; 16];
     arr.clone_from_slice(sl);
     Ipv6Addr::from(arr)

--- a/lib/src/protocol/proxy_protocol/relay.rs
+++ b/lib/src/protocol/proxy_protocol/relay.rs
@@ -112,11 +112,26 @@ impl<Front: SocketHandler> RelayProxyProtocol<Front> {
     }
 
     pub fn readable(&mut self, metrics: &mut SessionMetrics) -> SessionResult {
+        let space_before = self.frontend_buffer.available_space();
         let (sz, res) = self.frontend.socket_read(self.frontend_buffer.space());
         debug!("{} read {} bytes and res={:?}", log_context!(self), sz, res);
+        // The socket can only write into the free space it was handed.
+        debug_assert!(
+            sz <= space_before,
+            "socket_read cannot return more bytes than the available space"
+        );
 
         if sz > 0 {
+            let data_before = self.frontend_buffer.available_data();
             self.frontend_buffer.fill(sz);
+            // `fill` admits the freshly read bytes into the readable window:
+            // available data grows by exactly `sz` (the read fit, asserted
+            // above, so `fill` does not clamp).
+            debug_assert_eq!(
+                self.frontend_buffer.available_data(),
+                data_before + sz,
+                "fill must expose exactly the bytes just read"
+            );
 
             count!(names::backend::BYTES_IN, sz as i64);
             metrics.bin += sz;
@@ -136,6 +151,7 @@ impl<Front: SocketHandler> RelayProxyProtocol<Front> {
                 self.frontend_readiness.event.remove(Ready::READABLE);
             }
 
+            let data_len = self.frontend_buffer.available_data();
             let read_sz = match parse_v2_header(self.frontend_buffer.data()) {
                 Ok((rest, header)) => {
                     self.frontend_readiness.interest.remove(Ready::READABLE);
@@ -146,7 +162,16 @@ impl<Front: SocketHandler> RelayProxyProtocol<Front> {
                     // forwarded verbatim onto the backend by
                     // `back_writable`.
                     self.addresses = Some(header.addr);
-                    self.frontend_buffer.data().offset(rest)
+                    let consumed = self.frontend_buffer.data().offset(rest);
+                    // The header length is the prefix the parser consumed; it
+                    // is a real (non-empty) prefix of the buffered data and can
+                    // never exceed what was buffered.
+                    debug_assert!(
+                        consumed <= data_len,
+                        "parsed header length cannot exceed the buffered bytes"
+                    );
+                    debug_assert!(consumed > 0, "a recognized v2 header is non-empty");
+                    consumed
                 }
                 Err(Err::Incomplete(_)) => return SessionResult::Continue,
                 Err(e) => {
@@ -175,9 +200,25 @@ impl<Front: SocketHandler> RelayProxyProtocol<Front> {
         if let Some(ref mut socket) = self.backend {
             if let Some(ref header_size) = self.header_size {
                 loop {
+                    let available_before = self.frontend_buffer.available_data();
                     match socket.write(self.frontend_buffer.data()) {
                         Ok(sz) => {
+                            // A socket write reports at most the bytes it was
+                            // offered, so the forwarded count never exceeds the
+                            // buffered header tail.
+                            debug_assert!(
+                                sz <= available_before,
+                                "socket.write cannot send more than the buffered bytes"
+                            );
+                            let cursor_before = self.cursor_header;
                             self.cursor_header += sz;
+                            // The forwarding cursor is strictly monotonic and
+                            // tracks exactly the bytes emitted this write.
+                            debug_assert_eq!(
+                                self.cursor_header,
+                                cursor_before + sz,
+                                "header cursor advances by exactly the bytes written"
+                            );
 
                             count!(names::backend::BACK_BYTES_OUT, sz as i64);
                             metrics.backend_bout += sz;

--- a/lib/src/protocol/proxy_protocol/send.rs
+++ b/lib/src/protocol/proxy_protocol/send.rs
@@ -117,14 +117,23 @@ impl<Front: SocketHandler> SendProxyProtocol<Front> {
         if self.header.is_none() {
             if let Ok(local_addr) = self.front_socket().local_addr() {
                 if let Ok(frontend_addr) = self.front_socket().peer_addr() {
-                    self.header = Some(
-                        ProxyProtocolHeader::V2(HeaderV2::new(
-                            Command::Proxy,
-                            frontend_addr,
-                            local_addr,
-                        ))
-                        .into_bytes(),
+                    let v2 = HeaderV2::new(Command::Proxy, frontend_addr, local_addr);
+                    let declared_len = v2.len();
+                    let serialized = ProxyProtocolHeader::V2(v2).into_bytes();
+                    // Send postcondition: the byte vector we will stream out is
+                    // exactly the length the header model declared. The cursor
+                    // logic below relies on `header.len()` being this serialized
+                    // size to detect completion.
+                    debug_assert_eq!(
+                        serialized.len(),
+                        declared_len,
+                        "serialized send header length must match HeaderV2::len()"
                     );
+                    debug_assert!(
+                        serialized.len() >= 16,
+                        "a v2 send header is at least its 16-byte fixed prefix"
+                    );
+                    self.header = Some(serialized);
                 } else {
                     return SessionResult::Close;
                 }
@@ -134,9 +143,32 @@ impl<Front: SocketHandler> SendProxyProtocol<Front> {
         if let Some(ref mut socket) = self.backend {
             if let Some(ref mut header) = self.header {
                 loop {
+                    // The cursor never overruns the serialized header: it only
+                    // advances by reported write sizes and stops at `len()`.
+                    debug_assert!(
+                        self.cursor_header <= header.len(),
+                        "send cursor must stay within the serialized header"
+                    );
+                    let remaining = header.len() - self.cursor_header;
                     match socket.write(&header[self.cursor_header..]) {
                         Ok(sz) => {
+                            debug_assert!(
+                                sz <= remaining,
+                                "socket.write cannot send more than the unsent header tail"
+                            );
+                            let cursor_before = self.cursor_header;
                             self.cursor_header += sz;
+                            // Strictly monotonic: the cursor tracks exactly the
+                            // bytes emitted and never passes the header length.
+                            debug_assert_eq!(
+                                self.cursor_header,
+                                cursor_before + sz,
+                                "send cursor advances by exactly the bytes written"
+                            );
+                            debug_assert!(
+                                self.cursor_header <= header.len(),
+                                "send cursor must not pass the header length"
+                            );
                             count!(names::backend::BACK_BYTES_OUT, sz as i64);
                             metrics.backend_bout += sz;
 

--- a/lib/src/protocol/rustls.rs
+++ b/lib/src/protocol/rustls.rs
@@ -119,9 +119,24 @@ impl TlsHandshake {
     /// before any bytes were exchanged); callers should not emit
     /// `tls.handshake_ms` in that case.
     fn record_handshake_duration_ms(&mut self) -> Option<u128> {
-        self.handshake_started_at
+        let was_anchored = self.handshake_started_at.is_some();
+        let elapsed = self
+            .handshake_started_at
             .take()
-            .map(|t| t.elapsed().as_millis())
+            .map(|t| t.elapsed().as_millis());
+        // `take()` is idempotent-disarming: the anchor is always cleared so the
+        // histogram is recorded at most once, and a duration is returned iff an
+        // anchor existed.
+        debug_assert!(
+            self.handshake_started_at.is_none(),
+            "handshake anchor must be cleared after recording the duration"
+        );
+        debug_assert_eq!(
+            elapsed.is_some(),
+            was_anchored,
+            "a duration is returned iff the handshake had been anchored"
+        );
+        elapsed
     }
 
     pub fn readable(&mut self) -> SessionResult {
@@ -130,6 +145,16 @@ impl TlsHandshake {
         // anchor sticky across `WouldBlock` retries and across the
         // readable/writable boundary.
         self.handshake_started_at.get_or_insert_with(Instant::now);
+        // The anchor is sticky once set: this method must never run unanchored.
+        debug_assert!(
+            self.handshake_started_at.is_some(),
+            "handshake anchor must be set before driving TLS I/O"
+        );
+
+        // rustls handshake completion is monotonic (`true → false`, never
+        // back). Snapshot it so the exit assertions can prove we never resurrect
+        // a finished handshake.
+        let was_handshaking = self.session.is_handshaking();
 
         let mut can_read = true;
 
@@ -172,9 +197,22 @@ impl TlsHandshake {
             }
         }
 
+        // Handshake completion is monotonic: a handshake that had already
+        // finished at entry cannot become unfinished by pumping `read_tls`.
+        debug_assert!(
+            was_handshaking || !self.session.is_handshaking(),
+            "rustls handshake must not regress from finished back to handshaking"
+        );
+
+        // Readiness must mirror rustls's own wants: we only drop READABLE
+        // interest when the session no longer wants to read.
         if !self.session.wants_read() {
             self.frontend_readiness.interest.remove(Ready::READABLE);
         }
+        debug_assert!(
+            self.session.wants_read() || !self.frontend_readiness.interest.is_readable(),
+            "READABLE interest must be cleared once rustls stops wanting reads"
+        );
 
         if self.session.wants_write() {
             self.frontend_readiness.interest.insert(Ready::WRITABLE);
@@ -187,6 +225,12 @@ impl TlsHandshake {
             if self.session.wants_write() {
                 SessionResult::Continue
             } else {
+                // Upgrade is only signalled once the handshake is complete and
+                // there is nothing left to flush to the peer.
+                debug_assert!(
+                    !self.session.is_handshaking() && !self.session.wants_write(),
+                    "Upgrade requires a completed handshake with no pending output"
+                );
                 self.frontend_readiness.interest.insert(Ready::READABLE);
                 self.frontend_readiness.event.insert(Ready::READABLE);
                 self.frontend_readiness.interest.insert(Ready::WRITABLE);
@@ -201,6 +245,13 @@ impl TlsHandshake {
     pub fn writable(&mut self) -> SessionResult {
         // Same anchor logic as `readable()` — see the comment there.
         self.handshake_started_at.get_or_insert_with(Instant::now);
+        debug_assert!(
+            self.handshake_started_at.is_some(),
+            "handshake anchor must be set before driving TLS I/O"
+        );
+
+        // Snapshot handshake completion for the monotonicity post-condition.
+        let was_handshaking = self.session.is_handshaking();
 
         let mut can_write = true;
 
@@ -239,9 +290,22 @@ impl TlsHandshake {
             }
         }
 
+        // Handshake completion is monotonic: pumping `write_tls` can finish a
+        // handshake but never un-finish one.
+        debug_assert!(
+            was_handshaking || !self.session.is_handshaking(),
+            "rustls handshake must not regress from finished back to handshaking"
+        );
+
+        // Readiness mirrors rustls's wants: WRITABLE interest is only dropped
+        // once the session no longer wants to write.
         if !self.session.wants_write() {
             self.frontend_readiness.interest.remove(Ready::WRITABLE);
         }
+        debug_assert!(
+            self.session.wants_write() || !self.frontend_readiness.interest.is_writable(),
+            "WRITABLE interest must be cleared once rustls stops wanting writes"
+        );
 
         if self.session.wants_read() {
             self.frontend_readiness.interest.insert(Ready::READABLE);
@@ -250,12 +314,22 @@ impl TlsHandshake {
         if self.session.is_handshaking() {
             SessionResult::Continue
         } else if self.session.wants_read() {
+            // Upgrade after a completed handshake; the session still wants to
+            // read application data, which the upgraded state will drive.
+            debug_assert!(
+                !self.session.is_handshaking(),
+                "Upgrade requires a completed handshake"
+            );
             self.frontend_readiness.interest.insert(Ready::READABLE);
             if let Some(elapsed_ms) = self.record_handshake_duration_ms() {
                 time!(names::tls::HANDSHAKE_MS, elapsed_ms);
             }
             SessionResult::Upgrade
         } else {
+            debug_assert!(
+                !self.session.is_handshaking(),
+                "Upgrade requires a completed handshake"
+            );
             self.frontend_readiness.interest.insert(Ready::WRITABLE);
             self.frontend_readiness.interest.insert(Ready::READABLE);
             if let Some(elapsed_ms) = self.record_handshake_duration_ms() {
@@ -296,6 +370,13 @@ impl TlsHandshake {
     /// can split spikes by category without having to grep logs.
     fn log_handshake_error(&self, err: &RustlsError) {
         let reason = handshake_failure_reason(err);
+        // Every reason must stay inside the bounded `tls.handshake.failed.*`
+        // namespace so statsd cardinality is predictable — unknown variants
+        // collapse to `.other`, never an unnamespaced key.
+        debug_assert!(
+            reason.starts_with("tls.handshake.failed."),
+            "handshake failure metric {reason} escaped the tls.handshake.failed. namespace"
+        );
         match err {
             RustlsError::AlertReceived(_) => debug!(
                 "{} Could not perform handshake: {:?}",

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -144,10 +144,21 @@ impl Router {
                             match method_rule.matches(method) {
                                 // FIXME: the rule order will be important here
                                 MethodRuleResult::Equals => {
+                                    // Longest-prefix wins: the selected
+                                    // length is monotonically non-decreasing
+                                    // across the candidate scan.
+                                    debug_assert!(
+                                        size >= prefix_length,
+                                        "longest-prefix selection must never shrink the match length",
+                                    );
                                     prefix_length = size;
                                     matched = Some((rule, route));
                                 }
                                 MethodRuleResult::All => {
+                                    debug_assert!(
+                                        size >= prefix_length,
+                                        "longest-prefix selection must never shrink the match length",
+                                    );
                                     prefix_length = size;
                                     matched = Some((rule, route));
                                 }
@@ -337,16 +348,49 @@ impl Router {
                 let mut empty = true;
                 if let Some((_, paths)) = self.tree.domain_lookup_mut(hostname.as_bytes(), false) {
                     empty = false;
+                    let before = paths.len();
                     if !paths.iter().any(|(p, m, _)| p == path && m == method) {
                         paths.push((path.to_owned(), method.to_owned(), cluster.to_owned()));
+                        // Append must add exactly one (path, method) leaf
+                        // and the new rule must now be present.
+                        debug_assert_eq!(
+                            paths.len(),
+                            before + 1,
+                            "appending a tree rule must grow the leaf's rule list by exactly one",
+                        );
+                        debug_assert!(
+                            paths.iter().any(|(p, m, _)| p == path && m == method),
+                            "the freshly appended (path, method) rule must be present after insert",
+                        );
                         return true;
                     }
                 }
 
                 if empty {
+                    // Snapshot the ASCII host bytes before the move so the
+                    // post-insert reachability check can re-look-up the
+                    // domain. Ungated `let` (read only inside the gated
+                    // assert) → dropped by the optimizer in release.
+                    let inserted_host = hostname.clone().into_bytes();
                     self.tree.domain_insert(
                         hostname.into_bytes(),
                         vec![(path.to_owned(), method.to_owned(), cluster.to_owned())],
+                    );
+                    // A fresh domain must now be reachable, carrying the
+                    // single rule just inserted. Use `domain_lookup_mut`
+                    // (not the immutable `domain_lookup`): only the `_mut`
+                    // resolver handles a literal wildcard key (`*.sozu.io`)
+                    // via its `partial_key == b"*"` segment case, which is
+                    // exactly the resolution the append branch above relies
+                    // on. The immutable `lookup` lacks that case and would
+                    // miss wildcard entries.
+                    debug_assert!(
+                        self.tree
+                            .domain_lookup_mut(&inserted_host, false)
+                            .is_some_and(|(_, paths)| paths
+                                .iter()
+                                .any(|(p, m, _)| p == path && m == method)),
+                        "a freshly inserted tree domain must resolve to its inserted rule",
                     );
                     return true;
                 }
@@ -376,6 +420,12 @@ impl Router {
 
                     if let Some((_, paths)) = paths_opt {
                         paths.retain(|(p, m, _)| p != path || m != method);
+                        // `retain` evicts every matching (path, method)
+                        // rule; none may survive the filter.
+                        debug_assert!(
+                            !paths.iter().any(|(p, m, _)| p == path && m == method),
+                            "remove must evict every matching (path, method) rule from the leaf",
+                        );
                     }
 
                     paths_opt
@@ -385,7 +435,19 @@ impl Router {
                 };
 
                 if should_delete {
+                    let removed_host = hostname.clone().into_bytes();
                     self.tree.domain_remove(&hostname.into_bytes());
+                    // Dropping the last rule must make the whole domain
+                    // unreachable — no stranded empty leaf left behind.
+                    // `domain_lookup_mut` resolves literal wildcard keys
+                    // (`*.sozu.io`), so this genuinely verifies wildcard
+                    // entries are gone too (the immutable `lookup` lacks
+                    // the `partial_key == b"*"` case and would always read
+                    // None for a wildcard host, weakening the check).
+                    debug_assert!(
+                        self.tree.domain_lookup_mut(&removed_host, false).is_none(),
+                        "a domain whose last rule was removed must be unreachable",
+                    );
                 }
 
                 true
@@ -498,6 +560,7 @@ impl Router {
         method: &MethodRule,
         cluster_id: &Route,
     ) -> bool {
+        let before = self.pre.len();
         if !self
             .pre
             .iter()
@@ -509,8 +572,27 @@ impl Router {
                 method.to_owned(),
                 cluster_id.to_owned(),
             ));
+            // A new pre-rule grows the list by exactly one and is now
+            // present (dedup of the same triple is the caller's `false`
+            // path, not this one).
+            debug_assert_eq!(
+                self.pre.len(),
+                before + 1,
+                "adding a unique pre-rule must push exactly one entry",
+            );
+            debug_assert!(
+                self.pre
+                    .iter()
+                    .any(|(d, p, m, _)| d == domain && p == path && m == method),
+                "the freshly added pre-rule must be present",
+            );
             true
         } else {
+            debug_assert_eq!(
+                self.pre.len(),
+                before,
+                "a duplicate pre-rule must not change the list length",
+            );
             false
         }
     }
@@ -522,6 +604,7 @@ impl Router {
         method: &MethodRule,
         cluster_id: &Route,
     ) -> bool {
+        let before = self.post.len();
         if !self
             .post
             .iter()
@@ -533,8 +616,24 @@ impl Router {
                 method.to_owned(),
                 cluster_id.to_owned(),
             ));
+            debug_assert_eq!(
+                self.post.len(),
+                before + 1,
+                "adding a unique post-rule must push exactly one entry",
+            );
+            debug_assert!(
+                self.post
+                    .iter()
+                    .any(|(d, p, m, _)| d == domain && p == path && m == method),
+                "the freshly added post-rule must be present",
+            );
             true
         } else {
+            debug_assert_eq!(
+                self.post.len(),
+                before,
+                "a duplicate post-rule must not change the list length",
+            );
             false
         }
     }
@@ -545,14 +644,36 @@ impl Router {
         path: &PathRule,
         method: &MethodRule,
     ) -> bool {
+        let before = self.pre.len();
         match self
             .pre
             .iter()
             .position(|(d, p, m, _)| d == domain && p == path && m == method)
         {
-            None => false,
+            None => {
+                debug_assert_eq!(
+                    self.pre.len(),
+                    before,
+                    "a no-op pre-rule removal must not change the list length",
+                );
+                false
+            }
             Some(index) => {
+                debug_assert!(index < self.pre.len(), "found index must be in bounds");
                 self.pre.remove(index);
+                // Exactly one entry left, and the triple is now gone.
+                debug_assert_eq!(
+                    self.pre.len() + 1,
+                    before,
+                    "removing a pre-rule must drop exactly one entry",
+                );
+                debug_assert!(
+                    !self
+                        .pre
+                        .iter()
+                        .any(|(d, p, m, _)| d == domain && p == path && m == method),
+                    "the removed pre-rule must no longer be present",
+                );
                 true
             }
         }
@@ -564,14 +685,35 @@ impl Router {
         path: &PathRule,
         method: &MethodRule,
     ) -> bool {
+        let before = self.post.len();
         match self
             .post
             .iter()
             .position(|(d, p, m, _)| d == domain && p == path && m == method)
         {
-            None => false,
+            None => {
+                debug_assert_eq!(
+                    self.post.len(),
+                    before,
+                    "a no-op post-rule removal must not change the list length",
+                );
+                false
+            }
             Some(index) => {
+                debug_assert!(index < self.post.len(), "found index must be in bounds");
                 self.post.remove(index);
+                debug_assert_eq!(
+                    self.post.len() + 1,
+                    before,
+                    "removing a post-rule must drop exactly one entry",
+                );
+                debug_assert!(
+                    !self
+                        .post
+                        .iter()
+                        .any(|(d, p, m, _)| d == domain && p == path && m == method),
+                    "the removed post-rule must no longer be present",
+                );
                 true
             }
         }
@@ -691,10 +833,26 @@ impl DomainRule {
         match self {
             DomainRule::Any => true,
             DomainRule::Wildcard(s) => {
+                // A stored wildcard always keeps its leading `*`, so the
+                // suffix (pattern minus `*`) is a strict sub-slice and the
+                // bare `*` (Any) never reaches this arm.
+                debug_assert_eq!(
+                    s.as_bytes().first(),
+                    Some(&b'*'),
+                    "a Wildcard rule must retain its leading '*'",
+                );
                 let suffix = &s.as_bytes()[1..];
-                hostname
+                let matched = hostname
                     .strip_suffix(suffix)
-                    .is_some_and(|prefix| !prefix.is_empty() && !prefix.contains(&b'.'))
+                    .is_some_and(|prefix| !prefix.is_empty() && !prefix.contains(&b'.'));
+                // A wildcard never matches a hostname no longer than its
+                // own suffix — there is no room left for the mandatory
+                // single non-empty leftmost label.
+                debug_assert!(
+                    !matched || hostname.len() > suffix.len(),
+                    "a wildcard match requires a non-empty leftmost label before the suffix",
+                );
+                matched
             }
             DomainRule::Exact(s) => s.as_bytes() == hostname,
             DomainRule::Regex(r) => {
@@ -775,6 +933,13 @@ impl PathRule {
         match self {
             PathRule::Prefix(prefix) => {
                 if path.starts_with(prefix.as_bytes()) {
+                    // The reported prefix length is the matched-byte count
+                    // the router uses for longest-prefix tie-breaking; it
+                    // must equal the prefix and never exceed the path.
+                    debug_assert!(
+                        prefix.len() <= path.len(),
+                        "a matching prefix cannot be longer than the path it matched",
+                    );
                     PathRuleResult::Prefix(prefix.len())
                 } else {
                     PathRuleResult::None
@@ -1135,6 +1300,20 @@ impl RewriteParts {
                 result.push(RewritePart::String(template[start..i].to_owned()));
             }
         }
+        // Every capture reference the parser emitted is within the caps it
+        // was given; out-of-range indices return None above, never a part.
+        debug_assert!(
+            result.iter().all(|part| match part {
+                RewritePart::Host(idx) => *idx < host_cap_cap,
+                RewritePart::Path(idx) => *idx < path_cap_cap,
+                RewritePart::String(_) => true,
+            }),
+            "a parsed rewrite template must only reference captures within the rule's caps",
+        );
+        debug_assert!(
+            *used_index_host <= host_cap_cap && *used_index_path <= path_cap_cap,
+            "the highest referenced capture index cannot exceed the cap",
+        );
         Some(Self(result))
     }
 
@@ -1160,6 +1339,14 @@ impl RewriteParts {
                 RewritePart::Path(i) => result.write_str(path_captures.get(*i).unwrap_or(&"")),
             };
         }
+        // The capacity pass and the write pass consult the same parts and
+        // captures, so the single up-front allocation must be exact — the
+        // result never reallocates.
+        debug_assert_eq!(
+            result.len(),
+            cap,
+            "rewrite output length must equal the pre-computed one-pass capacity",
+        );
         result
     }
 }

--- a/lib/src/router/pattern_trie.rs
+++ b/lib/src/router/pattern_trie.rs
@@ -120,14 +120,48 @@ impl<V: Debug + Clone> TrieNode<V> {
             return InsertResult::Failed;
         }
 
+        #[cfg(debug_assertions)]
+        let before = self.count_values();
+
         let insert_result = self.insert_recursive(&key, &key, value);
         assert_ne!(insert_result, InsertResult::Failed);
+
+        // Post: the value count grows by exactly one on a fresh insert
+        // and is unchanged when the key already existed. `Failed` is
+        // ruled out above, so these two are the only reachable cases.
+        #[cfg(debug_assertions)]
+        {
+            let after = self.count_values();
+            match insert_result {
+                InsertResult::Ok => debug_assert_eq!(
+                    after,
+                    before + 1,
+                    "a fresh insert must add exactly one value to the trie",
+                ),
+                InsertResult::Existing => debug_assert_eq!(
+                    after, before,
+                    "an Existing insert must not change the trie value count",
+                ),
+                InsertResult::Failed => {
+                    unreachable!("insert_recursive returned Failed after key validation")
+                }
+            }
+            self.check_invariants();
+        }
+
         insert_result
     }
 
     pub fn insert_recursive(&mut self, partial_key: &[u8], key: &Key, value: V) -> InsertResult {
         //println!("insert_rec: key == {}", std::str::from_utf8(partial_key).unwrap());
         assert_ne!(partial_key, &b""[..]);
+        // `partial_key` is always a suffix of the full `key` being
+        // inserted — the recursion only ever shrinks the head, never
+        // rewrites the tail.
+        debug_assert!(
+            partial_key.len() <= key.len(),
+            "insert recursion must consume the key, never grow past it",
+        );
 
         if partial_key[partial_key.len() - 1] == b'/' {
             let pos = find_last_slash(&partial_key[..partial_key.len() - 1]);
@@ -139,9 +173,28 @@ impl<V: Debug + Clone> TrieNode<V> {
 
                 if let Ok(s) = str::from_utf8(&partial_key[pos + 1..partial_key.len() - 1]) {
                     let anchored_s = format!("\\A{s}\\z");
+                    debug_assert!(
+                        anchored_s.starts_with("\\A") && anchored_s.ends_with("\\z"),
+                        "segment regex must be fully anchored so it matches the whole segment only",
+                    );
                     for t in self.regexps.iter_mut() {
                         if t.0.as_str() == anchored_s {
-                            return t.1.insert_recursive(&partial_key[..pos - 1], key, value);
+                            // `pos > 0`: there is a `.`-separated prefix
+                            // before this regex segment; recurse on it
+                            // (dropping the leading `.` via `pos - 1`).
+                            // `pos == 0`: the regex is the leftmost/only
+                            // segment, so its subtree is already a
+                            // value-bearing leaf (the create-path below
+                            // built it via `TrieNode::new`); re-inserting
+                            // the same host is `Existing`. The pre-fix code
+                            // did `partial_key[..pos - 1]` unconditionally,
+                            // underflowing to `usize::MAX` and panicking on
+                            // `pos == 0` (same latent bug as `lookup_mut`).
+                            if pos > 0 {
+                                return t.1.insert_recursive(&partial_key[..pos - 1], key, value);
+                            } else {
+                                return InsertResult::Existing;
+                            }
                         }
                     }
 
@@ -193,6 +246,18 @@ impl<V: Debug + Clone> TrieNode<V> {
                 }
             }
             Some(pos) => {
+                // The dot at `pos` is kept on the child key (suffix) and
+                // stripped from the recursive prefix; the two slices
+                // partition `partial_key` exactly.
+                debug_assert_eq!(
+                    partial_key[..pos].len() + partial_key[pos..].len(),
+                    partial_key.len(),
+                    "dot-split must partition partial_key without losing bytes",
+                );
+                debug_assert_eq!(
+                    partial_key[pos], b'.',
+                    "find_last_dot must point at a '.' byte",
+                );
                 if let Some(child) = self.children.get_mut(&partial_key[pos..]) {
                     return child.insert_recursive(&partial_key[..pos], key, value);
                 }
@@ -210,7 +275,32 @@ impl<V: Debug + Clone> TrieNode<V> {
     }
 
     pub fn remove(&mut self, key: &Key) -> RemoveResult {
-        self.remove_recursive(key)
+        #[cfg(debug_assertions)]
+        let before = self.count_values();
+
+        let remove_result = self.remove_recursive(key);
+
+        // Post: a successful remove drops exactly one value; a NotFound
+        // is a no-op on the value count. The structural invariants then
+        // guarantee no emptied subtree was stranded by the prune.
+        #[cfg(debug_assertions)]
+        {
+            let after = self.count_values();
+            match remove_result {
+                RemoveResult::Ok => debug_assert_eq!(
+                    after + 1,
+                    before,
+                    "a successful remove must drop exactly one value from the trie",
+                ),
+                RemoveResult::NotFound => debug_assert_eq!(
+                    after, before,
+                    "a NotFound remove must not change the trie value count",
+                ),
+            }
+            self.check_invariants();
+        }
+
+        remove_result
     }
 
     pub fn remove_recursive(&mut self, partial_key: &[u8]) -> RemoveResult {
@@ -273,13 +363,34 @@ impl<V: Debug + Clone> TrieNode<V> {
             Some(pos) => (&partial_key[..pos], &partial_key[pos..]),
         };
         //println!("remove: prefix|suffix: {} | {}", std::str::from_utf8(prefix).unwrap(), std::str::from_utf8(suffix).unwrap());
+        debug_assert_eq!(
+            prefix.len() + suffix.len(),
+            partial_key.len(),
+            "dot-split must partition the key without losing or duplicating bytes",
+        );
 
         match self.children.get_mut(suffix) {
             Some(child) => match child.remove_recursive(prefix) {
                 RemoveResult::NotFound => RemoveResult::NotFound,
                 RemoveResult::Ok => {
+                    // An emptied child subtree MUST be pruned here so the
+                    // parent never strands a node with no value. After the
+                    // prune the suffix key is gone from `children`.
                     if child.is_empty() {
                         self.children.remove(suffix);
+                        debug_assert!(
+                            !self.children.contains_key(suffix),
+                            "an emptied child subtree must be removed from the parent",
+                        );
+                    } else {
+                        // `count_values` is debug-only; gate the whole
+                        // assert so the call does not have to compile in
+                        // release (HARD RULE 2 — E0425 guard).
+                        #[cfg(debug_assertions)]
+                        debug_assert!(
+                            child.count_values() > 0,
+                            "a retained child subtree must still hold at least one value",
+                        );
                     }
                     RemoveResult::Ok
                 }
@@ -311,6 +422,18 @@ impl<V: Debug + Clone> TrieNode<V> {
             None => (&b""[..], partial_key),
             Some(pos) => (&partial_key[..pos], &partial_key[pos..]),
         };
+        // The dot-split partitions the key exactly: prefix ++ suffix is
+        // the whole input, and a dotted split puts the `.` at the head
+        // of the suffix (this is the byte the wildcard/regex arms strip).
+        debug_assert_eq!(
+            prefix.len() + suffix.len(),
+            partial_key.len(),
+            "dot-split must partition the key without losing or duplicating bytes",
+        );
+        debug_assert!(
+            pos.is_none() || suffix.first() == Some(&b'.'),
+            "a dotted split must place the separator at the head of the suffix",
+        );
 
         match self.children.get(suffix) {
             Some(child) => child.lookup_with_path(prefix, accept_wildcard, trace),
@@ -355,6 +478,15 @@ impl<V: Debug + Clone> TrieNode<V> {
             Some(pos) => (&partial_key[..pos], &partial_key[pos..]),
         };
         //println!("lookup: prefix|suffix: {} | {}", std::str::from_utf8(prefix).unwrap(), std::str::from_utf8(suffix).unwrap());
+        debug_assert_eq!(
+            prefix.len() + suffix.len(),
+            partial_key.len(),
+            "dot-split must partition the key without losing or duplicating bytes",
+        );
+        debug_assert!(
+            !suffix.is_empty(),
+            "the suffix the trie matches children against must be non-empty",
+        );
 
         match self.children.get(suffix) {
             Some(child) => child.lookup(prefix, accept_wildcard),
@@ -414,7 +546,20 @@ impl<V: Debug + Clone> TrieNode<V> {
                     let anchored_s = format!("\\A{s}\\z");
                     for t in self.regexps.iter_mut() {
                         if t.0.as_str() == anchored_s {
-                            return t.1.lookup_mut(&partial_key[..pos - 1], accept_wildcard);
+                            // `pos == 0` means the regex is the leftmost
+                            // segment and its subtree is a value-bearing
+                            // leaf, reachable via the empty-prefix recursion
+                            // (`lookup_mut(b"")` returns `key_value`). The
+                            // pre-fix `partial_key[..pos - 1]` underflowed to
+                            // `usize::MAX` and panicked on `pos == 0` — the
+                            // same latent bug as the insert dedup loop. Drop
+                            // the leading `.` only when there is one.
+                            let rest = if pos > 0 {
+                                &partial_key[..pos - 1]
+                            } else {
+                                &partial_key[..0]
+                            };
+                            return t.1.lookup_mut(rest, accept_wildcard);
                         }
                     }
                 }
@@ -429,6 +574,15 @@ impl<V: Debug + Clone> TrieNode<V> {
             Some(pos) => (&partial_key[..pos], &partial_key[pos..]),
         };
         //println!("lookup: prefix|suffix: {} | {}", std::str::from_utf8(prefix).unwrap(), std::str::from_utf8(suffix).unwrap());
+        debug_assert_eq!(
+            prefix.len() + suffix.len(),
+            partial_key.len(),
+            "dot-split must partition the key without losing or duplicating bytes",
+        );
+        debug_assert!(
+            !suffix.is_empty(),
+            "the suffix the trie matches children against must be non-empty",
+        );
 
         match self.children.get_mut(suffix) {
             Some(child) => child.lookup_mut(prefix, accept_wildcard),
@@ -509,6 +663,80 @@ impl<V: Debug + Clone> TrieNode<V> {
         }
         for (_, child) in self.regexps.iter_mut() {
             child.for_each_value_mut(f);
+        }
+    }
+
+    /// Count every value slot reachable from this node: the literal
+    /// `key_value`, the leftmost `wildcard`, plus all values stored in
+    /// child subtrees and regex subtrees. Used only by the
+    /// `#[cfg(debug_assertions)]` invariant checks as the leaf-count
+    /// accounting (`inserts − removes`); never called in release.
+    #[cfg(debug_assertions)]
+    fn count_values(&self) -> usize {
+        let local = self.key_value.is_some() as usize + self.wildcard.is_some() as usize;
+        let in_children: usize = self.children.values().map(TrieNode::count_values).sum();
+        let in_regexps: usize = self.regexps.iter().map(|(_, c)| c.count_values()).sum();
+        local + in_children + in_regexps
+    }
+
+    /// Full structural invariant sweep for the trie, asserted as a
+    /// run-to-completion postcondition at the end of every mutating
+    /// public operation. Encodes the cross-field invariants that the
+    /// recursive insert/remove logic must preserve:
+    ///
+    /// - **No stranded interior node**: every non-root node reachable
+    ///   through `children` / `regexps` must hold a value somewhere in
+    ///   its subtree (`!is_empty()` and `count_values() > 0`). A node
+    ///   that holds neither a value nor any descendant value is a leak —
+    ///   `remove_recursive` is supposed to prune it via `is_empty()`.
+    /// - **Unique regex segments**: the anchored pattern strings stored
+    ///   in `regexps` are unique within a node (insert dedups by
+    ///   `as_str()` before pushing a new subtree).
+    /// - **Child-key invariant**: no child is keyed by the empty slice.
+    ///
+    /// `debug_assertions`-only; compiled out of release builds.
+    #[cfg(debug_assertions)]
+    fn check_invariants(&self) {
+        // Regex segment patterns are unique per node.
+        for i in 0..self.regexps.len() {
+            for j in (i + 1)..self.regexps.len() {
+                debug_assert_ne!(
+                    self.regexps[i].0.as_str(),
+                    self.regexps[j].0.as_str(),
+                    "trie node must not hold two subtrees for the same regex segment",
+                );
+            }
+        }
+
+        for (child_key, child) in self.children.iter() {
+            debug_assert!(
+                !child_key.is_empty(),
+                "trie child must not be keyed by the empty segment",
+            );
+            // A child subtree that has been fully emptied must have been
+            // pruned by remove_recursive; reaching it here means a
+            // subtree was stranded.
+            debug_assert!(
+                !child.is_empty(),
+                "trie must not strand an empty child subtree (remove must prune)",
+            );
+            debug_assert!(
+                child.count_values() > 0,
+                "trie child subtree must lead to at least one value",
+            );
+            child.check_invariants();
+        }
+
+        for (_, child) in self.regexps.iter() {
+            debug_assert!(
+                !child.is_empty(),
+                "trie must not strand an empty regex subtree (remove must prune)",
+            );
+            debug_assert!(
+                child.count_values() > 0,
+                "trie regex subtree must lead to at least one value",
+            );
+            child.check_invariants();
         }
     }
 
@@ -1000,5 +1228,51 @@ mod tests {
     #[test]
     fn size() {
         assert_size!(TrieNode<u32>, 136);
+    }
+
+    /// Regression: a hostname whose LEFTMOST segment is a regex
+    /// (`/test[0-9]/.example.com`) used to underflow `pos - 1` (to
+    /// `usize::MAX`) and panic on the second insert (the dedup loop) and
+    /// on any `lookup_mut`. Both paths now special-case `pos == 0`
+    /// (regex is the leftmost/only segment → value-bearing leaf). This
+    /// asserts the panic is gone and the entry resolves correctly.
+    #[test]
+    fn leftmost_regex_segment_reinsert_and_lookup_mut_do_not_panic() {
+        let mut root: TrieNode<u8> = TrieNode::root();
+
+        assert_eq!(
+            root.insert(Vec::from(&b"/test[0-9]/.example.com"[..]), 7),
+            InsertResult::Ok
+        );
+        // Second insert of the SAME leftmost-regex host: dedup loop with
+        // pos == 0. Previously panicked; must now report Existing.
+        assert_eq!(
+            root.insert(Vec::from(&b"/test[0-9]/.example.com"[..]), 8),
+            InsertResult::Existing
+        );
+
+        // lookup_mut on the existing leftmost-regex host: previously
+        // panicked at `partial_key[..pos - 1]`; must now resolve the leaf
+        // (value unchanged from the first insert — Existing did not
+        // overwrite).
+        let resolved = root.domain_lookup_mut(b"test4.example.com", false);
+        assert_eq!(
+            resolved.map(|(_, v)| *v),
+            Some(7),
+            "leftmost-regex host must resolve via lookup_mut without panicking",
+        );
+
+        // The immutable lookup path (never buggy) agrees.
+        assert_eq!(
+            root.domain_lookup(b"test4.example.com", false),
+            Some(&(b"/test[0-9]/.example.com"[..].to_vec(), 7))
+        );
+
+        // Removing the last rule clears the host.
+        assert_eq!(
+            root.domain_remove(&Vec::from(&b"/test[0-9]/.example.com"[..])),
+            RemoveResult::Ok
+        );
+        assert_eq!(root.domain_lookup(b"test4.example.com", false), None);
     }
 }

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -326,12 +326,28 @@ impl SessionManager {
         if limit == 0 {
             return false;
         }
-        if self
+        // Pure query: the limit==0 branch already returned, so any work below
+        // runs only with a positive cap.
+        debug_assert!(
+            limit > 0,
+            "limit==0 (unlimited) must have returned before reaching the bounded check"
+        );
+        let already_tracked = self
             .cluster_ip_tracks
             .get(&token)
             .and_then(|by_cluster| by_cluster.get(cluster_id))
-            .is_some_and(|ips| ips.contains(ip))
-        {
+            .is_some_and(|ips| ips.contains(ip));
+        if already_tracked {
+            // Reverse-index/forward-count coherence: if this token already
+            // holds a slot for (cluster, ip), the forward count must be > 0
+            // (decrement-to-zero reaps the inner entry in untrack_all).
+            debug_assert!(
+                self.connections_per_cluster_ip
+                    .get(cluster_id)
+                    .and_then(|by_ip| by_ip.get(ip))
+                    .is_some_and(|c| *c > 0),
+                "a tracked (token, cluster, ip) slot must have a positive forward count"
+            );
             return false;
         }
         self.connections_per_cluster_ip
@@ -350,6 +366,15 @@ impl SessionManager {
     /// new outer-map slot. Subsequent IPs under the same `(token,
     /// cluster)` reuse the existing slot.
     pub fn track_cluster_ip(&mut self, token: Token, cluster_id: String, ip: IpAddr) {
+        // Snapshot the forward count for this (cluster, ip) before the insert
+        // so we can pair-assert the delta. Ungated `let`: read only inside the
+        // debug_assert! below → optimised out in release (no E0425).
+        let count_before = self
+            .connections_per_cluster_ip
+            .get(&cluster_id)
+            .and_then(|by_ip| by_ip.get(&ip))
+            .copied()
+            .unwrap_or(0);
         let inserted = self
             .cluster_ip_tracks
             .entry(token)
@@ -360,11 +385,32 @@ impl SessionManager {
         if inserted {
             *self
                 .connections_per_cluster_ip
-                .entry(cluster_id)
+                .entry(cluster_id.clone())
                 .or_default()
                 .entry(ip)
                 .or_insert(0) += 1;
         }
+        // Postconditions: the reverse index now records this (token, cluster,
+        // ip), and the forward count advanced by exactly `inserted as usize`
+        // (idempotent: a repeat call for the same triple is a no-op on both).
+        debug_assert!(
+            self.cluster_ip_tracks
+                .get(&token)
+                .and_then(|by_cluster| by_cluster.get(&cluster_id))
+                .is_some_and(|ips| ips.contains(&ip)),
+            "track must leave the (token, cluster, ip) recorded in the reverse index"
+        );
+        debug_assert_eq!(
+            self.connections_per_cluster_ip
+                .get(&cluster_id)
+                .and_then(|by_ip| by_ip.get(&ip))
+                .copied()
+                .unwrap_or(0),
+            count_before + inserted as usize,
+            "forward count must advance by exactly 1 on first track, 0 on a repeat"
+        );
+        #[cfg(debug_assertions)]
+        self.check_invariants();
     }
 
     /// Drain every `(cluster, ip)` slot held by `token` and apply the
@@ -377,6 +423,12 @@ impl SessionManager {
         let Some(by_cluster) = self.cluster_ip_tracks.remove(&token) else {
             return;
         };
+        // The reverse index for this token was just drained by `remove`; no
+        // other code path re-inserts it within this call.
+        debug_assert!(
+            !self.cluster_ip_tracks.contains_key(&token),
+            "untrack_all must evict the token from the reverse index"
+        );
         for (cluster_id, ips) in by_cluster {
             let Entry::Occupied(mut outer) = self.connections_per_cluster_ip.entry(cluster_id)
             else {
@@ -395,6 +447,16 @@ impl SessionManager {
                 outer.remove();
             }
         }
+        // No orphan bookkeeping survives: the forward map must not retain a
+        // cluster with an empty inner ip-map, nor an ip whose count is zero.
+        debug_assert!(
+            self.connections_per_cluster_ip
+                .values()
+                .all(|by_ip| !by_ip.is_empty() && by_ip.values().all(|&c| c > 0)),
+            "untrack_all must not leave empty inner maps or zero-count ips behind"
+        );
+        #[cfg(debug_assertions)]
+        self.check_invariants();
     }
 
     /// Wipe every per-(cluster, source-IP) accounting bucket. Called by
@@ -404,6 +466,14 @@ impl SessionManager {
     pub fn clear_cluster_ip_tracking(&mut self) {
         self.cluster_ip_tracks.clear();
         self.connections_per_cluster_ip.clear();
+        // Both halves of the per-(cluster, ip) accounting are now empty; a
+        // future re-enable starts from a clean slate.
+        debug_assert!(
+            self.cluster_ip_tracks.is_empty() && self.connections_per_cluster_ip.is_empty(),
+            "clear must wipe both the reverse index and the forward count map"
+        );
+        #[cfg(debug_assertions)]
+        self.check_invariants();
     }
 
     /// The slab is considered at capacity if it contains more sessions than twice max_connections
@@ -423,16 +493,35 @@ impl SessionManager {
     /// (against `slab.capacity()`) and `slab.accept_threshold_percent`
     /// (against this gate) are emitted as independent gauges.
     pub fn accept_slab_threshold(&self) -> usize {
-        10 + 2 * self.max_connections
+        let threshold = 10 + 2 * self.max_connections;
+        // The gate must leave headroom above the connection cap so listener /
+        // system slots (Channel, Metrics, Timer, listeners) are never starved
+        // by frontend connections alone.
+        debug_assert!(
+            threshold > self.max_connections,
+            "accept gate must sit strictly above max_connections to reserve system slots"
+        );
+        threshold
     }
 
     /// Check the number of connections against max_connections, and the slab capacity.
     /// Returns false if limits are reached.
     pub fn check_limits(&mut self) -> bool {
+        // Live-count invariant: the accounted connection count never exceeds
+        // the configured cap (incr() enforces this, decr() never underflows).
+        debug_assert!(
+            self.nb_connections <= self.max_connections,
+            "nb_connections must never exceed max_connections"
+        );
         if self.nb_connections >= self.max_connections {
             error!("max number of session connection reached, flushing the accept queue");
             gauge!(names::accept_queue::BACKPRESSURE, 1);
             self.can_accept = false;
+            // A negative result must have closed the accept gate.
+            debug_assert!(
+                !self.can_accept,
+                "refusing at the cap must clear can_accept"
+            );
             return false;
         }
 
@@ -445,9 +534,18 @@ impl SessionManager {
             gauge!(names::accept_queue::BACKPRESSURE, 1);
             self.can_accept = false;
 
+            debug_assert!(
+                !self.can_accept,
+                "refusing at slab capacity must clear can_accept"
+            );
             return false;
         }
 
+        // A positive result means there is room under both gates.
+        debug_assert!(
+            self.nb_connections < self.max_connections && !self.at_capacity(),
+            "check_limits returned room while a gate was actually saturated"
+        );
         true
     }
 
@@ -456,8 +554,15 @@ impl SessionManager {
     }
 
     pub fn incr(&mut self) {
+        let before = self.nb_connections;
         self.nb_connections += 1;
         assert!(self.nb_connections <= self.max_connections);
+        // The counter advances by exactly one per accepted session.
+        debug_assert_eq!(
+            self.nb_connections,
+            before + 1,
+            "incr must raise nb_connections by exactly one"
+        );
         // `client.connections_max` and `client.connections_percent` are
         // emitted from the run loop alongside `process.uptime_seconds` /
         // `server.live` so all proxy gauges advance in lock-step. Keeping
@@ -470,7 +575,14 @@ impl SessionManager {
     /// if the capacity limit of 90% has not been reached.
     pub fn decr(&mut self) {
         assert!(self.nb_connections != 0);
+        let before = self.nb_connections;
         self.nb_connections -= 1;
+        // Mirror of incr: exactly one connection is released, no underflow.
+        debug_assert_eq!(
+            self.nb_connections,
+            before - 1,
+            "decr must lower nb_connections by exactly one"
+        );
         gauge!(names::client::CONNECTIONS, self.nb_connections);
 
         // do not be ready to accept right away, wait until we get back to 10% capacity
@@ -482,6 +594,53 @@ impl SessionManager {
             gauge!(names::accept_queue::BACKPRESSURE, 0);
             self.can_accept = true;
         }
+    }
+
+    /// Full cross-field invariant sweep for the session manager. Called as a
+    /// `debug_assert!`-guarded postcondition from the mutating cluster-IP
+    /// tracking methods. Asserts logic-bug conditions only — every clause
+    /// holds on any well-formed manager regardless of traffic.
+    #[cfg(debug_assertions)]
+    fn check_invariants(&self) {
+        // 1. Live connection count never exceeds the configured cap.
+        debug_assert!(
+            self.nb_connections <= self.max_connections,
+            "nb_connections {} exceeds max_connections {}",
+            self.nb_connections,
+            self.max_connections
+        );
+        // 2. The forward count map never retains an empty inner ip-map or a
+        //    zero count (both are reaped on the last untrack).
+        debug_assert!(
+            self.connections_per_cluster_ip
+                .values()
+                .all(|by_ip| !by_ip.is_empty() && by_ip.values().all(|&c| c > 0)),
+            "connections_per_cluster_ip holds an empty inner map or a zero count"
+        );
+        // 3. Reverse-index → forward-count coherence: every (token, cluster,
+        //    ip) recorded in the reverse index must have a positive forward
+        //    count. The forward count is the sum of contributing tokens, so a
+        //    tracked slot can never point at a missing/zero count.
+        debug_assert!(
+            self.cluster_ip_tracks.values().all(|by_cluster| {
+                by_cluster.iter().all(|(cluster_id, ips)| {
+                    ips.iter().all(|ip| {
+                        self.connections_per_cluster_ip
+                            .get(cluster_id)
+                            .and_then(|by_ip| by_ip.get(ip))
+                            .is_some_and(|&c| c > 0)
+                    })
+                })
+            }),
+            "a tracked (token, cluster, ip) slot has no positive forward count"
+        );
+        // 4. The reverse index never retains an empty inner structure.
+        debug_assert!(
+            self.cluster_ip_tracks.values().all(|by_cluster| {
+                !by_cluster.is_empty() && by_cluster.values().all(|ips| !ips.is_empty())
+            }),
+            "cluster_ip_tracks retains an empty per-token or per-cluster entry"
+        );
     }
 }
 
@@ -1194,6 +1353,12 @@ impl Server {
             return;
         }
         info!("zombie check");
+        // `now` is sampled this iteration and we only get here past the
+        // interval gate, so the check timestamp advances monotonically.
+        debug_assert!(
+            now >= self.last_zombie_check,
+            "zombie-check timestamp must never move backwards"
+        );
         self.last_zombie_check = now;
 
         let mut zombie_tokens = HashSet::new();
@@ -1212,6 +1377,22 @@ impl Server {
                 zombie_tokens.insert(session_token);
             }
         }
+
+        // Listen/system sessions report `Instant::now()` as their last event,
+        // so `now - last_event` is ~0 and never exceeds the interval: a
+        // listener can never be collected as a zombie. Assert the set is free
+        // of listen protocols before we reap it.
+        debug_assert!(
+            !self.sessions.borrow().slab.iter().any(|(_, session)| {
+                let s = session.borrow();
+                zombie_tokens.contains(&s.frontend_token())
+                    && matches!(
+                        s.protocol(),
+                        Protocol::HTTPListen | Protocol::HTTPSListen | Protocol::TCPListen
+                    )
+            }),
+            "zombie reaping must never target a listener session"
+        );
 
         let zombie_count = zombie_tokens.len() as i64;
         count!(names::misc::ZOMBIES, zombie_count);
@@ -1233,9 +1414,22 @@ impl Server {
         // close the sessions associated with the tokens
         for token in &tokens {
             if self.sessions.borrow().slab.contains(token.0) {
+                let slab_before = self.sessions.borrow().slab.len();
                 let session = { self.sessions.borrow_mut().slab.remove(token.0) };
                 session.borrow_mut().close();
                 self.sessions.borrow_mut().decr();
+                // The removed token is truly gone afterwards. The slab may shrink
+                // by MORE than one: `close()` also frees the session's backend
+                // slab slot(s) (the multi-token pattern), so assert it shrank by
+                // at least the frontend slot we just removed, not exactly one.
+                debug_assert!(
+                    !self.sessions.borrow().slab.contains(token.0),
+                    "removed token must be absent from the slab"
+                );
+                debug_assert!(
+                    self.sessions.borrow().slab.len() < slab_before,
+                    "removing a present session must free at least its own slab slot"
+                );
             }
         }
 
@@ -1256,6 +1450,18 @@ impl Server {
                 dangling_entries_count += 1;
             }
         }
+        // Postcondition: no surviving slab entry still references any of the
+        // closed frontend tokens — both the direct remove and the dangling
+        // sweep together leave the slab clean of these sessions.
+        debug_assert!(
+            !self
+                .sessions
+                .borrow()
+                .slab
+                .iter()
+                .any(|(_, session)| tokens.contains(&session.borrow().frontend_token())),
+            "no slab entry may reference a closed frontend token after teardown"
+        );
         dangling_entries_count
     }
 
@@ -1910,6 +2116,12 @@ impl Server {
             }
             Some(RequestType::RemoveListener(ref remove)) => {
                 debug!("{} remove {:?} listener {:?}", req_id, remove.proxy, remove);
+                // We only remove a listener that was previously added, so the
+                // base count is at least 1 — the subtraction cannot underflow.
+                debug_assert!(
+                    self.base_sessions_count > 0,
+                    "removing a listener with base_sessions_count == 0 would underflow"
+                );
                 self.base_sessions_count -= 1;
                 let response = match ListenerType::try_from(remove.proxy) {
                     Ok(ListenerType::Http) => self.http.borrow_mut().notify(request),
@@ -2011,6 +2223,14 @@ impl Server {
         }
 
         let mut session_manager = self.sessions.borrow_mut();
+        // The vacant entry's key is free now and becomes the listener's token.
+        let slab_before = session_manager.slab.len();
+        debug_assert!(
+            !session_manager
+                .slab
+                .contains(session_manager.slab.vacant_key()),
+            "the next vacant slab key must be free before insertion"
+        );
         let entry = session_manager.slab.vacant_entry();
         let token = Token(entry.key());
 
@@ -2019,6 +2239,17 @@ impl Server {
                 entry.insert(Rc::new(RefCell::new(ListenSession {
                     protocol: Protocol::HTTPListen,
                 })));
+                // The listener session occupies exactly the token's slab key,
+                // and the slab grew by exactly one slot.
+                debug_assert!(
+                    session_manager.slab.contains(token.0),
+                    "listener insert must occupy the token's slab key"
+                );
+                debug_assert_eq!(
+                    session_manager.slab.len(),
+                    slab_before + 1,
+                    "adding a listener must occupy exactly one slab slot"
+                );
                 self.base_sessions_count += 1;
                 WorkerResponse::ok(req_id)
             }
@@ -2038,6 +2269,13 @@ impl Server {
         }
 
         let mut session_manager = self.sessions.borrow_mut();
+        let slab_before = session_manager.slab.len();
+        debug_assert!(
+            !session_manager
+                .slab
+                .contains(session_manager.slab.vacant_key()),
+            "the next vacant slab key must be free before insertion"
+        );
         let entry = session_manager.slab.vacant_entry();
         let token = Token(entry.key());
 
@@ -2050,6 +2288,15 @@ impl Server {
                 entry.insert(Rc::new(RefCell::new(ListenSession {
                     protocol: Protocol::HTTPSListen,
                 })));
+                debug_assert!(
+                    session_manager.slab.contains(token.0),
+                    "listener insert must occupy the token's slab key"
+                );
+                debug_assert_eq!(
+                    session_manager.slab.len(),
+                    slab_before + 1,
+                    "adding a listener must occupy exactly one slab slot"
+                );
                 self.base_sessions_count += 1;
                 WorkerResponse::ok(req_id)
             }
@@ -2069,6 +2316,13 @@ impl Server {
         }
 
         let mut session_manager = self.sessions.borrow_mut();
+        let slab_before = session_manager.slab.len();
+        debug_assert!(
+            !session_manager
+                .slab
+                .contains(session_manager.slab.vacant_key()),
+            "the next vacant slab key must be free before insertion"
+        );
         let entry = session_manager.slab.vacant_entry();
         let token = Token(entry.key());
 
@@ -2077,6 +2331,15 @@ impl Server {
                 entry.insert(Rc::new(RefCell::new(ListenSession {
                     protocol: Protocol::TCPListen,
                 })));
+                debug_assert!(
+                    session_manager.slab.contains(token.0),
+                    "listener insert must occupy the token's slab key"
+                );
+                debug_assert_eq!(
+                    session_manager.slab.len(),
+                    slab_before + 1,
+                    "adding a listener must occupy exactly one slab slot"
+                );
                 self.base_sessions_count += 1;
                 WorkerResponse::ok(req_id)
             }
@@ -2534,6 +2797,24 @@ impl Server {
                 .map(|(addr, listener)| (*addr, listener.as_raw_fd()))
                 .collect(),
         };
+        // Each handed-back listener is collected exactly once: the assembled
+        // fd lists mirror the give_back lists one-to-one (the maps above are
+        // straight `.iter().map().collect()` with no filtering or dedup).
+        debug_assert_eq!(
+            listeners.http.len(),
+            http_listeners.len(),
+            "every HTTP listener must be collected exactly once"
+        );
+        debug_assert_eq!(
+            listeners.tls.len(),
+            https_listeners.len(),
+            "every HTTPS listener must be collected exactly once"
+        );
+        debug_assert_eq!(
+            listeners.tcp.len(),
+            tcp_listeners.len(),
+            "every TCP listener must be collected exactly once"
+        );
         info!("sending default listeners: {:?}", listeners);
         let res = self.scm.send_listeners(&listeners);
 
@@ -2589,6 +2870,16 @@ impl Server {
             }
         };
 
+        // Past the guard, `accepted_protocol` is one of the three listen
+        // variants — the inner dispatch's `unreachable!` arm relies on this.
+        debug_assert!(
+            matches!(
+                accepted_protocol,
+                Protocol::TCPListen | Protocol::HTTPListen | Protocol::HTTPSListen
+            ),
+            "accept dispatch must run with a listen protocol only"
+        );
+
         loop {
             let result = match accepted_protocol {
                 Protocol::TCPListen => self.tcp.borrow_mut().accept(token),
@@ -2614,6 +2905,7 @@ impl Server {
                     if let Some(peer_addr) = peer.as_ref() {
                         incr!(per_source_bucket(peer_addr));
                     }
+                    let queue_before = self.accept_queue.len();
                     self.accept_queue.push_back((
                         sock,
                         token,
@@ -2621,6 +2913,12 @@ impl Server {
                         Instant::now(),
                         peer,
                     ));
+                    // One accepted socket enqueues exactly one entry.
+                    debug_assert_eq!(
+                        self.accept_queue.len(),
+                        queue_before + 1,
+                        "each accepted socket must enqueue exactly one entry"
+                    );
                 }
                 Err(AcceptError::WouldBlock) => {
                     self.accept_ready.remove(&token);
@@ -2702,6 +3000,16 @@ impl Server {
             //FIXME: check the timestamp
             //TODO: create_session should return the session and
             // the server should insert it in the the SessionManager
+            // The accept path only ever enqueues listen protocols, so the
+            // `_ => panic!` arm below is genuinely unreachable. Assert the set
+            // here so a future enqueue regression trips in debug, not prod.
+            debug_assert!(
+                matches!(
+                    protocol,
+                    Protocol::TCPListen | Protocol::HTTPListen | Protocol::HTTPSListen
+                ),
+                "accept queue must only hold listen protocols, got {protocol:?}"
+            );
             match protocol {
                 Protocol::TCPListen => {
                     let proxy = self.tcp.clone();
@@ -2737,7 +3045,14 @@ impl Server {
                 }
                 _ => panic!("should not call accept() on a HTTP, HTTPS or TCP session"),
             };
+            let nb_before = self.sessions.borrow().nb_connections;
             self.sessions.borrow_mut().incr();
+            // A successfully created session bumps the live count by one.
+            debug_assert_eq!(
+                self.sessions.borrow().nb_connections,
+                nb_before + 1,
+                "create_sessions must account exactly one new connection per created session"
+            );
         }
 
         gauge!(names::accept_queue::CONNECTIONS, self.accept_queue.len());
@@ -2752,6 +3067,13 @@ impl Server {
             let protocol = self.sessions.borrow().slab[session_token]
                 .borrow()
                 .protocol();
+            // NOTE: `token` is NOT necessarily the session's frontend token. A
+            // session is registered under BOTH its frontend and its backend slab
+            // slots (the multi-token pattern: `connect_to_backend` inserts the
+            // same session Rc under a second vacant key), so `ready()` is also
+            // dispatched with the backend token, where `frontend_token() !=
+            // session_token`. There is therefore no `token == frontend_token`
+            // identity to assert here.
             //info!("protocol: {:?}", protocol);
             match protocol {
                 Protocol::HTTPListen | Protocol::HTTPSListen | Protocol::TCPListen => {

--- a/lib/src/socket.rs
+++ b/lib/src/socket.rs
@@ -186,12 +186,27 @@ fn tcp_socket_read(
             incr!(names::socket::READ_INFINITE_LOOP_ERROR);
             return (size, SocketResult::Error);
         }
+        // Loop invariant: the running cursor never overshoots the buffer, so the
+        // `&mut buf[size..]` slice below can never panic on a bad offset.
+        debug_assert!(
+            size <= buf.len(),
+            "read cursor {size} overran buffer len {} (would slice out of bounds)",
+            buf.len()
+        );
         if size == buf.len() {
             return (size, SocketResult::Continue);
         }
         match stream.read(&mut buf[size..]) {
             Ok(0) => return (size, SocketResult::Closed),
-            Ok(sz) => size += sz,
+            Ok(sz) => {
+                // `read` cannot report more bytes than the slice it was given.
+                debug_assert!(
+                    sz <= buf.len() - size,
+                    "read reported {sz} bytes into a {}-byte remaining slice",
+                    buf.len() - size
+                );
+                size += sz;
+            }
             Err(e) => match e.kind() {
                 ErrorKind::WouldBlock => return (size, SocketResult::WouldBlock),
                 // Treat `ConnectionRefused` as a closed socket, mirroring the
@@ -253,12 +268,27 @@ fn tcp_socket_write(
             incr!(names::socket::WRITE_INFINITE_LOOP_ERROR);
             return (size, SocketResult::Error);
         }
+        // Loop invariant: the cursor never overshoots the buffer, so the
+        // `&buf[size..]` slice below can never panic on a bad offset.
+        debug_assert!(
+            size <= buf.len(),
+            "write cursor {size} overran buffer len {} (would slice out of bounds)",
+            buf.len()
+        );
         if size == buf.len() {
             return (size, SocketResult::Continue);
         }
         match stream.write(&buf[size..]) {
             Ok(0) => return (size, SocketResult::Continue),
-            Ok(sz) => size += sz,
+            Ok(sz) => {
+                // `write` cannot report more bytes than the slice it was given.
+                debug_assert!(
+                    sz <= buf.len() - size,
+                    "write reported {sz} bytes from a {}-byte remaining slice",
+                    buf.len() - size
+                );
+                size += sz;
+            }
             Err(e) => match e.kind() {
                 ErrorKind::WouldBlock => return (size, SocketResult::WouldBlock),
                 ErrorKind::ConnectionReset
@@ -306,7 +336,15 @@ fn tcp_socket_write_vectored(
     configured_peer: Option<SocketAddr>,
 ) -> (usize, SocketResult) {
     match stream.write_vectored(bufs) {
-        Ok(sz) => (sz, SocketResult::Continue),
+        Ok(sz) => {
+            // `write_vectored` cannot report more bytes than the slices held.
+            debug_assert!(
+                sz <= bufs.iter().map(|b| b.len()).sum::<usize>(),
+                "write_vectored reported {sz} bytes from {}-byte slices",
+                bufs.iter().map(|b| b.len()).sum::<usize>()
+            );
+            (sz, SocketResult::Continue)
+        }
         Err(e) => match e.kind() {
             ErrorKind::WouldBlock => (0, SocketResult::WouldBlock),
             ErrorKind::ConnectionReset
@@ -509,6 +547,13 @@ impl SocketHandler for FrontRustls {
                 break;
             }
 
+            // Loop invariant: the plaintext cursor never overshoots the caller's
+            // buffer, so every `&mut buf[size..]` below is a valid slice.
+            debug_assert!(
+                size <= buf.len(),
+                "rustls read cursor {size} overran buffer len {} (would slice out of bounds)",
+                buf.len()
+            );
             if size == buf.len() {
                 break;
             }
@@ -574,6 +619,13 @@ impl SocketHandler for FrontRustls {
                 match self.session.reader().read(&mut buf[size..]) {
                     Ok(0) => break,
                     Ok(sz) => {
+                        // The rustls reader cannot return more plaintext than
+                        // the remaining slice it was handed.
+                        debug_assert!(
+                            sz <= buf.len() - size,
+                            "rustls reader returned {sz} bytes into a {}-byte remaining slice",
+                            buf.len() - size
+                        );
                         size += sz;
                     }
                     Err(e) => match e.kind() {
@@ -600,6 +652,18 @@ impl SocketHandler for FrontRustls {
             }
         }
 
+        // Post-condition: we never report more plaintext than the caller asked
+        // for, and Error/Closed are mutually exclusive (the loop `break`s on the
+        // first one set, so both can never be true on the same pass).
+        debug_assert!(
+            size <= buf.len(),
+            "rustls socket_read returned {size} bytes for a {}-byte buffer",
+            buf.len()
+        );
+        debug_assert!(
+            !(is_error && is_closed),
+            "rustls socket_read cannot be both Error and Closed"
+        );
         if is_error {
             (size, SocketResult::Error)
         } else if is_closed {
@@ -645,6 +709,13 @@ impl SocketHandler for FrontRustls {
                 is_error = true;
                 break;
             }
+            // Loop invariant: the absorbed-plaintext cursor never overshoots the
+            // caller's buffer, so `&buf[buffered_size..]` is always a valid slice.
+            debug_assert!(
+                buffered_size <= buf.len(),
+                "rustls write cursor {buffered_size} overran buffer len {} (would slice out of bounds)",
+                buf.len()
+            );
             if buffered_size == buf.len() {
                 break;
             }
@@ -656,6 +727,12 @@ impl SocketHandler for FrontRustls {
             match self.session.writer().write(&buf[buffered_size..]) {
                 Ok(0) => {} // zero byte written means that the Rustls buffers are full, we will try to write on the socket and try again
                 Ok(sz) => {
+                    // rustls cannot absorb more plaintext than the remaining slice.
+                    debug_assert!(
+                        sz <= buf.len() - buffered_size,
+                        "rustls writer absorbed {sz} bytes from a {}-byte remaining slice",
+                        buf.len() - buffered_size
+                    );
                     buffered_size += sz;
                 }
                 Err(e) => match e.kind() {
@@ -758,6 +835,18 @@ impl SocketHandler for FrontRustls {
             }
         }
 
+        // Post-condition: we never report absorbing more plaintext than the
+        // caller handed us — over-reporting is exactly the truncation-class bug
+        // these two symmetric paths exist to avoid.
+        debug_assert!(
+            buffered_size <= buf.len(),
+            "rustls socket_write reported {buffered_size} bytes for a {}-byte buffer",
+            buf.len()
+        );
+        debug_assert!(
+            !(is_error && is_closed),
+            "rustls socket_write cannot be both Error and Closed"
+        );
         if is_error {
             (buffered_size, SocketResult::Error)
         } else if is_closed {
@@ -808,6 +897,12 @@ impl SocketHandler for FrontRustls {
                 is_error = true;
                 break;
             }
+            // Loop invariant: the absorbed-plaintext cursor never overshoots the
+            // summed slice length we computed up front (mirrors the scalar path).
+            debug_assert!(
+                buffered_size <= total_len,
+                "rustls vectored write cursor {buffered_size} overran total slice len {total_len}"
+            );
             if buffered_size == total_len {
                 break;
             }
@@ -824,6 +919,11 @@ impl SocketHandler for FrontRustls {
                 match self.session.writer().write_vectored(bufs) {
                     Ok(0) => {}
                     Ok(sz) => {
+                        // rustls cannot absorb more plaintext than the slices held.
+                        debug_assert!(
+                            sz <= total_len,
+                            "rustls writer absorbed {sz} bytes from {total_len}-byte slices"
+                        );
                         buffered_size += sz;
                     }
                     Err(e) => match e.kind() {
@@ -955,6 +1055,17 @@ impl SocketHandler for FrontRustls {
             }
         }
 
+        // Post-condition: report no more than the summed slice length, and keep
+        // Error/Closed mutually exclusive — must stay structurally symmetric with
+        // `socket_write` (divergence here is the 4.5 MB truncation-class bug).
+        debug_assert!(
+            buffered_size <= total_len,
+            "rustls socket_write_vectored reported {buffered_size} bytes for {total_len}-byte slices"
+        );
+        debug_assert!(
+            !(is_error && is_closed),
+            "rustls socket_write_vectored cannot be both Error and Closed"
+        );
         if is_error {
             (buffered_size, SocketResult::Error)
         } else if is_closed {
@@ -1035,6 +1146,49 @@ pub fn server_bind(addr: SocketAddr) -> Result<TcpListener, ServerBindError> {
     // FIXME: make the backlog configurable?
     sock.listen(1024).map_err(ServerBindError::Listen)?;
 
+    // Post-conditions (invariant violations only — every fallible syscall above
+    // already returns an error; these `debug_assert!`s catch a flag we *set*
+    // silently not sticking, which would be our own logic bug, not a syscall
+    // failure on network input). The getters return `io::Result`; we only
+    // assert when the kernel answers, degrading to a no-op on the rare query
+    // failure so we never panic on a dying fd.
+    if let Ok(nonblocking) = sock.nonblocking() {
+        debug_assert!(
+            nonblocking,
+            "server_bind must return a non-blocking socket (the worker event loop is edge-triggered)"
+        );
+    }
+    // `SO_REUSEPORT` is set on every platform; assert it stuck so a SCM hand-off
+    // across a hot-upgrade can re-bind the same address.
+    #[cfg(unix)]
+    if let Ok(reuse_port) = sock.reuse_port() {
+        debug_assert!(
+            reuse_port,
+            "server_bind must set SO_REUSEPORT so the listener survives a hot-upgrade re-bind"
+        );
+    }
+    // `SO_REUSEADDR` is unix-only here (mirrors libstd).
+    #[cfg(unix)]
+    if let Ok(reuse_address) = sock.reuse_address() {
+        debug_assert!(
+            reuse_address,
+            "server_bind must set SO_REUSEADDR on unix (mirrors libstd)"
+        );
+    }
+    // A bound STREAM socket carries a local address in the requested family.
+    if let Ok(local) = sock.local_addr() {
+        debug_assert_eq!(
+            local.is_ipv4(),
+            addr.is_ipv4(),
+            "bound socket family must match the requested address family"
+        );
+        debug_assert_eq!(
+            local.is_ipv6(),
+            addr.is_ipv6(),
+            "bound socket family must match the requested address family"
+        );
+    }
+
     Ok(TcpListener::from_std(sock.into()))
 }
 
@@ -1066,6 +1220,44 @@ pub fn udp_bind(addr: SocketAddr) -> Result<UdpSocket, ServerBindError> {
         .map_err(ServerBindError::SetNonBlocking)?;
 
     // No `listen()` for DGRAM sockets.
+
+    // Post-conditions — same rationale as `server_bind`: assert the flags we set
+    // stuck (logic bug if not), degrading to a no-op when the kernel refuses the
+    // query so a dying fd never panics. There is deliberately no `listen()`
+    // check here: DGRAM sockets are never listened on.
+    if let Ok(nonblocking) = sock.nonblocking() {
+        debug_assert!(
+            nonblocking,
+            "udp_bind must return a non-blocking socket (the worker event loop is edge-triggered)"
+        );
+    }
+    #[cfg(unix)]
+    if let Ok(reuse_port) = sock.reuse_port() {
+        debug_assert!(
+            reuse_port,
+            "udp_bind must set SO_REUSEPORT so the listener survives a hot-upgrade re-bind"
+        );
+    }
+    #[cfg(unix)]
+    if let Ok(reuse_address) = sock.reuse_address() {
+        debug_assert!(
+            reuse_address,
+            "udp_bind must set SO_REUSEADDR on unix (mirrors libstd / server_bind)"
+        );
+    }
+    if let Ok(local) = sock.local_addr() {
+        debug_assert_eq!(
+            local.is_ipv4(),
+            addr.is_ipv4(),
+            "bound UDP socket family must match the requested address family"
+        );
+        debug_assert_eq!(
+            local.is_ipv6(),
+            addr.is_ipv6(),
+            "bound UDP socket family must match the requested address family"
+        );
+    }
+
     Ok(UdpSocket::from_std(sock.into()))
 }
 
@@ -1085,6 +1277,18 @@ pub fn udp_connect(backend: SocketAddr) -> Result<UdpSocket, ServerBindError> {
         SocketAddr::V4(_) => (std::net::Ipv4Addr::UNSPECIFIED, 0).into(),
         SocketAddr::V6(_) => (std::net::Ipv6Addr::UNSPECIFIED, 0).into(),
     };
+    // The ephemeral bind address must be in the backend's family with port 0,
+    // or the subsequent `connect` would mix families / pin a wrong local port.
+    debug_assert_eq!(
+        unspecified.is_ipv4(),
+        backend.is_ipv4(),
+        "ephemeral bind family must match the backend family"
+    );
+    debug_assert_eq!(
+        unspecified.port(),
+        0,
+        "ephemeral bind must use port 0 so the kernel picks the source port"
+    );
     let sock = Socket::new(
         Domain::for_address(backend),
         Type::DGRAM,
@@ -1100,6 +1304,41 @@ pub fn udp_connect(backend: SocketAddr) -> Result<UdpSocket, ServerBindError> {
     // connect on UDP completes immediately (no handshake).
     sock.connect(&backend.into())
         .map_err(ServerBindError::BindError)?;
+
+    // Post-conditions — assert the flag/connect state stuck (logic bug if not),
+    // degrading to a no-op when the kernel refuses the query so a dying fd never
+    // panics on this network-facing path.
+    if let Ok(nonblocking) = sock.nonblocking() {
+        debug_assert!(
+            nonblocking,
+            "udp_connect must return a non-blocking socket (the worker event loop is edge-triggered)"
+        );
+    }
+    // The connected return socket's local addr family must match the backend,
+    // and the kernel must have assigned a concrete source port (no longer 0).
+    if let Ok(local) = sock.local_addr() {
+        debug_assert_eq!(
+            local.is_ipv4(),
+            backend.is_ipv4(),
+            "connected UDP socket family must match the backend family"
+        );
+        if let Some(local) = local.as_socket() {
+            debug_assert_ne!(
+                local.port(),
+                0,
+                "connect must bind a concrete ephemeral source port (the return-demux key)"
+            );
+        }
+    }
+    // `connect` pinned the peer 4-tuple — `getpeername(2)` must echo the backend.
+    if let Ok(peer) = sock.peer_addr() {
+        if let Some(peer) = peer.as_socket() {
+            debug_assert_eq!(
+                peer, backend,
+                "connect must pin the peer to the requested backend (symmetric-NAT return-demux key)"
+            );
+        }
+    }
 
     Ok(UdpSocket::from_std(sock.into()))
 }
@@ -1147,7 +1386,8 @@ pub mod stats {
         // representation; zero-init satisfies `assume_init`'s invariant
         // (and `std::mem::zeroed` is the canonical idiom for that).
         let mut tcp_info: TcpInfo = unsafe { std::mem::zeroed() };
-        let mut len = std::mem::size_of::<TcpInfo>() as libc::socklen_t;
+        let struct_len = std::mem::size_of::<TcpInfo>() as libc::socklen_t;
+        let mut len = struct_len;
         // SAFETY: `tcp_info` and `len` are fully initialised above; libc
         // reads only `len` bytes through the pointer and writes back the
         // resulting length. We check the return value (`status != 0`) to
@@ -1161,7 +1401,19 @@ pub mod stats {
                 &mut len,
             )
         };
-        if status != 0 { None } else { Some(tcp_info) }
+        if status != 0 {
+            None
+        } else {
+            // The kernel writes back the number of bytes it populated. It must
+            // never claim to have written more than the buffer we handed it —
+            // that would mean it overran `tcp_info`, an out-of-bounds write we
+            // could not have detected by the return code alone.
+            debug_assert!(
+                len <= struct_len,
+                "getsockopt(TCP_INFO) wrote back len {len} > struct size {struct_len} (buffer overrun)"
+            );
+            Some(tcp_info)
+        }
     }
     #[cfg(not(unix))]
     pub fn socketinfo(fd: libc::c_int) -> Option<TcpInfo> {

--- a/lib/src/splice.rs
+++ b/lib/src/splice.rs
@@ -70,12 +70,20 @@ fn requested_pipe_capacity() -> usize {
 /// that `Pipe::check_connections` consumes to keep half-closed sessions
 /// alive while the kernel still owns the data.
 ///
-/// `capacity` is the realised kernel-pipe size in bytes after applying
+/// `capacity` is the nominal kernel-pipe size in bytes after applying
 /// the operator-requested capacity via `fcntl(F_SETPIPE_SZ)`. It may
 /// differ from the request: the kernel rounds up to a page boundary
 /// and clamps at `/proc/sys/fs/pipe-max-size` for unprivileged
 /// processes. `splice_in` uses this value as the per-call `len`, so a
 /// larger pipe means fewer syscalls under bulk-transfer load.
+///
+/// IMPORTANT: this is the *nominal* buffer size (what `F_GETPIPE_SZ`
+/// reports), NOT a hard cap on bytes in flight. `splice(2)` moves
+/// skb-backed segments by reference, so a single pipe ring slot can hold
+/// a GRO super-packet far larger than a page; the pipe's actual
+/// byte-occupancy (and thus `*_pipe_pending`) routinely *exceeds*
+/// `capacity` on loopback bulk transfers. Treat it as a soft backpressure
+/// threshold — never assert `pending <= capacity`.
 pub struct SplicePipe {
     pub in_pipe: [libc::c_int; 2],
     pub out_pipe: [libc::c_int; 2],

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -530,6 +530,13 @@ impl TcpSession {
     }
 
     fn set_back_token(&mut self, token: Token) {
+        // The frontend must own a token distinct from the backend's: the two
+        // index different slab slots, so wiring the same token to both would
+        // alias two sessions onto one slot.
+        debug_assert_ne!(
+            token, self.frontend_token,
+            "backend token must differ from the frontend token"
+        );
         self.backend_token = Some(token);
 
         match &mut self.state {
@@ -539,6 +546,15 @@ impl TcpSession {
             TcpStateMachine::ExpectProxyProtocol(_) => self.backend_token = Some(token),
             TcpStateMachine::FailedUpgrade(_) => unreachable!(),
         }
+
+        // Postcondition: the session now owns exactly the token it was asked
+        // to register — every arm above (including the Expect arm, which only
+        // stores the session-side token) leaves `backend_token == Some(token)`.
+        debug_assert_eq!(
+            self.backend_token,
+            Some(token),
+            "set_back_token must leave the session owning the registered token"
+        );
     }
 
     fn set_backend_id(&mut self, id: String) {
@@ -554,7 +570,24 @@ impl TcpSession {
 
     fn set_back_connected(&mut self, status: BackendConnectionStatus) {
         let last = self.backend_connected;
+        // Transitioning INTO `Connected` bumps the backend-connection gauge by
+        // exactly +1. Doing so from an already-`Connected` state would
+        // double-count (gauge drift that only `close_backend`'s single -1
+        // would later reconcile, leaving the gauge permanently +1). The
+        // promotion always comes from a `Connecting` (the normal handshake
+        // completion in `ready_inner`) — never from `Connected` itself.
+        debug_assert!(
+            status != BackendConnectionStatus::Connected
+                || last != BackendConnectionStatus::Connected,
+            "set_back_connected(Connected) must not run on an already-Connected backend (gauge would double-count)"
+        );
         self.backend_connected = status;
+
+        // Postcondition: the requested status is now in effect.
+        debug_assert_eq!(
+            self.backend_connected, status,
+            "set_back_connected must record the requested status"
+        );
 
         if status == BackendConnectionStatus::Connected {
             gauge_add!(names::backend::CONNECTIONS, 1);
@@ -622,6 +655,19 @@ impl TcpSession {
         }
 
         self.backend_token = None;
+
+        // Postcondition: the backend handle and its token are torn down
+        // together — neither may outlive the other (a dangling token would
+        // leave a stale slab reference; a dangling handle would over-count
+        // backend connections).
+        debug_assert!(
+            self.backend.is_none(),
+            "remove_backend must release the backend handle"
+        );
+        debug_assert!(
+            self.backend_token.is_none(),
+            "remove_backend must clear the backend token"
+        );
     }
 
     fn fail_backend_connection(&mut self) {
@@ -686,6 +732,67 @@ impl TcpSession {
     pub fn cancel_timeouts(&mut self) {
         self.container_frontend_timeout.cancel();
         self.container_backend_timeout.cancel();
+    }
+
+    /// Full cross-field invariant sweep for the TCP session state machine.
+    ///
+    /// Run as a run-to-completion postcondition at the END of `ready()` (the
+    /// only public entry point that drives the front/back token + readiness
+    /// state machine). These are OUR-logic invariants — never reachable from
+    /// hostile traffic — so a violation is a bug in Sōzu, not a malformed
+    /// peer. Compiled out in release.
+    #[cfg(debug_assertions)]
+    fn check_invariants(&self) {
+        // Connection-attempt budget: every retry path increments
+        // `connection_attempt` and `connect_to_backend` refuses once the
+        // counter reaches `CONN_RETRIES`, so the value can touch but never
+        // exceed the configured ceiling (and resets to 0 on success).
+        debug_assert!(
+            self.connection_attempt <= CONN_RETRIES,
+            "connection_attempt ({}) must never exceed CONN_RETRIES ({})",
+            self.connection_attempt,
+            CONN_RETRIES
+        );
+
+        // Token ownership: a fully-connected backend always owns a backend
+        // token (set by `set_back_token` during `connect_to_backend`, before
+        // the status can ever flip to `Connected`). The `Connecting` phase is
+        // deliberately excluded: there is a transient window inside
+        // `connect_to_backend` where the status is `Connecting` but the token
+        // has not been wired yet — that window never spans a `ready()`
+        // boundary, so the postcondition still holds here.
+        if self.backend_connected == BackendConnectionStatus::Connected {
+            debug_assert!(
+                self.backend_token.is_some(),
+                "a Connected backend must own a backend token"
+            );
+        }
+
+        // A live backend handle implies the matching token is present: the
+        // two are wired together in `connect_to_backend` and torn down
+        // together in `remove_backend` (which clears the token) — they must
+        // never drift apart. (For the pure-TCP proxy `backend` is currently
+        // always `None`, so this is a guard against a future regression that
+        // starts populating it without the token.)
+        if self.backend.is_some() {
+            debug_assert!(
+                self.backend_token.is_some(),
+                "a live backend handle must have a backend token"
+            );
+        }
+
+        // Once the session has been closed it is terminal: the backend has
+        // been released and the per-(cluster, source-IP) slot untracked.
+        if self.has_been_closed {
+            debug_assert!(
+                self.backend.is_none(),
+                "a closed session must have released its backend handle"
+            );
+            debug_assert!(
+                !self.cluster_ip_tracked,
+                "a closed session must have untracked its (cluster, source-IP) slot"
+            );
+        }
     }
 
     fn ready_inner(&mut self, session: Rc<RefCell<dyn ProxySession>>) -> SessionResult {
@@ -925,6 +1032,12 @@ impl TcpSession {
             }
         }
 
+        // The -1 here pairs with the +1 in `set_back_connected(Connected)`:
+        // we decrement the gauge exactly once, iff this session had actually
+        // reached `Connected`. A `Connecting`/`NotConnected` backend never
+        // bumped the gauge, so it must not decrement it either — that
+        // asymmetry would underflow the gauge (a correctness bug, never a
+        // rounding issue).
         if back_connected == BackendConnectionStatus::Connected {
             gauge_add!(names::backend::CONNECTIONS, -1);
             gauge_add!(
@@ -936,12 +1049,35 @@ impl TcpSession {
         }
 
         self.set_back_connected(BackendConnectionStatus::NotConnected);
+
+        // Postcondition: the backend is fully torn down — `remove_backend`
+        // cleared the token/handle above and the status is now `NotConnected`,
+        // so a subsequent `connect_to_backend` starts from a clean slate.
+        debug_assert_eq!(
+            self.backend_connected,
+            BackendConnectionStatus::NotConnected,
+            "close_backend must leave the backend NotConnected"
+        );
+        debug_assert!(
+            self.backend_token.is_none(),
+            "close_backend must clear the backend token"
+        );
     }
 
     fn connect_to_backend(
         &mut self,
         session_rc: Rc<RefCell<dyn ProxySession>>,
     ) -> Result<BackendConnectAction, BackendConnectionError> {
+        // Precondition: the retry budget can sit AT the ceiling (the gate
+        // below converts that into `MaxConnectionRetries`) but the increment
+        // in `ready_inner` must never have pushed it past `CONN_RETRIES`.
+        debug_assert!(
+            self.connection_attempt <= CONN_RETRIES,
+            "connection_attempt ({}) overflowed CONN_RETRIES ({}) before the retry gate",
+            self.connection_attempt,
+            CONN_RETRIES
+        );
+
         let cluster_id = self
             .listener
             .borrow()
@@ -1057,6 +1193,19 @@ impl TcpSession {
         self.metrics.backend_start();
         self.set_backend_id(backend.borrow().backend_id.clone());
 
+        // Postcondition of a successful New connect: the session is wired to
+        // its freshly-registered backend token and the status reflects an
+        // in-flight handshake (`Connecting`). The promotion to `Connected`
+        // happens later in `ready_inner` once the socket signals writable.
+        debug_assert!(
+            self.backend_token.is_some(),
+            "a New backend connection must own its backend token"
+        );
+        debug_assert!(
+            self.backend_connected.is_connecting(),
+            "a New backend connection must be in the Connecting state"
+        );
+
         Ok(BackendConnectAction::New)
     }
 }
@@ -1066,6 +1215,14 @@ impl ProxySession for TcpSession {
         if self.has_been_closed {
             return;
         }
+
+        // Past the idempotency guard the session is closing for the first
+        // time: every gauge-restore / untrack below must run exactly once, so
+        // re-entry on an already-closed session would double-decrement.
+        debug_assert!(
+            !self.has_been_closed,
+            "close() body must only run on a not-yet-closed session"
+        );
 
         // TODO: the state should handle the timeouts
         trace!("{} Closing TCP session", log_context!(self));
@@ -1144,9 +1301,31 @@ impl ProxySession for TcpSession {
 
         self.close_backend();
         self.has_been_closed = true;
+
+        // Postcondition of the normal close path: the session is terminal and
+        // every accounting slot has been released — `close_backend` cleared
+        // the backend token, and the per-(cluster, source-IP) untrack above
+        // reset the flag. The idempotency guard now short-circuits any repeat.
+        debug_assert!(self.has_been_closed, "close() must mark the session closed");
+        debug_assert!(
+            self.backend_token.is_none(),
+            "close() must leave no dangling backend token"
+        );
+        debug_assert!(
+            !self.cluster_ip_tracked,
+            "close() must untrack the (cluster, source-IP) slot"
+        );
     }
 
     fn timeout(&mut self, token: Token) -> SessionIsToBeClosed {
+        // The frontend and backend slots are distinct tokens, so the two
+        // dispatch arms below are mutually exclusive — a single token can
+        // never match both. (Obsolete tokens matching neither are tolerated
+        // and fall through to the `false` arm.)
+        debug_assert!(
+            self.backend_token != Some(self.frontend_token),
+            "frontend and backend tokens must never collide"
+        );
         if self.frontend_token == token {
             self.container_frontend_timeout.triggered();
             return true;
@@ -1198,6 +1377,14 @@ impl ProxySession for TcpSession {
         };
 
         self.metrics.service_stop();
+
+        // Run-to-completion postcondition: the front/back token + readiness
+        // state machine must satisfy its cross-field invariants after every
+        // `ready()` pass. Cfg-guarded so the call (and `check_invariants`
+        // itself) is absent from release builds.
+        #[cfg(debug_assertions)]
+        self.check_invariants();
+
         to_bo_closed
     }
 

--- a/lib/src/tls.rs
+++ b/lib/src/tls.rs
@@ -166,6 +166,27 @@ impl TryFrom<&AddCertificate> for CertifiedKeyWrapper {
         let private_key = PrivateKeyDer::from_pem_slice(cert.key.as_bytes())
             .map_err(|_| CertificateResolverError::EmptyKeys)?;
 
+        // Postconditions of chain assembly: the leaf was pushed first, so the
+        // chain is never empty and its head is exactly the parsed leaf DER.
+        // Dedup only ever *drops* entries it recognises as the leaf, so the
+        // assembled length can never exceed leaf + supplied links.
+        debug_assert!(
+            !chain.is_empty(),
+            "assembled certificate chain must contain at least the leaf"
+        );
+        debug_assert_eq!(
+            chain[0].as_ref(),
+            leaf_der.as_slice(),
+            "the leaf must remain at index 0 of the chain"
+        );
+        // SHA-256 fingerprint is exactly 32 bytes — anything else means the
+        // digest pipeline changed underneath us.
+        debug_assert_eq!(
+            fingerprint.0.len(),
+            32,
+            "a SHA-256 fingerprint must be 32 bytes"
+        );
+
         match any_supported_type(&private_key) {
             Ok(signing_key) => {
                 let stored_certificate = CertifiedKeyWrapper {
@@ -253,6 +274,17 @@ impl CertificateResolver {
             return Ok(cert_to_add.fingerprint);
         }
 
+        // Past the duplicate guard the fingerprint is genuinely new, so the
+        // store will grow by exactly one. Snapshot the count to assert that
+        // delta below (ungated `let` — read only inside the debug_assert, so
+        // the optimizer drops it in release while it still compiles).
+        let certificates_before = self.certificates.len();
+        let new_fingerprint = cert_to_add.fingerprint.clone();
+        debug_assert!(
+            !self.certificates.contains_key(&new_fingerprint),
+            "add_certificate past the dedup guard must be inserting a new fingerprint"
+        );
+
         for new_name in &cert_to_add.names {
             let fingerprints_for_this_name = self
                 .name_fingerprint_idx
@@ -288,6 +320,27 @@ impl CertificateResolver {
             .insert(cert_to_add.fingerprint.to_owned(), cert_to_add.clone());
         self.publish_min_expiration_gauge();
 
+        // Postconditions: the new fingerprint is now stored, the store grew by
+        // exactly one (the dedup guard above ruled out an overwrite), and
+        // every name the cert advertises now resolves to it through the index.
+        debug_assert!(
+            self.certificates.contains_key(&new_fingerprint),
+            "add_certificate must store the new certificate"
+        );
+        debug_assert_eq!(
+            self.certificates.len(),
+            certificates_before + 1,
+            "add_certificate must grow the store by exactly one"
+        );
+        debug_assert!(
+            cert_to_add.names.iter().all(|name| {
+                self.name_fingerprint_idx
+                    .get(name)
+                    .is_some_and(|fps| fps.iter().any(|(fp, _)| *fp == new_fingerprint))
+            }),
+            "every name of the added cert must be indexed to its fingerprint"
+        );
+
         trace!("{} {:#?}", log_module_context!(), self);
 
         Ok(cert_to_add.fingerprint)
@@ -299,7 +352,19 @@ impl CertificateResolver {
         &mut self,
         fingerprint: &Fingerprint,
     ) -> Result<(), CertificateResolverError> {
+        // Snapshot the store size so the postcondition can assert that a
+        // present cert drops the count by exactly one and an absent one is a
+        // no-op. Ungated `let`: read only inside the debug_asserts below, so
+        // it compiles in release and the optimizer drops it.
+        let certificates_before = self.certificates.len();
+        let was_present = self.certificates.contains_key(fingerprint);
+
         if let Some(certificate_to_remove) = self.get_certificate(fingerprint) {
+            // Names snapshot used only by the index-cleanup postcondition.
+            // Gate BOTH the `let` and its assert with `#[cfg(debug_assertions)]`
+            // so the clone never runs (and never warns) in release.
+            #[cfg(debug_assertions)]
+            let removed_names = certificate_to_remove.names.clone();
             for name in certificate_to_remove.names {
                 self.domains.domain_remove(&name.as_bytes().to_vec());
 
@@ -324,6 +389,40 @@ impl CertificateResolver {
 
             self.certificates.remove(fingerprint);
             self.publish_min_expiration_gauge();
+
+            // Postconditions on the present-cert path: the fingerprint is
+            // truly gone, the store shrank by exactly one, and no name still
+            // points at the removed fingerprint in the index (a leftover would
+            // let `resolve` hand back a fingerprint with no backing cert).
+            debug_assert!(
+                !self.certificates.contains_key(fingerprint),
+                "remove_certificate must evict the fingerprint"
+            );
+            debug_assert_eq!(
+                self.certificates.len(),
+                certificates_before - 1,
+                "removing a present cert must shrink the store by exactly one"
+            );
+            #[cfg(debug_assertions)]
+            debug_assert!(
+                removed_names.iter().all(|name| {
+                    self.name_fingerprint_idx
+                        .get(name)
+                        .is_none_or(|fps| fps.iter().all(|(fp, _)| fp != fingerprint))
+                }),
+                "no name may still index the removed fingerprint"
+            );
+        } else {
+            // Absent-cert path is a pure no-op: the store size is unchanged.
+            debug_assert!(
+                !was_present,
+                "the absent-cert branch must only run when the fingerprint was not stored"
+            );
+            debug_assert_eq!(
+                self.certificates.len(),
+                certificates_before,
+                "removing an absent cert must not change the store"
+            );
         }
         trace!("{} {:#?}", log_module_context!(), self);
 
@@ -362,14 +461,33 @@ impl CertificateResolver {
 
         if let Ok(old_fingerprint) = Fingerprint::from_str(&replace.old_fingerprint) {
             if old_fingerprint == new_fingerprint {
+                // Idempotent replace: the new cert is byte-identical to the
+                // one already serving this name. Removing `old == new` would
+                // delete the entry the caller meant to keep, so we must NOT
+                // touch the store — assert it is untouched on this path.
+                let stored_before = self.certificates.contains_key(&new_fingerprint);
                 // Re-publish the expiration gauge so dashboards observe the
                 // replace request even when the certificate set is unchanged.
                 self.publish_min_expiration_gauge();
+                debug_assert_eq!(
+                    self.certificates.contains_key(&new_fingerprint),
+                    stored_before,
+                    "idempotent replace must not change whether the cert is stored"
+                );
                 return Ok(new_fingerprint);
             }
         }
 
         let new_fingerprint = self.add_certificate(&add)?;
+
+        // After a non-idempotent add the new certificate is in the store,
+        // ready to serve handshakes before the old one is torn down (the
+        // add-before-remove ordering that keeps the name continuously
+        // resolvable).
+        debug_assert!(
+            self.certificates.contains_key(&new_fingerprint),
+            "the replacement certificate must be stored before the old one is removed"
+        );
 
         match Fingerprint::from_str(&replace.old_fingerprint) {
             Ok(old_fingerprint) => self.remove_certificate(&old_fingerprint)?,
@@ -501,10 +619,26 @@ impl ResolvesServerCert for MutexCertificateResolver {
                 fingerprint
             );
 
+            // Strict-binding invariant: when the SNI trie resolves a name to a
+            // fingerprint, the served cert is exactly the one stored under
+            // that fingerprint — never a substitute. This guards cert
+            // SELECTION (our own store consistency), not the peer-supplied SNI
+            // itself, so a `debug_assert` is correct here (a violation is a
+            // resolver bug, not hostile traffic). The cert may legitimately be
+            // `None` if the trie still indexes a fingerprint whose cert was
+            // concurrently removed; we only assert the positive case.
             let cert = resolver
                 .certificates
                 .get(fingerprint)
                 .map(|cert| cert.inner.clone());
+            debug_assert!(
+                cert.is_none()
+                    || resolver
+                        .certificates
+                        .get(fingerprint)
+                        .is_some_and(|stored| Arc::ptr_eq(&stored.inner, cert.as_ref().unwrap())),
+                "resolved certificate must be the one stored under the looked-up fingerprint"
+            );
 
             trace!(
                 "{} found for fingerprint {}: {}",


### PR DESCRIPTION
## Summary

Apply **TigerBeetle "TigerStyle" assertion density** across Sōzu's `lib` crate — the event-loop protocols and
data plane. Assertions turn silent correctness bugs into loud crashes that the test/fuzz/simulation suites catch
immediately, at zero release cost.

Every assertion is `debug_assert!`/`debug_assert_eq!`/`debug_assert_ne!` — **compiled out in release**, live in
every test/fuzz/dev build. **No behavior, wire-byte, or error-handling change**: invalid network input still
becomes a returned error / GOAWAY / RST_STREAM / default answer / close, never a panic. `debug_assert!` is reserved
for our own invariant violations.

This is the `lib` protocol + data-plane portion of a staged sweep (server/control-plane/bin to follow).

## Real bug fixed

A post-insert reachability assertion in the router exposed a **pre-existing arithmetic-underflow panic** in the
pattern trie: `lookup_mut` and the `insert_recursive` dedup loop did `partial_key[..pos - 1]` unconditionally, so a
hostname whose **leftmost segment is a regex** (e.g. `/test[0-9]/.example.com`) reached the recursion with
`pos == 0` → `pos - 1` wraps to `usize::MAX` → slice-index panic. Reachable in production by re-inserting or
removing/re-adding such a frontend (a config-plane crash). Fixed at the root (guard `pos == 0`, matching the
existing create/remove special-casing) + regression test. No routing change for any non-crashing input.

## What's covered

| Area | Files | Highlights |
|---|---|---|
| H2/H1 mux | `protocol/mux/{parser,serializer,pkawa,h2,h1,connection,stream}.rs` | `check_invariants()` on the H2 connection (stream-id watermark, RST/window-update caps); flood-detector (CVE-2023-44487 / -2024-27316 / -2025-8671) counter/threshold bounds; flow-control no-underflow; HPACK budget + pseudo-header invariants; parser never grows input |
| H1 sessions/answers | `protocol/kawa_h1/{mod,editor,answers}.rs` | session `check_invariants()`; **CR/LF header-injection guards (CWE-93/113)**; CL/answer-template invariants (≤1 Content-Length, CWE-444); byte accounting |
| Relay / TLS / PROXY | `protocol/{pipe,rustls}.rs`, `protocol/proxy_protocol/*` | no-`Shutdown::Both` write-only-close discipline; rustls handshake monotonicity; oversized/partial PROXY-header bounds + v2 length reconciliation |
| L4/L7 edges | `tcp.rs`, `tls.rs`, `http.rs`, `https.rs` | session `check_invariants()`; legal one-way upgrade chains; front-token==slab-key, back-token iff connected; gauge ±1 pairing; strict-SNI cert binding |
| Routing | `router/{mod,pattern_trie}.rs` | trie `check_invariants()` (no stranded subtree, value count == inserts−removes); wildcard precedence; **the underflow fix above** |
| Pool / health / crypto | `pool.rs`, `health_check.rs`, `crypto.rs` | Pool + Checkout `check_invariants()` (`available+checked_out==capacity`) + checkin underflow guard; rise/fall hysteresis bounds; provider-precedence `cfg!` relationships |
| Metrics | `metrics/{mod,local_drain,network_drain}.rs` | the canonical **gauge-underflow saturation-boundary** postcondition; counter monotonicity; count/sum/min/max/percentile consistency; map + lease accounting |

~930 assertions across 29 files; ~12 `check_invariants()` state-machine post-conditions.

## A key correctness note (and a lesson encoded for the future)

`debug_assert!` **compiles its arguments in every profile** — it gates only runtime execution. So a snapshot read
inside a `debug_assert!` must not be `#[cfg(debug_assertions)]`-gated, or release/bench builds fail (E0425). Every
agent in this sweep validated with a **release compile gate** (`cargo check --release`) precisely to catch that class.

## Validation

```
cargo build  -p sozu-lib --no-default-features --features crypto-ring        # debug, asserts live
cargo check  -p sozu-lib --release --no-default-features --features crypto-ring   # E0425 guard — clean
cargo clippy -p sozu-lib --all-targets --no-default-features --features crypto-ring -- -D warnings   # clean
cargo test   -p sozu-lib --no-default-features --features crypto-ring        # 596 passed, 4 ignored
cargo +nightly fmt -p sozu-lib -- --check                                    # clean
```

No assertion fired on the existing suite except one over-strict assert (a role-parity contract on an arbitrary
saturated stream-id), corrected during the sweep. The one real bug (trie underflow) is fixed with a regression test.

## Scope / follow-up

This PR is the `lib` protocol + data-plane layer. Still to sweep (staged): the server event loop (`server.rs`),
sockets/backends/load-balancing/`lib.rs` (these overlap the in-flight UDP PR #1274 — sweep after it merges to avoid
conflicts), the `command` control-plane (channel/scm/state/config), and the `bin` supervisor.
