### PR TITLE
fix(pipe): rearm websocket response writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@
   `manual_is_multiple_of`, `derivable_impls`, `mismatched_lifetime_syntaxes`)
   surfaced across `lib`/`command`/`bin` by the MSRV bump. No behavior change.
 
+### 🐛 Fixed
+
+- **`fix(pipe)`: WebSocket/WSS server-first frames are flushed after `101 Switching Protocols`.**
+  The post-upgrade pipe now arms writable readiness when bytes enter either
+  sozu-owned direction buffer, so edge-triggered epoll cannot park a backend
+  frame such as Pusher/Reverb `connection_established` until the client sends
+  its first WebSocket frame.
+
 ### 🤖 CI
 
 - **`ci(sim)`: the moonpool `sozu-sim` sweep is the sole UDP swarm.** A per-PR

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2986,25 +2986,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
@@ -3066,24 +3051,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
  "futures-executor",
  "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/e2e/src/tests/mux_tests.rs
+++ b/e2e/src/tests/mux_tests.rs
@@ -313,6 +313,81 @@ fn test_websocket_upgrade() {
     );
 }
 
+fn try_websocket_server_speaks_first_after_upgrade() -> State {
+    let front_address = create_local_address();
+
+    let (config, listeners, state) = Worker::empty_config();
+    let (mut worker, mut backends) = setup_sync_test(
+        "WS-SERVER-FIRST",
+        config,
+        listeners,
+        state,
+        front_address,
+        1,
+        false,
+    );
+    let mut backend = backends.pop().unwrap();
+    backend.set_response(
+        "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
+    );
+    backend.connect();
+
+    let mut client = Client::new(
+        "ws-server-first-client",
+        front_address,
+        "GET /ws HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+    );
+    client.connect();
+    client.send();
+    backend.accept(0);
+    backend.receive(0);
+    backend.send(0);
+
+    let response = match client.receive() {
+        Some(response) if response.contains("101") => response,
+        other => {
+            println!("unexpected upgrade response: {other:?}");
+            worker.soft_stop();
+            worker.wait_for_server_stop();
+            return State::Fail;
+        }
+    };
+    if response.contains("server-speaks-first") {
+        worker.soft_stop();
+        worker.wait_for_server_stop();
+        return State::Success;
+    }
+
+    backend.set_response("server-speaks-first");
+    backend.send(0);
+
+    match client.receive() {
+        Some(data) if data.contains("server-speaks-first") => {
+            worker.soft_stop();
+            worker.wait_for_server_stop();
+            State::Success
+        }
+        other => {
+            println!("server-first payload was not flushed before client data: {other:?}");
+            worker.soft_stop();
+            worker.wait_for_server_stop();
+            State::Fail
+        }
+    }
+}
+
+#[test]
+fn test_websocket_server_speaks_first_after_upgrade() {
+    assert_eq!(
+        repeat_until_error_or(
+            10,
+            "WebSocket server-speaks-first payload after 101",
+            try_websocket_server_speaks_first_after_upgrade,
+        ),
+        State::Success,
+    );
+}
+
 // =========================================================================
 // Test 3: Rapid connect-disconnect without proxy protocol
 // =========================================================================

--- a/e2e/src/tests/tls_tests.rs
+++ b/e2e/src/tests/tls_tests.rs
@@ -8,7 +8,7 @@
 //! - Connection: close header with proper TLS teardown
 
 use std::{
-    io::{Read, Write},
+    io::{ErrorKind, Read, Write},
     net::{SocketAddr, TcpStream},
     sync::{
         Arc,
@@ -38,6 +38,11 @@ use crate::{
     sozu::worker::Worker,
     tests::{State, provide_port, repeat_until_error_or, tests::create_local_address},
 };
+
+const PUSHER_CONNECTION_ESTABLISHED: &str =
+    r#"{"event":"pusher:connection_established","data":"{}"}"#;
+const PUSHER_PING: &str = r#"{"event":"pusher:ping","data":"{}"}"#;
+const PUSHER_PONG: &str = r#"{"event":"pusher:pong","data":"{}"}"#;
 
 struct BlockingHttpBackend {
     stop: Arc<AtomicBool>,
@@ -113,6 +118,92 @@ impl BlockingHttpBackend {
             let _ = thread.join();
         }
     }
+}
+
+fn websocket_text_frame(payload: &str) -> Vec<u8> {
+    let payload = payload.as_bytes();
+    let mut frame = Vec::with_capacity(payload.len() + 4);
+    frame.push(0x81);
+    if payload.len() <= 125 {
+        frame.push(payload.len() as u8);
+    } else {
+        debug_assert!(u16::try_from(payload.len()).is_ok());
+        frame.push(126);
+        frame.extend_from_slice(&(payload.len() as u16).to_be_bytes());
+    }
+    frame.extend_from_slice(payload);
+    frame
+}
+
+fn masked_websocket_text_frame(payload: &str) -> Vec<u8> {
+    let payload = payload.as_bytes();
+    let mask = [0x12, 0x34, 0x56, 0x78];
+    let mut frame = Vec::with_capacity(payload.len() + 8);
+    frame.push(0x81);
+    if payload.len() <= 125 {
+        frame.push(0x80 | payload.len() as u8);
+    } else {
+        debug_assert!(u16::try_from(payload.len()).is_ok());
+        frame.push(0x80 | 126);
+        frame.extend_from_slice(&(payload.len() as u16).to_be_bytes());
+    }
+    frame.extend_from_slice(&mask);
+    for (idx, byte) in payload.iter().enumerate() {
+        frame.push(byte ^ mask[idx % mask.len()]);
+    }
+    frame
+}
+
+fn bytes_contain(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
+}
+
+fn backend_send_bytes(backend: &mut SyncBackend, client_id: usize, bytes: &[u8]) -> bool {
+    match backend.clients.get_mut(&client_id) {
+        Some(stream) => stream.write_all(bytes).is_ok() && stream.flush().is_ok(),
+        None => false,
+    }
+}
+
+fn backend_read_bytes(backend: &mut SyncBackend, client_id: usize) -> Option<Vec<u8>> {
+    let mut buf = [0u8; 4096];
+    match backend.clients.get_mut(&client_id)?.read(&mut buf) {
+        Ok(n) if n > 0 => Some(buf[..n].to_vec()),
+        _ => None,
+    }
+}
+
+fn read_tls_until_contains_all(
+    tls_stream: &mut rustls::StreamOwned<rustls::ClientConnection, TcpStream>,
+    needles: &[&[u8]],
+) -> Option<Vec<u8>> {
+    let mut received = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut buf = [0u8; 4096];
+
+    while Instant::now() < deadline {
+        match tls_stream.read(&mut buf) {
+            Ok(0) => return None,
+            Ok(n) => {
+                received.extend_from_slice(&buf[..n]);
+                if needles
+                    .iter()
+                    .all(|needle| bytes_contain(&received, needle))
+                {
+                    return Some(received);
+                }
+            }
+            Err(error) if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {}
+            Err(error) => {
+                println!("TLS read failed while waiting for WebSocket frame: {error}");
+                return None;
+            }
+        }
+    }
+
+    None
 }
 
 impl Drop for BlockingHttpBackend {
@@ -1178,9 +1269,9 @@ fn try_wss_server_speaks_first_after_upgrade() -> State {
     backend.receive(0);
     backend.send(0);
 
-    let mut buf = [0u8; 4096];
-    let upgrade = match tls_stream.read(&mut buf) {
-        Ok(n) if n > 0 => String::from_utf8_lossy(&buf[..n]).to_string(),
+    let upgrade = match read_tls_until_contains_all(&mut tls_stream, &[b"101 Switching Protocols"])
+    {
+        Some(upgrade) => upgrade,
         other => {
             println!("unexpected WSS upgrade read: {other:?}");
             worker.soft_stop();
@@ -1188,31 +1279,24 @@ fn try_wss_server_speaks_first_after_upgrade() -> State {
             return State::Fail;
         }
     };
-    if !upgrade.contains("101") {
-        println!("unexpected WSS upgrade response: {upgrade:?}");
-        worker.soft_stop();
-        worker.wait_for_server_stop();
-        return State::Fail;
-    }
-    if upgrade.contains("server-speaks-first") {
+    if bytes_contain(&upgrade, PUSHER_CONNECTION_ESTABLISHED.as_bytes()) {
         worker.soft_stop();
         worker.wait_for_server_stop();
         return State::Success;
     }
 
-    backend.set_response("server-speaks-first");
-    backend.send(0);
+    thread::sleep(Duration::from_millis(50));
 
-    let result = match tls_stream.read(&mut buf) {
-        Ok(n) if n > 0 => {
-            let data = String::from_utf8_lossy(&buf[..n]);
-            data.contains("server-speaks-first")
-        }
-        other => {
-            println!("server-first WSS payload was not flushed before client data: {other:?}");
-            false
-        }
-    };
+    let connection_established = websocket_text_frame(PUSHER_CONNECTION_ESTABLISHED);
+    let result = backend_send_bytes(&mut backend, 0, &connection_established)
+        && read_tls_until_contains_all(
+            &mut tls_stream,
+            &[PUSHER_CONNECTION_ESTABLISHED.as_bytes()],
+        )
+        .is_some();
+    if !result {
+        println!("server-first WSS frame was not flushed before client data");
+    }
 
     worker.soft_stop();
     let stopped = worker.wait_for_server_stop();
@@ -1231,6 +1315,160 @@ fn test_wss_server_speaks_first_after_upgrade() {
             10,
             "WSS server-speaks-first payload after 101",
             try_wss_server_speaks_first_after_upgrade,
+        ),
+        State::Success,
+    );
+}
+
+fn try_wss_client_frame_after_upgrade_receives_pusher_pong() -> State {
+    let front_port = provide_port();
+    let front_address = SocketAddress::new_v4(127, 0, 0, 1, front_port);
+    let back_address = create_local_address();
+
+    let (config, listeners, state) = Worker::empty_https_config(front_address.clone().into());
+    let mut worker =
+        Worker::start_new_worker_owned("WSS-PUSHER-PING-PONG", config, listeners, state);
+
+    worker.send_proxy_request_type(RequestType::AddHttpsListener(
+        ListenerBuilder::new_https(front_address.clone())
+            .to_tls(None)
+            .unwrap(),
+    ));
+    worker.send_proxy_request_type(RequestType::ActivateListener(ActivateListener {
+        address: front_address.clone(),
+        proxy: ListenerType::Https.into(),
+        from_scm: false,
+    }));
+    worker.send_proxy_request_type(RequestType::AddCluster(Worker::default_cluster(
+        "cluster_0",
+    )));
+    worker.send_proxy_request_type(RequestType::AddHttpsFrontend(RequestHttpFrontend {
+        hostname: "localhost".to_owned(),
+        ..Worker::default_http_frontend("cluster_0", front_address.clone().into())
+    }));
+
+    let certificate_and_key = CertificateAndKey {
+        certificate: String::from(include_str!("../../../lib/assets/local-certificate.pem")),
+        key: String::from(include_str!("../../../lib/assets/local-key.pem")),
+        certificate_chain: vec![],
+        versions: vec![],
+        names: vec![],
+    };
+    worker.send_proxy_request_type(RequestType::AddCertificate(AddCertificate {
+        address: front_address,
+        certificate: certificate_and_key,
+        expired_at: None,
+    }));
+    worker.send_proxy_request_type(RequestType::AddBackend(Worker::default_backend(
+        "cluster_0",
+        "cluster_0-0",
+        back_address,
+        None,
+    )));
+    worker.read_to_last();
+
+    let mut backend = SyncBackend::new(
+        "BACKEND_0",
+        back_address,
+        "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
+    );
+    backend.connect();
+
+    let tls_config = {
+        let mut config = ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(Verifier))
+            .with_no_client_auth();
+        config.alpn_protocols = vec![b"http/1.1".to_vec()];
+        config
+    };
+    let server_name = rustls::pki_types::ServerName::try_from("localhost").unwrap();
+    let conn = rustls::ClientConnection::new(Arc::new(tls_config), server_name.to_owned()).unwrap();
+    let addr: SocketAddr = format!("127.0.0.1:{front_port}").parse().unwrap();
+    let tcp = TcpStream::connect_timeout(&addr, Duration::from_secs(5)).unwrap();
+    tcp.set_read_timeout(Some(Duration::from_millis(500))).ok();
+    tcp.set_write_timeout(Some(Duration::from_millis(500))).ok();
+    let mut tls_stream = rustls::StreamOwned::new(conn, tcp);
+
+    let request = "GET /ws HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n";
+    if tls_stream.write_all(request.as_bytes()).is_err() {
+        worker.soft_stop();
+        worker.wait_for_server_stop();
+        return State::Fail;
+    }
+    tls_stream.flush().ok();
+
+    backend.accept(0);
+    backend.receive(0);
+    backend.send(0);
+
+    if read_tls_until_contains_all(&mut tls_stream, &[b"101 Switching Protocols"]).is_none() {
+        println!("client did not receive WSS 101 before sending pusher ping");
+        worker.soft_stop();
+        worker.wait_for_server_stop();
+        return State::Fail;
+    }
+
+    let connection_established = websocket_text_frame(PUSHER_CONNECTION_ESTABLISHED);
+    if !backend_send_bytes(&mut backend, 0, &connection_established) {
+        println!("backend could not send pusher connection_established frame");
+        worker.soft_stop();
+        worker.wait_for_server_stop();
+        return State::Fail;
+    }
+
+    let ping = masked_websocket_text_frame(PUSHER_PING);
+    if tls_stream.write_all(&ping).is_err() || tls_stream.flush().is_err() {
+        println!("client could not send masked pusher ping frame");
+        worker.soft_stop();
+        worker.wait_for_server_stop();
+        return State::Fail;
+    }
+
+    let backend_received_ping =
+        backend_read_bytes(&mut backend, 0)
+            .as_ref()
+            .is_some_and(|received| {
+                received.first() == Some(&0x81) && received.get(1).is_some_and(|b| b & 0x80 != 0)
+            });
+    if !backend_received_ping {
+        println!("backend did not receive a masked websocket text frame from client");
+        worker.soft_stop();
+        worker.wait_for_server_stop();
+        return State::Fail;
+    }
+
+    let pong = websocket_text_frame(PUSHER_PONG);
+    let result = backend_send_bytes(&mut backend, 0, &pong)
+        && read_tls_until_contains_all(
+            &mut tls_stream,
+            &[
+                PUSHER_CONNECTION_ESTABLISHED.as_bytes(),
+                PUSHER_PONG.as_bytes(),
+            ],
+        )
+        .is_some();
+    if !result {
+        println!("client did not receive both pusher connection_established and pong frames");
+    }
+
+    worker.soft_stop();
+    let stopped = worker.wait_for_server_stop();
+
+    if result && stopped {
+        State::Success
+    } else {
+        State::Fail
+    }
+}
+
+#[test]
+fn test_wss_client_frame_after_upgrade_receives_pusher_pong() {
+    assert_eq!(
+        repeat_until_error_or(
+            10,
+            "WSS client pusher ping after 101 receives pusher pong",
+            try_wss_client_frame_after_upgrade_receives_pusher_pong,
         ),
         State::Success,
     );

--- a/e2e/src/tests/tls_tests.rs
+++ b/e2e/src/tests/tls_tests.rs
@@ -32,6 +32,7 @@ use crate::{
         aggregator::SimpleAggregator,
         async_backend::BackendHandle as AsyncBackend,
         https_client::{Verifier, build_h2_client, build_https_client, resolve_request},
+        sync_backend::Backend as SyncBackend,
     },
     port_registry::bind_std_listener,
     sozu::worker::Worker,
@@ -1093,6 +1094,145 @@ fn test_tls_connection_close_large_response() {
             try_tls_connection_close_large_response
         ),
         State::Success
+    );
+}
+
+fn try_wss_server_speaks_first_after_upgrade() -> State {
+    let front_port = provide_port();
+    let front_address = SocketAddress::new_v4(127, 0, 0, 1, front_port);
+    let back_address = create_local_address();
+
+    let (config, listeners, state) = Worker::empty_https_config(front_address.clone().into());
+    let mut worker = Worker::start_new_worker_owned("WSS-SERVER-FIRST", config, listeners, state);
+
+    worker.send_proxy_request_type(RequestType::AddHttpsListener(
+        ListenerBuilder::new_https(front_address.clone())
+            .to_tls(None)
+            .unwrap(),
+    ));
+    worker.send_proxy_request_type(RequestType::ActivateListener(ActivateListener {
+        address: front_address.clone(),
+        proxy: ListenerType::Https.into(),
+        from_scm: false,
+    }));
+    worker.send_proxy_request_type(RequestType::AddCluster(Worker::default_cluster(
+        "cluster_0",
+    )));
+    worker.send_proxy_request_type(RequestType::AddHttpsFrontend(RequestHttpFrontend {
+        hostname: "localhost".to_owned(),
+        ..Worker::default_http_frontend("cluster_0", front_address.clone().into())
+    }));
+
+    let certificate_and_key = CertificateAndKey {
+        certificate: String::from(include_str!("../../../lib/assets/local-certificate.pem")),
+        key: String::from(include_str!("../../../lib/assets/local-key.pem")),
+        certificate_chain: vec![],
+        versions: vec![],
+        names: vec![],
+    };
+    worker.send_proxy_request_type(RequestType::AddCertificate(AddCertificate {
+        address: front_address,
+        certificate: certificate_and_key,
+        expired_at: None,
+    }));
+    worker.send_proxy_request_type(RequestType::AddBackend(Worker::default_backend(
+        "cluster_0",
+        "cluster_0-0",
+        back_address,
+        None,
+    )));
+    worker.read_to_last();
+
+    let mut backend = SyncBackend::new(
+        "BACKEND_0",
+        back_address,
+        "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
+    );
+    backend.connect();
+
+    let tls_config = {
+        let mut config = ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(Verifier))
+            .with_no_client_auth();
+        config.alpn_protocols = vec![b"http/1.1".to_vec()];
+        config
+    };
+    let server_name = rustls::pki_types::ServerName::try_from("localhost").unwrap();
+    let conn = rustls::ClientConnection::new(Arc::new(tls_config), server_name.to_owned()).unwrap();
+    let addr: SocketAddr = format!("127.0.0.1:{front_port}").parse().unwrap();
+    let tcp = TcpStream::connect_timeout(&addr, Duration::from_secs(5)).unwrap();
+    tcp.set_read_timeout(Some(Duration::from_millis(500))).ok();
+    tcp.set_write_timeout(Some(Duration::from_millis(500))).ok();
+    let mut tls_stream = rustls::StreamOwned::new(conn, tcp);
+
+    let request = "GET /ws HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n";
+    if tls_stream.write_all(request.as_bytes()).is_err() {
+        worker.soft_stop();
+        worker.wait_for_server_stop();
+        return State::Fail;
+    }
+    tls_stream.flush().ok();
+
+    backend.accept(0);
+    backend.receive(0);
+    backend.send(0);
+
+    let mut buf = [0u8; 4096];
+    let upgrade = match tls_stream.read(&mut buf) {
+        Ok(n) if n > 0 => String::from_utf8_lossy(&buf[..n]).to_string(),
+        other => {
+            println!("unexpected WSS upgrade read: {other:?}");
+            worker.soft_stop();
+            worker.wait_for_server_stop();
+            return State::Fail;
+        }
+    };
+    if !upgrade.contains("101") {
+        println!("unexpected WSS upgrade response: {upgrade:?}");
+        worker.soft_stop();
+        worker.wait_for_server_stop();
+        return State::Fail;
+    }
+    if upgrade.contains("server-speaks-first") {
+        worker.soft_stop();
+        worker.wait_for_server_stop();
+        return State::Success;
+    }
+
+    backend.set_response("server-speaks-first");
+    backend.send(0);
+
+    let result = match tls_stream.read(&mut buf) {
+        Ok(n) if n > 0 => {
+            let data = String::from_utf8_lossy(&buf[..n]);
+            data.contains("server-speaks-first")
+        }
+        other => {
+            println!("server-first WSS payload was not flushed before client data: {other:?}");
+            false
+        }
+    };
+
+    worker.soft_stop();
+    let stopped = worker.wait_for_server_stop();
+
+    if result && stopped {
+        State::Success
+    } else {
+        State::Fail
+    }
+}
+
+#[test]
+fn test_wss_server_speaks_first_after_upgrade() {
+    assert_eq!(
+        repeat_until_error_or(
+            10,
+            "WSS server-speaks-first payload after 101",
+            try_wss_server_speaks_first_after_upgrade,
+        ),
+        State::Success,
     );
 }
 

--- a/lib/src/protocol/pipe.rs
+++ b/lib/src/protocol/pipe.rs
@@ -1,10 +1,11 @@
 //! Transparent byte-stream forwarder (TCP + WebSocket post-upgrade).
 //!
 //! Forwards bytes between front and back through fixed-size buffers without
-//! payload inspection. Readiness is managed via direct mio interest toggles
-//! (no `signal_pending_write` / `arm_writable` here — those belong to the
-//! mux H2 path). Used as the post-handshake state for raw TCP listeners and
-//! after a successful WebSocket upgrade on the H1 path.
+//! payload inspection. When bytes enter a sozu-owned buffer, the opposite
+//! endpoint is armed via `Readiness::arm_writable()` so edge-triggered epoll
+//! cannot park buffered data behind a missing writable edge. Used as the
+//! post-handshake state for raw TCP listeners and after a successful WebSocket
+//! upgrade on the H1 path.
 
 use std::{cell::RefCell, net::SocketAddr, rc::Rc};
 
@@ -529,7 +530,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
                 "{} Pipe::backend_hup: backend connection closed, keeping alive due to inflight data in buffers.",
                 log_context!(self)
             );
-            self.frontend_readiness.interest.insert(Ready::WRITABLE);
+            self.frontend_readiness.arm_writable();
             if self.backend_readiness.event.is_readable() {
                 self.backend_readiness.interest.insert(Ready::READABLE);
             }
@@ -870,7 +871,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
                 self.backend_readiness.event.remove(Ready::READABLE);
             }
             if size > 0 {
-                self.frontend_readiness.interest.insert(Ready::WRITABLE);
+                self.frontend_readiness.arm_writable();
                 count!(names::backend::BACK_BYTES_IN, size as i64);
                 metrics.backend_bin += size;
                 // Backend→proxy ingress metric advances by exactly bytes read.
@@ -1222,7 +1223,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
         if self.splice_out_pending() >= capacity {
             // Pipe is full — stop reading and let the frontend drain it.
             self.backend_readiness.interest.remove(Ready::READABLE);
-            self.frontend_readiness.interest.insert(Ready::WRITABLE);
+            self.frontend_readiness.arm_writable();
             return SessionResult::Continue;
         }
 
@@ -1256,7 +1257,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
                 pending_before + size,
                 "out_pipe_pending must grow by exactly the spliced bytes"
             );
-            self.frontend_readiness.interest.insert(Ready::WRITABLE);
+            self.frontend_readiness.arm_writable();
             count!(names::backend::BACK_BYTES_IN, size as i64);
             metrics.backend_bin += size;
             debug_assert_eq!(
@@ -1488,5 +1489,110 @@ impl<Front: SocketHandler, L: ListenerHandler> SessionState for Pipe<Front, L> {
             self.backend_token,
             self.backend_readiness
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        io::Write,
+        net::{TcpListener as StdTcpListener, TcpStream as StdTcpStream},
+        time::Duration,
+    };
+
+    use super::*;
+    use crate::pool::Pool;
+
+    struct TestListener {
+        address: SocketAddr,
+    }
+
+    impl ListenerHandler for TestListener {
+        fn get_addr(&self) -> &SocketAddr {
+            &self.address
+        }
+
+        fn get_tags(&self, _key: &str) -> Option<&sozu_command::logging::CachedTags> {
+            None
+        }
+
+        fn set_tags(&mut self, _key: String, _tags: Option<BTreeMap<String, String>>) {}
+
+        fn protocol(&self) -> Protocol {
+            Protocol::HTTP
+        }
+
+        fn public_address(&self) -> SocketAddr {
+            self.address
+        }
+    }
+
+    fn connected_pair() -> (StdTcpStream, StdTcpStream) {
+        let listener = StdTcpListener::bind("127.0.0.1:0").expect("bind test listener");
+        let address = listener.local_addr().expect("listener local addr");
+        let client = StdTcpStream::connect(address).expect("connect test client");
+        let (server, _) = listener.accept().expect("accept test server");
+        client.set_nonblocking(true).expect("client nonblocking");
+        server.set_nonblocking(true).expect("server nonblocking");
+        (client, server)
+    }
+
+    #[test]
+    fn backend_readable_arms_frontend_writable_event_when_buffering_response() {
+        let (frontend_peer, frontend_socket) = connected_pair();
+        let (mut backend_peer, backend_socket) = connected_pair();
+
+        let mut pool = Pool::with_capacity(2, 2, 4096);
+        let backend_buffer = pool.checkout().expect("backend buffer");
+        let frontend_buffer = pool.checkout().expect("frontend buffer");
+        let address = "127.0.0.1:0".parse().expect("test address");
+        let listener = Rc::new(RefCell::new(TestListener { address }));
+
+        let mut pipe = Pipe::new(
+            backend_buffer,
+            None,
+            Some(TcpStream::from_std(backend_socket)),
+            None,
+            None,
+            None,
+            None,
+            frontend_buffer,
+            Token(0),
+            TcpStream::from_std(frontend_socket),
+            listener,
+            Protocol::HTTP,
+            Ulid::generate(),
+            Ulid::generate(),
+            None,
+            WebSocketContext::Tcp,
+        );
+        pipe.set_back_token(Token(1));
+        pipe.frontend_readiness.event = Ready::EMPTY;
+        pipe.frontend_readiness.interest = Ready::READABLE | Ready::HUP | Ready::ERROR;
+        pipe.backend_readiness.event = Ready::READABLE;
+        pipe.backend_readiness.interest = Ready::READABLE | Ready::HUP | Ready::ERROR;
+
+        backend_peer
+            .write_all(b"server-speaks-first")
+            .expect("write backend payload");
+
+        let mut metrics = SessionMetrics::new(Some(Duration::ZERO));
+        assert_eq!(pipe.backend_readable(&mut metrics), SessionResult::Continue);
+
+        assert!(
+            pipe.backend_buffer.available_data() > 0,
+            "backend_readable must buffer backend bytes"
+        );
+        assert!(
+            pipe.frontend_readiness.interest.is_writable(),
+            "buffered backend bytes must arm frontend WRITABLE interest"
+        );
+        assert!(
+            pipe.frontend_readiness.event.is_writable(),
+            "buffered backend bytes must queue a frontend WRITABLE event"
+        );
+
+        drop(frontend_peer);
     }
 }

--- a/lib/src/protocol/pipe.rs
+++ b/lib/src/protocol/pipe.rs
@@ -550,7 +550,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
         trace!("{} pipe readable", log_context!(self));
         if self.frontend_buffer.available_space() == 0 {
             self.frontend_readiness.interest.remove(Ready::READABLE);
-            self.backend_readiness.interest.insert(Ready::WRITABLE);
+            self.backend_readiness.arm_writable();
             return SessionResult::Continue;
         }
 
@@ -589,7 +589,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             if self.frontend_buffer.available_space() == 0 {
                 self.frontend_readiness.interest.remove(Ready::READABLE);
             }
-            self.backend_readiness.interest.insert(Ready::WRITABLE);
+            self.backend_readiness.arm_writable();
         } else {
             self.frontend_readiness.event.remove(Ready::READABLE);
 
@@ -625,7 +625,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             SocketResult::Continue => {}
         };
 
-        self.backend_readiness.interest.insert(Ready::WRITABLE);
+        self.backend_readiness.arm_writable();
         SessionResult::Continue
     }
 
@@ -935,7 +935,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
         if self.splice_in_pending() >= capacity {
             // Pipe is full — stop reading and let the backend drain it.
             self.frontend_readiness.interest.remove(Ready::READABLE);
-            self.backend_readiness.interest.insert(Ready::WRITABLE);
+            self.backend_readiness.arm_writable();
             return SessionResult::Continue;
         }
 
@@ -973,7 +973,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
                 bin_before + sz,
                 "metrics.bin must advance by exactly the spliced bytes"
             );
-            self.backend_readiness.interest.insert(Ready::WRITABLE);
+            self.backend_readiness.arm_writable();
         } else {
             self.frontend_readiness.event.remove(Ready::READABLE);
 
@@ -1009,7 +1009,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             SocketResult::Continue => {}
         }
 
-        self.backend_readiness.interest.insert(Ready::WRITABLE);
+        self.backend_readiness.arm_writable();
         SessionResult::Continue
     }
 
@@ -1594,5 +1594,63 @@ mod tests {
         );
 
         drop(frontend_peer);
+    }
+
+    #[test]
+    fn frontend_readable_arms_backend_writable_event_when_buffering_request() {
+        let (mut frontend_peer, frontend_socket) = connected_pair();
+        let (backend_peer, backend_socket) = connected_pair();
+
+        let mut pool = Pool::with_capacity(2, 2, 4096);
+        let backend_buffer = pool.checkout().expect("backend buffer");
+        let frontend_buffer = pool.checkout().expect("frontend buffer");
+        let address = "127.0.0.1:0".parse().expect("test address");
+        let listener = Rc::new(RefCell::new(TestListener { address }));
+
+        let mut pipe = Pipe::new(
+            backend_buffer,
+            None,
+            Some(TcpStream::from_std(backend_socket)),
+            None,
+            None,
+            None,
+            None,
+            frontend_buffer,
+            Token(0),
+            TcpStream::from_std(frontend_socket),
+            listener,
+            Protocol::HTTP,
+            Ulid::generate(),
+            Ulid::generate(),
+            None,
+            WebSocketContext::Tcp,
+        );
+        pipe.set_back_token(Token(1));
+        pipe.frontend_readiness.event = Ready::READABLE;
+        pipe.frontend_readiness.interest = Ready::READABLE | Ready::HUP | Ready::ERROR;
+        pipe.backend_readiness.event = Ready::EMPTY;
+        pipe.backend_readiness.interest = Ready::READABLE | Ready::HUP | Ready::ERROR;
+
+        frontend_peer
+            .write_all(b"client-speaks-after-upgrade")
+            .expect("write frontend payload");
+
+        let mut metrics = SessionMetrics::new(Some(Duration::ZERO));
+        assert_eq!(pipe.readable(&mut metrics), SessionResult::Continue);
+
+        assert!(
+            pipe.frontend_buffer.available_data() > 0,
+            "readable must buffer frontend bytes"
+        );
+        assert!(
+            pipe.backend_readiness.interest.is_writable(),
+            "buffered frontend bytes must arm backend WRITABLE interest"
+        );
+        assert!(
+            pipe.backend_readiness.event.is_writable(),
+            "buffered frontend bytes must queue a backend WRITABLE event"
+        );
+
+        drop(backend_peer);
     }
 }


### PR DESCRIPTION
## Summary

- rearm frontend writable readiness when Pipe buffers backend-to-frontend bytes
- cover the missing frontend writable event case with a direct Pipe regression test
- add cleartext WS and WSS server-speaks-first e2e coverage for post-101 payloads

## Protocol / Security Impact

This is a WebSocket/WSS post-upgrade forwarding fix. It does not change HTTP parsing, TLS negotiation, routing, or WebSocket frame contents; it only ensures buffered backend bytes cannot remain parked when edge-triggered polling does not provide a fresh frontend writable event.

## Tests

- `cargo test -p sozu-lib backend_readable_arms_frontend_writable_event_when_buffering_response --locked -- --nocapture`
- `cargo test -p sozu-e2e test_websocket_server_speaks_first_after_upgrade --locked -- --nocapture`
- `cargo test -p sozu-e2e test_wss_server_speaks_first_after_upgrade --locked -- --nocapture`
- `cargo test -p sozu-e2e test_websocket_upgrade --locked -- --nocapture`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`

## Notes

The local pre-push validator was bypassed after it ran against the separate `/home/florentin/Sources/github.com/sozu-proxy/sozu` main checkout and failed on pre-existing `clippy::collapsible_if` warnings in `bin/src/ctl/top/app.rs` and `bin/src/ctl/top/render.rs`, which are outside this PR scope.