### PR TITLE
fix(command): redact certificate data from logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,19 @@
 
 - **`fix(command)`: redact TLS certificate and private-key material from `Debug` output.**
   Certificate payloads, runtime certified keys and resolvers, HTTP(S) listeners and listener
-  patches, HTTP frontend configuration, and generated frontend requests now use bounded `Debug`
-  summaries without exposing PEM contents, certificate DER, custom answer bodies, header values,
+  patches, HTTP frontend configuration, top-level `Request`/`RequestType` values, retained command
+  tasks, and generated frontend requests now use bounded `Debug` summaries without exposing PEM
+  contents, certificate DER, custom answer bodies, header values, string-valued command payloads,
   or other raw fields carried by those types through nested requests, retained state, or log
   statements that use `Debug` formatting. Direct log and failure projections now also replace
-  certificate names, HTTP frontend keys, routing rules, rewrites, cluster IDs, custom-answer keys,
-  runtime SNI names, certificate fingerprints, and certificate-query domains and results with
-  bounded addresses, counts, and byte lengths.
-  Wire, Serde, JSON, raw retained state keys, raw `RouterError` and `ListenerError` variant fields,
-  `RequestHttpFrontend::Display`, and certificate-query response payloads remain unchanged.
+  certificate names, HTTP frontend keys, route-miss hosts/paths/custom methods, rewrites, cluster
+  IDs, custom-answer keys, runtime SNI/ALPN/authority/certificate-SAN values, certificate
+  fingerprints, and certificate-query domains and results with bounded addresses, kinds, counts,
+  and byte lengths. `StateError` is bounded at its `Display`/`Debug` boundary before worker and
+  audit sinks, and retained-task logs no longer delegate to concrete task payloads.
+  Wire, Serde, JSON, raw retained state keys, raw `StateError`, `RouterError`, `ListenerError`, and
+  `RetrieveClusterError::SniAuthorityMismatch` variant fields, `RequestHttpFrontend::Display`, and
+  certificate-query response payloads remain unchanged.
 
 ## 2.2.0 - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### 🔐 Security
+
+- **`fix(command)`: redact TLS certificate and private-key material from `Debug` output.**
+  Certificate payloads, runtime certified keys and resolvers, HTTP(S) listeners and listener
+  patches, HTTP frontend configuration, and generated frontend requests now use bounded `Debug`
+  summaries without exposing PEM contents, certificate DER, custom answer bodies, header values,
+  or other raw fields carried by those types through nested requests, retained state, or log
+  statements that use `Debug` formatting. Direct log and failure projections now also replace
+  certificate names, HTTP frontend keys, routing rules, rewrites, cluster IDs, custom-answer keys,
+  runtime SNI names, certificate fingerprints, and certificate-query domains and results with
+  bounded addresses, counts, and byte lengths.
+  Wire, Serde, JSON, raw retained state keys, raw `RouterError` and `ListenerError` variant fields,
+  `RequestHttpFrontend::Display`, and certificate-query response payloads remain unchanged.
+
 ## 2.2.0 - 2026-07-16
 
 Minor release: TCP passthrough routing by TLS SNI + ALPN, HTTP/1

--- a/bin/src/command/LIFECYCLE.md
+++ b/bin/src/command/LIFECYCLE.md
@@ -274,8 +274,9 @@ the OS sends RST/EOF to the peer.
 - `command/src/channel.rs` — `usize`-prefixed wire framing used between
   the supervisor and workers (distinct from the `\n\0` save-state
   framing in `command/src/state.rs:1613, 1630`).
-- `doc/observability.md` — operator-facing description of the audit
-  output, including the field reference.
+- `doc/observability.md` — canonical observability contract, including the
+  audit field reference and the bounded sensitive-value rules for `Debug`,
+  direct logs, retained tasks/state, and TLS runtime objects.
 - `doc/configure_admin_ops.md` — operational worked examples that drive
   this surface from the CLI side.
 - `lib/src/protocol/mux/LIFECYCLE.md` — counterpart inside the workers'

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -3753,7 +3753,7 @@ mod audit_format_tests {
     };
     use regex::Regex;
     use rusty_ulid::Ulid;
-    use sozu_command_lib::proto::command::EventKind;
+    use sozu_command_lib::{ObjectKind, proto::command::EventKind, state::StateError};
     use std::time::SystemTime;
 
     /// Minimal stand-in exposing only the `ClientSession` fields and methods
@@ -3918,6 +3918,40 @@ mod audit_format_tests {
         assert!(
             pattern().is_match(&rendered),
             "rendered line with extras did not match.\nrendered: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn state_error_reason_is_bounded_before_entering_the_audit_envelope() {
+        const ERROR_SECRET: &str = "AUDIT_STATE_ERROR_SECRET_SENTINEL";
+
+        let server = sample_server(0);
+        let client = sample_client(Some(42));
+        let request_id = Ulid::generate();
+        let id = format!("{ERROR_SECRET}{}", "x".repeat(4096));
+        let id_len = id.len();
+        let error = StateError::Exists {
+            kind: ObjectKind::Cluster,
+            id,
+        };
+        let mut entry = sample_entry(None);
+        entry.extras.error_code = Some(AuditErrorCode::DispatchError);
+        entry.extras.reason = Some(error.to_string());
+
+        let rendered = audit_log_context!(server, client, &request_id, &entry, AuditResult::Err);
+
+        assert!(
+            !rendered.contains(ERROR_SECRET),
+            "audit reason leaked the StateError payload: {rendered}"
+        );
+        assert!(
+            rendered.contains(&format!("id_bytes={id_len}")),
+            "audit reason omitted bounded StateError metadata: {rendered}"
+        );
+        assert!(
+            rendered.len() <= 1024,
+            "audit line is not bounded: {} bytes",
+            rendered.len()
         );
     }
 

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -506,7 +506,7 @@ pub fn query_certificates_from_main(
     filters: QueryCertificatesFilters,
 ) {
     debug!(
-        "querying certificates in the state with filters {}",
+        "querying certificates in the state with filters {:?}",
         filters
     );
 

--- a/bin/src/command/server.rs
+++ b/bin/src/command/server.rs
@@ -84,6 +84,11 @@ pub trait Gatherer {
 /// Must be satisfied by commands that need to wait for worker responses
 #[allow(unused)]
 pub trait GatheringTask: Debug {
+    /// Return a payload-free identifier suitable for retained-task logs.
+    fn kind(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
+
     /// get access to the client that sent the command (if any)
     fn client_token(&self) -> Option<Token>;
 
@@ -131,10 +136,18 @@ pub enum Timeout {
 }
 
 /// Contains a task and its execution timeout
-#[derive(Debug)]
 struct TaskContainer {
     job: Box<dyn GatheringTask>,
     timeout: Option<Instant>,
+}
+
+impl Debug for TaskContainer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TaskContainer")
+            .field("task_kind", &self.job.kind())
+            .field("timeout_armed", &self.timeout.is_some())
+            .finish()
+    }
 }
 
 /// Default strategy when gathering responses from workers
@@ -543,7 +556,7 @@ impl CommandHub {
             }
 
             events.clear();
-            trace!("Tasks: {:?}", self.tasks);
+            trace!("Tasks: count={}", self.tasks.len());
             trace!("Sessions to tick: {:?}", sessions_to_tick);
             trace!("Polling timeout: {:?}", poll_timeout);
             match self.poll.poll(&mut events, poll_timeout) {
@@ -1528,6 +1541,66 @@ mod tests {
         let unix_listener = UnixListener::bind(&socket_path).expect("Could not bind socket");
         Server::new(unix_listener, Config::default(), "sozu".to_owned())
             .expect("Could not create server")
+    }
+
+    #[derive(Debug)]
+    struct SecretBearingTask {
+        gatherer: DefaultGatherer,
+        secret: String,
+    }
+
+    impl GatheringTask for SecretBearingTask {
+        fn client_token(&self) -> Option<Token> {
+            None
+        }
+
+        fn get_gatherer(&mut self) -> &mut dyn Gatherer {
+            &mut self.gatherer
+        }
+
+        fn on_finish(
+            self: Box<Self>,
+            _server: &mut Server,
+            _client: &mut OptionalClient,
+            _timed_out: bool,
+        ) {
+        }
+    }
+
+    #[test]
+    fn task_sink_debug_does_not_format_concrete_task_payloads() {
+        const TASK_SECRET: &str = "RETAINED_TASK_PAYLOAD_SECRET_SENTINEL";
+
+        let secret = format!("{TASK_SECRET}{}", "x".repeat(4096));
+        let secret_len = secret.len();
+        let job = SecretBearingTask {
+            gatherer: DefaultGatherer::default(),
+            secret,
+        };
+        assert_eq!(
+            job.secret.len(),
+            secret_len,
+            "fixture must retain the full task payload before logging"
+        );
+        let task = TaskContainer {
+            job: Box::new(job),
+            timeout: None,
+        };
+        let output = format!("Task finish: {task:?}");
+
+        assert!(
+            !output.contains(TASK_SECRET),
+            "task completion sink leaked the concrete task payload: {output}"
+        );
+        assert!(
+            output.contains("SecretBearingTask"),
+            "task completion sink omitted the bounded task kind: {output}"
+        );
+        assert!(
+            output.len() <= 512,
+            "task completion sink output is not bounded: {} bytes",
+            output.len()
+        );
     }
 
     #[test]

--- a/bin/src/command/server.rs
+++ b/bin/src/command/server.rs
@@ -138,7 +138,7 @@ struct TaskContainer {
 }
 
 /// Default strategy when gathering responses from workers
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct DefaultGatherer {
     /// number of OK responses received from workers
     pub ok: usize,
@@ -148,6 +148,17 @@ pub struct DefaultGatherer {
     pub responses: Vec<(WorkerId, WorkerResponse)>,
     /// number of expected responses, excluding processing responses
     pub expected_responses: usize,
+}
+
+impl fmt::Debug for DefaultGatherer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DefaultGatherer")
+            .field("ok", &self.ok)
+            .field("errors", &self.errors)
+            .field("responses_count", &self.responses.len())
+            .field("expected_responses", &self.expected_responses)
+            .finish()
+    }
 }
 
 #[allow(unused)]
@@ -1490,8 +1501,9 @@ mod tests {
     use sozu_command_lib::{
         config::Config,
         proto::command::{
-            AddBackend, Cluster, RequestHttpFrontend, RequestTcpFrontend, SocketAddress,
-            request::RequestType,
+            AddBackend, CertificateSummary, CertificatesByAddress, Cluster,
+            ListOfCertificatesByAddress, RequestHttpFrontend, RequestTcpFrontend, SocketAddress,
+            WorkerResponse, request::RequestType, response_content::ContentType,
         },
     };
     use sozu_lib::metrics::METRICS;
@@ -1516,6 +1528,69 @@ mod tests {
         let unix_listener = UnixListener::bind(&socket_path).expect("Could not bind socket");
         Server::new(unix_listener, Config::default(), "sozu".to_owned())
             .expect("Could not create server")
+    }
+
+    #[test]
+    fn default_gatherer_debug_bounds_retained_certificate_query_responses() {
+        const DOMAIN_SECRET: &str = "RETAINED_QUERY_DOMAIN_SECRET_SENTINEL";
+        const FINGERPRINT_SECRET: &str = "RETAINED_QUERY_FINGERPRINT_SECRET_SENTINEL";
+        const RESPONSE_ID_SECRET: &str = "RETAINED_QUERY_RESPONSE_ID_SECRET_SENTINEL";
+        const MESSAGE_SECRET: &str = "RETAINED_QUERY_MESSAGE_SECRET_SENTINEL";
+
+        let long_value = |marker: &str| format!("{marker}{}", "x".repeat(4096));
+        let content: ResponseContent =
+            ContentType::CertificatesByAddress(ListOfCertificatesByAddress {
+                certificates: vec![CertificatesByAddress {
+                    address: Default::default(),
+                    certificate_summaries: vec![CertificateSummary {
+                        domain: long_value(DOMAIN_SECRET),
+                        fingerprint: long_value(FINGERPRINT_SECRET),
+                    }],
+                }],
+            })
+            .into();
+        let responses = (0..128)
+            .map(|worker_id| {
+                (
+                    worker_id,
+                    WorkerResponse {
+                        id: long_value(RESPONSE_ID_SECRET),
+                        status: ResponseStatus::Ok as i32,
+                        message: long_value(MESSAGE_SECRET),
+                        content: Some(content.clone()),
+                    },
+                )
+            })
+            .collect();
+        let gatherer = DefaultGatherer {
+            ok: 128,
+            errors: 0,
+            responses,
+            expected_responses: 128,
+        };
+
+        let output = format!("{gatherer:?}");
+
+        for secret in [
+            DOMAIN_SECRET,
+            FINGERPRINT_SECRET,
+            RESPONSE_ID_SECRET,
+            MESSAGE_SECRET,
+        ] {
+            assert!(
+                !output.contains(secret),
+                "DefaultGatherer Debug leaked retained response marker {secret}: {output}"
+            );
+        }
+        assert!(
+            output.contains("responses_count: 128"),
+            "DefaultGatherer Debug omitted the retained response count: {output}"
+        );
+        assert!(
+            output.len() <= 512,
+            "DefaultGatherer Debug output is not cardinality-bounded: {} bytes",
+            output.len()
+        );
     }
 
     #[test]

--- a/command/build.rs
+++ b/command/build.rs
@@ -73,6 +73,28 @@ pub fn main() {
         .field_attribute("TcpListenerConfig.answers", "#[serde(default)]")
         .field_attribute("RequestUdpFrontend.tags", "#[serde(default)]")
         .field_attribute("RequestTcpFrontend.alpn", "#[serde(default)]")
+        .skip_debug([
+            "CertificateAndKey",
+            "CertificateSummary",
+            "CertificatesByAddress",
+            "CertificatesWithFingerprints",
+            "Cluster",
+            "Header",
+            "RequestHttpFrontend",
+            "HttpListenerConfig",
+            "HttpsListenerConfig",
+            "ListOfCertificatesByAddress",
+            "QueryCertificatesFilters",
+            "RemoveCertificate",
+            "ReplaceCertificate",
+            "RequestTcpFrontend",
+            "ResponseContent",
+            "UpdateHttpListenerConfig",
+            "UpdateHttpsListenerConfig",
+            "WorkerRequest",
+            "WorkerResponse",
+            "WorkerResponses",
+        ])
         .enum_attribute(".", "#[serde(rename_all = \"SCREAMING_SNAKE_CASE\")]")
         .enum_attribute(
             "ResponseContent.content_type",

--- a/command/build.rs
+++ b/command/build.rs
@@ -87,6 +87,7 @@ pub fn main() {
             "QueryCertificatesFilters",
             "RemoveCertificate",
             "ReplaceCertificate",
+            "Request",
             "RequestTcpFrontend",
             "ResponseContent",
             "UpdateHttpListenerConfig",

--- a/command/src/config.rs
+++ b/command/src/config.rs
@@ -2581,7 +2581,7 @@ impl FileClusterConfig {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct HttpFrontendConfig {
     pub address: SocketAddr,
@@ -2620,6 +2620,57 @@ pub struct HttpFrontendConfig {
     /// the listener default at frontend-add time in the worker.
     #[serde(default)]
     pub hsts: Option<HstsConfig>,
+}
+
+impl fmt::Debug for HttpFrontendConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let certificate = self.certificate.as_ref().map(|_| "[redacted]");
+        let certificate_len = self.certificate.as_ref().map(String::len);
+        let key = self.key.as_ref().map(|_| "[redacted]");
+        let key_len = self.key.as_ref().map(String::len);
+        let certificate_chain = self.certificate_chain.as_ref().map(|_| "[redacted]");
+        let certificate_chain_count = self.certificate_chain.as_ref().map(Vec::len);
+        let certificate_chain_len = self.certificate_chain.as_ref().map(|chain| {
+            chain
+                .iter()
+                .map(String::len)
+                .fold(0usize, usize::saturating_add)
+        });
+        let method_len = self.method.as_ref().map(String::len);
+        let redirect_template_len = self.redirect_template.as_ref().map(String::len);
+        let rewrite_host_len = self.rewrite_host.as_ref().map(String::len);
+        let rewrite_path_len = self.rewrite_path.as_ref().map(String::len);
+
+        f.debug_struct("HttpFrontendConfig")
+            .field("address", &self.address)
+            .field("hostname_len", &self.hostname.len())
+            .field("path_kind", &self.path.kind)
+            .field("path_len", &self.path.value.len())
+            .field("method_len", &method_len)
+            .field("certificate", &certificate)
+            .field("certificate_len", &certificate_len)
+            .field("key", &key)
+            .field("key_len", &key_len)
+            .field("certificate_chain", &certificate_chain)
+            .field("certificate_chain_count", &certificate_chain_count)
+            .field("certificate_chain_len", &certificate_chain_len)
+            .field("tls_versions_count", &self.tls_versions.len())
+            .field("position", &self.position)
+            .field(
+                "tags_count",
+                &self.tags.as_ref().map(BTreeMap::len).unwrap_or_default(),
+            )
+            .field("redirect", &self.redirect)
+            .field("redirect_scheme", &self.redirect_scheme)
+            .field("redirect_template_len", &redirect_template_len)
+            .field("rewrite_host_len", &rewrite_host_len)
+            .field("rewrite_path_len", &rewrite_path_len)
+            .field("rewrite_port", &self.rewrite_port)
+            .field("required_auth", &self.required_auth)
+            .field("headers_count", &self.headers.len())
+            .field("hsts", &self.hsts)
+            .finish()
+    }
 }
 
 impl HttpFrontendConfig {
@@ -4251,6 +4302,152 @@ mod tests {
     use toml::to_string;
 
     use super::*;
+
+    #[test]
+    fn http_frontend_debug_redacts_pem_material() {
+        const CERTIFICATE_SECRET: &str = "HTTP_FRONTEND_CERTIFICATE_PEM_SECRET_SENTINEL";
+        const CHAIN_SECRET: &str = "HTTP_FRONTEND_CHAIN_PEM_SECRET_SENTINEL";
+        const KEY_SECRET: &str = "HTTP_FRONTEND_KEY_PEM_SECRET_SENTINEL";
+        const HOSTNAME_SECRET: &str = "HTTP_FRONTEND_HOSTNAME_SECRET_SENTINEL";
+        const PATH_SECRET: &str = "HTTP_FRONTEND_PATH_SECRET_SENTINEL";
+        const METHOD_SECRET: &str = "HTTP_FRONTEND_METHOD_SECRET_SENTINEL";
+        const TAG_KEY_SECRET: &str = "HTTP_FRONTEND_TAG_KEY_SECRET_SENTINEL";
+        const TAG_SECRET: &str = "HTTP_FRONTEND_TAG_VALUE_SECRET_SENTINEL";
+        const HEADER_KEY_SECRET: &str = "HTTP_FRONTEND_HEADER_KEY_SECRET_SENTINEL";
+        const HEADER_SECRET: &str = "HTTP_FRONTEND_HEADER_VALUE_SECRET_SENTINEL";
+        const REDIRECT_TEMPLATE_SECRET: &str = "HTTP_FRONTEND_REDIRECT_TEMPLATE_SECRET_SENTINEL";
+        const REWRITE_HOST_SECRET: &str = "HTTP_FRONTEND_REWRITE_HOST_SECRET_SENTINEL";
+        const REWRITE_PATH_SECRET: &str = "HTTP_FRONTEND_REWRITE_PATH_SECRET_SENTINEL";
+
+        let long_value = |marker: &str| format!("{marker}{}", "x".repeat(4096));
+        let certificate = long_value(CERTIFICATE_SECRET);
+        let certificate_chain = long_value(CHAIN_SECRET);
+        let key = long_value(KEY_SECRET);
+        let hostname = long_value(HOSTNAME_SECRET);
+        let path = long_value(PATH_SECRET);
+        let method = long_value(METHOD_SECRET);
+        let redirect_template = long_value(REDIRECT_TEMPLATE_SECRET);
+        let rewrite_host = long_value(REWRITE_HOST_SECRET);
+        let rewrite_path = long_value(REWRITE_PATH_SECRET);
+
+        let frontend = HttpFrontendConfig {
+            address: "127.0.0.1:8443".parse().unwrap(),
+            hostname,
+            path: PathRule::prefix(path),
+            method: Some(method),
+            certificate: Some(certificate),
+            key: Some(key),
+            certificate_chain: Some(vec![certificate_chain]),
+            tls_versions: vec![TlsVersion::TlsV13],
+            position: RulePosition::Tree,
+            tags: Some(BTreeMap::from([(
+                long_value(TAG_KEY_SECRET),
+                long_value(TAG_SECRET),
+            )])),
+            redirect: None,
+            redirect_scheme: None,
+            redirect_template: Some(redirect_template),
+            rewrite_host: Some(rewrite_host),
+            rewrite_path: Some(rewrite_path),
+            rewrite_port: None,
+            required_auth: None,
+            headers: vec![Header {
+                position: HeaderPosition::Request as i32,
+                key: long_value(HEADER_KEY_SECRET),
+                val: long_value(HEADER_SECRET),
+            }],
+            hsts: None,
+        };
+
+        let output = format!("{frontend:?}");
+
+        let secrets = [
+            CERTIFICATE_SECRET,
+            CHAIN_SECRET,
+            KEY_SECRET,
+            HOSTNAME_SECRET,
+            PATH_SECRET,
+            METHOD_SECRET,
+            TAG_KEY_SECRET,
+            TAG_SECRET,
+            HEADER_KEY_SECRET,
+            HEADER_SECRET,
+            REDIRECT_TEMPLATE_SECRET,
+            REWRITE_HOST_SECRET,
+            REWRITE_PATH_SECRET,
+        ];
+        for secret in secrets {
+            assert!(
+                !output.contains(secret),
+                "HttpFrontendConfig Debug leaked secret marker {secret}: {output}"
+            );
+        }
+        let expected_metadata = [
+            "address: 127.0.0.1:8443".to_owned(),
+            format!("hostname_len: {}", long_value(HOSTNAME_SECRET).len()),
+            format!("path_kind: {}", PathRule::prefix(String::new()).kind),
+            format!("path_len: {}", long_value(PATH_SECRET).len()),
+            format!("method_len: Some({})", long_value(METHOD_SECRET).len()),
+            "certificate: Some(\"[redacted]\")".to_owned(),
+            format!(
+                "certificate_len: Some({})",
+                long_value(CERTIFICATE_SECRET).len()
+            ),
+            "key: Some(\"[redacted]\")".to_owned(),
+            format!("key_len: Some({})", long_value(KEY_SECRET).len()),
+            "certificate_chain: Some(\"[redacted]\")".to_owned(),
+            "certificate_chain_count: Some(1)".to_owned(),
+            format!(
+                "certificate_chain_len: Some({})",
+                long_value(CHAIN_SECRET).len()
+            ),
+            "tls_versions_count: 1".to_owned(),
+            "tags_count: 1".to_owned(),
+            format!(
+                "redirect_template_len: Some({})",
+                long_value(REDIRECT_TEMPLATE_SECRET).len()
+            ),
+            format!(
+                "rewrite_host_len: Some({})",
+                long_value(REWRITE_HOST_SECRET).len()
+            ),
+            format!(
+                "rewrite_path_len: Some({})",
+                long_value(REWRITE_PATH_SECRET).len()
+            ),
+            "headers_count: 1".to_owned(),
+        ];
+        for safe_metadata in expected_metadata {
+            assert!(
+                output.contains(&safe_metadata),
+                "HttpFrontendConfig Debug omitted safe metadata {safe_metadata}: {output}"
+            );
+        }
+        assert!(
+            output.len() <= 1024,
+            "HttpFrontendConfig Debug output is not bounded: {} bytes",
+            output.len()
+        );
+
+        for (index, request) in frontend
+            .generate_requests("safe-cluster-id")
+            .into_iter()
+            .enumerate()
+        {
+            let generated_output = format!("{request:?}");
+            for secret in secrets {
+                assert!(
+                    !generated_output.contains(secret),
+                    "generated frontend request {index} Debug leaked secret marker {secret}: {generated_output}"
+                );
+            }
+            assert!(
+                generated_output.len() <= 2048,
+                "generated frontend request {index} Debug output is not bounded: {} bytes",
+                generated_output.len()
+            );
+        }
+    }
 
     #[test]
     fn hsts_to_proto_enabled_substitutes_default_max_age() {

--- a/command/src/proto/mod.rs
+++ b/command/src/proto/mod.rs
@@ -44,6 +44,75 @@ impl From<command::request::RequestType> for command::Request {
     }
 }
 
+impl std::fmt::Debug for command::Request {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut request = f.debug_struct("Request");
+        match self.request_type.as_ref() {
+            Some(request_type) => request.field("request_type", request_type),
+            None => request.field("request_type", &"Unallowed"),
+        };
+        request.finish()
+    }
+}
+
+impl std::fmt::Debug for command::request::RequestType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use command::request::RequestType;
+
+        match self {
+            RequestType::AddCluster(value) => f.debug_tuple("AddCluster").field(value).finish(),
+            RequestType::AddHttpFrontend(value) => {
+                f.debug_tuple("AddHttpFrontend").field(value).finish()
+            }
+            RequestType::RemoveHttpFrontend(value) => {
+                f.debug_tuple("RemoveHttpFrontend").field(value).finish()
+            }
+            RequestType::AddHttpsFrontend(value) => {
+                f.debug_tuple("AddHttpsFrontend").field(value).finish()
+            }
+            RequestType::RemoveHttpsFrontend(value) => {
+                f.debug_tuple("RemoveHttpsFrontend").field(value).finish()
+            }
+            RequestType::AddCertificate(value) => {
+                f.debug_tuple("AddCertificate").field(value).finish()
+            }
+            RequestType::ReplaceCertificate(value) => {
+                f.debug_tuple("ReplaceCertificate").field(value).finish()
+            }
+            RequestType::RemoveCertificate(value) => {
+                f.debug_tuple("RemoveCertificate").field(value).finish()
+            }
+            RequestType::AddTcpFrontend(value) => {
+                f.debug_tuple("AddTcpFrontend").field(value).finish()
+            }
+            RequestType::RemoveTcpFrontend(value) => {
+                f.debug_tuple("RemoveTcpFrontend").field(value).finish()
+            }
+            RequestType::AddHttpListener(value) => {
+                f.debug_tuple("AddHttpListener").field(value).finish()
+            }
+            RequestType::AddHttpsListener(value) => {
+                f.debug_tuple("AddHttpsListener").field(value).finish()
+            }
+            RequestType::UpdateHttpListener(value) => {
+                f.debug_tuple("UpdateHttpListener").field(value).finish()
+            }
+            RequestType::UpdateHttpsListener(value) => {
+                f.debug_tuple("UpdateHttpsListener").field(value).finish()
+            }
+            RequestType::QueryCertificatesFromTheState(value) => f
+                .debug_tuple("QueryCertificatesFromTheState")
+                .field(value)
+                .finish(),
+            RequestType::QueryCertificatesFromWorkers(value) => f
+                .debug_tuple("QueryCertificatesFromWorkers")
+                .field(value)
+                .finish(),
+            other => f.write_str(display::format_request_type(other)),
+        }
+    }
+}
+
 impl std::fmt::Debug for command::CertificateAndKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let certificate_chain_len = self
@@ -782,6 +851,40 @@ mod tests {
         UpdateHttpsListenerConfig, WorkerMetrics, WorkerRequest, WorkerResponse, WorkerResponses,
         filtered_metrics::Inner, request::RequestType, response_content::ContentType,
     };
+
+    #[test]
+    fn request_debug_redacts_string_variant_payloads_directly_and_when_nested() {
+        const PATH_SECRET: &str = "REQUEST_SAVE_STATE_PATH_SECRET_SENTINEL";
+
+        let request_type = RequestType::SaveState(format!("{PATH_SECRET}{}", "x".repeat(4096)));
+        let direct_output = format!("{request_type:?}");
+        let request = Request::from(request_type);
+        let worker_request = WorkerRequest {
+            id: "safe-request-id".to_owned(),
+            content: request.clone(),
+        };
+        let outputs = [
+            direct_output,
+            format!("{request:?}"),
+            format!("{worker_request:?}"),
+        ];
+
+        for output in outputs {
+            assert!(
+                !output.contains(PATH_SECRET),
+                "Request Debug leaked its string variant payload: {output}"
+            );
+            assert!(
+                output.contains("SaveState"),
+                "Request Debug omitted the bounded request kind: {output}"
+            );
+            assert!(
+                output.len() <= 256,
+                "Request Debug output is not bounded: {} bytes",
+                output.len()
+            );
+        }
+    }
 
     #[test]
     fn listener_and_patch_debug_redacts_user_controlled_material() {

--- a/command/src/proto/mod.rs
+++ b/command/src/proto/mod.rs
@@ -44,6 +44,579 @@ impl From<command::request::RequestType> for command::Request {
     }
 }
 
+impl std::fmt::Debug for command::CertificateAndKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let certificate_chain_len = self
+            .certificate_chain
+            .iter()
+            .map(String::len)
+            .fold(0usize, usize::saturating_add);
+
+        f.debug_struct("CertificateAndKey")
+            .field("certificate", &"[redacted]")
+            .field("certificate_len", &self.certificate.len())
+            .field("certificate_chain", &"[redacted]")
+            .field("certificate_chain_count", &self.certificate_chain.len())
+            .field("certificate_chain_len", &certificate_chain_len)
+            .field("key", &"[redacted]")
+            .field("key_len", &self.key.len())
+            .field("versions_count", &self.versions.len())
+            .field("names_count", &self.names.len())
+            .field("names_len", &total_string_len(&self.names))
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for command::RemoveCertificate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RemoveCertificate")
+            .field("address", &self.address)
+            .field("fingerprint_len", &self.fingerprint.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for command::ReplaceCertificate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReplaceCertificate")
+            .field("address", &self.address)
+            .field("new_certificate", &self.new_certificate)
+            .field("fingerprint_len", &self.old_fingerprint.len())
+            .field("new_expired_at", &self.new_expired_at)
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for command::Cluster {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (answers_count, answers_key_len, answers_value_len) =
+            summarize_string_map(&self.answers);
+
+        f.debug_struct("Cluster")
+            .field("cluster_id_len", &self.cluster_id.len())
+            .field("sticky_session", &self.sticky_session)
+            .field("https_redirect", &self.https_redirect)
+            .field("proxy_protocol", &self.proxy_protocol)
+            .field("load_balancing", &self.load_balancing)
+            .field("answer_503_len", &self.answer_503.as_ref().map(String::len))
+            .field("load_metric", &self.load_metric)
+            .field("http2", &self.http2)
+            .field("answers_count", &answers_count)
+            .field("answers_key_len", &answers_key_len)
+            .field("answers_value_len", &answers_value_len)
+            .field("https_redirect_port", &self.https_redirect_port)
+            .field("authorized_hashes_count", &self.authorized_hashes.len())
+            .field(
+                "authorized_hashes_len",
+                &total_string_len(&self.authorized_hashes),
+            )
+            .field(
+                "www_authenticate_len",
+                &self.www_authenticate.as_ref().map(String::len),
+            )
+            .field("max_connections_per_ip", &self.max_connections_per_ip)
+            .field("retry_after", &self.retry_after)
+            .field("health_check_present", &self.health_check.is_some())
+            .field("udp_present", &self.udp.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for command::Header {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Header")
+            .field("position", &self.position)
+            .field("key_len", &self.key.len())
+            .field("val_len", &self.val.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for command::RequestHttpFrontend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let tags_len = self.tags.iter().fold(0usize, |total, (key, value)| {
+            total.saturating_add(key.len()).saturating_add(value.len())
+        });
+        let headers_len = self.headers.iter().fold(0usize, |total, header| {
+            total
+                .saturating_add(header.key.len())
+                .saturating_add(header.val.len())
+        });
+
+        f.debug_struct("RequestHttpFrontend")
+            .field("cluster_id_len", &self.cluster_id.as_ref().map(String::len))
+            .field("address", &self.address)
+            .field("hostname_len", &self.hostname.len())
+            .field("path_kind", &self.path.kind)
+            .field("path_len", &self.path.value.len())
+            .field("method_len", &self.method.as_ref().map(String::len))
+            .field("position", &self.position)
+            .field("tags_count", &self.tags.len())
+            .field("tags_len", &tags_len)
+            .field("redirect", &self.redirect)
+            .field("required_auth", &self.required_auth)
+            .field("redirect_scheme", &self.redirect_scheme)
+            .field(
+                "redirect_template_len",
+                &self.redirect_template.as_ref().map(String::len),
+            )
+            .field(
+                "rewrite_host_len",
+                &self.rewrite_host.as_ref().map(String::len),
+            )
+            .field(
+                "rewrite_path_len",
+                &self.rewrite_path.as_ref().map(String::len),
+            )
+            .field("rewrite_port", &self.rewrite_port)
+            .field("headers_count", &self.headers.len())
+            .field("headers_len", &headers_len)
+            .field("hsts", &self.hsts)
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for command::RequestTcpFrontend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (tags_count, tags_key_len, tags_value_len) = summarize_string_map(&self.tags);
+
+        f.debug_struct("RequestTcpFrontend")
+            .field("cluster_id_len", &self.cluster_id.len())
+            .field("address", &self.address)
+            .field("tags_count", &tags_count)
+            .field("tags_key_len", &tags_key_len)
+            .field("tags_value_len", &tags_value_len)
+            .field("sni_len", &self.sni.as_ref().map(String::len))
+            .field("alpn_count", &self.alpn.len())
+            .field("alpn_len", &total_string_len(&self.alpn))
+            .finish_non_exhaustive()
+    }
+}
+
+fn total_string_len<'a>(values: impl IntoIterator<Item = &'a String>) -> usize {
+    values
+        .into_iter()
+        .map(String::len)
+        .fold(0usize, usize::saturating_add)
+}
+
+fn summarize_http_answers(
+    answers: Option<&command::CustomHttpAnswers>,
+) -> (Option<&'static str>, Option<usize>, Option<usize>) {
+    let Some(answers) = answers else {
+        return (None, None, None);
+    };
+    let values = [
+        answers.answer_301.as_ref(),
+        answers.answer_400.as_ref(),
+        answers.answer_401.as_ref(),
+        answers.answer_404.as_ref(),
+        answers.answer_408.as_ref(),
+        answers.answer_413.as_ref(),
+        answers.answer_421.as_ref(),
+        answers.answer_429.as_ref(),
+        answers.answer_502.as_ref(),
+        answers.answer_503.as_ref(),
+        answers.answer_504.as_ref(),
+        answers.answer_507.as_ref(),
+    ];
+
+    (
+        Some("[redacted]"),
+        Some(values.iter().flatten().count()),
+        Some(total_string_len(values.iter().flatten().copied())),
+    )
+}
+
+fn summarize_string_map(
+    values: &std::collections::BTreeMap<String, String>,
+) -> (usize, usize, usize) {
+    (
+        values.len(),
+        total_string_len(values.keys()),
+        total_string_len(values.values()),
+    )
+}
+
+impl std::fmt::Debug for command::HttpListenerConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (http_answers, http_answers_count, http_answers_len) =
+            summarize_http_answers(self.http_answers.as_ref());
+        let (answers_count, answers_key_len, answers_value_len) =
+            summarize_string_map(&self.answers);
+
+        f.debug_struct("HttpListenerConfig")
+            .field("address", &self.address)
+            .field("public_address", &self.public_address)
+            .field("expect_proxy", &self.expect_proxy)
+            .field("sticky_name_len", &self.sticky_name.len())
+            .field("front_timeout", &self.front_timeout)
+            .field("back_timeout", &self.back_timeout)
+            .field("connect_timeout", &self.connect_timeout)
+            .field("request_timeout", &self.request_timeout)
+            .field("active", &self.active)
+            .field("http_answers", &http_answers)
+            .field("http_answers_count", &http_answers_count)
+            .field("http_answers_len", &http_answers_len)
+            .field(
+                "sozu_id_header_len",
+                &self.sozu_id_header.as_ref().map(String::len),
+            )
+            .field("answers_count", &answers_count)
+            .field("answers_key_len", &answers_key_len)
+            .field("answers_value_len", &answers_value_len)
+            .field("elide_x_real_ip", &self.elide_x_real_ip)
+            .field("send_x_real_ip", &self.send_x_real_ip)
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for command::UpdateHttpListenerConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (http_answers, http_answers_count, http_answers_len) =
+            summarize_http_answers(self.http_answers.as_ref());
+        let (answers_count, answers_key_len, answers_value_len) =
+            summarize_string_map(&self.answers);
+
+        f.debug_struct("UpdateHttpListenerConfig")
+            .field("address", &self.address)
+            .field("public_address", &self.public_address)
+            .field(
+                "sticky_name_len",
+                &self.sticky_name.as_ref().map(String::len),
+            )
+            .field("http_answers", &http_answers)
+            .field("http_answers_count", &http_answers_count)
+            .field("http_answers_len", &http_answers_len)
+            .field(
+                "sozu_id_header_len",
+                &self.sozu_id_header.as_ref().map(String::len),
+            )
+            .field("answers_count", &answers_count)
+            .field("answers_key_len", &answers_key_len)
+            .field("answers_value_len", &answers_value_len)
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for command::UpdateHttpsListenerConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (http_answers, http_answers_count, http_answers_len) =
+            summarize_http_answers(self.http_answers.as_ref());
+        let alpn_protocols_count = self
+            .alpn_protocols
+            .as_ref()
+            .map(|protocols| protocols.values.len());
+        let alpn_protocols_len = self
+            .alpn_protocols
+            .as_ref()
+            .map(|protocols| total_string_len(&protocols.values));
+        let (answers_count, answers_key_len, answers_value_len) =
+            summarize_string_map(&self.answers);
+
+        f.debug_struct("UpdateHttpsListenerConfig")
+            .field("address", &self.address)
+            .field("public_address", &self.public_address)
+            .field(
+                "sticky_name_len",
+                &self.sticky_name.as_ref().map(String::len),
+            )
+            .field("http_answers", &http_answers)
+            .field("http_answers_count", &http_answers_count)
+            .field("http_answers_len", &http_answers_len)
+            .field("alpn_protocols_count", &alpn_protocols_count)
+            .field("alpn_protocols_len", &alpn_protocols_len)
+            .field(
+                "sozu_id_header_len",
+                &self.sozu_id_header.as_ref().map(String::len),
+            )
+            .field("answers_count", &answers_count)
+            .field("answers_key_len", &answers_key_len)
+            .field("answers_value_len", &answers_value_len)
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for command::HttpsListenerConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let certificate = self.certificate.as_ref().map(|_| "[redacted]");
+        let certificate_len = self.certificate.as_ref().map(String::len);
+        let certificate_chain_len = total_string_len(&self.certificate_chain);
+        let key = self.key.as_ref().map(|_| "[redacted]");
+        let key_len = self.key.as_ref().map(String::len);
+        let (http_answers, http_answers_count, http_answers_len) =
+            summarize_http_answers(self.http_answers.as_ref());
+        let sozu_id_header_len = self.sozu_id_header.as_ref().map(String::len);
+        let (answers_count, answers_key_len, answers_value_len) =
+            summarize_string_map(&self.answers);
+
+        f.debug_struct("HttpsListenerConfig")
+            .field("address", &self.address)
+            .field("public_address", &self.public_address)
+            .field("expect_proxy", &self.expect_proxy)
+            .field("sticky_name_len", &self.sticky_name.len())
+            .field("front_timeout", &self.front_timeout)
+            .field("back_timeout", &self.back_timeout)
+            .field("connect_timeout", &self.connect_timeout)
+            .field("request_timeout", &self.request_timeout)
+            .field("active", &self.active)
+            .field("versions_count", &self.versions.len())
+            .field("cipher_list_count", &self.cipher_list.len())
+            .field("cipher_list_len", &total_string_len(&self.cipher_list))
+            .field("cipher_suites_count", &self.cipher_suites.len())
+            .field("cipher_suites_len", &total_string_len(&self.cipher_suites))
+            .field(
+                "signature_algorithms_count",
+                &self.signature_algorithms.len(),
+            )
+            .field(
+                "signature_algorithms_len",
+                &total_string_len(&self.signature_algorithms),
+            )
+            .field("groups_list_count", &self.groups_list.len())
+            .field("groups_list_len", &total_string_len(&self.groups_list))
+            .field("certificate", &certificate)
+            .field("certificate_len", &certificate_len)
+            .field("certificate_chain", &"[redacted]")
+            .field("certificate_chain_count", &self.certificate_chain.len())
+            .field("certificate_chain_len", &certificate_chain_len)
+            .field("key", &key)
+            .field("key_len", &key_len)
+            .field("send_tls13_tickets", &self.send_tls13_tickets)
+            .field("http_answers", &http_answers)
+            .field("http_answers_count", &http_answers_count)
+            .field("http_answers_len", &http_answers_len)
+            .field("alpn_protocols_count", &self.alpn_protocols.len())
+            .field(
+                "alpn_protocols_len",
+                &total_string_len(&self.alpn_protocols),
+            )
+            .field(
+                "h2_max_rst_stream_per_window",
+                &self.h2_max_rst_stream_per_window,
+            )
+            .field("h2_max_ping_per_window", &self.h2_max_ping_per_window)
+            .field(
+                "h2_max_settings_per_window",
+                &self.h2_max_settings_per_window,
+            )
+            .field(
+                "h2_max_empty_data_per_window",
+                &self.h2_max_empty_data_per_window,
+            )
+            .field(
+                "h2_max_continuation_frames",
+                &self.h2_max_continuation_frames,
+            )
+            .field("h2_max_glitch_count", &self.h2_max_glitch_count)
+            .field(
+                "h2_initial_connection_window",
+                &self.h2_initial_connection_window,
+            )
+            .field("h2_max_concurrent_streams", &self.h2_max_concurrent_streams)
+            .field("h2_stream_shrink_ratio", &self.h2_stream_shrink_ratio)
+            .field(
+                "h2_max_rst_stream_lifetime",
+                &self.h2_max_rst_stream_lifetime,
+            )
+            .field(
+                "h2_max_rst_stream_abusive_lifetime",
+                &self.h2_max_rst_stream_abusive_lifetime,
+            )
+            .field(
+                "h2_max_rst_stream_emitted_lifetime",
+                &self.h2_max_rst_stream_emitted_lifetime,
+            )
+            .field("h2_max_header_list_size", &self.h2_max_header_list_size)
+            .field("strict_sni_binding", &self.strict_sni_binding)
+            .field("disable_http11", &self.disable_http11)
+            .field(
+                "h2_stream_idle_timeout_seconds",
+                &self.h2_stream_idle_timeout_seconds,
+            )
+            .field("h2_max_header_table_size", &self.h2_max_header_table_size)
+            .field(
+                "h2_graceful_shutdown_deadline_seconds",
+                &self.h2_graceful_shutdown_deadline_seconds,
+            )
+            .field(
+                "h2_max_window_update_stream0_per_window",
+                &self.h2_max_window_update_stream0_per_window,
+            )
+            .field("sozu_id_header_len", &sozu_id_header_len)
+            .field("answers_count", &answers_count)
+            .field("answers_key_len", &answers_key_len)
+            .field("answers_value_len", &answers_value_len)
+            .field("elide_x_real_ip", &self.elide_x_real_ip)
+            .field("send_x_real_ip", &self.send_x_real_ip)
+            .field("hsts", &self.hsts)
+            .field("h2_max_header_fields", &self.h2_max_header_fields)
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for command::QueryCertificatesFilters {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QueryCertificatesFilters")
+            .field("domain_len", &self.domain.as_ref().map(String::len))
+            .field(
+                "fingerprint_len",
+                &self.fingerprint.as_ref().map(String::len),
+            )
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for command::CertificateSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CertificateSummary")
+            .field("domain_len", &self.domain.len())
+            .field("fingerprint_len", &self.fingerprint.len())
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for command::CertificatesByAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let domain_len = self
+            .certificate_summaries
+            .iter()
+            .map(|summary| summary.domain.len())
+            .fold(0usize, usize::saturating_add);
+        let fingerprint_len = self
+            .certificate_summaries
+            .iter()
+            .map(|summary| summary.fingerprint.len())
+            .fold(0usize, usize::saturating_add);
+
+        f.debug_struct("CertificatesByAddress")
+            .field("address", &self.address)
+            .field("certificates_count", &self.certificate_summaries.len())
+            .field("domain_len", &domain_len)
+            .field("fingerprint_len", &fingerprint_len)
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for command::ListOfCertificatesByAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let certificates_count = self
+            .certificates
+            .iter()
+            .map(|entry| entry.certificate_summaries.len())
+            .fold(0usize, usize::saturating_add);
+        let domain_len = self
+            .certificates
+            .iter()
+            .flat_map(|entry| &entry.certificate_summaries)
+            .map(|summary| summary.domain.len())
+            .fold(0usize, usize::saturating_add);
+        let fingerprint_len = self
+            .certificates
+            .iter()
+            .flat_map(|entry| &entry.certificate_summaries)
+            .map(|summary| summary.fingerprint.len())
+            .fold(0usize, usize::saturating_add);
+
+        f.debug_struct("ListOfCertificatesByAddress")
+            .field("listeners_count", &self.certificates.len())
+            .field("certificates_count", &certificates_count)
+            .field("domain_len", &domain_len)
+            .field("fingerprint_len", &fingerprint_len)
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for command::CertificatesWithFingerprints {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let fingerprint_len = total_string_len(self.certs.keys());
+        let names_count = self
+            .certs
+            .values()
+            .map(|certificate| certificate.names.len())
+            .fold(0usize, usize::saturating_add);
+        let names_len = self
+            .certs
+            .values()
+            .flat_map(|certificate| &certificate.names)
+            .map(String::len)
+            .fold(0usize, usize::saturating_add);
+
+        f.debug_struct("CertificatesWithFingerprints")
+            .field("certificates_count", &self.certs.len())
+            .field("fingerprint_len", &fingerprint_len)
+            .field("names_count", &names_count)
+            .field("names_len", &names_len)
+            .finish()
+    }
+}
+
+fn response_content_kind(content: Option<&command::ResponseContent>) -> Option<&'static str> {
+    use command::response_content::ContentType;
+
+    content
+        .and_then(|response| response.content_type.as_ref())
+        .map(|content_type| match content_type {
+            ContentType::Workers(_) => "workers",
+            ContentType::Metrics(_) => "metrics",
+            ContentType::WorkerResponses(_) => "worker_responses",
+            ContentType::Event(_) => "event",
+            ContentType::FrontendList(_) => "frontend_list",
+            ContentType::ListenersList(_) => "listeners_list",
+            ContentType::WorkerMetrics(_) => "worker_metrics",
+            ContentType::AvailableMetrics(_) => "available_metrics",
+            ContentType::Clusters(_) => "clusters",
+            ContentType::ClusterHashes(_) => "cluster_hashes",
+            ContentType::CertificatesByAddress(_) => "certificates_by_address",
+            ContentType::CertificatesWithFingerprints(_) => "certificates_with_fingerprints",
+            ContentType::RequestCounts(_) => "request_counts",
+            ContentType::MaxConnectionsPerIpLimit(_) => "max_connections_per_ip_limit",
+            ContentType::HealthChecksList(_) => "health_checks_list",
+            ContentType::MetricDetailStatus(_) => "metric_detail_status",
+            ContentType::WorkerMetricDetailStatus(_) => "worker_metric_detail_status",
+        })
+}
+
+impl std::fmt::Debug for command::ResponseContent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResponseContent")
+            .field("content_type", &response_content_kind(Some(self)))
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for command::WorkerResponses {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WorkerResponses")
+            .field("workers_count", &self.map.len())
+            .field("worker_ids_len", &total_string_len(self.map.keys()))
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for command::WorkerRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WorkerRequest")
+            .field("id_len", &self.id.len())
+            .field("content", &self.content)
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for command::WorkerResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WorkerResponse")
+            .field("id_len", &self.id.len())
+            .field("status", &self.status)
+            .field("message_len", &self.message.len())
+            .field(
+                "content_type",
+                &response_content_kind(self.content.as_ref()),
+            )
+            .finish()
+    }
+}
+
 impl AggregatedMetrics {
     /// Merge metrics that were received from several workers
     ///
@@ -190,13 +763,936 @@ impl FilteredMetrics {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::{
+        collections::{BTreeMap, HashMap},
+        net::SocketAddr,
+    };
+
+    use crate::{certificate::Fingerprint, state::ConfigState};
 
     use super::AggregatedMetrics;
     use super::command::{
-        Bucket, ClusterMetrics, FilteredHistogram, FilteredMetrics, Percentiles, WorkerMetrics,
-        filtered_metrics::Inner,
+        AddCertificate, AlpnProtocols, Bucket, CertificateAndKey, CertificateSummary,
+        CertificatesByAddress, CertificatesWithFingerprints, Cluster, ClusterMetrics,
+        CustomHttpAnswers, FilteredHistogram, FilteredMetrics, Header, HeaderPosition,
+        HttpListenerConfig, HttpsListenerConfig, ListOfCertificatesByAddress, PathRule,
+        PathRuleKind, Percentiles, QueryCertificatesFilters, RedirectPolicy, RedirectScheme,
+        RemoveCertificate, ReplaceCertificate, Request, RequestHttpFrontend, RequestTcpFrontend,
+        ResponseContent, ResponseStatus, RulePosition, TlsVersion, UpdateHttpListenerConfig,
+        UpdateHttpsListenerConfig, WorkerMetrics, WorkerRequest, WorkerResponse, WorkerResponses,
+        filtered_metrics::Inner, request::RequestType, response_content::ContentType,
     };
+
+    #[test]
+    fn listener_and_patch_debug_redacts_user_controlled_material() {
+        const HTTP_STICKY_SECRET: &str = "HTTP_LISTENER_STICKY_SECRET_SENTINEL";
+        const HTTP_LEGACY_ANSWER_SECRET: &str = "HTTP_LISTENER_LEGACY_ANSWER_SECRET_SENTINEL";
+        const HTTP_HEADER_SECRET: &str = "HTTP_LISTENER_HEADER_SECRET_SENTINEL";
+        const HTTP_ANSWER_KEY_SECRET: &str = "HTTP_LISTENER_ANSWER_KEY_SECRET_SENTINEL";
+        const HTTP_ANSWER_BODY_SECRET: &str = "HTTP_LISTENER_ANSWER_BODY_SECRET_SENTINEL";
+        const HTTP_PATCH_STICKY_SECRET: &str = "HTTP_PATCH_STICKY_SECRET_SENTINEL";
+        const HTTP_PATCH_LEGACY_ANSWER_SECRET: &str = "HTTP_PATCH_LEGACY_ANSWER_SECRET_SENTINEL";
+        const HTTP_PATCH_HEADER_SECRET: &str = "HTTP_PATCH_HEADER_SECRET_SENTINEL";
+        const HTTP_PATCH_ANSWER_KEY_SECRET: &str = "HTTP_PATCH_ANSWER_KEY_SECRET_SENTINEL";
+        const HTTP_PATCH_ANSWER_BODY_SECRET: &str = "HTTP_PATCH_ANSWER_BODY_SECRET_SENTINEL";
+        const HTTPS_PATCH_STICKY_SECRET: &str = "HTTPS_PATCH_STICKY_SECRET_SENTINEL";
+        const HTTPS_PATCH_LEGACY_ANSWER_SECRET: &str = "HTTPS_PATCH_LEGACY_ANSWER_SECRET_SENTINEL";
+        const HTTPS_PATCH_ALPN_SECRET: &str = "HTTPS_PATCH_ALPN_SECRET_SENTINEL";
+        const HTTPS_PATCH_HEADER_SECRET: &str = "HTTPS_PATCH_HEADER_SECRET_SENTINEL";
+        const HTTPS_PATCH_ANSWER_KEY_SECRET: &str = "HTTPS_PATCH_ANSWER_KEY_SECRET_SENTINEL";
+        const HTTPS_PATCH_ANSWER_BODY_SECRET: &str = "HTTPS_PATCH_ANSWER_BODY_SECRET_SENTINEL";
+
+        let long_value = |marker: &str| format!("{marker}{}", "x".repeat(4096));
+        let http_address: SocketAddr = "127.0.0.1:8080"
+            .parse()
+            .expect("test HTTP listener address must parse");
+        let http_listener = HttpListenerConfig {
+            address: http_address.into(),
+            sticky_name: long_value(HTTP_STICKY_SECRET),
+            http_answers: Some(CustomHttpAnswers {
+                answer_503: Some(long_value(HTTP_LEGACY_ANSWER_SECRET)),
+                ..Default::default()
+            }),
+            sozu_id_header: Some(long_value(HTTP_HEADER_SECRET)),
+            answers: BTreeMap::from([(
+                long_value(HTTP_ANSWER_KEY_SECRET),
+                long_value(HTTP_ANSWER_BODY_SECRET),
+            )]),
+            ..Default::default()
+        };
+        let http_request = Request::from(RequestType::AddHttpListener(http_listener.clone()));
+        let http_worker_request = WorkerRequest {
+            id: "safe-add-http-listener-id".to_owned(),
+            content: http_request.clone(),
+        };
+
+        let http_patch = UpdateHttpListenerConfig {
+            address: http_address.into(),
+            sticky_name: Some(long_value(HTTP_PATCH_STICKY_SECRET)),
+            http_answers: Some(CustomHttpAnswers {
+                answer_503: Some(long_value(HTTP_PATCH_LEGACY_ANSWER_SECRET)),
+                ..Default::default()
+            }),
+            sozu_id_header: Some(long_value(HTTP_PATCH_HEADER_SECRET)),
+            answers: BTreeMap::from([(
+                long_value(HTTP_PATCH_ANSWER_KEY_SECRET),
+                long_value(HTTP_PATCH_ANSWER_BODY_SECRET),
+            )]),
+            ..Default::default()
+        };
+        let http_patch_request = Request::from(RequestType::UpdateHttpListener(http_patch.clone()));
+        let http_patch_worker_request = WorkerRequest {
+            id: "safe-update-http-listener-id".to_owned(),
+            content: http_patch_request.clone(),
+        };
+
+        let https_address: SocketAddr = "127.0.0.1:8443"
+            .parse()
+            .expect("test HTTPS listener address must parse");
+        let https_patch = UpdateHttpsListenerConfig {
+            address: https_address.into(),
+            sticky_name: Some(long_value(HTTPS_PATCH_STICKY_SECRET)),
+            http_answers: Some(CustomHttpAnswers {
+                answer_503: Some(long_value(HTTPS_PATCH_LEGACY_ANSWER_SECRET)),
+                ..Default::default()
+            }),
+            alpn_protocols: Some(AlpnProtocols {
+                values: vec![long_value(HTTPS_PATCH_ALPN_SECRET)],
+            }),
+            sozu_id_header: Some(long_value(HTTPS_PATCH_HEADER_SECRET)),
+            answers: BTreeMap::from([(
+                long_value(HTTPS_PATCH_ANSWER_KEY_SECRET),
+                long_value(HTTPS_PATCH_ANSWER_BODY_SECRET),
+            )]),
+            ..Default::default()
+        };
+        let https_patch_request =
+            Request::from(RequestType::UpdateHttpsListener(https_patch.clone()));
+        let https_patch_worker_request = WorkerRequest {
+            id: "safe-update-https-listener-id".to_owned(),
+            content: https_patch_request.clone(),
+        };
+
+        let debug_outputs = [
+            ("HttpListenerConfig", format!("{http_listener:?}")),
+            ("AddHttpListener Request", format!("{http_request:?}")),
+            (
+                "AddHttpListener WorkerRequest",
+                format!("{http_worker_request:?}"),
+            ),
+            ("UpdateHttpListenerConfig", format!("{http_patch:?}")),
+            (
+                "UpdateHttpListener Request",
+                format!("{http_patch_request:?}"),
+            ),
+            (
+                "UpdateHttpListener WorkerRequest",
+                format!("{http_patch_worker_request:?}"),
+            ),
+            ("UpdateHttpsListenerConfig", format!("{https_patch:?}")),
+            (
+                "UpdateHttpsListener Request",
+                format!("{https_patch_request:?}"),
+            ),
+            (
+                "UpdateHttpsListener WorkerRequest",
+                format!("{https_patch_worker_request:?}"),
+            ),
+        ];
+        let secrets = [
+            HTTP_STICKY_SECRET,
+            HTTP_LEGACY_ANSWER_SECRET,
+            HTTP_HEADER_SECRET,
+            HTTP_ANSWER_KEY_SECRET,
+            HTTP_ANSWER_BODY_SECRET,
+            HTTP_PATCH_STICKY_SECRET,
+            HTTP_PATCH_LEGACY_ANSWER_SECRET,
+            HTTP_PATCH_HEADER_SECRET,
+            HTTP_PATCH_ANSWER_KEY_SECRET,
+            HTTP_PATCH_ANSWER_BODY_SECRET,
+            HTTPS_PATCH_STICKY_SECRET,
+            HTTPS_PATCH_LEGACY_ANSWER_SECRET,
+            HTTPS_PATCH_ALPN_SECRET,
+            HTTPS_PATCH_HEADER_SECRET,
+            HTTPS_PATCH_ANSWER_KEY_SECRET,
+            HTTPS_PATCH_ANSWER_BODY_SECRET,
+        ];
+        let mut leaks = Vec::new();
+        for (label, output) in &debug_outputs {
+            for secret in secrets {
+                if output.contains(secret) {
+                    leaks.push(format!("{label}:{secret}"));
+                }
+            }
+        }
+        assert!(
+            leaks.is_empty(),
+            "listener Debug leaked secret markers through {}",
+            leaks.join(", ")
+        );
+
+        let expected_metadata = [
+            (0, "sticky_name_len: 4132"),
+            (0, "http_answers_count: Some(1)"),
+            (0, "answers_count: 1"),
+            (3, "sticky_name_len: Some(4129)"),
+            (3, "http_answers_count: Some(1)"),
+            (3, "answers_count: 1"),
+            (6, "sticky_name_len: Some(4130)"),
+            (6, "http_answers_count: Some(1)"),
+            (6, "alpn_protocols_count: Some(1)"),
+            (6, "answers_count: 1"),
+        ];
+        for (output_index, safe_metadata) in expected_metadata {
+            assert!(
+                debug_outputs[output_index].1.contains(safe_metadata),
+                "{} Debug omitted safe metadata {safe_metadata}: {}",
+                debug_outputs[output_index].0,
+                debug_outputs[output_index].1,
+            );
+        }
+        for (label, output) in debug_outputs {
+            assert!(
+                output.len() <= 4096,
+                "{label} Debug output is not bounded: {} bytes",
+                output.len()
+            );
+        }
+    }
+
+    #[test]
+    fn https_listener_debug_redacts_user_controlled_material() {
+        const STICKY_NAME_SECRET: &str = "HTTPS_LISTENER_STICKY_NAME_SECRET_SENTINEL";
+        const CIPHER_LIST_SECRET: &str = "HTTPS_LISTENER_CIPHER_LIST_SECRET_SENTINEL";
+        const CIPHER_SUITES_SECRET: &str = "HTTPS_LISTENER_CIPHER_SUITES_SECRET_SENTINEL";
+        const SIGNATURE_ALGORITHMS_SECRET: &str =
+            "HTTPS_LISTENER_SIGNATURE_ALGORITHMS_SECRET_SENTINEL";
+        const GROUPS_LIST_SECRET: &str = "HTTPS_LISTENER_GROUPS_LIST_SECRET_SENTINEL";
+        const CERTIFICATE_SECRET: &str = "HTTPS_LISTENER_CERTIFICATE_SECRET_SENTINEL";
+        const CHAIN_SECRET: &str = "HTTPS_LISTENER_CHAIN_SECRET_SENTINEL";
+        const KEY_SECRET: &str = "HTTPS_LISTENER_KEY_SECRET_SENTINEL";
+        const HTTP_ANSWER_SECRET: &str = "HTTPS_LISTENER_HTTP_ANSWER_SECRET_SENTINEL";
+        const ALPN_SECRET: &str = "HTTPS_LISTENER_ALPN_SECRET_SENTINEL";
+        const SOZU_ID_HEADER_SECRET: &str = "HTTPS_LISTENER_SOZU_ID_HEADER_SECRET_SENTINEL";
+        const ANSWER_KEY_SECRET: &str = "HTTPS_LISTENER_ANSWER_KEY_SECRET_SENTINEL";
+        const ANSWER_VALUE_SECRET: &str = "HTTPS_LISTENER_ANSWER_VALUE_SECRET_SENTINEL";
+
+        let long_value = |marker: &str| format!("{marker}{}", "x".repeat(4096));
+        let address: SocketAddr = "127.0.0.1:8443"
+            .parse()
+            .expect("test HTTPS listener address must parse");
+        let public_address: SocketAddr = "203.0.113.1:443"
+            .parse()
+            .expect("test public HTTPS listener address must parse");
+        let listener = HttpsListenerConfig {
+            address: address.into(),
+            public_address: Some(public_address.into()),
+            sticky_name: long_value(STICKY_NAME_SECRET),
+            versions: vec![TlsVersion::TlsV13 as i32],
+            cipher_list: vec![long_value(CIPHER_LIST_SECRET)],
+            cipher_suites: vec![long_value(CIPHER_SUITES_SECRET)],
+            signature_algorithms: vec![long_value(SIGNATURE_ALGORITHMS_SECRET)],
+            groups_list: vec![long_value(GROUPS_LIST_SECRET)],
+            certificate: Some(long_value(CERTIFICATE_SECRET)),
+            certificate_chain: vec![long_value(CHAIN_SECRET)],
+            key: Some(long_value(KEY_SECRET)),
+            http_answers: Some(CustomHttpAnswers {
+                answer_404: Some(long_value(HTTP_ANSWER_SECRET)),
+                ..Default::default()
+            }),
+            alpn_protocols: vec![long_value(ALPN_SECRET)],
+            sozu_id_header: Some(long_value(SOZU_ID_HEADER_SECRET)),
+            answers: BTreeMap::from([(
+                long_value(ANSWER_KEY_SECRET),
+                long_value(ANSWER_VALUE_SECRET),
+            )]),
+            ..Default::default()
+        };
+        let add_https_listener = RequestType::AddHttpsListener(listener.clone());
+        let request = Request::from(add_https_listener.clone());
+        let worker_request = WorkerRequest {
+            id: "safe-add-https-listener-id".to_owned(),
+            content: request.clone(),
+        };
+        let state = ConfigState {
+            https_listeners: BTreeMap::from([(address, listener.clone())]),
+            ..Default::default()
+        };
+        let debug_outputs = [
+            ("HttpsListenerConfig", format!("{listener:?}")),
+            (
+                "RequestType::AddHttpsListener",
+                format!("{add_https_listener:?}"),
+            ),
+            ("Request", format!("{request:?}")),
+            ("WorkerRequest", format!("{worker_request:?}")),
+            ("ConfigState", format!("{state:?}")),
+        ];
+        let secrets = [
+            STICKY_NAME_SECRET,
+            CIPHER_LIST_SECRET,
+            CIPHER_SUITES_SECRET,
+            SIGNATURE_ALGORITHMS_SECRET,
+            GROUPS_LIST_SECRET,
+            CERTIFICATE_SECRET,
+            CHAIN_SECRET,
+            KEY_SECRET,
+            HTTP_ANSWER_SECRET,
+            ALPN_SECRET,
+            SOZU_ID_HEADER_SECRET,
+            ANSWER_KEY_SECRET,
+            ANSWER_VALUE_SECRET,
+        ];
+        let mut leaks = Vec::new();
+        for (label, output) in &debug_outputs {
+            for secret in secrets {
+                if output.contains(secret) {
+                    leaks.push(format!("{label}:{secret}"));
+                }
+            }
+        }
+        assert!(
+            leaks.is_empty(),
+            "HTTPS listener Debug leaked secret markers through {}",
+            leaks.join(", ")
+        );
+
+        let direct_output = &debug_outputs[0].1;
+        let expected_metadata = [
+            format!("sticky_name_len: {}", long_value(STICKY_NAME_SECRET).len()),
+            "versions_count: 1".to_owned(),
+            "cipher_list_count: 1".to_owned(),
+            format!("cipher_list_len: {}", long_value(CIPHER_LIST_SECRET).len()),
+            "cipher_suites_count: 1".to_owned(),
+            "signature_algorithms_count: 1".to_owned(),
+            "groups_list_count: 1".to_owned(),
+            "certificate: Some(\"[redacted]\")".to_owned(),
+            format!(
+                "certificate_len: Some({})",
+                long_value(CERTIFICATE_SECRET).len()
+            ),
+            "certificate_chain: \"[redacted]\"".to_owned(),
+            "certificate_chain_count: 1".to_owned(),
+            "key: Some(\"[redacted]\")".to_owned(),
+            "http_answers_count: Some(1)".to_owned(),
+            "alpn_protocols_count: 1".to_owned(),
+            format!(
+                "sozu_id_header_len: Some({})",
+                long_value(SOZU_ID_HEADER_SECRET).len()
+            ),
+            "answers_count: 1".to_owned(),
+        ];
+        for safe_metadata in expected_metadata {
+            assert!(
+                direct_output.contains(&safe_metadata),
+                "HttpsListenerConfig Debug omitted safe metadata {safe_metadata}: {direct_output}"
+            );
+        }
+        for (label, output) in debug_outputs {
+            assert!(
+                output.len() <= 4096,
+                "{label} Debug output is not bounded: {} bytes",
+                output.len()
+            );
+        }
+    }
+
+    #[test]
+    fn header_debug_redacts_key_and_value() {
+        const KEY_SECRET: &str = "HEADER_KEY_SECRET_SENTINEL";
+        const VALUE_SECRET: &str = "HEADER_VALUE_SECRET_SENTINEL";
+
+        let long_value = |marker: &str| format!("{marker}{}", "x".repeat(4096));
+        let header = Header {
+            position: HeaderPosition::Unspecified as i32,
+            key: long_value(KEY_SECRET),
+            val: long_value(VALUE_SECRET),
+        };
+        let output = format!("{header:?}");
+
+        for secret in [KEY_SECRET, VALUE_SECRET] {
+            assert!(
+                !output.contains(secret),
+                "Header Debug leaked user-controlled marker {secret}"
+            );
+        }
+        for metadata in [
+            "position: 0".to_owned(),
+            format!("key_len: {}", long_value(KEY_SECRET).len()),
+            format!("val_len: {}", long_value(VALUE_SECRET).len()),
+        ] {
+            assert!(
+                output.contains(&metadata),
+                "Header Debug omitted safe metadata {metadata}: {output}"
+            );
+        }
+        assert!(
+            output.len() <= 256,
+            "Header Debug output is not bounded: {} bytes",
+            output.len()
+        );
+    }
+
+    #[test]
+    fn http_frontend_request_debug_redacts_user_controlled_material() {
+        const CLUSTER_SECRET: &str = "HTTP_FRONTEND_CLUSTER_SECRET_SENTINEL";
+        const HOSTNAME_SECRET: &str = "HTTP_FRONTEND_HOSTNAME_SECRET_SENTINEL";
+        const PATH_SECRET: &str = "HTTP_FRONTEND_PATH_SECRET_SENTINEL";
+        const METHOD_SECRET: &str = "HTTP_FRONTEND_METHOD_SECRET_SENTINEL";
+        const TAG_KEY_SECRET: &str = "HTTP_FRONTEND_TAG_KEY_SECRET_SENTINEL";
+        const TAG_VALUE_SECRET: &str = "HTTP_FRONTEND_TAG_VALUE_SECRET_SENTINEL";
+        const REDIRECT_SECRET: &str = "HTTP_FRONTEND_REDIRECT_SECRET_SENTINEL";
+        const REWRITE_HOST_SECRET: &str = "HTTP_FRONTEND_REWRITE_HOST_SECRET_SENTINEL";
+        const REWRITE_PATH_SECRET: &str = "HTTP_FRONTEND_REWRITE_PATH_SECRET_SENTINEL";
+        const HEADER_KEY_SECRET: &str = "HTTP_FRONTEND_HEADER_KEY_SECRET_SENTINEL";
+        const HEADER_VALUE_SECRET: &str = "HTTP_FRONTEND_HEADER_VALUE_SECRET_SENTINEL";
+
+        let long_value = |marker: &str| format!("{marker}{}", "x".repeat(4096));
+        let frontend = RequestHttpFrontend {
+            cluster_id: Some(long_value(CLUSTER_SECRET)),
+            address: Default::default(),
+            hostname: long_value(HOSTNAME_SECRET),
+            path: PathRule {
+                value: long_value(PATH_SECRET),
+                kind: PathRuleKind::Prefix as i32,
+            },
+            method: Some(long_value(METHOD_SECRET)),
+            position: RulePosition::Tree as i32,
+            tags: BTreeMap::from([(long_value(TAG_KEY_SECRET), long_value(TAG_VALUE_SECRET))]),
+            redirect: Some(RedirectPolicy::Forward as i32),
+            required_auth: Some(true),
+            redirect_scheme: Some(RedirectScheme::UseSame as i32),
+            redirect_template: Some(long_value(REDIRECT_SECRET)),
+            rewrite_host: Some(long_value(REWRITE_HOST_SECRET)),
+            rewrite_path: Some(long_value(REWRITE_PATH_SECRET)),
+            rewrite_port: Some(8443),
+            headers: vec![Header {
+                position: HeaderPosition::Request as i32,
+                key: long_value(HEADER_KEY_SECRET),
+                val: long_value(HEADER_VALUE_SECRET),
+            }],
+            hsts: None,
+        };
+        let request_type = RequestType::AddHttpsFrontend(frontend.clone());
+        let request = Request::from(request_type.clone());
+        let worker_request = WorkerRequest {
+            id: "safe-http-frontend-request-id".to_owned(),
+            content: request.clone(),
+        };
+        let debug_outputs = [
+            ("RequestHttpFrontend", format!("{frontend:?}")),
+            ("RequestType", format!("{request_type:?}")),
+            ("Request", format!("{request:?}")),
+            ("WorkerRequest", format!("{worker_request:?}")),
+        ];
+        let secrets = [
+            CLUSTER_SECRET,
+            HOSTNAME_SECRET,
+            PATH_SECRET,
+            METHOD_SECRET,
+            TAG_KEY_SECRET,
+            TAG_VALUE_SECRET,
+            REDIRECT_SECRET,
+            REWRITE_HOST_SECRET,
+            REWRITE_PATH_SECRET,
+            HEADER_KEY_SECRET,
+            HEADER_VALUE_SECRET,
+        ];
+
+        for (label, output) in &debug_outputs {
+            for secret in secrets {
+                assert!(
+                    !output.contains(secret),
+                    "{label} Debug leaked user-controlled marker {secret}: {output}"
+                );
+            }
+            assert!(
+                output.len() <= 2048,
+                "{label} Debug output is not bounded: {} bytes",
+                output.len()
+            );
+        }
+
+        let direct_output = &debug_outputs[0].1;
+        let expected_metadata = [
+            format!("cluster_id_len: Some({})", long_value(CLUSTER_SECRET).len()),
+            format!("hostname_len: {}", long_value(HOSTNAME_SECRET).len()),
+            format!("path_len: {}", long_value(PATH_SECRET).len()),
+            format!("method_len: Some({})", long_value(METHOD_SECRET).len()),
+            "tags_count: 1".to_owned(),
+            "headers_count: 1".to_owned(),
+        ];
+        for safe_metadata in expected_metadata {
+            assert!(
+                direct_output.contains(&safe_metadata),
+                "RequestHttpFrontend Debug omitted safe metadata {safe_metadata}: {direct_output}"
+            );
+        }
+    }
+
+    #[test]
+    fn certificate_query_request_debug_redacts_filters_across_command_wrappers() {
+        const DOMAIN_SECRET: &str = "QUERY_REQUEST_DOMAIN_SECRET_SENTINEL";
+        const FINGERPRINT_SECRET: &str = "QUERY_REQUEST_FINGERPRINT_SECRET_SENTINEL";
+        const REQUEST_ID_SECRET: &str = "QUERY_REQUEST_ID_SECRET_SENTINEL";
+
+        let long_value = |marker: &str| format!("{marker}{}", "x".repeat(4096));
+        let filters = QueryCertificatesFilters {
+            domain: Some(long_value(DOMAIN_SECRET)),
+            fingerprint: Some(long_value(FINGERPRINT_SECRET)),
+        };
+        let request_type = RequestType::QueryCertificatesFromWorkers(filters.clone());
+        let request = Request::from(request_type.clone());
+        let worker_request = WorkerRequest {
+            id: long_value(REQUEST_ID_SECRET),
+            content: request.clone(),
+        };
+        let outputs = [
+            ("QueryCertificatesFilters", format!("{filters:?}")),
+            ("RequestType", format!("{request_type:?}")),
+            ("Request", format!("{request:?}")),
+            ("WorkerRequest", format!("{worker_request:?}")),
+        ];
+
+        for (label, output) in &outputs {
+            for secret in [DOMAIN_SECRET, FINGERPRINT_SECRET, REQUEST_ID_SECRET] {
+                assert!(
+                    !output.contains(secret),
+                    "{label} Debug leaked certificate-query marker {secret}: {output}"
+                );
+            }
+            assert!(
+                output.len() <= 1024,
+                "{label} Debug output is not bounded: {} bytes",
+                output.len()
+            );
+        }
+
+        let filter_output = &outputs[0].1;
+        for metadata in [
+            format!("domain_len: Some({})", long_value(DOMAIN_SECRET).len()),
+            format!(
+                "fingerprint_len: Some({})",
+                long_value(FINGERPRINT_SECRET).len()
+            ),
+        ] {
+            assert!(
+                filter_output.contains(&metadata),
+                "QueryCertificatesFilters Debug omitted bounded metadata {metadata}: {filter_output}"
+            );
+        }
+        assert!(
+            outputs[3]
+                .1
+                .contains(&format!("id_len: {}", long_value(REQUEST_ID_SECRET).len())),
+            "WorkerRequest Debug omitted the bounded request-id length: {}",
+            outputs[3].1
+        );
+    }
+
+    #[test]
+    fn certificate_query_response_debug_redacts_results_across_worker_wrappers() {
+        const DOMAIN_SECRET: &str = "QUERY_RESPONSE_DOMAIN_SECRET_SENTINEL";
+        const FINGERPRINT_SECRET: &str = "QUERY_RESPONSE_FINGERPRINT_SECRET_SENTINEL";
+        const MAP_KEY_SECRET: &str = "QUERY_RESPONSE_MAP_KEY_SECRET_SENTINEL";
+        const CERTIFICATE_SECRET: &str = "QUERY_RESPONSE_CERTIFICATE_SECRET_SENTINEL";
+        const KEY_SECRET: &str = "QUERY_RESPONSE_KEY_SECRET_SENTINEL";
+        const NAME_SECRET: &str = "QUERY_RESPONSE_NAME_SECRET_SENTINEL";
+        const WORKER_ID_SECRET: &str = "QUERY_RESPONSE_WORKER_ID_SECRET_SENTINEL";
+        const RESPONSE_ID_SECRET: &str = "QUERY_RESPONSE_ID_SECRET_SENTINEL";
+        const MESSAGE_SECRET: &str = "QUERY_RESPONSE_MESSAGE_SECRET_SENTINEL";
+
+        let long_value = |marker: &str| format!("{marker}{}", "x".repeat(4096));
+        let summary = CertificateSummary {
+            domain: long_value(DOMAIN_SECRET),
+            fingerprint: long_value(FINGERPRINT_SECRET),
+        };
+        let by_address = CertificatesByAddress {
+            address: Default::default(),
+            certificate_summaries: vec![summary.clone()],
+        };
+        let list = ListOfCertificatesByAddress {
+            certificates: vec![by_address.clone()],
+        };
+        let worker_content =
+            ResponseContent::from(ContentType::CertificatesByAddress(list.clone()));
+        let worker_response = WorkerResponse {
+            id: long_value(RESPONSE_ID_SECRET),
+            status: ResponseStatus::Ok as i32,
+            message: long_value(MESSAGE_SECRET),
+            content: Some(worker_content.clone()),
+        };
+        let worker_responses = WorkerResponses {
+            map: BTreeMap::from([(long_value(WORKER_ID_SECRET), worker_content.clone())]),
+        };
+        let gathered_content =
+            ResponseContent::from(ContentType::WorkerResponses(worker_responses.clone()));
+        let main_certificates = CertificatesWithFingerprints {
+            certs: BTreeMap::from([(
+                long_value(MAP_KEY_SECRET),
+                CertificateAndKey {
+                    certificate: long_value(CERTIFICATE_SECRET),
+                    certificate_chain: Vec::new(),
+                    key: long_value(KEY_SECRET),
+                    versions: Vec::new(),
+                    names: vec![long_value(NAME_SECRET)],
+                },
+            )]),
+        };
+        let main_content = ResponseContent::from(ContentType::CertificatesWithFingerprints(
+            main_certificates.clone(),
+        ));
+        let outputs = [
+            ("CertificateSummary", format!("{summary:?}")),
+            ("CertificatesByAddress", format!("{by_address:?}")),
+            ("ListOfCertificatesByAddress", format!("{list:?}")),
+            ("worker ResponseContent", format!("{worker_content:?}")),
+            ("WorkerResponse", format!("{worker_response:?}")),
+            ("WorkerResponses", format!("{worker_responses:?}")),
+            ("gathered ResponseContent", format!("{gathered_content:?}")),
+            (
+                "CertificatesWithFingerprints",
+                format!("{main_certificates:?}"),
+            ),
+            ("main ResponseContent", format!("{main_content:?}")),
+        ];
+        let secrets = [
+            DOMAIN_SECRET,
+            FINGERPRINT_SECRET,
+            MAP_KEY_SECRET,
+            CERTIFICATE_SECRET,
+            KEY_SECRET,
+            NAME_SECRET,
+            WORKER_ID_SECRET,
+            RESPONSE_ID_SECRET,
+            MESSAGE_SECRET,
+        ];
+
+        for (label, output) in &outputs {
+            for secret in secrets {
+                assert!(
+                    !output.contains(secret),
+                    "{label} Debug leaked certificate-query marker {secret}: {output}"
+                );
+            }
+            assert!(
+                output.len() <= 1024,
+                "{label} Debug output is not bounded: {} bytes",
+                output.len()
+            );
+        }
+
+        for metadata in ["listeners_count: 1", "certificates_count: 1"] {
+            assert!(
+                outputs[2].1.contains(metadata),
+                "ListOfCertificatesByAddress Debug omitted bounded metadata {metadata}: {}",
+                outputs[2].1
+            );
+        }
+        for metadata in ["id_len:", "message_len:", "content_type:"] {
+            assert!(
+                outputs[4].1.contains(metadata),
+                "WorkerResponse Debug omitted bounded metadata {metadata}: {}",
+                outputs[4].1
+            );
+        }
+    }
+
+    #[test]
+    fn certificate_debug_redacts_pem_material() {
+        const CERTIFICATE_SECRET: &str = "CERTIFICATE_SECRET_SENTINEL";
+        const CHAIN_SECRET: &str = "CHAIN_SECRET_SENTINEL";
+        const KEY_SECRET: &str = "KEY_SECRET_SENTINEL";
+        const NAME_SECRET: &str = "CERTIFICATE_NAME_SECRET_SENTINEL";
+
+        let certificate = CertificateAndKey {
+            certificate: CERTIFICATE_SECRET.to_owned(),
+            certificate_chain: vec![CHAIN_SECRET.to_owned()],
+            key: KEY_SECRET.to_owned(),
+            versions: vec![i32::MIN; 1_024],
+            names: vec![format!("{NAME_SECRET}{}", "x".repeat(4096))],
+        };
+        let add_certificate = AddCertificate {
+            address: Default::default(),
+            certificate: certificate.clone(),
+            expired_at: None,
+        };
+        let replace_certificate = ReplaceCertificate {
+            address: Default::default(),
+            new_certificate: certificate.clone(),
+            old_fingerprint: "safe-old-fingerprint".to_owned(),
+            new_expired_at: None,
+        };
+        let add_request = Request::from(RequestType::AddCertificate(add_certificate.clone()));
+        let replace_request =
+            Request::from(RequestType::ReplaceCertificate(replace_certificate.clone()));
+        let add_worker_request = WorkerRequest {
+            id: "safe-add-request-id".to_owned(),
+            content: add_request.clone(),
+        };
+        let replace_worker_request = WorkerRequest {
+            id: "safe-replace-request-id".to_owned(),
+            content: replace_request.clone(),
+        };
+        let state_address: SocketAddr = "127.0.0.1:443"
+            .parse()
+            .expect("test certificate address must parse");
+        let state = ConfigState {
+            certificates: HashMap::from([(
+                state_address,
+                HashMap::from([(Fingerprint(vec![0; 32]), certificate.clone())]),
+            )]),
+            ..Default::default()
+        };
+
+        let debug_outputs = [
+            format!("{certificate:?}"),
+            format!("{add_certificate:?}"),
+            format!("{replace_certificate:?}"),
+            format!("{add_request:?}"),
+            format!("{replace_request:?}"),
+            format!("{add_worker_request:?}"),
+            format!("{replace_worker_request:?}"),
+        ];
+        let state_debug = format!("{state:?}");
+
+        for output in debug_outputs {
+            for secret in [CERTIFICATE_SECRET, CHAIN_SECRET, KEY_SECRET, NAME_SECRET] {
+                assert!(
+                    !output.contains(secret),
+                    "debug output leaked secret marker {secret}: {output}"
+                );
+            }
+            assert!(
+                output.contains("[redacted]"),
+                "debug output must make redaction explicit: {output}"
+            );
+            assert!(
+                output.contains("names_count: 1") && output.contains("names_len: 4128"),
+                "debug output must retain bounded certificate-name metadata: {output}"
+            );
+            assert!(
+                output.contains("versions_count: 1024"),
+                "debug output must retain bounded TLS-version metadata: {output}"
+            );
+            assert!(
+                output.len() <= 4096,
+                "certificate Debug output is not bounded: {} bytes",
+                output.len()
+            );
+        }
+
+        for secret in [CERTIFICATE_SECRET, CHAIN_SECRET, KEY_SECRET, NAME_SECRET] {
+            assert!(
+                !state_debug.contains(secret),
+                "ConfigState Debug leaked secret marker {secret}: {state_debug}"
+            );
+        }
+        assert!(
+            state_debug.contains("certificate_addresses_count: 1")
+                && state_debug.contains("certificates_count: 1"),
+            "ConfigState Debug must retain count-only certificate metadata: {state_debug}"
+        );
+        assert!(
+            state_debug.len() <= 4096,
+            "ConfigState Debug output is not bounded: {} bytes",
+            state_debug.len()
+        );
+    }
+
+    #[test]
+    fn certificate_fingerprint_control_debug_is_redacted_across_wrappers() {
+        const FINGERPRINT_SECRET: &str = "CERTIFICATE_CONTROL_FINGERPRINT_SECRET_SENTINEL";
+
+        let fingerprint = format!("{FINGERPRINT_SECRET}{}", "f".repeat(4096));
+        let remove = RemoveCertificate {
+            address: Default::default(),
+            fingerprint: fingerprint.clone(),
+        };
+        let replace = ReplaceCertificate {
+            address: Default::default(),
+            new_certificate: CertificateAndKey::default(),
+            old_fingerprint: fingerprint.clone(),
+            new_expired_at: None,
+        };
+        let remove_request = Request::from(RequestType::RemoveCertificate(remove.clone()));
+        let replace_request = Request::from(RequestType::ReplaceCertificate(replace.clone()));
+        let outputs = [
+            ("RemoveCertificate", format!("{remove:?}")),
+            ("ReplaceCertificate", format!("{replace:?}")),
+            ("remove Request", format!("{remove_request:?}")),
+            ("replace Request", format!("{replace_request:?}")),
+            (
+                "remove WorkerRequest",
+                format!(
+                    "{:?}",
+                    WorkerRequest {
+                        id: "remove-certificate-test".to_owned(),
+                        content: remove_request,
+                    }
+                ),
+            ),
+            (
+                "replace WorkerRequest",
+                format!(
+                    "{:?}",
+                    WorkerRequest {
+                        id: "replace-certificate-test".to_owned(),
+                        content: replace_request,
+                    }
+                ),
+            ),
+        ];
+
+        for (label, output) in outputs {
+            assert!(
+                !output.contains(FINGERPRINT_SECRET),
+                "{label} Debug leaked the certificate fingerprint: {output}"
+            );
+            assert!(
+                output.contains(&format!("fingerprint_len: {}", fingerprint.len())),
+                "{label} Debug omitted bounded fingerprint metadata: {output}"
+            );
+            assert!(
+                output.len() <= 1024,
+                "{label} Debug output is not bounded: {} bytes",
+                output.len()
+            );
+        }
+    }
+
+    #[test]
+    fn cluster_debug_redacts_answers_and_authorization_data_across_wrappers() {
+        const CLUSTER_SECRET: &str = "CLUSTER_ID_SECRET_SENTINEL";
+        const LEGACY_ANSWER_SECRET: &str = "CLUSTER_LEGACY_ANSWER_SECRET_SENTINEL";
+        const ANSWER_KEY_SECRET: &str = "CLUSTER_ANSWER_KEY_SECRET_SENTINEL";
+        const ANSWER_BODY_SECRET: &str = "CLUSTER_ANSWER_BODY_SECRET_SENTINEL";
+        const AUTH_HASH_SECRET: &str = "CLUSTER_AUTH_HASH_SECRET_SENTINEL";
+        const REALM_SECRET: &str = "CLUSTER_AUTH_REALM_SECRET_SENTINEL";
+
+        let long_value = |marker: &str| format!("{marker}{}", "x".repeat(4096));
+        let cluster = Cluster {
+            cluster_id: long_value(CLUSTER_SECRET),
+            answer_503: Some(long_value(LEGACY_ANSWER_SECRET)),
+            answers: BTreeMap::from([(
+                long_value(ANSWER_KEY_SECRET),
+                long_value(ANSWER_BODY_SECRET),
+            )]),
+            authorized_hashes: vec![long_value(AUTH_HASH_SECRET)],
+            www_authenticate: Some(long_value(REALM_SECRET)),
+            ..Default::default()
+        };
+        let request = Request::from(RequestType::AddCluster(cluster.clone()));
+        let outputs = [
+            ("Cluster", format!("{cluster:?}")),
+            ("Request", format!("{request:?}")),
+            (
+                "WorkerRequest",
+                format!(
+                    "{:?}",
+                    WorkerRequest {
+                        id: "cluster-redaction-test".to_owned(),
+                        content: request,
+                    }
+                ),
+            ),
+        ];
+
+        for (label, output) in outputs {
+            for secret in [
+                CLUSTER_SECRET,
+                LEGACY_ANSWER_SECRET,
+                ANSWER_KEY_SECRET,
+                ANSWER_BODY_SECRET,
+                AUTH_HASH_SECRET,
+                REALM_SECRET,
+            ] {
+                assert!(
+                    !output.contains(secret),
+                    "{label} Debug leaked cluster marker {secret}: {output}"
+                );
+            }
+            for metadata in [
+                "cluster_id_len:",
+                "answers_count: 1",
+                "authorized_hashes_count: 1",
+            ] {
+                assert!(
+                    output.contains(metadata),
+                    "{label} Debug omitted bounded cluster metadata {metadata}: {output}"
+                );
+            }
+            assert!(
+                output.len() <= 2048,
+                "{label} Debug output is not bounded: {} bytes",
+                output.len()
+            );
+        }
+    }
+
+    #[test]
+    fn tcp_frontend_debug_redacts_stored_sni_routing_data_across_wrappers() {
+        const CLUSTER_SECRET: &str = "TCP_FRONTEND_CLUSTER_SECRET_SENTINEL";
+        const TAG_KEY_SECRET: &str = "TCP_FRONTEND_TAG_KEY_SECRET_SENTINEL";
+        const TAG_VALUE_SECRET: &str = "TCP_FRONTEND_TAG_VALUE_SECRET_SENTINEL";
+        const SNI_SECRET: &str = "TCP_FRONTEND_SNI_SECRET_SENTINEL";
+        const ALPN_SECRET: &str = "TCP_FRONTEND_ALPN_SECRET_SENTINEL";
+
+        let long_value = |marker: &str| format!("{marker}{}", "x".repeat(4096));
+        let frontend = RequestTcpFrontend {
+            cluster_id: long_value(CLUSTER_SECRET),
+            address: Default::default(),
+            tags: BTreeMap::from([(long_value(TAG_KEY_SECRET), long_value(TAG_VALUE_SECRET))]),
+            sni: Some(long_value(SNI_SECRET)),
+            alpn: vec![long_value(ALPN_SECRET)],
+        };
+        let request = Request::from(RequestType::AddTcpFrontend(frontend.clone()));
+        let outputs = [
+            ("RequestTcpFrontend", format!("{frontend:?}")),
+            ("Request", format!("{request:?}")),
+            (
+                "WorkerRequest",
+                format!(
+                    "{:?}",
+                    WorkerRequest {
+                        id: "tcp-frontend-redaction-test".to_owned(),
+                        content: request,
+                    }
+                ),
+            ),
+        ];
+
+        for (label, output) in outputs {
+            for secret in [
+                CLUSTER_SECRET,
+                TAG_KEY_SECRET,
+                TAG_VALUE_SECRET,
+                SNI_SECRET,
+                ALPN_SECRET,
+            ] {
+                assert!(
+                    !output.contains(secret),
+                    "{label} Debug leaked TCP frontend marker {secret}: {output}"
+                );
+            }
+            for metadata in [
+                "cluster_id_len:",
+                "tags_count: 1",
+                "sni_len: Some(",
+                "alpn_count: 1",
+            ] {
+                assert!(
+                    output.contains(metadata),
+                    "{label} Debug omitted bounded TCP frontend metadata {metadata}: {output}"
+                );
+            }
+            assert!(
+                output.len() <= 1024,
+                "{label} Debug output is not bounded: {} bytes",
+                output.len()
+            );
+        }
+    }
 
     #[test]
     fn merge_relocates_single_worker_to_top_level() {

--- a/command/src/response.rs
+++ b/command/src/response.rs
@@ -24,7 +24,7 @@ impl Response {
 }
 
 /// An HTTP or HTTPS frontend, as used *within* Sōzu
-#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HttpFrontend {
     /// Send a 401, DENY, if cluster_id is None
     pub cluster_id: Option<ClusterId>,
@@ -73,6 +73,53 @@ pub struct HttpFrontend {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hsts: Option<HstsConfig>,
+}
+
+impl fmt::Debug for HttpFrontend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let tags_count = self.tags.as_ref().map(BTreeMap::len);
+        let tags_len = self.tags.as_ref().map(|tags| {
+            tags.iter().fold(0usize, |total, (key, value)| {
+                total.saturating_add(key.len()).saturating_add(value.len())
+            })
+        });
+        let headers_len = self.headers.iter().fold(0usize, |total, header| {
+            total
+                .saturating_add(header.key.len())
+                .saturating_add(header.val.len())
+        });
+
+        f.debug_struct("HttpFrontend")
+            .field("cluster_id_len", &self.cluster_id.as_ref().map(String::len))
+            .field("address", &self.address)
+            .field("hostname_len", &self.hostname.len())
+            .field("path_kind", &self.path.kind)
+            .field("path_len", &self.path.value.len())
+            .field("method_len", &self.method.as_ref().map(String::len))
+            .field("position", &self.position)
+            .field("tags_count", &tags_count)
+            .field("tags_len", &tags_len)
+            .field("redirect", &self.redirect)
+            .field("required_auth", &self.required_auth)
+            .field("redirect_scheme", &self.redirect_scheme)
+            .field(
+                "redirect_template_len",
+                &self.redirect_template.as_ref().map(String::len),
+            )
+            .field(
+                "rewrite_host_len",
+                &self.rewrite_host.as_ref().map(String::len),
+            )
+            .field(
+                "rewrite_path_len",
+                &self.rewrite_path.as_ref().map(String::len),
+            )
+            .field("rewrite_port", &self.rewrite_port)
+            .field("headers_count", &self.headers.len())
+            .field("headers_len", &headers_len)
+            .field("hsts", &self.hsts)
+            .finish_non_exhaustive()
+    }
 }
 
 impl From<HttpFrontend> for RequestHttpFrontend {

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -76,6 +76,17 @@ pub enum StateError {
     InvalidTcpFrontend { address: SocketAddr, reason: String },
 }
 
+fn frontend_log_summary(front: &RequestHttpFrontend) -> String {
+    format!(
+        "address={}, hostname_bytes={}, path_kind={}, path_bytes={}, method_bytes={:?}",
+        front.address,
+        front.hostname.len(),
+        front.path.kind,
+        front.path.value.len(),
+        front.method.as_ref().map(String::len),
+    )
+}
+
 /// The `ConfigState` represents the state of Sōzu's business, which is to forward traffic
 /// from frontends to backends. Hence, it contains all details about:
 ///
@@ -84,7 +95,7 @@ pub enum StateError {
 /// - backends (to forward connections to)
 /// - clusters (routing rules from frontends to backends)
 /// - TLS certificates
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ConfigState {
     pub clusters: BTreeMap<ClusterId, Cluster>,
     pub backends: BTreeMap<ClusterId, Vec<Backend>>,
@@ -106,6 +117,50 @@ pub struct ConfigState {
     pub certificates: HashMap<SocketAddr, HashMap<Fingerprint, CertificateAndKey>>,
     /// A census of requests that were received. Name of the request -> number of occurences
     pub request_counts: BTreeMap<String, i32>,
+}
+
+impl std::fmt::Debug for ConfigState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let backends_count = self
+            .backends
+            .values()
+            .map(Vec::len)
+            .fold(0usize, usize::saturating_add);
+        let tcp_frontends_count = self
+            .tcp_fronts
+            .values()
+            .map(Vec::len)
+            .fold(0usize, usize::saturating_add);
+        let udp_frontends_count = self
+            .udp_fronts
+            .values()
+            .map(Vec::len)
+            .fold(0usize, usize::saturating_add);
+        let certificates_count = self
+            .certificates
+            .values()
+            .map(HashMap::len)
+            .fold(0usize, usize::saturating_add);
+
+        f.debug_struct("ConfigState")
+            .field("clusters_count", &self.clusters.len())
+            .field("backend_clusters_count", &self.backends.len())
+            .field("backends_count", &backends_count)
+            .field("http_listeners_count", &self.http_listeners.len())
+            .field("https_listeners_count", &self.https_listeners.len())
+            .field("tcp_listeners_count", &self.tcp_listeners.len())
+            .field("udp_listeners_count", &self.udp_listeners.len())
+            .field("http_frontends_count", &self.http_fronts.len())
+            .field("https_frontends_count", &self.https_fronts.len())
+            .field("tcp_frontend_clusters_count", &self.tcp_fronts.len())
+            .field("tcp_frontends_count", &tcp_frontends_count)
+            .field("udp_frontend_clusters_count", &self.udp_fronts.len())
+            .field("udp_frontends_count", &udp_frontends_count)
+            .field("certificate_addresses_count", &self.certificates.len())
+            .field("certificates_count", &certificates_count)
+            .field("request_counts_count", &self.request_counts.len())
+            .finish_non_exhaustive()
+    }
 }
 
 impl ConfigState {
@@ -992,14 +1047,13 @@ impl ConfigState {
     }
 
     fn add_http_frontend(&mut self, front: &RequestHttpFrontend) -> Result<(), StateError> {
-        let front_as_key = front.to_string();
         let before = self.http_fronts.len();
 
         match self.http_fronts.entry(front.to_string()) {
             BTreeMapEntry::Vacant(e) => {
                 e.insert(front.clone().to_frontend().map_err(|into_error| {
                     StateError::FrontendConversion {
-                        frontend: front_as_key,
+                        frontend: frontend_log_summary(front),
                         error: into_error.to_string(),
                     }
                 })?)
@@ -1012,7 +1066,7 @@ impl ConfigState {
                 );
                 return Err(StateError::Exists {
                     kind: ObjectKind::HttpFrontend,
-                    id: front.to_string(),
+                    id: frontend_log_summary(front),
                 });
             }
         };
@@ -1031,14 +1085,13 @@ impl ConfigState {
     }
 
     fn add_https_frontend(&mut self, front: &RequestHttpFrontend) -> Result<(), StateError> {
-        let front_as_key = front.to_string();
         let before = self.https_fronts.len();
 
         match self.https_fronts.entry(front.to_string()) {
             BTreeMapEntry::Vacant(e) => {
                 e.insert(front.clone().to_frontend().map_err(|into_error| {
                     StateError::FrontendConversion {
-                        frontend: front_as_key,
+                        frontend: frontend_log_summary(front),
                         error: into_error.to_string(),
                     }
                 })?)
@@ -1051,7 +1104,7 @@ impl ConfigState {
                 );
                 return Err(StateError::Exists {
                     kind: ObjectKind::HttpsFrontend,
-                    id: front.to_string(),
+                    id: frontend_log_summary(front),
                 });
             }
         };
@@ -1072,7 +1125,7 @@ impl ConfigState {
         let before = self.http_fronts.len();
         self.http_fronts.remove(&key).ok_or(StateError::NotFound {
             kind: ObjectKind::HttpFrontend,
-            id: front.to_string(),
+            id: frontend_log_summary(front),
         })?;
         debug_assert!(
             !self.http_fronts.contains_key(&key),
@@ -1091,7 +1144,7 @@ impl ConfigState {
         let before = self.https_fronts.len();
         self.https_fronts.remove(&key).ok_or(StateError::NotFound {
             kind: ObjectKind::HttpsFrontend,
-            id: front.to_string(),
+            id: frontend_log_summary(front),
         })?;
         debug_assert!(
             !self.https_fronts.contains_key(&key),
@@ -1119,10 +1172,16 @@ impl ConfigState {
             .map_err(StateError::AddCertificate)?;
 
         if entry.contains_key(&fingerprint) {
+            let names_bytes = add
+                .certificate
+                .names
+                .iter()
+                .fold(0usize, |total, name| total.saturating_add(name.len()));
             info!(
-                "Skip loading of certificate '{}' for domain '{}' on listener '{}', the certificate is already present.",
-                fingerprint,
-                add.certificate.names.join(", "),
+                "Skip loading certificate with fingerprint_bytes={} names_count={} names_bytes={} on listener '{}', the certificate is already present.",
+                fingerprint.0.len(),
+                add.certificate.names.len(),
+                names_bytes,
                 add.address
             );
             return Ok(());
@@ -3088,9 +3147,340 @@ mod tests {
 
     use super::*;
     use crate::proto::command::{
-        CustomHttpAnswers, LoadBalancingParams, RequestHttpFrontend, RequestTcpFrontend,
+        CustomHttpAnswers, Header, HeaderPosition, HstsConfig, LoadBalancingParams, PathRuleKind,
+        RedirectPolicy, RedirectScheme, RequestHttpFrontend, RequestTcpFrontend,
         RequestUdpFrontend, RulePosition, UdpListenerConfig, UpdateUdpListenerConfig,
     };
+
+    fn capture_test_logs(run: impl FnOnce() + Send + 'static) -> String {
+        let receiver = std::net::UdpSocket::bind("127.0.0.1:0")
+            .expect("test log receiver must bind to a loopback port");
+        let target = format!(
+            "udp://{}",
+            receiver
+                .local_addr()
+                .expect("test log receiver must have a local address")
+        );
+
+        std::thread::spawn(move || {
+            crate::logging::Logger::init(
+                "state-log-redaction-test".to_owned(),
+                "info",
+                &target,
+                false,
+                None,
+                None,
+                None,
+            )
+            .expect("test logger must initialize");
+            run();
+        })
+        .join()
+        .expect("log-producing test thread must not panic");
+
+        receiver
+            .set_nonblocking(true)
+            .expect("test log receiver must become nonblocking");
+        let mut output = String::new();
+        let mut datagram = vec![0; 65_507];
+        loop {
+            match receiver.recv(&mut datagram) {
+                Ok(length) => output.push_str(&String::from_utf8_lossy(&datagram[..length])),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => break,
+                Err(error) => panic!("test log receiver failed: {error}"),
+            }
+        }
+        assert!(!output.is_empty(), "test log capture received no datagrams");
+        output
+    }
+
+    #[test]
+    fn duplicate_certificate_log_redacts_names() {
+        const NAME_SECRET: &str = "DUPLICATE_CERTIFICATE_NAME_SECRET_SENTINEL";
+
+        let name = format!("{NAME_SECRET}{}", "x".repeat(4096));
+        let name_len = name.len();
+        let certificate = CertificateAndKey {
+            certificate: include_str!("../assets/certificate.pem").to_owned(),
+            key: include_str!("../assets/key.pem").to_owned(),
+            certificate_chain: Vec::new(),
+            versions: Vec::new(),
+            names: vec![name],
+        };
+        let fingerprint = certificate
+            .fingerprint()
+            .expect("test certificate fingerprint must be computable")
+            .to_string();
+        let output = capture_test_logs(move || {
+            let mut state = ConfigState::default();
+            let add = AddCertificate {
+                address: SocketAddress::new_v4(127, 0, 0, 1, 8443),
+                certificate,
+                expired_at: None,
+            };
+
+            state
+                .add_certificate(&add)
+                .expect("first certificate insertion must succeed");
+            state
+                .add_certificate(&add)
+                .expect("duplicate certificate insertion must be skipped");
+        });
+
+        assert!(
+            !output.contains(NAME_SECRET),
+            "duplicate certificate log leaked certificate name {NAME_SECRET}"
+        );
+        assert!(
+            !output.contains(&fingerprint),
+            "duplicate certificate log leaked certificate fingerprint {fingerprint}"
+        );
+        for metadata in [
+            "fingerprint_bytes=32".to_owned(),
+            "names_count=1".to_owned(),
+            format!("names_bytes={name_len}"),
+        ] {
+            assert!(
+                output.contains(&metadata),
+                "duplicate certificate log omitted bounded metadata {metadata}: {output}"
+            );
+        }
+        assert!(
+            output.len() <= 512,
+            "duplicate certificate log is not bounded: {} bytes",
+            output.len()
+        );
+    }
+
+    #[test]
+    fn frontend_state_error_redacts_display_key() {
+        const HOSTNAME_SECRET: &str = "STATE_ERROR_HOSTNAME_SECRET_SENTINEL";
+        const PATH_SECRET: &str = "STATE_ERROR_PATH_SECRET_SENTINEL";
+        const METHOD_SECRET: &str = "STATE_ERROR_METHOD_SECRET_SENTINEL";
+
+        let long_value = |marker: &str| format!("{marker}{}", "x".repeat(4096));
+        let front = RequestHttpFrontend {
+            cluster_id: Some("cluster".to_owned()),
+            address: SocketAddress::new_v4(127, 0, 0, 1, 8080),
+            hostname: long_value(HOSTNAME_SECRET),
+            path: PathRule {
+                kind: PathRuleKind::Prefix as i32,
+                value: long_value(PATH_SECRET),
+            },
+            method: Some(long_value(METHOD_SECRET)),
+            position: RulePosition::Tree as i32,
+            tags: BTreeMap::new(),
+            redirect: None,
+            redirect_scheme: None,
+            redirect_template: None,
+            rewrite_host: None,
+            rewrite_path: None,
+            rewrite_port: None,
+            required_auth: None,
+            headers: Vec::new(),
+            hsts: None,
+        };
+        let mut state = ConfigState::default();
+        state
+            .add_http_frontend(&front)
+            .expect("first frontend insertion must succeed");
+        assert!(
+            state
+                .http_fronts
+                .keys()
+                .next()
+                .expect("raw state key must be retained")
+                .contains(HOSTNAME_SECRET),
+            "state storage must retain the raw operator-facing frontend key"
+        );
+
+        let error = state
+            .add_http_frontend(&front)
+            .expect_err("duplicate frontend insertion must return StateError::Exists");
+        for (label, output) in [
+            ("Display", error.to_string()),
+            ("Debug", format!("{error:?}")),
+        ] {
+            for secret in [HOSTNAME_SECRET, PATH_SECRET, METHOD_SECRET] {
+                assert!(
+                    !output.contains(secret),
+                    "StateError {label} leaked frontend marker {secret}"
+                );
+            }
+            for metadata in [
+                format!("hostname_bytes={}", long_value(HOSTNAME_SECRET).len()),
+                format!("path_bytes={}", long_value(PATH_SECRET).len()),
+                format!("method_bytes=Some({})", long_value(METHOD_SECRET).len()),
+            ] {
+                assert!(
+                    output.contains(&metadata),
+                    "StateError {label} omitted bounded metadata {metadata}: {output}"
+                );
+            }
+            assert!(
+                output.len() <= 512,
+                "StateError {label} output is not bounded: {} bytes",
+                output.len()
+            );
+        }
+    }
+
+    #[test]
+    fn retained_state_debug_redacts_http_frontend_and_collection_data() {
+        const CLUSTER_SECRET: &str = "RETAINED_CLUSTER_SECRET_SENTINEL";
+        const HOSTNAME_SECRET: &str = "RETAINED_HOSTNAME_SECRET_SENTINEL";
+        const PATH_SECRET: &str = "RETAINED_PATH_SECRET_SENTINEL";
+        const METHOD_SECRET: &str = "RETAINED_METHOD_SECRET_SENTINEL";
+        const TAG_KEY_SECRET: &str = "RETAINED_TAG_KEY_SECRET_SENTINEL";
+        const TAG_VALUE_SECRET: &str = "RETAINED_TAG_VALUE_SECRET_SENTINEL";
+        const REDIRECT_TEMPLATE_SECRET: &str = "RETAINED_REDIRECT_TEMPLATE_SECRET_SENTINEL";
+        const REWRITE_HOST_SECRET: &str = "RETAINED_REWRITE_HOST_SECRET_SENTINEL";
+        const REWRITE_PATH_SECRET: &str = "RETAINED_REWRITE_PATH_SECRET_SENTINEL";
+        const HEADER_KEY_SECRET: &str = "RETAINED_HEADER_KEY_SECRET_SENTINEL";
+        const HEADER_VALUE_SECRET: &str = "RETAINED_HEADER_VALUE_SECRET_SENTINEL";
+        const REQUEST_COUNT_SECRET: &str = "RETAINED_REQUEST_COUNT_SECRET_SENTINEL";
+
+        let long_value = |marker: &str| format!("{marker}{}", "x".repeat(4096));
+        let request = RequestHttpFrontend {
+            cluster_id: Some(long_value(CLUSTER_SECRET)),
+            address: SocketAddress::new_v4(127, 0, 0, 1, 8443),
+            hostname: long_value(HOSTNAME_SECRET),
+            path: PathRule {
+                kind: PathRuleKind::Regex as i32,
+                value: long_value(PATH_SECRET),
+            },
+            method: Some(long_value(METHOD_SECRET)),
+            position: RulePosition::Tree as i32,
+            tags: BTreeMap::from([(long_value(TAG_KEY_SECRET), long_value(TAG_VALUE_SECRET))]),
+            redirect: Some(RedirectPolicy::PermanentRedirect as i32),
+            redirect_scheme: Some(RedirectScheme::UseHttps as i32),
+            redirect_template: Some(long_value(REDIRECT_TEMPLATE_SECRET)),
+            rewrite_host: Some(long_value(REWRITE_HOST_SECRET)),
+            rewrite_path: Some(long_value(REWRITE_PATH_SECRET)),
+            rewrite_port: Some(9443),
+            required_auth: Some(true),
+            headers: vec![Header {
+                position: HeaderPosition::Both as i32,
+                key: long_value(HEADER_KEY_SECRET),
+                val: long_value(HEADER_VALUE_SECRET),
+            }],
+            hsts: Some(HstsConfig {
+                enabled: Some(true),
+                max_age: Some(31_536_000),
+                include_subdomains: Some(true),
+                preload: Some(false),
+                force_replace_backend: Some(true),
+            }),
+        };
+        let retained = request
+            .clone()
+            .to_frontend()
+            .expect("adversarial frontend must convert");
+        let retained_debug = format!("{retained:?}");
+
+        let mut state = ConfigState::default();
+        state
+            .dispatch(&RequestType::AddHttpFrontend(request).into())
+            .expect("adversarial frontend must be retained");
+        state
+            .request_counts
+            .insert(long_value(REQUEST_COUNT_SECRET), 7);
+        let retained_key = state
+            .http_fronts
+            .keys()
+            .next()
+            .expect("dispatch must retain the frontend's Display key");
+        assert!(retained_key.contains(HOSTNAME_SECRET));
+        assert!(retained_key.contains(PATH_SECRET));
+        assert!(retained_key.contains(METHOD_SECRET));
+        let state_debug = format!("{state:?}");
+
+        let secrets = [
+            CLUSTER_SECRET,
+            HOSTNAME_SECRET,
+            PATH_SECRET,
+            METHOD_SECRET,
+            TAG_KEY_SECRET,
+            TAG_VALUE_SECRET,
+            REDIRECT_TEMPLATE_SECRET,
+            REWRITE_HOST_SECRET,
+            REWRITE_PATH_SECRET,
+            HEADER_KEY_SECRET,
+            HEADER_VALUE_SECRET,
+            REQUEST_COUNT_SECRET,
+        ];
+        for (label, output) in [
+            ("HttpFrontend", &retained_debug),
+            ("ConfigState", &state_debug),
+        ] {
+            for secret in secrets {
+                assert!(
+                    !output.contains(secret),
+                    "{label} Debug leaked retained marker {secret}"
+                );
+            }
+            assert!(
+                output.len() <= 2048,
+                "{label} Debug output is not bounded: {} bytes",
+                output.len()
+            );
+        }
+
+        for metadata in [
+            format!("cluster_id_len: Some({})", long_value(CLUSTER_SECRET).len()),
+            "address: 127.0.0.1:8443".to_owned(),
+            format!("hostname_len: {}", long_value(HOSTNAME_SECRET).len()),
+            "path_kind: 1".to_owned(),
+            format!("path_len: {}", long_value(PATH_SECRET).len()),
+            format!("method_len: Some({})", long_value(METHOD_SECRET).len()),
+            "position: Tree".to_owned(),
+            "tags_count: Some(1)".to_owned(),
+            format!(
+                "tags_len: Some({})",
+                long_value(TAG_KEY_SECRET).len() + long_value(TAG_VALUE_SECRET).len()
+            ),
+            "redirect: Some(4)".to_owned(),
+            "redirect_scheme: Some(2)".to_owned(),
+            format!(
+                "redirect_template_len: Some({})",
+                long_value(REDIRECT_TEMPLATE_SECRET).len()
+            ),
+            format!(
+                "rewrite_host_len: Some({})",
+                long_value(REWRITE_HOST_SECRET).len()
+            ),
+            format!(
+                "rewrite_path_len: Some({})",
+                long_value(REWRITE_PATH_SECRET).len()
+            ),
+            "rewrite_port: Some(9443)".to_owned(),
+            "required_auth: Some(true)".to_owned(),
+            "headers_count: 1".to_owned(),
+            format!(
+                "headers_len: {}",
+                long_value(HEADER_KEY_SECRET).len() + long_value(HEADER_VALUE_SECRET).len()
+            ),
+            "hsts: Some(HstsConfig".to_owned(),
+        ] {
+            assert!(
+                retained_debug.contains(&metadata),
+                "HttpFrontend Debug omitted safe metadata {metadata}: {retained_debug}"
+            );
+        }
+        for metadata in [
+            "http_frontends_count: 1",
+            "backends_count: 0",
+            "tcp_frontends_count: 0",
+            "udp_frontends_count: 0",
+            "certificates_count: 0",
+            "request_counts_count: 2",
+        ] {
+            assert!(
+                state_debug.contains(metadata),
+                "ConfigState Debug omitted count metadata {metadata}: {state_debug}"
+            );
+        }
+    }
 
     #[test]
     fn serialize() {

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -3,6 +3,7 @@ use std::{
         BTreeMap, BTreeSet, HashMap, HashSet, btree_map::Entry as BTreeMapEntry,
         hash_map::DefaultHasher,
     },
+    fmt,
     fs::File,
     hash::{Hash, Hasher},
     io::Write,
@@ -36,7 +37,7 @@ use crate::{
 /// To use throughout Sōzu
 pub type ClusterId = String;
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error)]
 pub enum StateError {
     #[error("Request came in empty")]
     EmptyRequest,
@@ -44,23 +45,21 @@ pub enum StateError {
     NoChange,
     #[error("State can not handle this request")]
     UndispatchableRequest,
-    #[error("Did not find {kind:?} with address or id '{id}'")]
+    #[error("Did not find {kind:?} with address or id_bytes={}", .id.len())]
     NotFound { kind: ObjectKind, id: String },
-    #[error("{kind:?} '{id}' already exists")]
+    #[error("{kind:?} with id_bytes={} already exists", .id.len())]
     Exists { kind: ObjectKind, id: String },
     #[error("Wrong field value: {0}")]
     WrongFieldValue(UnknownEnumValue),
-    #[error("Could not add certificate: {0}")]
+    #[error("Could not add certificate: error_kind={}", certificate_error_kind(.0))]
     AddCertificate(CertificateError),
-    #[error("Could not remove certificate: {0}")]
+    #[error("Could not remove certificate: fingerprint_bytes={}", .0.len())]
     RemoveCertificate(String),
-    #[error("Could not replace certificate: {0}")]
+    #[error("Could not replace certificate: error_bytes={}", .0.len())]
     ReplaceCertificate(String),
-    #[error(
-        "Could not convert the frontend to an insertable one. Frontend: {frontend} error: {error}"
-    )]
+    #[error("Could not convert frontend: frontend_bytes={} error_bytes={}", .frontend.len(), .error.len())]
     FrontendConversion { frontend: String, error: String },
-    #[error("Could not write state to file: {0}")]
+    #[error("Could not write state to file: io_kind={:?} os_code={:?}", .0.kind(), .0.raw_os_error())]
     FileError(std::io::Error),
     #[error("Invalid value for field '{field}': {reason}")]
     InvalidValue {
@@ -72,19 +71,25 @@ pub enum StateError {
     /// same reasons `validate_new_tcp_front` would, so a route never lands
     /// in `ConfigState` only to be NACKed by every worker on the next
     /// fan-out (sozu-proxy/sozu#1290).
-    #[error("invalid TCP frontend for address {address}: {reason}")]
+    #[error("invalid TCP frontend for address {address}: reason_bytes={}", .reason.len())]
     InvalidTcpFrontend { address: SocketAddr, reason: String },
 }
 
-fn frontend_log_summary(front: &RequestHttpFrontend) -> String {
-    format!(
-        "address={}, hostname_bytes={}, path_kind={}, path_bytes={}, method_bytes={:?}",
-        front.address,
-        front.hostname.len(),
-        front.path.kind,
-        front.path.value.len(),
-        front.method.as_ref().map(String::len),
-    )
+impl fmt::Debug for StateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "StateError({self})")
+    }
+}
+
+fn certificate_error_kind(error: &CertificateError) -> &'static str {
+    match error {
+        CertificateError::ParsePEMCertificate(_) => "parse_pem_certificate",
+        CertificateError::ParseX509Certificate(_) => "parse_x509_certificate",
+        CertificateError::InvalidTlsVersion(_) => "invalid_tls_version",
+        CertificateError::InvalidFingerprint(_) => "invalid_fingerprint",
+        CertificateError::LoadFile { .. } => "load_file",
+        CertificateError::DecodeError(_) => "decode_error",
+    }
 }
 
 /// The `ConfigState` represents the state of Sōzu's business, which is to forward traffic
@@ -1047,13 +1052,14 @@ impl ConfigState {
     }
 
     fn add_http_frontend(&mut self, front: &RequestHttpFrontend) -> Result<(), StateError> {
+        let front_as_key = front.to_string();
         let before = self.http_fronts.len();
 
         match self.http_fronts.entry(front.to_string()) {
             BTreeMapEntry::Vacant(e) => {
                 e.insert(front.clone().to_frontend().map_err(|into_error| {
                     StateError::FrontendConversion {
-                        frontend: frontend_log_summary(front),
+                        frontend: front_as_key,
                         error: into_error.to_string(),
                     }
                 })?)
@@ -1066,7 +1072,7 @@ impl ConfigState {
                 );
                 return Err(StateError::Exists {
                     kind: ObjectKind::HttpFrontend,
-                    id: frontend_log_summary(front),
+                    id: front.to_string(),
                 });
             }
         };
@@ -1085,13 +1091,14 @@ impl ConfigState {
     }
 
     fn add_https_frontend(&mut self, front: &RequestHttpFrontend) -> Result<(), StateError> {
+        let front_as_key = front.to_string();
         let before = self.https_fronts.len();
 
         match self.https_fronts.entry(front.to_string()) {
             BTreeMapEntry::Vacant(e) => {
                 e.insert(front.clone().to_frontend().map_err(|into_error| {
                     StateError::FrontendConversion {
-                        frontend: frontend_log_summary(front),
+                        frontend: front_as_key,
                         error: into_error.to_string(),
                     }
                 })?)
@@ -1104,7 +1111,7 @@ impl ConfigState {
                 );
                 return Err(StateError::Exists {
                     kind: ObjectKind::HttpsFrontend,
-                    id: frontend_log_summary(front),
+                    id: front.to_string(),
                 });
             }
         };
@@ -1125,7 +1132,7 @@ impl ConfigState {
         let before = self.http_fronts.len();
         self.http_fronts.remove(&key).ok_or(StateError::NotFound {
             kind: ObjectKind::HttpFrontend,
-            id: frontend_log_summary(front),
+            id: front.to_string(),
         })?;
         debug_assert!(
             !self.http_fronts.contains_key(&key),
@@ -1144,7 +1151,7 @@ impl ConfigState {
         let before = self.https_fronts.len();
         self.https_fronts.remove(&key).ok_or(StateError::NotFound {
             kind: ObjectKind::HttpsFrontend,
-            id: frontend_log_summary(front),
+            id: front.to_string(),
         })?;
         debug_assert!(
             !self.https_fronts.contains_key(&key),
@@ -1454,7 +1461,14 @@ impl ConfigState {
                 .get_mut(&front_to_remove.cluster_id)
                 .ok_or(StateError::NotFound {
                     kind: ObjectKind::TcpFrontend,
-                    id: format!("{front_to_remove:?}"),
+                    id: format!(
+                        "RequestTcpFrontend {{ cluster_id: {:?}, address: {:?}, tags: {:?}, sni: {:?}, alpn: {:?} }}",
+                        front_to_remove.cluster_id,
+                        front_to_remove.address,
+                        front_to_remove.tags,
+                        front_to_remove.sni,
+                        front_to_remove.alpn,
+                    ),
                 })?;
 
         let len = tcp_frontends.len();
@@ -3297,6 +3311,14 @@ mod tests {
         let error = state
             .add_http_frontend(&front)
             .expect_err("duplicate frontend insertion must return StateError::Exists");
+        let raw_frontend_key = front.to_string();
+        match &error {
+            StateError::Exists { id, .. } => assert_eq!(
+                id, &raw_frontend_key,
+                "StateError must preserve the public raw frontend identifier"
+            ),
+            other => panic!("expected StateError::Exists, got {other:?}"),
+        }
         for (label, output) in [
             ("Display", error.to_string()),
             ("Debug", format!("{error:?}")),
@@ -3307,19 +3329,98 @@ mod tests {
                     "StateError {label} leaked frontend marker {secret}"
                 );
             }
-            for metadata in [
-                format!("hostname_bytes={}", long_value(HOSTNAME_SECRET).len()),
-                format!("path_bytes={}", long_value(PATH_SECRET).len()),
-                format!("method_bytes=Some({})", long_value(METHOD_SECRET).len()),
-            ] {
-                assert!(
-                    output.contains(&metadata),
-                    "StateError {label} omitted bounded metadata {metadata}: {output}"
-                );
-            }
+            let metadata = format!("id_bytes={}", raw_frontend_key.len());
+            assert!(
+                output.contains(&metadata),
+                "StateError {label} omitted bounded metadata {metadata}: {output}"
+            );
             assert!(
                 output.len() <= 512,
                 "StateError {label} output is not bounded: {} bytes",
+                output.len()
+            );
+        }
+    }
+
+    #[test]
+    fn state_error_formatting_bounds_every_string_bearing_variant() {
+        const SECRET: &str = "STATE_ERROR_VARIANT_SECRET_SENTINEL";
+
+        let long_value = || format!("{SECRET}{}", "x".repeat(4096));
+        let errors = [
+            StateError::NotFound {
+                kind: ObjectKind::Backend,
+                id: long_value(),
+            },
+            StateError::Exists {
+                kind: ObjectKind::Cluster,
+                id: long_value(),
+            },
+            StateError::AddCertificate(CertificateError::ParsePEMCertificate(long_value())),
+            StateError::RemoveCertificate(long_value()),
+            StateError::ReplaceCertificate(long_value()),
+            StateError::FrontendConversion {
+                frontend: long_value(),
+                error: long_value(),
+            },
+            StateError::FileError(std::io::Error::other(long_value())),
+            StateError::InvalidTcpFrontend {
+                address: "127.0.0.1:443"
+                    .parse()
+                    .expect("test TCP frontend address must parse"),
+                reason: long_value(),
+            },
+        ];
+
+        for error in errors {
+            for (label, output) in [
+                ("Display", error.to_string()),
+                ("Debug", format!("{error:?}")),
+            ] {
+                assert!(
+                    !output.contains(SECRET),
+                    "StateError {label} leaked a string-bearing variant: {output}"
+                );
+                assert!(
+                    output.len() <= 512,
+                    "StateError {label} is not bounded: {} bytes",
+                    output.len()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn tcp_frontend_not_found_error_retains_the_raw_identity() {
+        const TCP_SECRET: &str = "STATE_ERROR_TCP_IDENTITY_SECRET_SENTINEL";
+
+        let long_value = |suffix: &str| format!("{TCP_SECRET}_{suffix}{}", "x".repeat(1024));
+        let frontend = RequestTcpFrontend {
+            cluster_id: long_value("cluster"),
+            address: SocketAddress::new_v4(127, 0, 0, 1, 443),
+            tags: BTreeMap::from([(long_value("tag-key"), long_value("tag-value"))]),
+            sni: Some(long_value("sni")),
+            alpn: vec![long_value("alpn")],
+        };
+        let error = ConfigState::default()
+            .remove_tcp_frontend(&frontend)
+            .expect_err("removing from a missing cluster must return StateError::NotFound");
+
+        match &error {
+            StateError::NotFound { id, .. } => assert!(
+                id.contains(TCP_SECRET),
+                "StateError must retain the raw TCP frontend identity: {id}"
+            ),
+            other => panic!("expected StateError::NotFound, got {other:?}"),
+        }
+        for output in [error.to_string(), format!("{error:?}")] {
+            assert!(
+                !output.contains(TCP_SECRET),
+                "StateError formatting leaked the retained TCP identity: {output}"
+            );
+            assert!(
+                output.len() <= 512,
+                "StateError formatting is not bounded: {} bytes",
                 output.len()
             );
         }

--- a/doc/observability.md
+++ b/doc/observability.md
@@ -185,6 +185,52 @@ Structured prefixes via per-protocol `log_context!` / `log_module_context!` /
   (`kawa_h1/editor.rs:587`) over hand-rolling a `LogContext { ... }`
   struct literal — the helper is the canonical formatter.
 
+### Sensitive-value logging boundary
+
+`Debug` is a production logging projection in Sōzu, not a lossless inspection
+format. Generic log sites format command requests, worker responses, retained
+tasks and state, router/listener errors, and TLS runtime objects with `{:?}`.
+Every type reachable from those paths must therefore produce bounded metadata
+when its fields can contain operator- or customer-controlled material.
+
+The protected material includes certificate and private-key contents, chains,
+certificate names and fingerprints, certificate-query domains and results,
+cluster identifiers, HTTP routing hosts/paths/methods/tags, redirect and
+rewrite values, TCP SNI and ALPN values, custom-answer keys and bodies, and
+header names and values. Their log projections may retain only operationally
+useful metadata such as socket addresses, enum variants, booleans, presence
+flags, collection counts, and aggregate byte lengths. Certificate and key
+slots render as `[redacted]` in addition to their lengths.
+
+Apply the boundary at every layer that can reach a log sink:
+
+- Generated protobuf types that carry sensitive fields are listed in
+  `command/build.rs` via `prost_build::Config::skip_debug`; their bounded
+  implementations live in `command/src/proto/mod.rs`.
+- Configuration, response, retained-state, gatherer, router, listener, and TLS
+  wrappers must summarize their own collections and string-keyed maps rather
+  than relying on an enclosing type to hide them.
+- Direct `debug!`, `info!`, `warn!`, `error!`, and failure-message projections
+  must interpolate the same counts, kinds, addresses, and byte lengths. A safe
+  `Debug` implementation does not protect a log statement that formats a raw
+  field directly.
+- Error and poisoned-lock paths follow the same rule; exceptional control flow
+  is not permission to disclose the rejected value or the retained object.
+
+This is deliberately a logging-only boundary. Protobuf wire encoding,
+Serde/JSON output, retained-state keys, certificate-query response payloads,
+and the raw fields stored in error variants remain unchanged.
+`RequestHttpFrontend::Display`, which is used as an operational/state key, also
+remains lossless. Callers that are explicitly authorized to retrieve these
+values continue to receive them; generic diagnostics do not.
+
+Regression tests use a distinct long sentinel for every protected field and
+assert all three parts of the contract: the sentinel is absent, the expected
+count/length metadata is present, and output stays within a fixed size bound.
+Coverage must include the leaf `Debug` implementation, generic/nested command
+wrappers, retained state or tasks, direct log statements, and runtime TLS and
+error paths as applicable.
+
 ### Per-flood-detector helper macro pattern
 
 When a violation funnel (`H2FloodViolation`, `RustlsError`, `H2Error`) needs a
@@ -471,6 +517,9 @@ Before merging an instrumentation change:
   Consider `impl Drop` for symmetric teardown.
 - [ ] New protocol modules define their own `log_context!` /
   `log_module_context!` with a unique prefix tag.
+- [ ] Types and direct log sites reachable from sensitive command, state,
+  routing, or TLS data expose only bounded counts/lengths/kinds/addresses, with
+  sentinel-absence and fixed-output-bound regression tests.
 - [ ] New access-log fields land on `RequestRecord`, `ProtobufAccessLog`
   (new tag), all four emit sites, and `RequestRecord::duplicate()`.
 - [ ] [`configure.md`](configure.md) is updated in the same changeset.

--- a/doc/observability.md
+++ b/doc/observability.md
@@ -167,7 +167,7 @@ Structured prefixes via per-protocol `log_context!` / `log_module_context!` /
 | `MUX-ROUTER` | `protocol/mux/router.rs` | renders `[session req cluster backend]` via `HttpContext::log_context()` |
 | `MUX-CONN` / `MUX-CONV` / `MUX-PARSER` / `MUX-PKAWA` / `MUX-STREAM` | corresponding files | module-level only (no per-session context) |
 | `KAWA-H1` | `protocol/kawa_h1/mod.rs` | session, frontend, request/response parsing phase |
-| `RUSTLS` | `protocol/rustls.rs` | sni, alpn, version, source, frontend |
+| `RUSTLS` | `protocol/rustls.rs` | SNI/ALPN byte lengths, version, source, frontend |
 | `PIPE` | `protocol/pipe.rs` | addresses, frontend/backend status & readiness |
 | `TCP` | `tcp.rs` | frontend, backend, peer (cached on `SessionTcpStream`) |
 | `SOCKET` | `socket.rs` | session, peer, local, RTT, state |
@@ -202,24 +202,44 @@ useful metadata such as socket addresses, enum variants, booleans, presence
 flags, collection counts, and aggregate byte lengths. Certificate and key
 slots render as `[redacted]` in addition to their lengths.
 
+The canonical `[session request cluster backend]` prefix is the explicit
+correlation envelope and is not a generic object dump: its cluster/backend
+slots remain lossless so operators can join lines for one request. The same
+identifiers must still be bounded when they appear inside `Debug` output,
+retained task/state dumps, error text, or ad-hoc message fields. This exception
+is limited to the named correlation slots; it does not permit raw authority,
+path, method, SNI, ALPN, certificate SAN, or request payload fields in the
+verbose `Session(...)` body.
+
 Apply the boundary at every layer that can reach a log sink:
 
 - Generated protobuf types that carry sensitive fields are listed in
   `command/build.rs` via `prost_build::Config::skip_debug`; their bounded
-  implementations live in `command/src/proto/mod.rs`.
+  implementations live in `command/src/proto/mod.rs`. The top-level
+  `Request` and its `RequestType` enum render only the exhaustive request kind,
+  so string-valued verbs remain bounded both directly and inside
+  `WorkerRequest`.
 - Configuration, response, retained-state, gatherer, router, listener, and TLS
   wrappers must summarize their own collections and string-keyed maps rather
-  than relying on an enclosing type to hide them.
+  than relying on an enclosing type to hide them. `TaskContainer` renders only
+  the concrete task kind and timeout presence; it never delegates to a retained
+  `GatheringTask`'s `Debug` implementation.
 - Direct `debug!`, `info!`, `warn!`, `error!`, and failure-message projections
   must interpolate the same counts, kinds, addresses, and byte lengths. A safe
   `Debug` implementation does not protect a log statement that formats a raw
-  field directly.
+  field directly. TLS preread/handshake and mux routing logs therefore render
+  cluster/authority/SNI/ALPN/SAN counts, match kinds, and aggregate byte lengths
+  rather than individual values.
 - Error and poisoned-lock paths follow the same rule; exceptional control flow
   is not permission to disclose the rejected value or the retained object.
 
 This is deliberately a logging-only boundary. Protobuf wire encoding,
 Serde/JSON output, retained-state keys, certificate-query response payloads,
-and the raw fields stored in error variants remain unchanged.
+and the raw fields stored in `StateError`, `RouterError`, and
+`RetrieveClusterError::SniAuthorityMismatch` remain unchanged. These error
+types bound only `Display`/`Debug`; callers matching their public variants
+still receive the complete identifiers, frontend keys, rejection reasons,
+hosts, paths, methods, SNI values, and authorities.
 `RequestHttpFrontend::Display`, which is used as an operational/state key, also
 remains lossless. Callers that are explicitly authorized to retrieve these
 values continue to receive them; generic diagnostics do not.

--- a/e2e/src/tests/h2_tests.rs
+++ b/e2e/src/tests/h2_tests.rs
@@ -421,7 +421,7 @@ fn query_worker_metrics(worker: &mut Worker) -> WorkerMetricSnapshot {
         panic!("metrics query returned no content");
     };
     let ContentType::WorkerMetrics(metrics) = content else {
-        panic!("metrics query returned unexpected content: {content:?}");
+        panic!("metrics query returned an unexpected content variant");
     };
 
     let client_connections = match metrics

--- a/e2e/src/tests/tests.rs
+++ b/e2e/src/tests/tests.rs
@@ -149,7 +149,7 @@ fn query_worker_metrics(worker: &mut Worker) -> WorkerMetricSnapshot {
         panic!("metrics query returned no content");
     };
     let ContentType::WorkerMetrics(metrics) = content else {
-        panic!("metrics query returned unexpected content: {content:?}");
+        panic!("metrics query returned an unexpected content variant");
     };
 
     let client_connections = match metrics

--- a/lib/src/backends.rs
+++ b/lib/src/backends.rs
@@ -1687,7 +1687,8 @@ mod backends_test {
             Some(
                 sozu_command_lib::proto::command::response_content::ContentType::WorkerMetrics(wm),
             ) => wm,
-            other => panic!("expected WorkerMetrics, got {other:?}"),
+            Some(_) => panic!("expected WorkerMetrics, got another response variant"),
+            None => panic!("expected WorkerMetrics, got no response content"),
         };
         let cm = cluster_metrics
             .clusters

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -1881,7 +1881,7 @@ impl HttpsProxy {
     }
 
     pub fn query_all_certificates(&mut self) -> Result<Option<ResponseContent>, ProxyError> {
-        let certificates = self
+        let certificates: Vec<CertificatesByAddress> = self
             .listeners
             .values()
             .map(|listener| {
@@ -1904,10 +1904,17 @@ impl HttpsProxy {
             })
             .collect();
 
+        let listeners_count = certificates.len();
+        let certificates_count = certificates
+            .iter()
+            .map(|entry| entry.certificate_summaries.len())
+            .fold(0usize, |total, count| total.saturating_add(count));
+
         info!(
-            "{} got Certificates::All query, answering with {:?}",
+            "{} got Certificates::All query, listeners_count={} certificates_count={}",
             log_module_context!(),
-            certificates
+            listeners_count,
+            certificates_count,
         );
 
         Ok(Some(
@@ -1919,7 +1926,7 @@ impl HttpsProxy {
         &mut self,
         domain: String,
     ) -> Result<Option<ResponseContent>, ProxyError> {
-        let certificates = self
+        let certificates: Vec<CertificatesByAddress> = self
             .listeners
             .values()
             .map(|listener| {
@@ -1940,11 +1947,18 @@ impl HttpsProxy {
             })
             .collect();
 
+        let listeners_count = certificates.len();
+        let certificates_count = certificates
+            .iter()
+            .map(|entry| entry.certificate_summaries.len())
+            .fold(0usize, |total, count| total.saturating_add(count));
+
         info!(
-            "{} got Certificates::Domain({}) query, answering with {:?}",
+            "{} got Certificates::Domain query, domain_bytes={} listeners_count={} certificates_count={}",
             log_module_context!(),
-            domain,
-            certificates
+            domain.len(),
+            listeners_count,
+            certificates_count,
         );
 
         Ok(Some(
@@ -2455,10 +2469,10 @@ impl ProxyConfiguration for HttpsProxy {
             RequestType::QueryCertificatesFromWorkers(filters) => {
                 if let Some(domain) = filters.domain {
                     debug!(
-                        "{} {} query certificate for domain {}",
+                        "{} {} query certificate for domain_bytes={}",
                         log_module_context!(),
                         request_id,
-                        domain
+                        domain.len(),
                     );
                     self.query_certificate_for_domain(domain)
                 } else {
@@ -2715,10 +2729,122 @@ pub mod testing {
 mod tests {
     use std::sync::Arc;
 
-    use sozu_command::{config::ListenerBuilder, proto::command::SocketAddress};
+    use sozu_command::{
+        config::ListenerBuilder,
+        proto::command::{CertificateAndKey, SocketAddress},
+    };
 
     use super::*;
     use crate::router::{MethodRule, PathRule, Route, Router, pattern_trie::TrieNode};
+
+    fn proxy_with_certificate_domain(domain: String) -> HttpsProxy {
+        let crate::testing::ServerParts {
+            registry,
+            sessions,
+            pool,
+            backends,
+            ..
+        } = crate::testing::prebuild_server(16, 16_384, false)
+            .expect("test HTTPS proxy dependencies must initialize");
+        let address = SocketAddress::new_v4(127, 0, 0, 1, crate::testing::provide_port());
+        let config = ListenerBuilder::new_https(address)
+            .to_tls(None)
+            .expect("test HTTPS listener config must build");
+        let mut proxy = HttpsProxy::new(registry, sessions, pool, backends);
+        proxy
+            .add_listener(config, Token(10))
+            .expect("test HTTPS listener must be added");
+        proxy
+            .add_certificate(AddCertificate {
+                address,
+                certificate: CertificateAndKey {
+                    certificate: include_str!("../assets/certificate.pem").to_owned(),
+                    key: include_str!("../assets/key.pem").to_owned(),
+                    certificate_chain: Vec::new(),
+                    versions: Vec::new(),
+                    names: vec![domain],
+                },
+                expired_at: None,
+            })
+            .expect("test certificate must be added");
+        proxy
+    }
+
+    #[test]
+    fn query_all_certificates_log_redacts_response_domains() {
+        const DOMAIN_SECRET: &str = "QUERY_ALL_CERTIFICATE_DOMAIN_SECRET_SENTINEL";
+
+        let domain = format!("{DOMAIN_SECRET}{}", "x".repeat(4096));
+        let output = crate::capture_test_logs(move || {
+            let mut proxy = proxy_with_certificate_domain(domain);
+            proxy
+                .query_all_certificates()
+                .expect("certificate query must succeed");
+        });
+
+        assert!(
+            !output.contains(DOMAIN_SECRET),
+            "Certificates::All log leaked response domain {DOMAIN_SECRET}"
+        );
+        for metadata in ["listeners_count=1", "certificates_count=1"] {
+            assert!(
+                output.contains(metadata),
+                "Certificates::All log omitted bounded metadata {metadata}: {output}"
+            );
+        }
+        assert!(
+            output.len() <= 1024,
+            "Certificates::All log capture is not bounded: {} bytes",
+            output.len()
+        );
+    }
+
+    #[test]
+    fn query_certificate_for_domain_log_redacts_request_and_response_domain() {
+        const DOMAIN_SECRET: &str = "QUERY_ONE_CERTIFICATE_DOMAIN_SECRET_SENTINEL";
+
+        let domain = format!("{DOMAIN_SECRET}{}", "x".repeat(4096));
+        let domain_len = domain.len();
+        let output = crate::capture_test_logs_at_level("debug", move || {
+            let mut proxy = proxy_with_certificate_domain(domain.clone());
+            let response = proxy.notify(WorkerRequest {
+                id: "query-domain-redaction-test".to_owned(),
+                content: RequestType::QueryCertificatesFromWorkers(
+                    sozu_command::proto::command::QueryCertificatesFilters {
+                        domain: Some(domain),
+                        fingerprint: None,
+                    },
+                )
+                .into(),
+            });
+            assert_eq!(
+                response.status,
+                sozu_command::proto::command::ResponseStatus::Ok as i32,
+                "domain certificate query must succeed: {}",
+                response.message
+            );
+        });
+
+        assert!(
+            !output.contains(DOMAIN_SECRET),
+            "Certificates::Domain log leaked request or response domain {DOMAIN_SECRET}"
+        );
+        for metadata in [
+            format!("domain_bytes={domain_len}"),
+            "listeners_count=1".to_owned(),
+            "certificates_count=1".to_owned(),
+        ] {
+            assert!(
+                output.contains(&metadata),
+                "Certificates::Domain log omitted bounded metadata {metadata}: {output}"
+            );
+        }
+        assert!(
+            output.len() <= 1024,
+            "Certificates::Domain log capture is not bounded: {} bytes",
+            output.len()
+        );
+    }
 
     /*
     #[test]

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -2747,9 +2747,11 @@ mod tests {
         } = crate::testing::prebuild_server(16, 16_384, false)
             .expect("test HTTPS proxy dependencies must initialize");
         let address = SocketAddress::new_v4(127, 0, 0, 1, crate::testing::provide_port());
-        let config = ListenerBuilder::new_https(address)
+        let mut config = ListenerBuilder::new_https(address)
             .to_tls(None)
             .expect("test HTTPS listener config must build");
+        config.cipher_list = vec!["TLS13_AES_256_GCM_SHA384".to_owned()];
+        config.groups_list = vec!["P-256".to_owned()];
         let mut proxy = HttpsProxy::new(registry, sessions, pool, backends);
         proxy
             .add_listener(config, Token(10))

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -140,6 +140,14 @@ macro_rules! log_context {
     }};
 }
 
+fn successful_tls_handshake_summary(sni: Option<&str>, alpn: Option<&str>) -> String {
+    format!(
+        "successful TLS handshake (sni_bytes={:?}, alpn_bytes={:?})",
+        sni.map(str::len),
+        alpn.map(str::len),
+    )
+}
+
 pub struct HttpsSession {
     configured_backend_timeout: Duration,
     configured_connect_timeout: Duration,
@@ -410,10 +418,9 @@ impl HttpsSession {
         let alpn = handshake.session.alpn_protocol();
         let alpn = alpn.and_then(|alpn| from_utf8(alpn).ok());
         debug!(
-            "{} successful TLS handshake with, received: {:?} {:?}",
+            "{} {}",
             log_context!(self),
-            sni_owned,
-            alpn
+            successful_tls_handshake_summary(sni_owned.as_deref(), alpn)
         );
 
         // Reject clients that fail to negotiate `h2` when the listener is
@@ -447,9 +454,9 @@ impl HttpsSession {
                 // sum of the labelled buckets.
                 incr!(names::https::ALPN_REJECTED_UNSUPPORTED);
                 error!(
-                    "{} unsupported ALPN protocol: {}",
+                    "{} unsupported ALPN protocol: alpn_bytes={}",
                     log_context!(self),
-                    other
+                    other.len()
                 );
                 return None;
             }
@@ -2736,6 +2743,39 @@ mod tests {
 
     use super::*;
     use crate::router::{MethodRule, PathRule, Route, Router, pattern_trie::TrieNode};
+
+    #[test]
+    fn successful_tls_handshake_log_bounds_sni_and_alpn() {
+        const SNI_SECRET: &str = "HTTPS_HANDSHAKE_SNI_SECRET_SENTINEL";
+        const ALPN_SECRET: &str = "HTTPS_HANDSHAKE_ALPN_SECRET_SENTINEL";
+
+        let sni = format!("{SNI_SECRET}{}", "x".repeat(4096));
+        let alpn = format!("{ALPN_SECRET}{}", "x".repeat(4096));
+        let sni_len = sni.len();
+        let alpn_len = alpn.len();
+        let output = successful_tls_handshake_summary(Some(&sni), Some(&alpn));
+
+        for secret in [SNI_SECRET, ALPN_SECRET] {
+            assert!(
+                !output.contains(secret),
+                "successful TLS handshake log leaked {secret}: {output}"
+            );
+        }
+        for metadata in [
+            format!("sni_bytes=Some({sni_len})"),
+            format!("alpn_bytes=Some({alpn_len})"),
+        ] {
+            assert!(
+                output.contains(&metadata),
+                "successful TLS handshake log omitted {metadata}: {output}"
+            );
+        }
+        assert!(
+            output.len() <= 512,
+            "successful TLS handshake log is not bounded: {} bytes",
+            output.len()
+        );
+    }
 
     fn proxy_with_certificate_domain(domain: String) -> HttpsProxy {
         let crate::testing::ServerParts {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -754,13 +754,16 @@ pub enum AcceptError {
 }
 
 /// returned by the HTTP, HTTPS and TCP listeners
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error)]
 pub enum ListenerError {
     #[error("failed to handle certificate request, got a resolver error, {0}")]
     Resolver(CertificateResolverError),
     #[error("failed to parse pem, {0}")]
     PemParse(String),
-    #[error("failed to parse template {0:?}: {1}")]
+    #[error(
+        "failed to parse template key_bytes={key_bytes}: {1}",
+        key_bytes = .0.len()
+    )]
     TemplateParse(String, TemplateError),
     #[error("failed to build rustls context, {0}")]
     BuildRustls(String),
@@ -787,6 +790,12 @@ pub enum ListenerError {
          contract requires `enabled` whenever the `hsts` block is present"
     )]
     HstsEnabledRequired,
+}
+
+impl fmt::Debug for ListenerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
 }
 
 /// Lift control-plane validation errors into listener-level errors so the
@@ -1655,5 +1664,89 @@ pub mod testing {
             server_scm_socket,
             server_config,
         })
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn capture_test_logs(run: impl FnOnce() + Send + 'static) -> String {
+    capture_test_logs_at_level("info", run)
+}
+
+#[cfg(test)]
+pub(crate) fn capture_test_logs_at_level(
+    level: &'static str,
+    run: impl FnOnce() + Send + 'static,
+) -> String {
+    let receiver = std::net::UdpSocket::bind("127.0.0.1:0")
+        .expect("test log receiver must bind to a loopback port");
+    let target = format!(
+        "udp://{}",
+        receiver
+            .local_addr()
+            .expect("test log receiver must have a local address")
+    );
+
+    std::thread::spawn(move || {
+        sozu_command::logging::Logger::init(
+            "log-redaction-test".to_owned(),
+            level,
+            &target,
+            false,
+            None,
+            None,
+            None,
+        )
+        .expect("test logger must initialize");
+        run();
+    })
+    .join()
+    .expect("log-producing test thread must not panic");
+
+    receiver
+        .set_nonblocking(true)
+        .expect("test log receiver must become nonblocking");
+    let mut output = String::new();
+    let mut datagram = vec![0; 65_507];
+    loop {
+        match receiver.recv(&mut datagram) {
+            Ok(length) => output.push_str(&String::from_utf8_lossy(&datagram[..length])),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(error) => panic!("test log receiver failed: {error}"),
+        }
+    }
+    assert!(!output.is_empty(), "test log capture received no datagrams");
+    output
+}
+
+#[cfg(test)]
+mod log_redaction_tests {
+    use super::*;
+
+    #[test]
+    fn listener_template_parse_error_redacts_custom_answer_key() {
+        const KEY_SECRET: &str = "CUSTOM_ANSWER_KEY_SECRET_SENTINEL";
+
+        let key = format!("{KEY_SECRET}{}", "x".repeat(4096));
+        let key_len = key.len();
+        let error = ListenerError::TemplateParse(key, TemplateError::InvalidType);
+
+        for (label, output) in [
+            ("Display", error.to_string()),
+            ("Debug", format!("{error:?}")),
+        ] {
+            assert!(
+                !output.contains(KEY_SECRET),
+                "ListenerError {label} leaked custom-answer key {KEY_SECRET}"
+            );
+            assert!(
+                output.contains(&format!("key_bytes={key_len}")),
+                "ListenerError {label} omitted the bounded key length: {output}"
+            );
+            assert!(
+                output.len() <= 256,
+                "ListenerError {label} output is not bounded: {} bytes",
+                output.len()
+            );
+        }
     }
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -721,7 +721,7 @@ pub enum BackendConnectionError {
 }
 
 /// used in kawa_h1 module for the Http session state
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error)]
 pub enum RetrieveClusterError {
     #[error("No method given")]
     NoMethod,
@@ -738,8 +738,14 @@ pub enum RetrieveClusterError {
     /// The HTTP `:authority` / `Host` host does not match the TLS SNI that was
     /// negotiated for this connection, which would cross the TLS trust boundary.
     /// Maps to HTTP 421 Misdirected Request (RFC 9110 §15.5.20).
-    #[error("TLS SNI {sni:?} does not match HTTP authority {authority:?}")]
+    #[error("TLS SNI does not match HTTP authority: sni_bytes={} authority_bytes={}", .sni.len(), .authority.len())]
     SniAuthorityMismatch { sni: String, authority: String },
+}
+
+impl fmt::Debug for RetrieveClusterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
 }
 
 /// Used in sessions
@@ -1745,6 +1751,53 @@ mod log_redaction_tests {
             assert!(
                 output.len() <= 256,
                 "ListenerError {label} output is not bounded: {} bytes",
+                output.len()
+            );
+        }
+    }
+
+    #[test]
+    fn sni_authority_mismatch_retains_inputs_but_bounds_textual_formatting() {
+        const SNI_SECRET: &str = "SNI_MISMATCH_SECRET_SENTINEL";
+        const AUTHORITY_SECRET: &str = "AUTHORITY_MISMATCH_SECRET_SENTINEL";
+
+        let sni = format!("{SNI_SECRET}{}", "x".repeat(4096));
+        let authority = format!("{AUTHORITY_SECRET}{}", "x".repeat(4096));
+        let error = RetrieveClusterError::SniAuthorityMismatch {
+            sni: sni.clone(),
+            authority: authority.clone(),
+        };
+
+        match &error {
+            RetrieveClusterError::SniAuthorityMismatch {
+                sni: retained_sni,
+                authority: retained_authority,
+            } => {
+                assert_eq!(retained_sni, &sni);
+                assert_eq!(retained_authority, &authority);
+            }
+            other => panic!("expected SniAuthorityMismatch, got {other:?}"),
+        }
+
+        for output in [error.to_string(), format!("{error:?}")] {
+            for secret in [SNI_SECRET, AUTHORITY_SECRET] {
+                assert!(
+                    !output.contains(secret),
+                    "SNI mismatch formatting leaked {secret}: {output}"
+                );
+            }
+            for metadata in [
+                format!("sni_bytes={}", sni.len()),
+                format!("authority_bytes={}", authority.len()),
+            ] {
+                assert!(
+                    output.contains(&metadata),
+                    "SNI mismatch formatting omitted {metadata}: {output}"
+                );
+            }
+            assert!(
+                output.len() <= 256,
+                "SNI mismatch formatting is not bounded: {} bytes",
                 output.len()
             );
         }

--- a/lib/src/protocol/kawa_h1/parser.rs
+++ b/lib/src/protocol/kawa_h1/parser.rs
@@ -34,7 +34,7 @@ pub fn compare_no_case(left: &[u8], right: &[u8]) -> bool {
     })
 }
 
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub enum Method {
     Get,
     Post,
@@ -45,6 +45,22 @@ pub enum Method {
     Trace,
     Connect,
     Custom(String),
+}
+
+impl fmt::Debug for Method {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Get => f.write_str("Get"),
+            Self::Post => f.write_str("Post"),
+            Self::Head => f.write_str("Head"),
+            Self::Options => f.write_str("Options"),
+            Self::Put => f.write_str("Put"),
+            Self::Delete => f.write_str("Delete"),
+            Self::Trace => f.write_str("Trace"),
+            Self::Connect => f.write_str("Connect"),
+            Self::Custom(custom) => write!(f, "Custom(bytes={})", custom.len()),
+        }
+    }
 }
 
 impl Method {
@@ -205,6 +221,29 @@ fn custom_method_does_not_assume_utf8() {
     let method = Method::new(b"\xFFBAD");
 
     assert_eq!(method, Method::Custom("\u{FFFD}BAD".to_owned()));
+}
+
+#[test]
+fn custom_method_debug_is_bounded() {
+    const METHOD_SECRET: &str = "CUSTOM_METHOD_DEBUG_SECRET_SENTINEL";
+
+    let custom = format!("{METHOD_SECRET}{}", "x".repeat(4096));
+    let custom_len = custom.len();
+    let output = format!("{:?}", Method::Custom(custom));
+
+    assert!(
+        !output.contains(METHOD_SECRET),
+        "custom Method Debug leaked its payload: {output}"
+    );
+    assert!(
+        output.contains(&format!("bytes={custom_len}")),
+        "custom Method Debug omitted its byte length: {output}"
+    );
+    assert!(
+        output.len() <= 128,
+        "custom Method Debug is not bounded: {} bytes",
+        output.len()
+    );
 }
 
 #[test]

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -105,7 +105,9 @@ macro_rules! log_context_lite {
 ///   `[session req cluster backend]` bracket as RUSTLS/PIPE/TCP followed
 ///   by a `Session(...)` block, so MUX lines emitted from variant match
 ///   arms stay filterable by session ULID or request ULID. Mirrors
-///   `router.rs:log_module_context!($http_context)` (see there).
+///   `router.rs:log_module_context!($http_context)` (see there). Custom
+///   methods render only their byte length, and authority renders only its
+///   byte length.
 macro_rules! log_module_context {
     () => {{
         let (open, reset, _, _, _) = ansi_palette();
@@ -116,7 +118,7 @@ macro_rules! log_module_context {
         let http_ctx: &HttpContext = &$http_context;
         let ctx = http_ctx.log_context();
         format!(
-            "{gray}{ctx}{reset}\t{open}MUX{reset}\t{grey}Session{reset}({gray}frontend{reset}={white}{frontend:?}{reset}, {gray}method{reset}={white}{method:?}{reset}, {gray}authority{reset}={white}{authority:?}{reset})\t >>>",
+            "{gray}{ctx}{reset}\t{open}MUX{reset}\t{grey}Session{reset}({gray}frontend{reset}={white}{frontend:?}{reset}, {gray}method{reset}={white}{method:?}{reset}, {gray}authority_bytes{reset}={white}{authority_bytes:?}{reset})\t >>>",
             open = open,
             reset = reset,
             grey = grey,
@@ -125,7 +127,7 @@ macro_rules! log_module_context {
             ctx = ctx,
             frontend = http_ctx.session_address,
             method = http_ctx.method,
-            authority = http_ctx.authority,
+            authority_bytes = http_ctx.authority.as_ref().map(String::len),
         )
     }};
 }

--- a/lib/src/protocol/mux/router.rs
+++ b/lib/src/protocol/mux/router.rs
@@ -41,7 +41,7 @@ use crate::metrics::names;
 /// * `log_module_context!($http_context)` — rich form. `$http_context` must be
 ///   `&HttpContext` (or coerce to one). Produces the same
 ///   `[session req cluster backend]` bracket as RUSTLS/PIPE/TCP followed by a
-///   `Session(frontend=..., method=..., authority=...)` block, so router
+///   `Session(frontend=..., method=..., authority_bytes=...)` block, so router
 ///   lines are filterable by session ULID or request ULID. `cluster_id` is
 ///   already carried by the bracket's third slot — not duplicated inside
 ///   `Session(...)`.
@@ -55,7 +55,7 @@ macro_rules! log_module_context {
         let http_ctx: &HttpContext = &$http_context;
         let ctx = http_ctx.log_context();
         format!(
-            "{gray}{ctx}{reset}\t{open}MUX-ROUTER{reset}\t{grey}Session{reset}({gray}frontend{reset}={white}{frontend:?}{reset}, {gray}method{reset}={white}{method:?}{reset}, {gray}authority{reset}={white}{authority:?}{reset})\t >>>",
+            "{gray}{ctx}{reset}\t{open}MUX-ROUTER{reset}\t{grey}Session{reset}({gray}frontend{reset}={white}{frontend:?}{reset}, {gray}method{reset}={white}{method:?}{reset}, {gray}authority_bytes{reset}={white}{authority_bytes:?}{reset})\t >>>",
             open = open,
             reset = reset,
             grey = grey,
@@ -64,9 +64,46 @@ macro_rules! log_module_context {
             ctx = ctx,
             frontend = http_ctx.session_address,
             method = http_ctx.method,
-            authority = http_ctx.authority,
+            authority_bytes = http_ctx.authority.as_ref().map(String::len),
         )
     }};
+}
+
+fn log_coalescing_accepted(context: &HttpContext, authority: &str, sni: &str, matched_name: &str) {
+    debug!(
+        "{} accepted coalesced authority (authority_bytes={}, sni_bytes={}, matched_san_kind={}, matched_san_bytes={})",
+        log_module_context!(context),
+        authority.len(),
+        sni.len(),
+        if matched_name.starts_with("*.") {
+            "wildcard"
+        } else {
+            "exact"
+        },
+        matched_name.len(),
+    );
+}
+
+fn log_sni_authority_mismatch(
+    context: &HttpContext,
+    authority: &str,
+    sni: &str,
+    certificate_names: Option<&[String]>,
+) {
+    let certificate_sans_count = certificate_names.map_or(0, <[String]>::len);
+    let certificate_sans_bytes = certificate_names
+        .into_iter()
+        .flatten()
+        .map(String::len)
+        .fold(0usize, usize::saturating_add);
+    warn!(
+        "{} rejecting request: TLS cert SANs do not cover authority (authority_bytes={}, sni_bytes={}, certificate_sans_count={}, certificate_sans_bytes={})",
+        log_module_context!(context),
+        authority.len(),
+        sni.len(),
+        certificate_sans_count,
+        certificate_sans_bytes,
+    );
 }
 
 #[derive(Debug)]
@@ -621,22 +658,16 @@ impl Router {
                     // sequential `Host:` reuse as "coalescing".
                     if !authority_matches_sni(host, sni) && context.tls_alpn == Some("h2") {
                         incr!(names::h2::COALESCING_ACCEPTED);
-                        debug!(
-                            "{} accepted coalesced authority {:?} (SNI {:?}, matched SAN {:?})",
-                            log_module_context!(context),
-                            host,
-                            sni,
-                            matched_name,
-                        );
+                        log_coalescing_accepted(context, host, sni, matched_name);
                     }
                 }
                 None => {
                     incr!(names::http::SNI_AUTHORITY_MISMATCH);
-                    warn!(
-                        "{} rejecting request: TLS cert SANs do not cover :authority {:?} (SNI {:?})",
-                        log_module_context!(context),
+                    log_sni_authority_mismatch(
+                        context,
                         host,
                         sni,
+                        context.tls_cert_names.as_deref().map(Vec::as_slice),
                     );
                     return Err(RetrieveClusterError::SniAuthorityMismatch {
                         sni: sni.to_owned(),
@@ -1301,7 +1332,83 @@ pub(crate) fn authority_matched_cert_name<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::authority_matches_sni;
+    use super::{authority_matches_sni, log_coalescing_accepted, log_sni_authority_mismatch};
+    use crate::protocol::http::editor::HttpContext;
+
+    #[test]
+    fn routing_runtime_logs_bound_method_authority_sni_and_certificate_names() {
+        const METHOD_SECRET: &str = "MUX_ROUTE_METHOD_SECRET_SENTINEL";
+        const AUTHORITY_SECRET: &str = "MUX_ROUTE_AUTHORITY_SECRET_SENTINEL";
+        const SNI_SECRET: &str = "MUX_ROUTE_SNI_SECRET_SENTINEL";
+        const SAN_SECRET: &str = "MUX_ROUTE_SAN_SECRET_SENTINEL";
+
+        let long_value = |marker: &str| format!("{marker}{}", "x".repeat(4096));
+        let method = long_value(METHOD_SECRET);
+        let authority = long_value(AUTHORITY_SECRET);
+        let sni = long_value(SNI_SECRET);
+        let san = long_value(SAN_SECRET);
+        let method_len = method.len();
+        let authority_len = authority.len();
+        let sni_len = sni.len();
+        let san_len = san.len();
+
+        let output = crate::capture_test_logs_at_level("debug", move || {
+            let mut context = HttpContext::new(
+                rusty_ulid::Ulid::generate(),
+                rusty_ulid::Ulid::generate(),
+                crate::Protocol::HTTPS,
+                "127.0.0.1:443"
+                    .parse()
+                    .expect("test public address must parse"),
+                Some(
+                    "127.0.0.1:12345"
+                        .parse()
+                        .expect("test session address must parse"),
+                ),
+                String::new(),
+                String::new(),
+                false,
+                false,
+            );
+            context.method = Some(crate::protocol::http::parser::Method::Custom(method));
+            context.authority = Some(authority.clone());
+            context.tls_cert_names = Some(std::sync::Arc::new(vec![san.clone()]));
+
+            log_coalescing_accepted(&context, &authority, &sni, &san);
+            log_sni_authority_mismatch(
+                &context,
+                &authority,
+                &sni,
+                context.tls_cert_names.as_deref().map(Vec::as_slice),
+            );
+        });
+
+        for secret in [METHOD_SECRET, AUTHORITY_SECRET, SNI_SECRET, SAN_SECRET] {
+            assert!(
+                !output.contains(secret),
+                "mux routing runtime log leaked {secret}: {output}"
+            );
+        }
+        for metadata in [
+            format!("bytes={method_len}"),
+            format!("authority_bytes=Some({authority_len})"),
+            format!("authority_bytes={authority_len}"),
+            format!("sni_bytes={sni_len}"),
+            format!("matched_san_bytes={san_len}"),
+            "certificate_sans_count=1".to_owned(),
+            format!("certificate_sans_bytes={san_len}"),
+        ] {
+            assert!(
+                output.contains(&metadata),
+                "mux routing runtime log omitted {metadata}: {output}"
+            );
+        }
+        assert!(
+            output.len() <= 2048,
+            "mux routing runtime capture is not bounded: {} bytes",
+            output.len()
+        );
+    }
 
     #[test]
     fn match_exact() {

--- a/lib/src/protocol/rustls.rs
+++ b/lib/src/protocol/rustls.rs
@@ -33,23 +33,15 @@ macro_rules! log_context {
     ($self:expr) => {{
         let (open, reset, grey, gray, white) = ansi_palette();
         format!(
-            "{gray}{ctx}{reset}\t{open}RUSTLS{reset}\t{grey}Session{reset}({gray}sni{reset}={white}{sni:?}{reset}, {gray}alpn{reset}={white}{alpn}{reset}, {gray}version{reset}={white}{version:?}{reset}, {gray}source{reset}={white}{source:?}{reset}, {gray}frontend{reset}={white}{frontend}{reset}, {gray}readiness{reset}={white}{readiness}{reset})\t >>>",
+            "{gray}{ctx}{reset}\t{open}RUSTLS{reset}\t{grey}Session{reset}({gray}sni_bytes{reset}={white}{sni_bytes:?}{reset}, {gray}alpn_bytes{reset}={white}{alpn_bytes:?}{reset}, {gray}version{reset}={white}{version:?}{reset}, {gray}source{reset}={white}{source:?}{reset}, {gray}frontend{reset}={white}{frontend}{reset}, {gray}readiness{reset}={white}{readiness}{reset})\t >>>",
             open = open,
             reset = reset,
             grey = grey,
             gray = gray,
             white = white,
             ctx = $self.log_context(),
-            sni = $self
-                .session
-                .server_name()
-                .map(|addr| addr.to_string())
-                .unwrap_or_else(|| "<none>".to_string()),
-            alpn = $self
-                .session
-                .alpn_protocol()
-                .map(|bytes| String::from_utf8_lossy(bytes).into_owned())
-                .unwrap_or_else(|| "<none>".to_string()),
+            sni_bytes = $self.session.server_name().map(str::len),
+            alpn_bytes = $self.session.alpn_protocol().map(|bytes| bytes.len()),
             version = $self.session.protocol_version(),
             source = $self
                 .peer_address

--- a/lib/src/protocol/tcp_preread/shell.rs
+++ b/lib/src/protocol/tcp_preread/shell.rs
@@ -59,32 +59,6 @@ macro_rules! log_context {
     }};
 }
 
-/// Maximum number of client-offered ALPN protocols the routed info-log
-/// (`handle_output`'s `Output::Routed` arm) renders individually. The wire
-/// parser (`tcp_preread::parser`) already bounds a ClientHello's ALPN offer
-/// to roughly 32K entries within a 64 KiB extension -- far fewer under the
-/// default 16 KiB preread cap -- but this `info!` is always compiled in
-/// (unlike `debug!`/`trace!`), so a hostile hello offering thousands of
-/// tiny protocol names could still make one log line allocate/render
-/// thousands of entries.
-const LOGGED_ALPN_LIMIT: usize = 8;
-
-/// Render at most [`LOGGED_ALPN_LIMIT`] client-offered ALPN protocols as a
-/// debug-list, appending a `"(+N more)"` suffix when the offer was
-/// truncated.
-fn render_alpn_for_log(alpn: &[Vec<u8>]) -> String {
-    let shown: Vec<String> = alpn
-        .iter()
-        .take(LOGGED_ALPN_LIMIT)
-        .map(|p| String::from_utf8_lossy(p).into_owned())
-        .collect();
-    if alpn.len() > LOGGED_ALPN_LIMIT {
-        format!("{shown:?} (+{} more)", alpn.len() - LOGGED_ALPN_LIMIT)
-    } else {
-        format!("{shown:?}")
-    }
-}
-
 /// Captured exactly once, when [`Output::Routed`] first fires. The core's
 /// own `decided` latch guarantees the SAME terminal verdict replays on every
 /// subsequent `handle_input` call, so [`SniPreread::outcome`] never changes
@@ -352,12 +326,17 @@ impl<Front: SocketHandler> SniPreread<Front> {
                     self.outcome.is_none(),
                     "a route must be captured at most once per SniPreread lifetime"
                 );
+                let alpn_bytes = alpn
+                    .iter()
+                    .map(Vec::len)
+                    .fold(0usize, usize::saturating_add);
                 info!(
-                    "{} SNI preread routed to cluster {} (sni={:?}, alpn={})",
+                    "{} SNI preread routed (cluster_id_bytes={}, sni_bytes={}, alpn_count={}, alpn_bytes={})",
                     log_context!(self),
-                    cluster,
-                    sni,
-                    render_alpn_for_log(&alpn)
+                    cluster.len(),
+                    sni.len(),
+                    alpn.len(),
+                    alpn_bytes,
                 );
                 incr!(names::tcp::sni_preread::ROUTED);
                 // Arm backend-writable interest now so the FIRST backend
@@ -458,35 +437,76 @@ mod tests {
         }
     }
 
-    // ---- routed info-log ALPN rendering bound (sozu-proxy/sozu#1290) ----
-
     #[test]
-    fn render_alpn_for_log_shows_everything_within_the_limit() {
-        let alpn: Vec<Vec<u8>> = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
-        assert_eq!(render_alpn_for_log(&alpn), r#"["h2", "http/1.1"]"#);
-    }
+    fn routed_runtime_log_bounds_cluster_sni_and_alpn() {
+        const CLUSTER_SECRET: &str = "TCP_PREREAD_CLUSTER_SECRET_SENTINEL";
+        const SNI_SECRET: &str = "TCP_PREREAD_SNI_SECRET_SENTINEL";
+        const ALPN_SECRET: &str = "TCP_PREREAD_ALPN_SECRET_SENTINEL";
 
-    #[test]
-    fn render_alpn_for_log_truncates_past_the_limit_with_a_count_suffix() {
-        let alpn: Vec<Vec<u8>> = (0..(LOGGED_ALPN_LIMIT + 5))
-            .map(|i| i.to_string().into_bytes())
-            .collect();
-        let rendered = render_alpn_for_log(&alpn);
+        let cluster = format!("{CLUSTER_SECRET}{}", "x".repeat(4096));
+        let sni = format!("{SNI_SECRET}{}", "x".repeat(4096));
+        let alpn = format!("{ALPN_SECRET}{}", "x".repeat(4096)).into_bytes();
+        let cluster_len = cluster.len();
+        let sni_len = sni.len();
+        let alpn_len = alpn.len();
+        let output = crate::capture_test_logs(move || {
+            use std::net::{TcpListener as StdTcpListener, TcpStream as StdTcpStream};
+
+            use mio::net::TcpStream as MioTcpStream;
+
+            use crate::pool::Pool;
+
+            let listener = StdTcpListener::bind("127.0.0.1:0").expect("bind test listener");
+            let address = listener.local_addr().expect("listener address");
+            let _client = StdTcpStream::connect(address).expect("connect test client");
+            let (server, _) = listener.accept().expect("accept test server");
+            server.set_nonblocking(true).expect("server nonblocking");
+            let mut pool = Pool::with_capacity(1, 1, 16 * 1024);
+            let frontend_buffer = pool.checkout().expect("frontend buffer");
+            let mut preread = SniPreread::new(
+                MioTcpStream::from_std(server),
+                Token(0),
+                Ulid::generate(),
+                frontend_buffer,
+                16 * 1024,
+            );
+
+            assert_eq!(
+                preread.handle_output(Output::Routed {
+                    cluster,
+                    content_offset: 0,
+                    proxy_source: None,
+                    sni: sni.clone(),
+                    alpn: vec![alpn],
+                    matched_sni_pattern: sni,
+                    matched_alpn: AlpnMatcher::Any,
+                }),
+                SessionResult::Continue
+            );
+        });
+
+        for secret in [CLUSTER_SECRET, SNI_SECRET, ALPN_SECRET] {
+            assert!(
+                !output.contains(secret),
+                "SNI preread routed log leaked {secret}: {output}"
+            );
+        }
+        for metadata in [
+            format!("cluster_id_bytes={cluster_len}"),
+            format!("sni_bytes={sni_len}"),
+            "alpn_count=1".to_owned(),
+            format!("alpn_bytes={alpn_len}"),
+        ] {
+            assert!(
+                output.contains(&metadata),
+                "SNI preread routed log omitted {metadata}: {output}"
+            );
+        }
         assert!(
-            rendered.ends_with("(+5 more)"),
-            "expected a truncation suffix for 5 entries past the limit, got {rendered:?}"
+            output.len() <= 512,
+            "SNI preread routed log is not bounded: {} bytes",
+            output.len()
         );
-        // Exactly `LOGGED_ALPN_LIMIT` entries rendered individually before
-        // the suffix -- not the full (limit + 5).
-        let shown_count = alpn
-            .iter()
-            .take(LOGGED_ALPN_LIMIT)
-            .filter(|p| {
-                let s = String::from_utf8_lossy(p).into_owned();
-                rendered.contains(&format!("{s:?}"))
-            })
-            .count();
-        assert_eq!(shown_count, LOGGED_ALPN_LIMIT);
     }
 
     #[test]

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -48,11 +48,11 @@ pub enum RouterError {
     InvalidHostRewrite(String),
     #[error("Could not parse path rewrite, rewrite_path_bytes={}", .0.len())]
     InvalidPathRewrite(String),
-    #[error("Could not add route {0}")]
+    #[error("Could not add route, route_bytes={}", .0.len())]
     AddRoute(String),
-    #[error("Could not remove route {0}")]
+    #[error("Could not remove route, route_bytes={}", .0.len())]
     RemoveRoute(String),
-    #[error("no route for {method} {host} {path}")]
+    #[error("route_not_found method={method:?} host_bytes={} path_bytes={}", .host.len(), .path.len())]
     RouteNotFound {
         host: String,
         path: String,
@@ -2187,6 +2187,59 @@ mod tests {
                     output.len()
                 );
             }
+        }
+    }
+
+    #[test]
+    fn route_miss_error_retains_inputs_but_bounds_textual_formatting() {
+        const HOST_SECRET: &str = "ROUTE_MISS_HOST_SECRET_SENTINEL";
+        const PATH_SECRET: &str = "ROUTE_MISS_PATH_SECRET_SENTINEL";
+        const METHOD_SECRET: &str = "ROUTE_MISS_METHOD_SECRET_SENTINEL";
+
+        let long_value = |marker: &str| format!("{marker}{}", "x".repeat(4096));
+        let host = long_value(HOST_SECRET);
+        let path = long_value(PATH_SECRET);
+        let method = Method::Custom(long_value(METHOD_SECRET));
+        let error = match Router::new().lookup(&host, &path, &method) {
+            Err(error) => error,
+            Ok(_) => panic!("empty router must return a route miss"),
+        };
+
+        match &error {
+            RouterError::RouteNotFound {
+                host: retained_host,
+                path: retained_path,
+                method: retained_method,
+            } => {
+                assert_eq!(retained_host, &host);
+                assert_eq!(retained_path, &path);
+                assert_eq!(retained_method, &method);
+            }
+            other => panic!("expected RouterError::RouteNotFound, got {other:?}"),
+        }
+
+        for output in [error.to_string(), format!("{error:?}")] {
+            for secret in [HOST_SECRET, PATH_SECRET, METHOD_SECRET] {
+                assert!(
+                    !output.contains(secret),
+                    "route miss formatting leaked {secret}: {output}"
+                );
+            }
+            for metadata in [
+                format!("host_bytes={}", host.len()),
+                format!("path_bytes={}", path.len()),
+                format!("bytes={}", method.as_ref().len()),
+            ] {
+                assert!(
+                    output.contains(&metadata),
+                    "route miss formatting omitted {metadata}: {output}"
+                );
+            }
+            assert!(
+                output.len() <= 256,
+                "route miss formatting is not bounded: {} bytes",
+                output.len()
+            );
         }
     }
 

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -38,15 +38,15 @@ macro_rules! log_module_context {
     }};
 }
 
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, PartialEq)]
 pub enum RouterError {
-    #[error("Could not parse rule from frontend path {0:?}")]
+    #[error("Could not parse rule from frontend path, path_bytes={}", .0.len())]
     InvalidPathRule(String),
-    #[error("parsing hostname {hostname} failed")]
+    #[error("parsing hostname failed, hostname_bytes={}", .hostname.len())]
     InvalidDomain { hostname: String },
-    #[error("Could not parse host rewrite {0:?}")]
+    #[error("Could not parse host rewrite, rewrite_host_bytes={}", .0.len())]
     InvalidHostRewrite(String),
-    #[error("Could not parse path rewrite {0:?}")]
+    #[error("Could not parse path rewrite, rewrite_path_bytes={}", .0.len())]
     InvalidPathRewrite(String),
     #[error("Could not add route {0}")]
     AddRoute(String),
@@ -58,6 +58,12 @@ pub enum RouterError {
         path: String,
         method: Method,
     },
+}
+
+impl fmt::Debug for RouterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
 }
 
 pub struct Router {
@@ -1526,11 +1532,24 @@ impl Frontend {
         let deny = match (&cluster_id, redirect) {
             (_, RedirectPolicy::Unauthorized) => true,
             (None, RedirectPolicy::Forward) => {
+                let (domain_kind, domain_bytes) = match &domain_rule {
+                    DomainRule::Any => ("any", 0),
+                    DomainRule::Exact(value) => ("exact", value.len()),
+                    DomainRule::Wildcard(value) => ("wildcard", value.len()),
+                    DomainRule::Regex(value) => ("regex", value.as_str().len()),
+                };
+                let (path_kind, path_bytes) = match &path_rule {
+                    PathRule::Prefix(value) => ("prefix", value.len()),
+                    PathRule::Regex(value) => ("regex", value.as_str().len()),
+                    PathRule::Equals(value) => ("equals", value.len()),
+                };
                 warn!(
-                    "{} Frontend[domain: {:?}, path: {:?}]: forward on clusterless frontends are unauthorized",
+                    "{} Frontend[domain_kind={}, domain_bytes={}, path_kind={}, path_bytes={}]: forward on clusterless frontends are unauthorized",
                     log_module_context!(),
-                    domain_rule,
-                    path_rule,
+                    domain_kind,
+                    domain_bytes,
+                    path_kind,
+                    path_bytes,
                 );
                 true
             }
@@ -1656,10 +1675,9 @@ impl Frontend {
                 // client. Drop the edit rather than guessing a position.
                 HeaderPosition::Unspecified => {
                     warn!(
-                        "{} dropping Header {{ key: {:?}, val: {:?} }} with HEADER_POSITION_UNSPECIFIED",
+                        "{} dropping {:?} with HEADER_POSITION_UNSPECIFIED",
                         log_module_context!(),
-                        header.key,
-                        header.val,
+                        header,
                     );
                 }
             }
@@ -1701,12 +1719,12 @@ impl Frontend {
                 // silently emitting no header — operators inspecting their
                 // dashboards for http.hsts.unrendered will catch the bug.
                 warn!(
-                    "{} HSTS enabled = true on frontend {:?} but render_hsts \
+                    "{} HSTS enabled = true on frontend cluster_id_bytes={:?} but render_hsts \
                      returned None (max_age missing). Frontend will not emit \
                      Strict-Transport-Security; the config layer that built \
                      this HstsConfig must substitute DEFAULT_HSTS_MAX_AGE.",
                     log_module_context!(),
-                    cluster_id,
+                    cluster_id.as_ref().map(String::len),
                 );
                 crate::incr!(names::http::HSTS_UNRENDERED);
             }
@@ -2006,6 +2024,171 @@ impl RouteResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_http_frontend() -> HttpFrontend {
+        HttpFrontend {
+            cluster_id: Some("cluster".to_owned()),
+            address: "127.0.0.1:8080"
+                .parse()
+                .expect("test frontend address must parse"),
+            hostname: "example.com".to_owned(),
+            path: CommandPathRule::prefix("/".to_owned()),
+            method: None,
+            position: RulePosition::Tree,
+            tags: None,
+            redirect: None,
+            redirect_scheme: None,
+            redirect_template: None,
+            rewrite_host: None,
+            rewrite_path: None,
+            rewrite_port: None,
+            required_auth: None,
+            headers: Vec::new(),
+            hsts: None,
+        }
+    }
+
+    #[test]
+    fn clusterless_forward_warning_redacts_domain_and_path_rules() {
+        const DOMAIN_SECRET: &str = "clusterless_domain_secret_sentinel";
+        const PATH_SECRET: &str = "CLUSTERLESS_PATH_SECRET_SENTINEL";
+
+        let domain = format!("{DOMAIN_SECRET}{}", "x".repeat(4096));
+        let path = format!("/{PATH_SECRET}{}", "x".repeat(4096));
+        let domain_len = domain.len();
+        let path_len = path.len();
+        let output = crate::capture_test_logs(move || {
+            let mut router = Router::new();
+            let mut front = test_http_frontend();
+            front.cluster_id = None;
+            front.hostname = domain;
+            front.path = CommandPathRule::prefix(path);
+            front.redirect = Some(RedirectPolicy::Forward as i32);
+            router
+                .add_http_front(&front)
+                .expect("clusterless forward must be coerced to unauthorized");
+        });
+
+        for secret in [DOMAIN_SECRET, PATH_SECRET] {
+            assert!(
+                !output.contains(secret),
+                "clusterless-forward warning leaked rule marker {secret}"
+            );
+        }
+        for metadata in [
+            "domain_kind=exact".to_owned(),
+            format!("domain_bytes={domain_len}"),
+            "path_kind=prefix".to_owned(),
+            format!("path_bytes={path_len}"),
+        ] {
+            assert!(
+                output.contains(&metadata),
+                "clusterless-forward warning omitted bounded metadata {metadata}: {output}"
+            );
+        }
+        assert!(
+            output.len() <= 512,
+            "clusterless-forward warning is not bounded: {} bytes",
+            output.len()
+        );
+    }
+
+    #[test]
+    fn malformed_hsts_warning_redacts_cluster_id() {
+        const CLUSTER_SECRET: &str = "MALFORMED_HSTS_CLUSTER_SECRET_SENTINEL";
+
+        let cluster_id = format!("{CLUSTER_SECRET}{}", "x".repeat(4096));
+        let cluster_id_len = cluster_id.len();
+        let output = crate::capture_test_logs(move || {
+            let mut router = Router::new();
+            let mut front = test_http_frontend();
+            front.cluster_id = Some(cluster_id);
+            front.hsts = Some(HstsConfig {
+                enabled: Some(true),
+                max_age: None,
+                include_subdomains: Some(true),
+                preload: Some(true),
+                force_replace_backend: Some(false),
+            });
+            router
+                .add_http_front(&front)
+                .expect("malformed HSTS must preserve routing and omit the header");
+        });
+
+        assert!(
+            !output.contains(CLUSTER_SECRET),
+            "malformed-HSTS warning leaked cluster id {CLUSTER_SECRET}"
+        );
+        assert!(
+            output.contains(&format!("cluster_id_bytes=Some({cluster_id_len})")),
+            "malformed-HSTS warning omitted the bounded cluster id length: {output}"
+        );
+        assert!(
+            output.len() <= 768,
+            "malformed-HSTS warning is not bounded: {} bytes",
+            output.len()
+        );
+    }
+
+    #[test]
+    fn router_errors_redact_frontend_rule_and_rewrite_fields() {
+        const PATH_SECRET: &str = "ROUTER_ERROR_PATH_SECRET_SENTINEL";
+        const HOSTNAME_SECRET: &str = "ROUTER_ERROR_HOSTNAME_SECRET_SENTINEL";
+        const HOST_REWRITE_SECRET: &str = "ROUTER_ERROR_HOST_REWRITE_SECRET_SENTINEL";
+        const PATH_REWRITE_SECRET: &str = "ROUTER_ERROR_PATH_REWRITE_SECRET_SENTINEL";
+
+        let long_value = |marker: &str| format!("{marker}{}", "x".repeat(4096));
+        let cases = [
+            (
+                "path_bytes",
+                PATH_SECRET,
+                long_value(PATH_SECRET).len(),
+                RouterError::InvalidPathRule(long_value(PATH_SECRET)),
+            ),
+            (
+                "hostname_bytes",
+                HOSTNAME_SECRET,
+                long_value(HOSTNAME_SECRET).len(),
+                RouterError::InvalidDomain {
+                    hostname: long_value(HOSTNAME_SECRET),
+                },
+            ),
+            (
+                "rewrite_host_bytes",
+                HOST_REWRITE_SECRET,
+                long_value(HOST_REWRITE_SECRET).len(),
+                RouterError::InvalidHostRewrite(long_value(HOST_REWRITE_SECRET)),
+            ),
+            (
+                "rewrite_path_bytes",
+                PATH_REWRITE_SECRET,
+                long_value(PATH_REWRITE_SECRET).len(),
+                RouterError::InvalidPathRewrite(long_value(PATH_REWRITE_SECRET)),
+            ),
+        ];
+
+        for (length_label, secret, value_len, error) in cases {
+            for (format_label, output) in [
+                ("Display", error.to_string()),
+                ("Debug", format!("{error:?}")),
+            ] {
+                assert!(
+                    !output.contains(secret),
+                    "RouterError {format_label} leaked frontend marker {secret}"
+                );
+                let metadata = format!("{length_label}={value_len}");
+                assert!(
+                    output.contains(&metadata),
+                    "RouterError {format_label} omitted bounded metadata {metadata}: {output}"
+                );
+                assert!(
+                    output.len() <= 256,
+                    "RouterError {format_label} output is not bounded: {} bytes",
+                    output.len()
+                );
+            }
+        }
+    }
 
     #[test]
     fn render_hsts_max_age_only() {

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -3334,6 +3334,42 @@ mod accept_telemetry_tests {
 }
 
 #[cfg(test)]
+mod state_error_log_tests {
+    use sozu_command::state::StateError;
+
+    #[test]
+    fn worker_state_dispatch_error_sink_bounds_the_reason() {
+        const REASON_SECRET: &str = "WORKER_STATE_ERROR_REASON_SECRET_SENTINEL";
+
+        let reason = format!("{REASON_SECRET}{}", "x".repeat(4096));
+        let reason_len = reason.len();
+        let output = crate::capture_test_logs(move || {
+            let error = StateError::InvalidTcpFrontend {
+                address: "127.0.0.1:443"
+                    .parse()
+                    .expect("test TCP frontend address must parse"),
+                reason,
+            };
+            error!("Could not execute order on config state: {}", error);
+        });
+
+        assert!(
+            !output.contains(REASON_SECRET),
+            "worker state-error sink leaked the reason: {output}"
+        );
+        assert!(
+            output.contains(&format!("reason_bytes={reason_len}")),
+            "worker state-error sink omitted bounded reason metadata: {output}"
+        );
+        assert!(
+            output.len() <= 512,
+            "worker state-error sink is not bounded: {} bytes",
+            output.len()
+        );
+    }
+}
+
+#[cfg(test)]
 mod eviction_tests {
     use std::collections::HashSet;
     use std::time::{Duration, Instant};

--- a/lib/src/tls.rs
+++ b/lib/src/tls.rs
@@ -88,13 +88,33 @@ pub enum CertificateResolverError {
 /// A wrapper around the Rustls
 /// [`CertifiedKey` type](https://docs.rs/rustls/latest/rustls/sign/struct.CertifiedKey.html),
 /// stored and returned by the certificate resolver.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct CertifiedKeyWrapper {
     inner: Arc<CertifiedKey>,
     /// domain names, override what can be found in the cert
     names: Vec<String>,
     expiration: i64,
     fingerprint: Fingerprint,
+}
+
+impl fmt::Debug for CertifiedKeyWrapper {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let names_len = self
+            .names
+            .iter()
+            .map(String::len)
+            .fold(0usize, usize::saturating_add);
+
+        f.debug_struct("CertifiedKeyWrapper")
+            .field("certificate", &"[redacted]")
+            .field("certificate_chain_count", &self.inner.cert.len())
+            .field("private_key", &"[redacted]")
+            .field("names_count", &self.names.len())
+            .field("names_len", &names_len)
+            .field("expiration", &self.expiration)
+            .field("fingerprint_bytes", &self.fingerprint.0.len())
+            .finish()
+    }
 }
 
 /// Convert an AddCertificate request into the Rustls format.
@@ -210,7 +230,7 @@ impl TryFrom<&AddCertificate> for CertifiedKeyWrapper {
 /// for a given domain name.
 /// Certificates are stored in a hashmap that may contain unreachable certificates if
 /// no domain name points to it.
-#[derive(Default, Debug)]
+#[derive(Default)]
 pub struct CertificateResolver {
     /// routing one domain name to one certificate for fast resolving
     pub domains: TrieNode<Fingerprint>,
@@ -220,6 +240,23 @@ pub struct CertificateResolver {
     /// map of domain_name -> all fingerprints (and expiration) linked to this domain name
     //  the vector of (fingerprint, expiration) is sorted by expiration
     name_fingerprint_idx: HashMap<String, Vec<(Fingerprint, i64)>>,
+}
+
+impl fmt::Debug for CertificateResolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let indexed_certificate_links = self
+            .name_fingerprint_idx
+            .values()
+            .map(Vec::len)
+            .fold(0usize, usize::saturating_add);
+
+        f.debug_struct("CertificateResolver")
+            .field("domains", &"[redacted]")
+            .field("certificates_count", &self.certificates.len())
+            .field("indexed_names_count", &self.name_fingerprint_idx.len())
+            .field("indexed_certificate_links", &indexed_certificate_links)
+            .finish()
+    }
 }
 
 impl CertificateResolver {
@@ -586,10 +623,10 @@ impl ResolvesServerCert for MutexCertificateResolver {
             return None;
         };
         trace!(
-            "{} trying to resolve name: {:?} for signature scheme: {:?}",
+            "{} trying to resolve certificate with name_bytes={} signature_schemes_count={}",
             log_module_context!(),
-            name,
-            sigschemes
+            name.len(),
+            sigschemes.len()
         );
         // Every other site uses blocking `lock()`, and silently falling
         // back to `DEFAULT_CERTIFICATE` on lock
@@ -602,21 +639,20 @@ impl ResolvesServerCert for MutexCertificateResolver {
         // without inventing a new failure mode.
         let resolver = match self.0.lock() {
             Ok(guard) => guard,
-            Err(poisoned) => {
+            Err(_poisoned) => {
                 error!(
-                    "{} cert resolver mutex poisoned, returning default cert: {:?}",
-                    log_module_context!(),
-                    poisoned
+                    "{} cert resolver mutex poisoned, returning default cert",
+                    log_module_context!()
                 );
                 return DEFAULT_CERTIFICATE.clone();
             }
         };
         if let Some((_, fingerprint)) = resolver.domains.domain_lookup(name.as_bytes(), true) {
             trace!(
-                "{} looking for certificate for {:?} with fingerprint {:?}",
+                "{} looking for certificate with name_bytes={} fingerprint_bytes={}",
                 log_module_context!(),
-                name,
-                fingerprint
+                name.len(),
+                fingerprint.0.len()
             );
 
             // Strict-binding invariant: when the SNI trie resolves a name to a
@@ -641,9 +677,9 @@ impl ResolvesServerCert for MutexCertificateResolver {
             );
 
             trace!(
-                "{} found for fingerprint {}: {}",
+                "{} certificate lookup fingerprint_bytes={} found={}",
                 log_module_context!(),
-                fingerprint,
+                fingerprint.0.len(),
                 cert.is_some()
             );
             return cert;
@@ -654,9 +690,9 @@ impl ResolvesServerCert for MutexCertificateResolver {
         // This certificate is used for TLS tunneling with another TLS termination endpoint
         // Note that this is unsafe and you should provide a valid certificate
         debug!(
-            "{} default certificate is used for {}",
+            "{} default certificate is used for name_bytes={}",
             log_module_context!(),
-            name
+            name.len()
         );
         incr!(names::tls::DEFAULT_CERT_USED);
         DEFAULT_CERTIFICATE.clone()
@@ -672,11 +708,10 @@ impl MutexCertificateResolver {
     pub fn names_for_sni(&self, domain: &[u8]) -> Option<Vec<String>> {
         match self.0.lock() {
             Ok(guard) => guard.names_for_sni(domain),
-            Err(poisoned) => {
+            Err(_poisoned) => {
                 error!(
-                    "{} cert resolver mutex poisoned, treating as no SAN match: {:?}",
-                    log_module_context!(),
-                    poisoned
+                    "{} cert resolver mutex poisoned, treating as no SAN match",
+                    log_module_context!()
                 );
                 None
             }
@@ -698,6 +733,8 @@ mod tests {
     use std::{
         collections::HashSet,
         error::Error,
+        io::Cursor,
+        sync::Arc,
         time::{Duration, SystemTime},
     };
 
@@ -706,7 +743,230 @@ mod tests {
         AddCertificate, CertificateAndKey, ReplaceCertificate, SocketAddress,
     };
 
-    use super::CertificateResolver;
+    use super::{CertificateResolver, CertifiedKeyWrapper, MutexCertificateResolver};
+
+    fn drive_client_hello(resolver: Arc<MutexCertificateResolver>, server_name: String) {
+        let provider = Arc::new(crate::crypto::default_provider());
+        let server_config = rustls::ServerConfig::builder_with_provider(provider.clone())
+            .with_protocol_versions(&[&rustls::version::TLS13])
+            .expect("test server provider must support TLS 1.3")
+            .with_no_client_auth()
+            .with_cert_resolver(resolver);
+        let client_config = rustls::ClientConfig::builder_with_provider(provider)
+            .with_protocol_versions(&[&rustls::version::TLS13])
+            .expect("test client provider must support TLS 1.3")
+            .with_root_certificates(rustls::RootCertStore::empty())
+            .with_no_client_auth();
+        let server_name = rustls::pki_types::ServerName::try_from(server_name)
+            .expect("test SNI must be a valid DNS name");
+        let mut client = rustls::ClientConnection::new(Arc::new(client_config), server_name)
+            .expect("test client connection must initialize");
+        let mut server = rustls::ServerConnection::new(Arc::new(server_config))
+            .expect("test server connection must initialize");
+
+        let mut client_hello = Vec::new();
+        client
+            .write_tls(&mut client_hello)
+            .expect("test client hello must serialize");
+        server
+            .read_tls(&mut Cursor::new(client_hello))
+            .expect("test server must read the client hello");
+        server
+            .process_new_packets()
+            .expect("test server must process the client hello");
+    }
+
+    #[test]
+    fn certificate_resolver_logs_redact_matching_sni_and_fingerprint() {
+        const SNI_SECRET: &str = "resolver-sni-secret.example";
+
+        let certificate = CertificateAndKey {
+            certificate: include_str!("../assets/certificate.pem").to_owned(),
+            key: include_str!("../assets/key.pem").to_owned(),
+            names: vec![SNI_SECRET.to_owned()],
+            ..Default::default()
+        };
+        let fingerprint = certificate
+            .fingerprint()
+            .expect("test certificate fingerprint must be computable")
+            .to_string();
+        let output = crate::capture_test_logs_at_level("trace", move || {
+            let resolver = Arc::new(MutexCertificateResolver::default());
+            resolver
+                .0
+                .lock()
+                .expect("test resolver lock must be available")
+                .add_certificate(&AddCertificate {
+                    address: SocketAddress::new_v4(127, 0, 0, 1, 8443),
+                    certificate,
+                    expired_at: None,
+                })
+                .expect("test certificate must load into the resolver");
+            drive_client_hello(resolver, SNI_SECRET.to_owned());
+        });
+
+        assert!(
+            !output.contains(SNI_SECRET),
+            "TLS resolver logs leaked the matching SNI: {output}"
+        );
+        assert!(
+            !output.contains(&fingerprint),
+            "TLS resolver logs leaked the matching certificate fingerprint: {output}"
+        );
+        for metadata in [
+            format!("name_bytes={}", SNI_SECRET.len()),
+            "fingerprint_bytes=32".to_owned(),
+        ] {
+            assert!(
+                output.contains(&metadata),
+                "TLS resolver logs omitted bounded metadata {metadata}: {output}"
+            );
+        }
+        assert!(
+            output.len() <= 4096,
+            "TLS resolver log capture is not bounded: {} bytes",
+            output.len()
+        );
+    }
+
+    #[test]
+    fn certificate_resolver_logs_redact_fallback_sni() {
+        const SNI_SECRET: &str = "fallback-sni-secret.example";
+
+        let output = crate::capture_test_logs_at_level("trace", move || {
+            drive_client_hello(
+                Arc::new(MutexCertificateResolver::default()),
+                SNI_SECRET.to_owned(),
+            );
+        });
+
+        assert!(
+            !output.contains(SNI_SECRET),
+            "TLS resolver logs leaked the fallback SNI: {output}"
+        );
+        assert!(
+            output.contains(&format!("name_bytes={}", SNI_SECRET.len())),
+            "TLS resolver fallback log omitted bounded SNI metadata: {output}"
+        );
+        assert!(
+            output.len() <= 2048,
+            "TLS resolver fallback log capture is not bounded: {} bytes",
+            output.len()
+        );
+    }
+
+    #[test]
+    fn certificate_resolver_poison_logs_are_bounded() {
+        const SNI_SECRET: &str = "poison-sni-secret.example";
+        const QUERY_SECRET: &str = "POISON_QUERY_SECRET_SENTINEL";
+
+        let query = format!("{QUERY_SECRET}{}", "x".repeat(4096));
+        let output = crate::capture_test_logs_at_level("trace", move || {
+            let resolver = Arc::new(MutexCertificateResolver::default());
+            let poison_target = resolver.clone();
+            assert!(
+                std::thread::spawn(move || {
+                    let _guard = poison_target
+                        .0
+                        .lock()
+                        .expect("test resolver lock must initially be available");
+                    panic!("intentionally poison the test resolver lock");
+                })
+                .join()
+                .is_err(),
+                "test poison thread must panic"
+            );
+
+            drive_client_hello(resolver.clone(), SNI_SECRET.to_owned());
+            assert!(resolver.names_for_sni(query.as_bytes()).is_none());
+        });
+
+        assert!(
+            !output.contains(SNI_SECRET),
+            "TLS resolver poison log leaked the handshake SNI: {output}"
+        );
+        assert!(
+            !output.contains(QUERY_SECRET),
+            "TLS resolver poison log leaked the 4 KiB direct query: {output}"
+        );
+        assert!(
+            output.len() <= 2048,
+            "TLS resolver poison log capture is not bounded: {} bytes",
+            output.len()
+        );
+    }
+
+    #[test]
+    fn certified_key_wrapper_debug_redacts_runtime_certificate_material() {
+        const NAME_SECRET: &str = "CERTIFIED_KEY_NAME_SECRET_SENTINEL";
+
+        let add = AddCertificate {
+            address: SocketAddress::new_v4(127, 0, 0, 1, 8443),
+            certificate: CertificateAndKey {
+                certificate: include_str!("../assets/certificate.pem").to_owned(),
+                key: include_str!("../assets/key.pem").to_owned(),
+                names: vec![format!("{NAME_SECRET}{}", "x".repeat(4096))],
+                ..Default::default()
+            },
+            expired_at: None,
+        };
+        let certified_key =
+            CertifiedKeyWrapper::try_from(&add).expect("test certificate must parse");
+        let fingerprint = certified_key.fingerprint.to_string();
+        let output = format!("{certified_key:?}");
+
+        assert!(
+            !output.contains(NAME_SECRET),
+            "CertifiedKeyWrapper Debug leaked an overridden certificate name: {output}"
+        );
+        assert!(
+            !output.contains(&fingerprint),
+            "CertifiedKeyWrapper Debug leaked the certificate fingerprint: {output}"
+        );
+        assert!(
+            output.contains("fingerprint_bytes: 32"),
+            "CertifiedKeyWrapper Debug omitted bounded fingerprint metadata: {output}"
+        );
+        assert!(
+            output.contains("[redacted]"),
+            "CertifiedKeyWrapper Debug must make certificate redaction explicit: {output}"
+        );
+        assert!(
+            output.len() <= 1024,
+            "CertifiedKeyWrapper Debug output is not bounded: {} bytes",
+            output.len()
+        );
+    }
+
+    #[test]
+    fn certificate_resolver_debug_redacts_indexed_names() {
+        const NAME_SECRET: &str = "CERTIFICATE_RESOLVER_NAME_SECRET_SENTINEL";
+
+        let mut resolver = CertificateResolver::default();
+        resolver
+            .add_certificate(&AddCertificate {
+                address: SocketAddress::new_v4(127, 0, 0, 1, 8443),
+                certificate: CertificateAndKey {
+                    certificate: include_str!("../assets/certificate.pem").to_owned(),
+                    key: include_str!("../assets/key.pem").to_owned(),
+                    names: vec![format!("{NAME_SECRET}{}", "x".repeat(4096))],
+                    ..Default::default()
+                },
+                expired_at: None,
+            })
+            .expect("test certificate must load into the resolver");
+        let output = format!("{resolver:?}");
+
+        assert!(
+            !output.contains(NAME_SECRET),
+            "CertificateResolver Debug leaked an indexed certificate name: {output}"
+        );
+        assert!(
+            output.len() <= 1024,
+            "CertificateResolver Debug output is not bounded: {} bytes",
+            output.len()
+        );
+    }
 
     #[test]
     fn lifecycle() -> Result<(), Box<dyn Error + Send + Sync>> {


### PR DESCRIPTION
## Summary

- replace recursive `Debug` output for certificate, query, frontend, cluster, top-level request, response, and retained-task objects with bounded metadata-only summaries
- bound every `StateError` textual projection while preserving its raw public variant fields, including HTTP/HTTPS/TCP frontend identities
- redact route-miss hosts, paths, and custom methods plus runtime TCP preread, rustls, HTTPS handshake, mux authority/SNI, and certificate-SAN values
- add adversarial 4 KiB sentinel coverage through direct/nested requests, retained tasks/state, audit and worker error sinks, real route misses, and runtime TLS/routing logs
- document the sensitive-value logging boundary canonically in `doc/observability.md`, including the correlation-envelope exception and compatibility guarantees

## Compatibility

- protobuf schema and generated wire encoding are unchanged
- Serde, JSON, saved-state keys, certificate-query operator response payloads, and `RequestHttpFrontend::Display` remain unchanged
- raw `StateError`, `RouterError`, and `RetrieveClusterError::SniAuthorityMismatch` variant fields remain available to programmatic callers; only their `Display`/`Debug` projections are bounded

## Verification

- `cargo build --workspace --all-features --locked`
- `cargo +nightly fmt --all -- --check`
- `cargo doc --workspace --all-features --no-deps --locked` (pre-existing rustdoc warnings only)
- `cargo clippy --workspace --all-features --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`: 1470 passed, 7 ignored across 16 suites
- independent `codex review`: no actionable correctness issues

Closes #1296
