### PR TITLE
fix(ci): install cargo-fuzz under nightly, not the 1.88.0 override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,8 +207,13 @@ jobs:
           prefix-key: ci-fuzz
           workspaces: . -> target/
 
+      # `+nightly` is REQUIRED here: the repo's `rust-toolchain` file pins
+      # 1.88.0, and that directory override beats the nightly default installed
+      # above. Without the explicit toolchain, `cargo install` runs under 1.88.0
+      # and cargo-fuzz's locked dep tree (cargo-platform 0.3.3, rust-version
+      # 1.91) fails the MSRV gate. The fuzz steps below use `cargo +nightly`.
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
+        run: cargo +nightly install cargo-fuzz --locked
 
       # 300s per target × 3 targets = ~15 min wall, fits inside the
       # 30-min timeout with ~15 min slack for libFuzzer warm-up and

--- a/.github/workflows/simulation-sweep.yml
+++ b/.github/workflows/simulation-sweep.yml
@@ -106,8 +106,13 @@ jobs:
           prefix-key: sim-sweep-fuzz
           workspaces: . -> target/
 
+      # `+nightly` is REQUIRED here: the repo's `rust-toolchain` file pins
+      # 1.88.0, and that directory override beats the nightly default installed
+      # above. Without the explicit toolchain, `cargo install` runs under 1.88.0
+      # and cargo-fuzz's locked dep tree (cargo-platform 0.3.3, rust-version
+      # 1.91) fails the MSRV gate. The fuzz step below uses `cargo +nightly`.
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
+        run: cargo +nightly install cargo-fuzz --locked
 
       - name: Fuzz ${{ matrix.target }}
         working-directory: fuzz


### PR DESCRIPTION
## Problem

The fuzz jobs are red on `main`, in two workflows:

- **CI** (`ci.yml`) — the `Fuzz (nightly)` job fails on every push/PR.
- **Simulation sweep** (`simulation-sweep.yml`) — all three daily `Extended fuzz` jobs (`fuzz_frame_parser`, `fuzz_hpack_decoder`, `fuzz_udp_flow`) fail.

Both fail with:

```
error: failed to compile `cargo-fuzz v0.13.2`
  rustc 1.88.0 is not supported by the following package:
    cargo-platform@0.3.3 requires rustc 1.91
```

## Root cause

Both jobs install nightly via `dtolnay/rust-toolchain@nightly`, which only sets `rustup default`. The repo's `rust-toolchain` file pins `1.88.0`, and a directory toolchain file outranks `rustup default` in rustup's selection order. So the un-prefixed `cargo install cargo-fuzz --locked` step ran under **1.88.0**, even though the actual `cargo +nightly fuzz run` steps ran under nightly.

`cargo-fuzz` 0.13.2's locked dependency tree now pulls `cargo-platform 0.3.3` (`rust-version = 1.91`), which the 1.88.0 MSRV-aware resolver rejects. `--locked` does not bypass the gate — it checks against the locked versions. The failure is a time-bomb: it only appeared once that transitive dep published its 1.91 bump.

## Fix

Pin the install to nightly in both workflows so it stops inheriting the `rust-toolchain` pin:

```diff
-        run: cargo install cargo-fuzz --locked
+        run: cargo +nightly install cargo-fuzz --locked
```

A comment is added at each site explaining the toolchain-override gotcha.

## Validation

- Reproduced locally: `cargo install cargo-fuzz --locked` from the repo root fails identically (the `rust-toolchain` file forces 1.88.0).
- Verified the fix: `cargo +nightly install cargo-fuzz --locked` clears the MSRV gate — `cargo-platform`, `cargo_metadata`, and `cargo-fuzz` all compile.
- Both workflow YAML files re-validated.

## Scope / impact

- CI-only change; no library, protocol, or security code touched.
- The `cargo install cargo-audit` step (cargo-audit job) is intentionally left as-is: that job runs under `dtolnay/rust-toolchain@1.88.0`, matching the pin, and stays green.