### PR TITLE
fix(h1): harden Transfer-Encoding framing (reopen #726)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@
   `HttpContext::on_request_headers` (`lib/src/protocol/kawa_h1/editor.rs`) now
   answers `400` when a request carries a `Transfer-Encoding` header that the
   parser did not accept as chunked framing, rather than forwarding it alongside
-  a `Content-Length`. Per RFC 9110 §7.6 / RFC 9112 §6.1 an intermediary must not
-  forward ambiguous message framing. The rejection runs before routing and
-  increments the new `http.frontend.transfer_encoding_smuggling` metric; it
-  mirrors the existing HTTP/2 → H1 framing-conflict rejection. A complementary
-  upstream `kawa` parser fix is the follow-up.
+  a `Content-Length`, and also when more than one non-elided `Transfer-Encoding`
+  header survives kawa's header pass (kawa evaluates each TE field line
+  independently, so a first `chunked` line can latch chunked framing while a
+  second, differently-framed line rides along uncaught). Per RFC 9110 §7.6 /
+  RFC 9112 §6.1 an intermediary must not forward ambiguous message framing. The
+  rejection runs before routing and increments the
+  `http.frontend.transfer_encoding_smuggling` metric; it mirrors the existing
+  HTTP/2 → H1 framing-conflict rejection. A complementary upstream `kawa`
+  parser fix is the follow-up.
 
 ## 2.1.1 - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### 🔐 Security
+
+- **`fix(h1)`: harden HTTP/1 `Transfer-Encoding` framing (reopen of [#726](https://github.com/sozu-proxy/sozu/issues/726)).**
+  `HttpContext::on_request_headers` (`lib/src/protocol/kawa_h1/editor.rs`) now
+  answers `400` when a request carries a `Transfer-Encoding` header that the
+  parser did not accept as chunked framing, rather than forwarding it alongside
+  a `Content-Length`. Per RFC 9110 §7.6 / RFC 9112 §6.1 an intermediary must not
+  forward ambiguous message framing. The rejection runs before routing and
+  increments the new `http.frontend.transfer_encoding_smuggling` metric; it
+  mirrors the existing HTTP/2 → H1 framing-conflict rejection. A complementary
+  upstream `kawa` parser fix is the follow-up.
+
 ## 2.1.1 - 2026-07-10
 
 Patch release: dependency updates, Rust 1.91.0 MSRV alignment, deterministic

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,7 @@ Conservative changes + tests required in:
 
 - `lib/src/tls.rs`, `lib/src/https.rs`, `lib/src/protocol/rustls.rs` — rustls config, ALPN, SNI binding, cert loading, close-notify.
 - `lib/src/protocol/mux/` — parser, HPACK, pseudo-header ordering, request smuggling, content-length reconciliation, flow control, GOAWAY/RST_STREAM semantics, edge-triggered readiness.
+- `lib/src/protocol/kawa_h1/editor.rs` — the H1 request path rejects (400) any request carrying an unhonored `Transfer-Encoding` header (CL.TE smuggling guard in `on_request_headers`, CWE-444).
 - `lib/src/protocol/proxy_protocol/` — partial headers, oversized headers, TCP health checks.
 - `command/src/channel.rs`, `command/src/scm_socket.rs`, `command/src/command.proto`, `bin/src/command/` — message framing, buffer sizing, FD passing, state replay.
 - Metrics / logs — never leak sensitive values; counters/gauges must stay correct on error paths and shutdown.

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -2173,7 +2173,7 @@ Incremented when Sōzu generates a default error response instead of proxying:
 | Metric                                      | Type    | Scope | Description                                                                                                                                                                                     |
 | -------------------------------------------- | ------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `http.frontend_parse_errors`                 | counter | proxy | Frontend request parsing failures (malformed HTTP/1.1 or HPACK decode errors in HTTP/2)                                                                                                        |
-| `http.frontend.transfer_encoding_smuggling`  | counter | proxy | H1 request rejected (400) because a `Transfer-Encoding` header was not accepted as chunked framing (ambiguous framing, RFC 9110 §7.6 / RFC 9112 §6.1; #726)                                      |
+| `http.frontend.transfer_encoding_smuggling`  | counter | proxy | H1 request rejected (400) for ambiguous `Transfer-Encoding` framing: more than one non-elided `Transfer-Encoding` header, or one present without kawa adopting chunked framing (RFC 9110 §7.6 / RFC 9112 §6.1; #726)                                      |
 | `http.backend_parse_errors`                  | counter | proxy | Backend response parsing failures                                                                                                                                                              |
 
 #### Backend health

--- a/doc/configure.md
+++ b/doc/configure.md
@@ -2170,10 +2170,11 @@ Incremented when Sōzu generates a default error response instead of proxying:
 
 #### Parse errors
 
-| Metric                       | Type    | Scope | Description                                                                             |
-| ---------------------------- | ------- | ----- | --------------------------------------------------------------------------------------- |
-| `http.frontend_parse_errors` | counter | proxy | Frontend request parsing failures (malformed HTTP/1.1 or HPACK decode errors in HTTP/2) |
-| `http.backend_parse_errors`  | counter | proxy | Backend response parsing failures                                                       |
+| Metric                                      | Type    | Scope | Description                                                                                                                                                                                     |
+| -------------------------------------------- | ------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `http.frontend_parse_errors`                 | counter | proxy | Frontend request parsing failures (malformed HTTP/1.1 or HPACK decode errors in HTTP/2)                                                                                                        |
+| `http.frontend.transfer_encoding_smuggling`  | counter | proxy | H1 request rejected (400) because a `Transfer-Encoding` header was not accepted as chunked framing (ambiguous framing, RFC 9110 §7.6 / RFC 9112 §6.1; #726)                                      |
+| `http.backend_parse_errors`                  | counter | proxy | Backend response parsing failures                                                                                                                                                              |
 
 #### Backend health
 

--- a/e2e/src/tests/h1_security_tests.rs
+++ b/e2e/src/tests/h1_security_tests.rs
@@ -17,9 +17,18 @@ use std::{
     time::{Duration, Instant},
 };
 
+use base64::Engine;
+use sozu_command_lib::{
+    config::ListenerBuilder,
+    proto::command::{
+        ActivateListener, Cluster, ListenerType, Request, RequestHttpFrontend, request::RequestType,
+    },
+};
+
 use crate::{
     http_utils::http_ok_response,
     mock::{client::Client, sync_backend::Backend as SyncBackend},
+    port_registry::attach_reserved_http_listener,
     sozu::worker::Worker,
     tests::{State, repeat_until_error_or, setup_sync_test},
 };
@@ -1374,6 +1383,421 @@ fn test_h1_connection_close_terminates() {
             5,
             "H1 security: Connection: close properly terminates the connection",
             try_h1_connection_close_terminates,
+        ),
+        State::Success,
+    );
+}
+
+// =========================================================================
+// Test 13: CL.TE request smuggling via an unhonored Transfer-Encoding
+// (regression of #726 / kawa 0.6.8's suffix-only "chunked" check)
+//
+// RFC 9110 §7.6 / RFC 7230 §3.3.3: a message carrying a Transfer-Encoding
+// header that is not actually honored as the framing mechanism, alongside
+// a Content-Length, is a desync primitive (CWE-444) — a lenient backend
+// may trim trailing whitespace/control bytes and treat the message as
+// chunked while sozu framed it by Content-Length (or treat it as
+// length-framed while sozu forwarded a value it never validated).
+//
+// kawa 0.6.8's chunked recognition is a bare suffix compare with no OWS
+// trim (`lib/src/protocol/kawa_h1/editor.rs`'s guard comment cites the
+// exact kawa source), so `Transfer-Encoding: chunked\t` (trailing tab),
+// `chunked ` (trailing space), and `chunked, gzip` (chunked not the final
+// coding) all fail the match while the header itself survives forwarding
+// unelided. Sozu must fail closed rather than forward the ambiguity.
+// =========================================================================
+
+/// Malformed Transfer-Encoding shapes that must each be rejected with 400
+/// before ever reaching the backend, with or without a Content-Length.
+const TE_SMUGGLING_CASES: [(&str, &[u8]); 4] = [
+    (
+        "trailing-tab",
+        b"POST /api HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\t\r\nContent-Length: 5\r\nConnection: close\r\n\r\nHello",
+    ),
+    (
+        "trailing-space",
+        b"POST /api HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked \r\nContent-Length: 5\r\nConnection: close\r\n\r\nHello",
+    ),
+    (
+        "not-final-coding",
+        b"POST /api HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked, gzip\r\nContent-Length: 5\r\nConnection: close\r\n\r\nHello",
+    ),
+    (
+        "no-content-length",
+        b"GET /api HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\t\r\nConnection: close\r\n\r\n",
+    ),
+];
+
+fn try_h1_smuggling_te_cl_trailing_tab() -> State {
+    for (label, request) in TE_SMUGGLING_CASES {
+        let front_address = create_local_address();
+
+        let (config, listeners, state) = Worker::empty_config();
+        let (mut worker, mut backends) = setup_sync_test(
+            format!("TE-SMUGGLE-{label}"),
+            config,
+            listeners,
+            state,
+            front_address,
+            1,
+            false,
+        );
+        let mut backend = backends.pop().unwrap();
+        backend.connect();
+
+        let mut stream = raw_connect(front_address);
+        stream
+            .write_all(request)
+            .unwrap_or_else(|e| panic!("{label}: write attack bytes: {e}"));
+
+        // Assertion 2: the malformed request must never reach the backend.
+        if !assert_attack_not_forwarded(label, &mut backend, Duration::from_millis(300)) {
+            println!("{label}: FAIL — malformed framing reached the backend");
+            worker.soft_stop();
+            worker.wait_for_server_stop();
+            return State::Fail;
+        }
+
+        // Assertion 1: sozu answers 400.
+        match raw_read(&mut stream) {
+            Some(r) if r.contains("400") => {
+                println!("{label}: correctly rejected with 400");
+            }
+            other => {
+                println!("{label}: FAIL — expected 400, got {other:?}");
+                worker.soft_stop();
+                worker.wait_for_server_stop();
+                return State::Fail;
+            }
+        }
+        drop(stream);
+
+        if !verify_sozu_healthy(front_address, &mut backend, false) {
+            println!("{label}: FAIL — sozu unhealthy after the attack");
+            worker.soft_stop();
+            worker.wait_for_server_stop();
+            return State::Fail;
+        }
+
+        worker.soft_stop();
+        worker.wait_for_server_stop();
+    }
+    State::Success
+}
+
+#[test]
+fn test_h1_smuggling_te_cl_trailing_tab() {
+    assert_eq!(
+        repeat_until_error_or(
+            5,
+            "H1 security: CL.TE smuggling via an unhonored Transfer-Encoding (trailing tab/space/non-final coding, with and without Content-Length)",
+            try_h1_smuggling_te_cl_trailing_tab,
+        ),
+        State::Success,
+    );
+}
+
+// =========================================================================
+// Test 14: Non-regression — legitimately framed requests are still forwarded
+//
+// The CL.TE guard added to `editor.rs::on_request_headers` must reject
+// only requests where a Transfer-Encoding header survives without kawa
+// adopting chunked framing. It must never fire when the framing is
+// unambiguous, including the shapes below.
+// =========================================================================
+
+fn try_h1_valid_framing_still_forwarded() -> State {
+    let cases: [(&str, &[u8]); 5] = [
+        (
+            "chunked",
+            b"POST /api HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n5\r\nHello\r\n0\r\n\r\n",
+        ),
+        (
+            "multi-coding-chunked-final",
+            b"POST /api HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: gzip, chunked\r\nConnection: close\r\n\r\n5\r\nHello\r\n0\r\n\r\n",
+        ),
+        (
+            "content-length-only",
+            b"POST /api HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\nConnection: close\r\n\r\nHello",
+        ),
+        (
+            "cl-and-te-together",
+            b"POST /api HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n5\r\nHello\r\n0\r\n\r\n",
+        ),
+        (
+            "get-no-body",
+            b"GET /api HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+        ),
+    ];
+
+    for (label, request) in cases {
+        let front_address = create_local_address();
+
+        let (config, listeners, state) = Worker::empty_config();
+        let (mut worker, mut backends) = setup_sync_test(
+            format!("VALID-FRAME-{label}"),
+            config,
+            listeners,
+            state,
+            front_address,
+            1,
+            false,
+        );
+        let mut backend = backends.pop().unwrap();
+        backend.connect();
+
+        let mut stream = raw_connect(front_address);
+        stream
+            .write_all(request)
+            .unwrap_or_else(|e| panic!("{label}: write request: {e}"));
+
+        let deadline = Instant::now() + Duration::from_millis(300);
+        let mut forwarded = false;
+        while Instant::now() < deadline {
+            if backend.accept(0) {
+                forwarded = true;
+                break;
+            }
+        }
+        if !forwarded {
+            println!("{label}: FAIL — request never reached the backend");
+            worker.soft_stop();
+            worker.wait_for_server_stop();
+            return State::Fail;
+        }
+
+        let received = backend.receive(0);
+        backend.send(0);
+        let response = raw_read(&mut stream);
+        drop(stream);
+
+        let ok = received.is_some()
+            && matches!(&response, Some(r) if r.contains("200") && r.contains("pong0"));
+
+        worker.soft_stop();
+        worker.wait_for_server_stop();
+
+        if !ok {
+            println!(
+                "{label}: FAIL — expected 200/pong0, got response={response:?} received={received:?}"
+            );
+            return State::Fail;
+        }
+        println!("{label}: correctly forwarded, got 200");
+    }
+    State::Success
+}
+
+#[test]
+fn test_h1_valid_framing_still_forwarded() {
+    assert_eq!(
+        repeat_until_error_or(
+            5,
+            "H1 security: legitimately framed requests (chunked, CL, both, neither) are still forwarded",
+            try_h1_valid_framing_still_forwarded,
+        ),
+        State::Success,
+    );
+}
+
+// =========================================================================
+// Test 15: CL.TE smuggling cannot bypass per-frontend Basic auth
+//
+// Sozu supports per-frontend HTTP Basic auth (`required_auth = true` +
+// `authorized_hashes` + `www_authenticate`). A classic use of CL/TE
+// desync is to hide a second, unauthenticated request inside what the
+// auth-enforcing proxy believes is opaque body content of the first
+// request, so the smuggled request never passes through the proxy's
+// per-request auth gate at all. With the CL.TE guard, the outer request
+// is rejected (400) before routing or the auth check ever run — see
+// `lib/src/protocol/mux/h1.rs`'s `kawa.is_error()` short-circuit, which
+// fires immediately after `kawa::h1::parse` and before the router/auth
+// check further down the same read event.
+// =========================================================================
+
+/// SHA-256 hex of the literal byte string `s3cr3t` (`printf 's3cr3t' |
+/// sha256sum`). The attack request in this test never supplies a matching
+/// `Authorization` header — the guard must reject the malformed framing
+/// before the auth check ever runs — so this hash only backs the
+/// post-attack health check, which authenticates for real to prove the
+/// CL.TE guard didn't collaterally break the (unrelated) Basic-auth gate.
+const AUTH_BYPASS_SECRET_SHA256_HEX: &str =
+    "4e738ca5563c06cfd0018299933d58db1dd8bf97f6973dc99bf6cdc64b5550bd";
+
+/// Spins up a worker with a single HTTP listener, one cluster gated by
+/// per-frontend Basic auth, and one backend. Duplicated locally rather
+/// than reusing `redirect_rewrite_auth_tests::spawn_worker_with_http_listener`
+/// / `make_basic_auth_cluster` — those helpers are private to that module.
+fn spawn_auth_gated_worker(
+    label: &str,
+    front_address: SocketAddr,
+    back_address: SocketAddr,
+) -> Worker {
+    let (config, mut listeners, state) = Worker::empty_config();
+    attach_reserved_http_listener(&mut listeners, front_address);
+    let mut worker = Worker::start_new_worker_owned(label, config, listeners, state);
+
+    worker.send_proxy_request(Request {
+        request_type: Some(RequestType::AddHttpListener(
+            ListenerBuilder::new_http(front_address.into())
+                .to_http(None)
+                .expect("default HTTP listener must build"),
+        )),
+    });
+    worker.send_proxy_request(Request {
+        request_type: Some(RequestType::ActivateListener(ActivateListener {
+            address: front_address.into(),
+            proxy: ListenerType::Http.into(),
+            from_scm: true,
+        })),
+    });
+    worker.send_proxy_request(
+        RequestType::AddCluster(Cluster {
+            authorized_hashes: vec![format!("admin:{AUTH_BYPASS_SECRET_SHA256_HEX}")],
+            www_authenticate: Some("Basic realm=\"sozu\"".to_owned()),
+            ..Worker::default_cluster("auth_bypass_cluster")
+        })
+        .into(),
+    );
+    worker.send_proxy_request(
+        RequestType::AddHttpFrontend(RequestHttpFrontend {
+            required_auth: Some(true),
+            ..Worker::default_http_frontend("auth_bypass_cluster", front_address)
+        })
+        .into(),
+    );
+    worker.send_proxy_request(
+        RequestType::AddBackend(Worker::default_backend(
+            "auth_bypass_cluster",
+            "auth_bypass_back_0",
+            back_address,
+            None,
+        ))
+        .into(),
+    );
+    worker.read_to_last();
+    worker
+}
+
+fn try_h1_smuggling_auth_bypass() -> State {
+    let front_address = create_local_address();
+    let back_address = create_local_address();
+    let mut worker = spawn_auth_gated_worker("AUTH-BYPASS", front_address, back_address);
+    let mut backend = SyncBackend::new(
+        "auth_bypass_back_0",
+        back_address,
+        "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\npong",
+    );
+    backend.connect();
+
+    let token = base64::engine::general_purpose::STANDARD.encode(b"admin:s3cr3t");
+
+    // The outer request carries VALID `Authorization` credentials — this is
+    // the actual bypass primitive: a per-request Basic-auth gate that only
+    // ever validates the *outer* request's headers is worthless if a
+    // malformed Transfer-Encoding/Content-Length pair lets a second, fully
+    // -formed request ride along hidden inside what sozu treats as opaque,
+    // already-authenticated body bytes. Pre-fix, sozu's auth check passes
+    // on the outer headers and forwards the whole Content-Length-framed
+    // blob — smuggled request included — to the backend, having checked
+    // credentials exactly once for what a lenient backend treats as two
+    // requests. Post-fix, the CL.TE guard rejects the whole thing (400)
+    // before routing or the auth check ever run, regardless of whether the
+    // outer credentials were valid.
+    let smuggled_request = concat!("GET /admin HTTP/1.1\r\n", "Host: localhost\r\n", "\r\n",);
+    let body = format!("0\r\n\r\n{smuggled_request}");
+    let attack = format!(
+        "POST /secured HTTP/1.1\r\nHost: localhost\r\nAuthorization: Basic {token}\r\nTransfer-Encoding: chunked\t\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body,
+    );
+
+    let mut stream = raw_connect(front_address);
+    stream
+        .write_all(attack.as_bytes())
+        .expect("write CL.TE auth-bypass attack");
+
+    // Even with valid outer credentials, neither the outer request nor the
+    // smuggled inner request may reach the backend — the malformed framing
+    // must be rejected before the (would-be successful) auth check runs.
+    if !assert_attack_not_forwarded("AUTH-BYPASS", &mut backend, Duration::from_millis(300)) {
+        println!(
+            "AUTH-BYPASS: FAIL — authenticated-but-malformed request (with smuggled payload) reached the backend"
+        );
+        worker.soft_stop();
+        worker.wait_for_server_stop();
+        return State::Fail;
+    }
+
+    match raw_read(&mut stream) {
+        Some(r) if r.contains("400") => {
+            println!("AUTH-BYPASS: correctly rejected with 400 before routing/auth");
+        }
+        other => {
+            println!("AUTH-BYPASS: FAIL — expected 400, got {other:?}");
+            worker.soft_stop();
+            worker.wait_for_server_stop();
+            return State::Fail;
+        }
+    }
+    drop(stream);
+
+    // Post-attack health check: this deliberately does NOT reuse the
+    // shared `verify_sozu_healthy` helper, which sends an unauthenticated
+    // GET to `/healthz` — against this test's `required_auth = true`
+    // frontend on path prefix "/", that would itself get a 401 and the
+    // helper would misreport failure. Instead, authenticate for real
+    // against the same auth-gated route to prove the CL.TE guard didn't
+    // collaterally break the Basic-auth gate.
+    let healthy_request = format!(
+        "GET /secured HTTP/1.1\r\nHost: localhost\r\nAuthorization: Basic {token}\r\nConnection: close\r\n\r\n"
+    );
+    let mut stream = raw_connect(front_address);
+    stream
+        .write_all(healthy_request.as_bytes())
+        .expect("write authenticated health-check request");
+
+    let deadline = Instant::now() + Duration::from_millis(500);
+    let mut connected = false;
+    while Instant::now() < deadline {
+        if backend.accept(0) {
+            connected = true;
+            break;
+        }
+    }
+    if !connected {
+        println!("AUTH-BYPASS: FAIL — authenticated health check never reached the backend");
+        worker.soft_stop();
+        worker.wait_for_server_stop();
+        return State::Fail;
+    }
+    backend.receive(0);
+    backend.send(0);
+
+    match raw_read(&mut stream) {
+        Some(r) if r.contains("200") => {
+            println!("AUTH-BYPASS: post-attack authenticated health check succeeded");
+        }
+        other => {
+            println!("AUTH-BYPASS: FAIL — authenticated health check got {other:?}");
+            worker.soft_stop();
+            worker.wait_for_server_stop();
+            return State::Fail;
+        }
+    }
+
+    worker.soft_stop();
+    worker.wait_for_server_stop();
+    State::Success
+}
+
+#[test]
+fn test_h1_smuggling_auth_bypass() {
+    assert_eq!(
+        repeat_until_error_or(
+            5,
+            "H1 security: CL.TE smuggling cannot bypass per-frontend Basic auth",
+            try_h1_smuggling_auth_bypass,
         ),
         State::Success,
     );

--- a/e2e/src/tests/h1_security_tests.rs
+++ b/e2e/src/tests/h1_security_tests.rs
@@ -1405,11 +1405,22 @@ fn test_h1_connection_close_terminates() {
 // `chunked ` (trailing space), and `chunked, gzip` (chunked not the final
 // coding) all fail the match while the header itself survives forwarding
 // unelided. Sozu must fail closed rather than forward the ambiguity.
+//
+// The `multi-line-chunked-then-identity` case covers a second bypass: kawa
+// evaluates each Transfer-Encoding *field line* independently rather than
+// eliding/merging them, so a first `Transfer-Encoding: chunked` line
+// latches `body_size = Chunked` while a second, separate
+// `Transfer-Encoding: identity` line is left in place (kawa only `warn!`s
+// on it). A guard gated on `body_size != Chunked` alone would treat this
+// message as already-resolved chunked framing and skip the scan entirely,
+// forwarding both TE lines (`chunked, identity` — chunked NOT the final
+// coding). The guard must instead count every non-elided TE header and
+// reject whenever more than one survives, regardless of `body_size`.
 // =========================================================================
 
 /// Malformed Transfer-Encoding shapes that must each be rejected with 400
 /// before ever reaching the backend, with or without a Content-Length.
-const TE_SMUGGLING_CASES: [(&str, &[u8]); 4] = [
+const TE_SMUGGLING_CASES: [(&str, &[u8]); 5] = [
     (
         "trailing-tab",
         b"POST /api HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\t\r\nContent-Length: 5\r\nConnection: close\r\n\r\nHello",
@@ -1425,6 +1436,10 @@ const TE_SMUGGLING_CASES: [(&str, &[u8]); 4] = [
     (
         "no-content-length",
         b"GET /api HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\t\r\nConnection: close\r\n\r\n",
+    ),
+    (
+        "multi-line-chunked-then-identity",
+        b"POST /api HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\nTransfer-Encoding: identity\r\nConnection: close\r\n\r\n5\r\nHello\r\n0\r\n\r\n",
     ),
 ];
 
@@ -1490,7 +1505,7 @@ fn test_h1_smuggling_te_cl_trailing_tab() {
     assert_eq!(
         repeat_until_error_or(
             5,
-            "H1 security: CL.TE smuggling via an unhonored Transfer-Encoding (trailing tab/space/non-final coding, with and without Content-Length)",
+            "H1 security: CL.TE smuggling via an unhonored Transfer-Encoding (trailing tab/space/non-final coding, with and without Content-Length, and duplicate TE field lines)",
             try_h1_smuggling_te_cl_trailing_tab,
         ),
         State::Success,

--- a/lib/src/metrics/names.rs
+++ b/lib/src/metrics/names.rs
@@ -183,6 +183,9 @@ pub mod http {
     pub const E2E_HTTP11: &str = "http.e2e.http11";
     pub const EARLY_RESPONSE_CLOSE: &str = "http.early_response_close";
     pub const FAILED_BACKEND_MATCHING: &str = "http.failed_backend_matching";
+    /// Requests rejected because a Transfer-Encoding header survived parsing without
+    /// kawa adopting chunked framing (CL.TE request-smuggling defense, CWE-444).
+    pub const FRONTEND_TE_SMUGGLING: &str = "http.frontend.transfer_encoding_smuggling";
     pub const FRONTEND_PARSE_ERRORS: &str = "http.frontend_parse_errors";
     pub const HSTS_FRONTEND_ADDED: &str = "http.hsts.frontend_added";
     pub const HSTS_FRONTEND_REFRESHED: &str = "http.hsts.frontend_refreshed";

--- a/lib/src/protocol/kawa_h1/LIFECYCLE.md
+++ b/lib/src/protocol/kawa_h1/LIFECYCLE.md
@@ -178,19 +178,32 @@ Notable security-relevant fields on `HttpContext`:
 
 ### 3.1 CL.TE framing guard (`on_request_headers`)
 
-The very first thing `on_request_headers` does (`editor.rs:558-591`, before
-capturing `:method`/authority/path) is reject requests where a
-`Transfer-Encoding` header survived kawa's header pass without kawa actually
-adopting chunked framing (RFC 9110 §7.6 / RFC 9112 §6.1; reopen of
+The very first thing `on_request_headers` does (`editor.rs:558-597`, before
+capturing `:method`/authority/path) is reject requests whose Transfer-Encoding
+framing is ambiguous (RFC 9110 §7.6 / RFC 9112 §6.1; reopen of
 [#726](https://github.com/sozu-proxy/sozu/issues/726)). An intermediary must not
-forward a message whose framing is ambiguous — a `Transfer-Encoding` the parser
-did not resolve to chunked, left in place next to a `Content-Length`, is exactly
-that.
+forward a message whose framing is ambiguous.
 
 The guard runs once per request, after kawa's own header pass (`process_headers`)
 has finalised `body_size` but before `HttpContext` captures anything from the
-request. If `body_size != BodySize::Chunked`, it scans `request.blocks` for
-any non-elided `Transfer-Encoding` header; if one is found, it increments
+request. kawa never elides the `Transfer-Encoding` header and evaluates each TE
+field line independently — a leading `Transfer-Encoding: chunked` line latches
+`body_size = Chunked`, but a second, later TE line (e.g. `identity`) that does
+not itself end in `chunked` is left in place (kawa only `warn!`s), so gating the
+scan on `body_size != Chunked` alone would let that second line ride through.
+The guard therefore counts every non-elided `Transfer-Encoding` header in
+`request.blocks` (`te_count`) and rejects when either:
+
+- `te_count > 1` — more than one non-elided TE header. RFC 9112 §6.1 requires
+  `chunked` be applied once and be the final coding; multiple TE field lines
+  cannot be safely reconciled here, and it is exactly the shape that lets a
+  `Chunked` latch from an earlier line mask a later, differently-framed line
+  (the multi-line CL.TE bypass this guard was hardened against); or
+- `te_count >= 1 && body_size != BodySize::Chunked` — a TE header is present
+  but kawa did not adopt chunked framing (e.g. `chunked\t`, trailing OWS, or
+  `chunked` not the final coding on a single line).
+
+If either condition holds, the guard increments
 `names::http::FRONTEND_TE_SMUGGLING`, logs a `warn!`, and calls
 `request.parsing_phase.error(...)` before returning early. It does **not**
 short-circuit anything else in kawa — the very next line back in

--- a/lib/src/protocol/kawa_h1/LIFECYCLE.md
+++ b/lib/src/protocol/kawa_h1/LIFECYCLE.md
@@ -176,6 +176,43 @@ Notable security-relevant fields on `HttpContext`:
   unconditionally in `on_request_headers` so the access log always has a
   cross-component join key.
 
+### 3.1 CL.TE framing guard (`on_request_headers`)
+
+The very first thing `on_request_headers` does (`editor.rs:558-591`, before
+capturing `:method`/authority/path) is reject requests where a
+`Transfer-Encoding` header survived kawa's header pass without kawa actually
+adopting chunked framing (RFC 9110 §7.6 / RFC 9112 §6.1; reopen of
+[#726](https://github.com/sozu-proxy/sozu/issues/726)). An intermediary must not
+forward a message whose framing is ambiguous — a `Transfer-Encoding` the parser
+did not resolve to chunked, left in place next to a `Content-Length`, is exactly
+that.
+
+The guard runs once per request, after kawa's own header pass (`process_headers`)
+has finalised `body_size` but before `HttpContext` captures anything from the
+request. If `body_size != BodySize::Chunked`, it scans `request.blocks` for
+any non-elided `Transfer-Encoding` header; if one is found, it increments
+`names::http::FRONTEND_TE_SMUGGLING`, logs a `warn!`, and calls
+`request.parsing_phase.error(...)` before returning early. It does **not**
+short-circuit anything else in kawa — the very next line back in
+`kawa::h1::parse`'s loop re-checks `parsing_phase`, sees `Error`, and returns.
+
+Both `HttpContext` consumers observe the resulting `ParsingPhase::Error`
+identically, since they share the same `HttpContext`/`ParserCallbacks` impl
+(`crate::protocol::http` is a `pub use ... kawa_h1 as http` re-export, not a
+separate type):
+
+- the standalone `Http` session (`mod.rs:529-567`) turns it into
+  `DefaultAnswer::Answer400` via `set_answer`;
+- the mux H1 connection (`lib/src/protocol/mux/h1.rs:313-336`) checks
+  `kawa.is_error()` immediately after `kawa::h1::parse` and, on the server
+  side, calls `set_default_answer(..., 400, ...)` and returns — before routing
+  or the per-frontend Basic-auth check (`mux/router.rs:834`,
+  `mux/auth.rs::check_basic`) run, so an ambiguously-framed request is rejected
+  before it reaches routing.
+
+Mirrors the equivalent HTTP/2 → H1 defense, `RejectReason::ClTeConflict`
+(`lib/src/protocol/mux/pkawa.rs:287`).
+
 ---
 
 ## 4. Default Answers

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -561,6 +561,37 @@ impl HttpContext {
         // so the postcondition can pin "blocks only grow" for the whole edit.
         let blocks_at_entry = request.blocks.len();
 
+        // Defense-in-depth against CL.TE request smuggling (CWE-444, RFC 9110 §7.6 /
+        // RFC 7230 §3.3.3; reopen of #726). kawa never elides the Transfer-Encoding
+        // header itself; when its chunked check does not fire (e.g. a trailing tab in
+        // `chunked\t`, trailing OWS, or `chunked` not the final coding), the TE header
+        // survives to forwarding while the body stays length/empty-framed. Forwarding an
+        // unhonored Transfer-Encoding next to a Content-Length is a desync primitive, so
+        // reject rather than forward ambiguous framing. Mirrors the HTTP/2 -> H1
+        // `RejectReason::ClTeConflict` rejection in `mux/pkawa.rs`.
+        if request.body_size != kawa::BodySize::Chunked {
+            let unhonored_te = {
+                let buf0 = request.storage.buffer();
+                request.blocks.iter().any(|block| {
+                    matches!(block,
+                        kawa::Block::Header(header)
+                            if !header.is_elided()
+                                && compare_no_case(header.key.data(buf0), b"transfer-encoding"))
+                })
+            };
+            if unhonored_te {
+                incr!(names::http::FRONTEND_TE_SMUGGLING);
+                warn!(
+                    "{} rejecting request: Transfer-Encoding not honored as chunked framing (possible CL.TE request smuggling)",
+                    self.log_context()
+                );
+                request
+                    .parsing_phase
+                    .error("Transfer-Encoding conflicts with message framing".into());
+                return;
+            }
+        }
+
         let buf = request.storage.mut_buffer();
 
         // Captures the request line

--- a/lib/src/protocol/kawa_h1/editor.rs
+++ b/lib/src/protocol/kawa_h1/editor.rs
@@ -562,34 +562,38 @@ impl HttpContext {
         let blocks_at_entry = request.blocks.len();
 
         // Defense-in-depth against CL.TE request smuggling (CWE-444, RFC 9110 §7.6 /
-        // RFC 7230 §3.3.3; reopen of #726). kawa never elides the Transfer-Encoding
-        // header itself; when its chunked check does not fire (e.g. a trailing tab in
-        // `chunked\t`, trailing OWS, or `chunked` not the final coding), the TE header
-        // survives to forwarding while the body stays length/empty-framed. Forwarding an
-        // unhonored Transfer-Encoding next to a Content-Length is a desync primitive, so
-        // reject rather than forward ambiguous framing. Mirrors the HTTP/2 -> H1
-        // `RejectReason::ClTeConflict` rejection in `mux/pkawa.rs`.
-        if request.body_size != kawa::BodySize::Chunked {
-            let unhonored_te = {
-                let buf0 = request.storage.buffer();
-                request.blocks.iter().any(|block| {
+        // RFC 9112 §6.1; reopen of #726). kawa never elides the Transfer-Encoding header
+        // and evaluates each TE field line independently, so we must reason about ALL
+        // surviving TE headers, not kawa's aggregate `body_size` (which a leading
+        // `chunked` line can latch while a later non-chunked line rides along). Reject:
+        //   * more than one non-elided TE header  (RFC 9112 §6.1: chunked must be applied
+        //     once and be the final coding; multiple field lines can't be safely
+        //     reconciled here and a Chunked latch would leave a second line forwarded), or
+        //   * a TE header present while kawa did not adopt chunked framing (e.g. `chunked\t`,
+        //     trailing OWS, or `chunked` not the final coding).
+        let te_count = {
+            let buf0 = request.storage.buffer();
+            request
+                .blocks
+                .iter()
+                .filter(|block| {
                     matches!(block,
                         kawa::Block::Header(header)
                             if !header.is_elided()
                                 && compare_no_case(header.key.data(buf0), b"transfer-encoding"))
                 })
-            };
-            if unhonored_te {
-                incr!(names::http::FRONTEND_TE_SMUGGLING);
-                warn!(
-                    "{} rejecting request: Transfer-Encoding not honored as chunked framing (possible CL.TE request smuggling)",
-                    self.log_context()
-                );
-                request
-                    .parsing_phase
-                    .error("Transfer-Encoding conflicts with message framing".into());
-                return;
-            }
+                .count()
+        };
+        if te_count > 1 || (te_count >= 1 && request.body_size != kawa::BodySize::Chunked) {
+            incr!(names::http::FRONTEND_TE_SMUGGLING);
+            warn!(
+                "{} rejecting request: ambiguous Transfer-Encoding framing (possible CL.TE request smuggling)",
+                self.log_context()
+            );
+            request
+                .parsing_phase
+                .error("Transfer-Encoding conflicts with message framing".into());
+            return;
         }
 
         let buf = request.storage.mut_buffer();


### PR DESCRIPTION
## Summary

Harden HTTP/1 `Transfer-Encoding` handling so Sōzu never forwards a request with ambiguous
message framing (RFC 9110 §7.6 / RFC 9112 §6.1; reopen of #726).

`HttpContext::on_request_headers` (`lib/src/protocol/kawa_h1/editor.rs`) now answers **400** when a
request carries a `Transfer-Encoding` header that the parser did not accept as chunked framing,
instead of forwarding it alongside a `Content-Length`. The rejection runs before routing and
increments a new `http.frontend.transfer_encoding_smuggling` counter. It mirrors the existing
HTTP/2 → H1 framing-conflict rejection (`RejectReason::ClTeConflict`, `mux/pkawa.rs`), giving H1/H2
parity, and is independent of any `kawa` release.

Legitimate framing is unaffected: valid `chunked`, `gzip, chunked`, `Content-Length`, and
well-formed `Content-Length` + `Transfer-Encoding: chunked` all pass through.

## Tests

- `test_h1_smuggling_te_cl_trailing_tab` — rejection cases → 400 with nothing forwarded to the
  backend (verified failing without the guard, passing with it).
- `test_h1_valid_framing_still_forwarded` — non-regression: every legitimate framing is forwarded
  and returns 200 (the guard does not over-reject).
- `test_h1_smuggling_auth_bypass` — end-to-end framing-bypass reproduction on an auth-gated frontend.
- Four pre-existing H1 smuggling tests unchanged and green.

## Docs

CHANGELOG (`### 🔐 Security`), `doc/configure.md` (new metric), `LIFECYCLE.md`, `CLAUDE.md`.

## Validation

`cargo build --all-features --locked`, `cargo clippy --all-targets --locked -- -D warnings`,
`cargo +nightly fmt --all -- --check`, `cargo test --workspace --locked` (e2e 421 passed) — all green.

## Follow-up

A complementary upstream `kawa` parser fix (require `chunked` as the final transfer-coding, trim
OWS) is prepared separately.
