### PR TITLE
fix(pipe): preserve websocket bytes after upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,9 @@
   The post-upgrade pipe now arms writable readiness when bytes enter either
   sozu-owned direction buffer, so edge-triggered epoll cannot park a backend
   frame such as Pusher/Reverb `connection_established` until the client sends
-  its first WebSocket frame.
+  its first WebSocket frame. It also arms writable readiness for bytes already
+  inherited from the H1 mux during upgrade, including a backend frame carried in
+  the same read buffer as the `101 Switching Protocols` response.
 
 ### 🤖 CI
 

--- a/bin/src/ctl/top/app.rs
+++ b/bin/src/ctl/top/app.rs
@@ -994,10 +994,10 @@ impl App {
         // incremented at request-receive time without cluster_id, so it
         // surfaces traffic the user is generating even before the first
         // response cycle finishes.
-        if total_requests_observed == 0 {
-            if let Some(v) = count_value(m.proxying.get(names::http::REQUESTS)) {
-                total_requests = total_requests.saturating_add(v);
-            }
+        if total_requests_observed == 0
+            && let Some(v) = count_value(m.proxying.get(names::http::REQUESTS))
+        {
+            total_requests = total_requests.saturating_add(v);
         }
 
         // Per-second rate from the cumulative counter. The first observation

--- a/bin/src/ctl/top/render.rs
+++ b/bin/src/ctl/top/render.rs
@@ -235,10 +235,10 @@ pub fn run(
             if cfg.tick_once && frames_drawn >= 1 {
                 break;
             }
-            if let Some(target) = snapshot_frames_target {
-                if frames_drawn >= target {
-                    break;
-                }
+            if let Some(target) = snapshot_frames_target
+                && frames_drawn >= target
+            {
+                break;
             }
         }
     }

--- a/e2e/src/tests/mux_tests.rs
+++ b/e2e/src/tests/mux_tests.rs
@@ -164,6 +164,23 @@ fn raw_read(stream: &mut TcpStream) -> Option<String> {
     }
 }
 
+fn websocket_text_frame(payload: &str) -> Vec<u8> {
+    let payload = payload.as_bytes();
+    let mut frame = Vec::with_capacity(payload.len() + 2);
+    debug_assert!(payload.len() <= 125);
+    frame.push(0x81);
+    frame.push(payload.len() as u8);
+    frame.extend_from_slice(payload);
+    frame
+}
+
+fn backend_send_bytes(backend: &mut SyncBackend, client_id: usize, bytes: &[u8]) -> bool {
+    match backend.clients.get_mut(&client_id) {
+        Some(stream) => stream.write_all(bytes).is_ok() && stream.flush().is_ok(),
+        None => false,
+    }
+}
+
 // =========================================================================
 // Test 1: Client HUP during in-flight request
 // =========================================================================
@@ -383,6 +400,72 @@ fn test_websocket_server_speaks_first_after_upgrade() {
             10,
             "WebSocket server-speaks-first payload after 101",
             try_websocket_server_speaks_first_after_upgrade,
+        ),
+        State::Success,
+    );
+}
+
+fn try_websocket_backend_frame_in_same_read_as_101() -> State {
+    let front_address = create_local_address();
+
+    let (config, listeners, state) = Worker::empty_config();
+    let (mut worker, mut backends) = setup_sync_test(
+        "WS-ONEFLUSH",
+        config,
+        listeners,
+        state,
+        front_address,
+        1,
+        false,
+    );
+    let mut backend = backends.pop().unwrap();
+    backend.connect();
+
+    let mut client = raw_connect(front_address);
+    let request = b"GET /ws HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n";
+    if client.write_all(request).is_err() || client.flush().is_err() {
+        worker.soft_stop();
+        worker.wait_for_server_stop();
+        return State::Fail;
+    }
+
+    backend.accept(0);
+    backend.receive(0);
+
+    let mut response =
+        b"HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"
+            .to_vec();
+    response.extend_from_slice(&websocket_text_frame("HELLO-ONEFLUSH"));
+    if !backend_send_bytes(&mut backend, 0, &response) {
+        worker.soft_stop();
+        worker.wait_for_server_stop();
+        return State::Fail;
+    }
+
+    let result = match raw_read(&mut client) {
+        Some(data)
+            if data.contains("101 Switching Protocols") && data.contains("HELLO-ONEFLUSH") =>
+        {
+            State::Success
+        }
+        other => {
+            println!("upgrade plus same-buffer websocket frame read: {other:?}");
+            State::Fail
+        }
+    };
+
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+    result
+}
+
+#[test]
+fn test_websocket_backend_frame_in_same_read_as_101() {
+    assert_eq!(
+        repeat_until_error_or(
+            10,
+            "WebSocket backend frame in same read buffer as 101",
+            try_websocket_backend_frame_in_same_read_as_101,
         ),
         State::Success,
     );

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -517,8 +517,7 @@ impl HttpSession {
             ws_context,
         );
 
-        pipe.frontend_readiness.event = frontend_readiness.event;
-        pipe.backend_readiness.event = backend_readiness.event;
+        pipe.restore_readiness_events(frontend_readiness.event, backend_readiness.event);
         // The WebSocket pipe inherits the live backend connection, so its back
         // token must be set (back token present iff a backend is connected).
         pipe.set_back_token(back_token);

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -806,8 +806,7 @@ impl HttpsSession {
             ws_context,
         );
 
-        pipe.frontend_readiness.event = frontend_readiness.event;
-        pipe.backend_readiness.event = backend_readiness.event;
+        pipe.restore_readiness_events(frontend_readiness.event, backend_readiness.event);
         pipe.set_back_token(back_token);
         // The WSS pipe is a frontend↔backend bridge: it only exists because the
         // upgrading stream was `Linked(back_token)` to a *connected* backend (the

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -637,6 +637,21 @@ impl<Front: SocketHandler, L: ListenerHandler + L7ListenerHandler> Mux<Front, L>
 }
 
 impl<Front: SocketHandler + std::fmt::Debug, L: ListenerHandler + L7ListenerHandler> Mux<Front, L> {
+    fn sync_upgrade_buffers(&mut self) {
+        for stream in &mut self.context.streams {
+            stream
+                .front
+                .storage
+                .buffer
+                .sync(stream.front.storage.end, stream.front.storage.head);
+            stream
+                .back
+                .storage
+                .buffer
+                .sync(stream.back.storage.end, stream.back.storage.head);
+        }
+    }
+
     fn delay_close_for_frontend_flush(&mut self, reason: &'static str) -> bool {
         let _ = self.frontend.initiate_close_notify();
         // LIFECYCLE §9 invariant 16: consult per-stream back-buffers in
@@ -798,7 +813,10 @@ impl<Front: SocketHandler + std::fmt::Debug, L: ListenerHandler + L7ListenerHand
                                 return SessionResult::Close;
                             }
                         }
-                        MuxResult::Upgrade => return SessionResult::Upgrade,
+                        MuxResult::Upgrade => {
+                            self.sync_upgrade_buffers();
+                            return SessionResult::Upgrade;
+                        }
                     }
                 }
 
@@ -1118,7 +1136,10 @@ impl<Front: SocketHandler + std::fmt::Debug, L: ListenerHandler + L7ListenerHand
                                 return SessionResult::Close;
                             }
                         }
-                        MuxResult::Upgrade => return SessionResult::Upgrade,
+                        MuxResult::Upgrade => {
+                            self.sync_upgrade_buffers();
+                            return SessionResult::Upgrade;
+                        }
                     }
                     // Cross-readiness: frontend wrote → wake parked backends.
                     // If any backend resumes, invalidate the stale readiness

--- a/lib/src/protocol/pipe.rs
+++ b/lib/src/protocol/pipe.rs
@@ -161,7 +161,7 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             ConnectionStatus::Normal
         };
 
-        let session = Pipe {
+        let mut session = Pipe {
             backend_buffer,
             backend_id,
             backend_readiness: Readiness {
@@ -200,6 +200,13 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
                 None
             },
         };
+
+        if session.backend_buffer.available_data() > 0 {
+            session.frontend_readiness.arm_writable();
+        }
+        if session.frontend_buffer.available_data() > 0 && session.backend_socket.is_some() {
+            session.backend_readiness.arm_writable();
+        }
 
         trace!("{} created pipe", log_context!(session));
         session

--- a/lib/src/protocol/pipe.rs
+++ b/lib/src/protocol/pipe.rs
@@ -201,15 +201,25 @@ impl<Front: SocketHandler, L: ListenerHandler> Pipe<Front, L> {
             },
         };
 
-        if session.backend_buffer.available_data() > 0 {
-            session.frontend_readiness.arm_writable();
-        }
-        if session.frontend_buffer.available_data() > 0 && session.backend_socket.is_some() {
-            session.backend_readiness.arm_writable();
-        }
+        session.arm_inherited_buffer_writes();
 
         trace!("{} created pipe", log_context!(session));
         session
+    }
+
+    fn arm_inherited_buffer_writes(&mut self) {
+        if self.backend_buffer.available_data() > 0 {
+            self.frontend_readiness.arm_writable();
+        }
+        if self.frontend_buffer.available_data() > 0 && self.backend_socket.is_some() {
+            self.backend_readiness.arm_writable();
+        }
+    }
+
+    pub fn restore_readiness_events(&mut self, frontend_event: Ready, backend_event: Ready) {
+        self.frontend_readiness.event = frontend_event;
+        self.backend_readiness.event = backend_event;
+        self.arm_inherited_buffer_writes();
     }
 
     /// Stamp connection-scoped TLS metadata captured at handshake time onto
@@ -1658,6 +1668,57 @@ mod tests {
             "buffered frontend bytes must queue a backend WRITABLE event"
         );
 
+        drop(backend_peer);
+    }
+
+    #[test]
+    fn restore_readiness_events_rearms_inherited_buffered_writes() {
+        let (frontend_peer, frontend_socket) = connected_pair();
+        let (backend_peer, backend_socket) = connected_pair();
+
+        let mut pool = Pool::with_capacity(2, 2, 4096);
+        let mut backend_buffer = pool.checkout().expect("backend buffer");
+        let mut frontend_buffer = pool.checkout().expect("frontend buffer");
+        backend_buffer
+            .write_all(b"backend bytes inherited from 101 read")
+            .expect("write backend buffer");
+        frontend_buffer
+            .write_all(b"frontend bytes inherited from upgrade read")
+            .expect("write frontend buffer");
+        let address = "127.0.0.1:0".parse().expect("test address");
+        let listener = Rc::new(RefCell::new(TestListener { address }));
+
+        let mut pipe = Pipe::new(
+            backend_buffer,
+            None,
+            Some(TcpStream::from_std(backend_socket)),
+            None,
+            None,
+            None,
+            None,
+            frontend_buffer,
+            Token(0),
+            TcpStream::from_std(frontend_socket),
+            listener,
+            Protocol::HTTP,
+            Ulid::generate(),
+            Ulid::generate(),
+            None,
+            WebSocketContext::Tcp,
+        );
+
+        pipe.restore_readiness_events(Ready::EMPTY, Ready::EMPTY);
+
+        assert!(
+            pipe.frontend_readiness.event.is_writable(),
+            "restoring inherited frontend events must not park backend-buffered bytes"
+        );
+        assert!(
+            pipe.backend_readiness.event.is_writable(),
+            "restoring inherited backend events must not park frontend-buffered bytes"
+        );
+
+        drop(frontend_peer);
         drop(backend_peer);
     }
 }


### PR DESCRIPTION
## Summary

- Preserve backend bytes that arrive in the same read buffer as a WebSocket `101 Switching Protocols` response.
- Sync mux buffers before the upgrade handoff, then restore inherited readiness through `Pipe::restore_readiness_events(...)` so already-buffered bytes keep a writable event after HTTP/HTTPS handoff restores mux readiness.
- Add e2e coverage for a backend write containing both the `101` response and the first WebSocket text frame.
- Add pipe-level regression coverage for inherited buffered bytes after readiness-event restore.
- Collapse two existing clippy-only nested conditionals required by the repository pre-push all-features gate.

## Root Cause

The H1 mux returned `SessionResult::Upgrade` without syncing Kawa's remaining post-header bytes back into the `Checkout` buffer window. When the backend sent `101 Switching Protocols` and the first WebSocket frame in the same TCP segment, the pipe inherited a buffer whose readable window did not expose the post-`101` bytes.

The first fix also needed one follow-up: HTTP and HTTPS restore the pre-upgrade mux readiness events after constructing the `Pipe`, so any synthetic `WRITABLE` event set during `Pipe::new()` could be erased. `Pipe::restore_readiness_events(...)` now performs that restore and then re-arms writable readiness for inherited frontend/backend buffers.

## User Impact

This fixes WebSocket backends such as Reverb, Soketi, and Pusher-compatible servers that send `connection_established` immediately after the upgrade response. The first frame is now forwarded even when it shares the same backend read buffer as the `101` response.

## Review Follow-Up

Addressed the inline review on `lib/src/protocol/pipe.rs` by moving the inherited-event restore behind a `Pipe` helper that re-arms buffered writes after the restore. The new `restore_readiness_events_rearms_inherited_buffered_writes` regression was observed red before the re-arm and green after the fix.

## Validation

- `cargo test -p sozu-lib restore_readiness_events_rearms_inherited_buffered_writes --locked`
- `cargo test -p sozu-lib protocol::pipe --locked`
- `cargo test -p sozu-e2e test_websocket_backend_frame_in_same_read_as_101 --locked`
- `cargo test -p sozu-e2e websocket --locked`
- `cargo +nightly fmt --all -- --check`
- `cargo build --all-features --locked`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo clippy --all-features --all-targets --locked -- -D warnings`
- `git diff --check`
