### PR TITLE
fix(command): validate listener config before committing it to main-process state (#1301)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,11 @@
   so an invalid listener never reserves its address and a corrected reload applies cleanly. Invalid
   listeners in the static config or a loaded state file are likewise skipped without reserving their
   address. The `StateError::Exists` message now also points at the remedy (remove it first, or apply
-  the corresponding update, instead of re-adding).
+  the corresponding update, instead of re-adding). As defense-in-depth, when a committed change is
+  rejected by *every* worker it was fanned out to, the main process now reverts its own `ConfigState`
+  with the inverse request (listener and HTTP/HTTPS-frontend adds), so its authoritative state — the
+  one replayed into restarted and upgraded workers — never permanently holds an add the whole fleet
+  refused.
 
 ## 2.2.0 - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@
   one replayed into restarted and upgraded workers — never permanently holds an add the whole fleet
   refused.
 
+- **`fix(command)`: report a fan-out timeout as a failure, not a success.** `handle_finishing_task`
+  passed a hard-coded `timed_out = false` into every task completion handler, so a command whose
+  worker fan-out timed out was reported to the operator as `Successfully applied request to all
+  workers` and its audit line mislabeled the `FanoutStatus`/`result`. The real `timed_out` flag is
+  now forwarded, so a timed-out command correctly returns a failure (and the `#1301` rollback
+  safety-net's timeout guard now engages as intended).
+
 ## 2.2.0 - 2026-07-16
 
 Minor release: TCP passthrough routing by TLS SNI + ALPN, HTTP/1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,21 @@
   `RetrieveClusterError::SniAuthorityMismatch` variant fields, `RequestHttpFrontend::Display`, and
   certificate-query response payloads remain unchanged.
 
+### 🐛 Fixed
+
+- **`fix(command)`: validate a listener configuration before committing it to the main-process
+  state** ([#1301](https://github.com/sozu-proxy/sozu/issues/1301)). An HTTPS listener whose
+  configuration the worker cannot build (an unusable TLS version/cipher set, or an unparseable
+  answer template) was recorded in the main process's `ConfigState` before the worker rejected it,
+  reserving the address; a corrected reload was then refused with `StateError::Exists` and never
+  reached the workers, so the listener stayed down until an explicit `RemoveListener` or a restart.
+  The main process now validates every `Add{Http,Https,Tcp,Udp}Listener` the way the worker builds
+  it — reusing the worker's own construction check, before `ConfigState` is mutated and fanned out —
+  so an invalid listener never reserves its address and a corrected reload applies cleanly. Invalid
+  listeners in the static config or a loaded state file are likewise skipped without reserving their
+  address. The `StateError::Exists` message now also points at the remedy (remove it first, or apply
+  the corresponding update, instead of re-adding).
+
 ## 2.2.0 - 2026-07-16
 
 Minor release: TCP passthrough routing by TLS SNI + ALPN, HTTP/1

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -2266,18 +2266,24 @@ pub fn worker_request(
     // Committing an unbuildable listener first reserves its address, and the
     // corrected reload is then refused with StateError::Exists. Validation is
     // read-only on state and runs first; dispatch happens only if it passes.
+    // Tag the two failure classes distinctly for the audit taxonomy: a rejected
+    // `validate_listener_request` is operator-invalid *input* (bad TLS
+    // versions/ciphers or an unparseable answer template) → `InvalidInput`
+    // (same class as the `set_logging_level` filter check); a rejected
+    // `state.dispatch` is a genuine state conflict → `DispatchError`.
     let apply_result = request
         .request_type
         .as_ref()
         .map_or(Ok(()), validate_listener_request)
+        .map_err(|reason| (AuditErrorCode::InvalidInput, reason))
         .and_then(|()| {
             server
                 .state
                 .dispatch(&request)
-                .map_err(|error| error.to_string())
+                .map_err(|error| (AuditErrorCode::DispatchError, error.to_string()))
         });
 
-    if let Err(reason) = apply_result {
+    if let Err((error_code, reason)) = apply_result {
         // INVARIANT: neither a rejected validation nor a rejected dispatch may
         // mutate persisted state — validation never touches it, and a rejected
         // dispatch is a guaranteed no-op (see ConfigState::dispatch).
@@ -2287,7 +2293,7 @@ pub fn worker_request(
             "a rejected validation or dispatch must leave ConfigState byte-identical (no partial apply)"
         );
         if let Some(mut entry) = audit {
-            entry.extras.error_code = Some(AuditErrorCode::DispatchError);
+            entry.extras.error_code = Some(error_code);
             entry.extras.reason = Some(reason.clone());
             entry.extras.elapsed_ms = Some(elapsed_ms(started_at));
             entry.extras.request_sha256 = Some(request_sha256.clone());
@@ -2304,7 +2310,7 @@ pub fn worker_request(
                 AuditResult::Err,
                 AuditExtras {
                     elapsed_ms: Some(elapsed_ms(started_at)),
-                    error_code: Some(AuditErrorCode::DispatchError),
+                    error_code: Some(error_code),
                     reason: Some(reason.clone()),
                     ..Default::default()
                 },
@@ -2314,7 +2320,7 @@ pub fn worker_request(
             let target = fields.target.clone();
             let mut extras = fields.into_extras();
             extras.elapsed_ms = Some(elapsed_ms(started_at));
-            extras.error_code = Some(AuditErrorCode::DispatchError);
+            extras.error_code = Some(error_code);
             extras.reason = Some(reason.clone());
             audit_emit_inline(
                 server,

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -27,12 +27,13 @@ use sozu_command_lib::{
     parser::parse_several_requests,
     proto::command::{
         AggregatedMetrics, AvailableMetrics, CertificatesWithFingerprints, ClusterHashes,
-        ClusterInformations, Event, EventKind, FrontendFilters, HardStop, MetricDetail,
-        MetricDetailStatus, MetricsConfiguration, QueryCertificatesFilters, QueryHealthChecks,
-        QueryMetricsOptions, Request, ResponseContent, ResponseStatus, RunState, SetMetricDetail,
-        SoftStop, Status, UpdateHttpListenerConfig, UpdateHttpsListenerConfig,
-        UpdateTcpListenerConfig, UpdateUdpListenerConfig, WorkerInfo, WorkerInfos, WorkerRequest,
-        WorkerResponses, request::RequestType, response_content::ContentType,
+        ClusterInformations, Event, EventKind, FrontendFilters, HardStop, ListenerType,
+        MetricDetail, MetricDetailStatus, MetricsConfiguration, QueryCertificatesFilters,
+        QueryHealthChecks, QueryMetricsOptions, RemoveListener, Request, ResponseContent,
+        ResponseStatus, RunState, SetMetricDetail, SoftStop, Status, UpdateHttpListenerConfig,
+        UpdateHttpsListenerConfig, UpdateTcpListenerConfig, UpdateUdpListenerConfig, WorkerInfo,
+        WorkerInfos, WorkerRequest, WorkerResponses, request::RequestType,
+        response_content::ContentType,
     },
     sd_notify,
 };
@@ -1993,6 +1994,12 @@ struct WorkerTask {
     /// the audit would repopulate one counter, and the "wipes everything"
     /// contract would silently drift by exactly one row per clear.
     clear_master_metrics_on_finish: bool,
+    /// Inverse of the request (sozu#1301 rollback safety-net), computed by
+    /// [`compute_rollback`] before fan-out. When EVERY worker rejects the
+    /// request, [`WorkerTask::on_finish`] applies this to the main process's
+    /// `ConfigState` to revert the committed change. `None` for requests
+    /// without a defined inverse (they keep today's best-effort behavior).
+    rollback: Option<Request>,
 }
 
 /// Carry the per-verb metadata needed to emit a completion-time audit
@@ -2068,6 +2075,50 @@ fn validate_listener_request(request: &RequestType) -> Result<(), String> {
         _ => return Ok(()),
     }
     .map_err(|listener_error| listener_error.to_string())
+}
+
+/// The inverse of a mutating request, used by the fan-out rollback safety-net
+/// (sozu#1301, defense-in-depth on top of `validate_listener_request`).
+///
+/// When the main process commits a request to its `ConfigState` and fans it
+/// out, but **every** worker rejects it, [`WorkerTask::on_finish`] applies this
+/// inverse to revert the main process's own state — so its authoritative
+/// `ConfigState` (the source of truth replayed into restarted or upgraded
+/// workers) never permanently holds an `Add` the whole fleet refused. Because
+/// the trigger is a *unanimous* rejection, no worker applied the change, so
+/// reverting the main process alone reconverges master and workers — there is
+/// nothing to compensate on the worker side.
+///
+/// Only requests whose inverse is unambiguous WITHOUT capturing the prior value
+/// are covered: the non-upsert `Add` verbs — every listener type (inverse
+/// `RemoveListener`) and HTTP/HTTPS frontends (inverse is the same payload under
+/// the `Remove` variant). Upsert verbs (`AddCluster`, `AddBackend`, which
+/// replace a prior value in place) and certificates would need the prior value
+/// captured to revert correctly, so they are deliberately NOT covered and keep
+/// today's best-effort behavior; every other request returns `None`.
+fn compute_rollback(request: &RequestType) -> Option<Request> {
+    let inverse = match request {
+        RequestType::AddHttpListener(config) => RequestType::RemoveListener(RemoveListener {
+            address: config.address,
+            proxy: ListenerType::Http.into(),
+        }),
+        RequestType::AddHttpsListener(config) => RequestType::RemoveListener(RemoveListener {
+            address: config.address,
+            proxy: ListenerType::Https.into(),
+        }),
+        RequestType::AddTcpListener(config) => RequestType::RemoveListener(RemoveListener {
+            address: config.address,
+            proxy: ListenerType::Tcp.into(),
+        }),
+        RequestType::AddUdpListener(config) => RequestType::RemoveListener(RemoveListener {
+            address: config.address,
+            proxy: ListenerType::Udp.into(),
+        }),
+        RequestType::AddHttpFrontend(front) => RequestType::RemoveHttpFrontend(front.clone()),
+        RequestType::AddHttpsFrontend(front) => RequestType::RemoveHttpsFrontend(front.clone()),
+        _ => return None,
+    };
+    Some(inverse.into())
 }
 
 pub fn worker_request(
@@ -2382,6 +2433,12 @@ pub fn worker_request(
 
     client.return_processing("Processing worker request...");
 
+    // sozu#1301 rollback safety-net: compute the inverse of this request now,
+    // while we still hold it, so `on_finish` can revert the main-process state
+    // if every worker rejects the change. `None` for verbs without a defined
+    // inverse (they keep today's best-effort behavior).
+    let rollback = request.request_type.as_ref().and_then(compute_rollback);
+
     server.scatter(
         request,
         Box::new(WorkerTask {
@@ -2392,6 +2449,7 @@ pub fn worker_request(
             inline_audit,
             metric_detail_audit: metric_detail_audit_completion,
             clear_master_metrics_on_finish,
+            rollback,
         }),
         Timeout::Default,
         None,
@@ -2558,6 +2616,35 @@ impl GatheringTask for WorkerTask {
             METRICS.with(|metrics| {
                 (*metrics.borrow_mut()).clear_local();
             });
+        }
+
+        // sozu#1301 rollback safety-net: if the change committed to ConfigState
+        // was rejected by EVERY worker it was scattered to (a unanimous,
+        // definitive failure — no timeout, at least one worker answered, and
+        // none accepted it), revert the main process's own state with the
+        // precomputed inverse. Because no worker applied the change, reverting
+        // the main process alone reconverges the fleet; there is nothing to
+        // compensate worker-side. A mixed result (some workers accepted) is
+        // deliberately left as-is to avoid diverging the main process from the
+        // workers that did accept.
+        if !timed_out
+            && expected > 0
+            && ok == 0
+            && errors > 0
+            && let Some(rollback) = self.rollback.as_ref()
+        {
+            match server.state.dispatch(rollback) {
+                Ok(()) => warn!(
+                    "sozu#1301 rollback: reverted a change from main-process state after all {} \
+                     worker(s) rejected it",
+                    expected
+                ),
+                Err(revert_error) => error!(
+                    "sozu#1301 rollback: could not revert main-process state after unanimous \
+                     worker rejection: {}",
+                    revert_error
+                ),
+            }
         }
 
         if errors > 0 || timed_out {
@@ -4260,6 +4347,40 @@ mod listener_validation_tests {
         assert!(
             validate_listener_request(&request).is_err(),
             "an unbuildable HTTP listener must be rejected before commit"
+        );
+    }
+
+    #[test]
+    fn rollback_inverse_targets_the_same_listener_and_skips_uncovered_verbs() {
+        use sozu_command_lib::proto::command::ListenerType;
+
+        // sozu#1301 rollback safety-net: a listener add inverts to a
+        // RemoveListener for the SAME address and proxy type, so a unanimous
+        // worker rejection can revert the main-process commit.
+        let address = SocketAddress::new_v4(127, 0, 0, 1, 8443);
+        let add = RequestType::AddHttpsListener(https_config(address, true));
+        let inverse = super::compute_rollback(&add).expect("a listener add must have an inverse");
+        match inverse.request_type {
+            Some(RequestType::RemoveListener(remove)) => {
+                assert_eq!(
+                    remove.proxy,
+                    ListenerType::Https as i32,
+                    "inverse must target the HTTPS listener type"
+                );
+                assert_eq!(
+                    remove.address, address,
+                    "inverse must target the same address"
+                );
+            }
+            other => panic!("expected a RemoveListener inverse, got {other:?}"),
+        }
+
+        // Upsert Add verbs (AddCluster/AddBackend) and non-add verbs have no
+        // simple prior-value-free inverse and are deliberately uncovered — they
+        // keep today's best-effort behavior rather than risk a wrong revert.
+        assert!(
+            super::compute_rollback(&RequestType::Logging("info".to_owned())).is_none(),
+            "a non-add verb must have no rollback inverse"
         );
     }
 }

--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -874,6 +874,18 @@ pub fn load_static_config(server: &mut Server, mut client: OptionalClient, path:
 
     for (request_index, message) in config_messages.into_iter().enumerate() {
         let request = message.content;
+        // sozu#1301: skip an unbuildable listener at boot without reserving its
+        // address, so a corrected reload can still add it. Fail-open — one bad
+        // listener does not stop the others (matches the dispatch-error skip
+        // below), it just never enters ConfigState.
+        if let Some(reason) = request
+            .request_type
+            .as_ref()
+            .and_then(|request_type| validate_listener_request(request_type).err())
+        {
+            client.return_processing(format!("Skipping invalid listener config: {reason}"));
+            continue;
+        }
         if let Err(error) = server.state.dispatch(&request) {
             client.return_processing(format!("Could not execute request on state: {error:#}"));
             continue;
@@ -2027,6 +2039,37 @@ impl MetricDetailAuditFields {
     }
 }
 
+/// Master-side pre-validation for listener-add requests (sozu#1301).
+///
+/// A worker rejects an unbuildable listener configuration only when it
+/// constructs the listener (building the rustls context / parsing the answer
+/// templates) — but by then the main process has already committed the listener
+/// to its `ConfigState` and reserved the address, so a corrected reload is
+/// refused with `StateError::Exists` and never reaches the workers. Running the
+/// worker's OWN construction check here, BEFORE `ConfigState::dispatch`, keeps
+/// the two in lockstep (same binary, same crypto provider) and lets an invalid
+/// listener be rejected without ever reserving its address. This mirrors the
+/// existing `SetMetricDetail` pre-validation in [`worker_request`]: fail fast
+/// before fan-out rather than amplifying a bad input across every worker.
+///
+/// Only listener-add requests are validated; every other request returns `Ok`.
+/// TCP/UDP construction has no fallible config today (see their
+/// `validate_config`), so those arms currently always succeed.
+fn validate_listener_request(request: &RequestType) -> Result<(), String> {
+    match request {
+        RequestType::AddHttpListener(config) => {
+            sozu_lib::http::HttpListener::validate_config(config)
+        }
+        RequestType::AddHttpsListener(config) => {
+            sozu_lib::https::HttpsListener::validate_config(config)
+        }
+        RequestType::AddTcpListener(config) => sozu_lib::tcp::TcpListener::validate_config(config),
+        RequestType::AddUdpListener(config) => sozu_lib::udp::UdpListener::validate_config(config),
+        _ => return Ok(()),
+    }
+    .map_err(|listener_error| listener_error.to_string())
+}
+
 pub fn worker_request(
     server: &mut Server,
     client: &mut ClientSession,
@@ -2167,14 +2210,31 @@ pub fn worker_request(
     // below, so it is dead code in release but must stay ungated (E0425).
     let state_hash_before = server.state.hash_state();
 
-    if let Err(error) = server.state.dispatch(&request) {
-        // INVARIANT: a rejected dispatch must not mutate persisted state.
+    // sozu#1301: validate a listener-add config the way the worker will build
+    // it (rustls context + answer templates) BEFORE committing to ConfigState.
+    // Committing an unbuildable listener first reserves its address, and the
+    // corrected reload is then refused with StateError::Exists. Validation is
+    // read-only on state and runs first; dispatch happens only if it passes.
+    let apply_result = request
+        .request_type
+        .as_ref()
+        .map_or(Ok(()), validate_listener_request)
+        .and_then(|()| {
+            server
+                .state
+                .dispatch(&request)
+                .map_err(|error| error.to_string())
+        });
+
+    if let Err(reason) = apply_result {
+        // INVARIANT: neither a rejected validation nor a rejected dispatch may
+        // mutate persisted state — validation never touches it, and a rejected
+        // dispatch is a guaranteed no-op (see ConfigState::dispatch).
         debug_assert_eq!(
             server.state.hash_state(),
             state_hash_before,
-            "a dispatch that returns Err must leave ConfigState byte-identical (no partial apply)"
+            "a rejected validation or dispatch must leave ConfigState byte-identical (no partial apply)"
         );
-        let reason = error.to_string();
         if let Some(mut entry) = audit {
             entry.extras.error_code = Some(AuditErrorCode::DispatchError);
             entry.extras.reason = Some(reason.clone());
@@ -2217,7 +2277,7 @@ pub fn worker_request(
             );
         }
         client.finish_failure(format!(
-            "could not dispatch request on the main process state: {error}",
+            "could not apply request on the main process state: {reason}",
         ));
         return;
     }
@@ -3154,6 +3214,15 @@ pub fn load_state(server: &mut Server, mut client: OptionalClient, path: &str) {
                 offset = buffer.data().offset(i);
 
                 for request in requests {
+                    // sozu#1301: skip an unbuildable listener from the saved
+                    // state without reserving its address, so a corrected
+                    // reload can add it (mirrors the dispatch-failure skip).
+                    if let Some(request_type) = &request.content.request_type
+                        && let Err(reason) = validate_listener_request(request_type)
+                    {
+                        debug!("load_state: skipping invalid listener config: {}", reason);
+                        continue;
+                    }
                     if server.state.dispatch(&request.content).is_ok() {
                         // INVARIANT: the scatter request_id advances by
                         // exactly one per dispatched request. `scatter_on`
@@ -4062,6 +4131,135 @@ mod mutating_verb_policy_tests {
             !is_mutating_verb(&req),
             "SetMetricDetail is an observability knob, not a state transition; \
              keeping it out of is_mutating_verb prevents RELOADING flap on lease renewal"
+        );
+    }
+}
+
+#[cfg(test)]
+mod listener_validation_tests {
+    //! sozu#1301: an invalid listener config must be rejected by the main
+    //! process BEFORE it is committed to `ConfigState`, so it never reserves
+    //! its address and blocks a corrected reload with `StateError::Exists`.
+    //! These exercise the production [`validate_listener_request`] guard that
+    //! all three master apply paths (`worker_request`, `load_static_config`,
+    //! `load_state`) share.
+    //!
+    //! To SEE THESE RED (regression proof): make `validate_listener_request`
+    //! return `Ok(())` unconditionally — the pre-fix behavior where the main
+    //! process committed listener configs without validating them. The
+    //! `is_err()` assertions below then fail.
+    use super::validate_listener_request;
+    use sozu_command_lib::{
+        config::ListenerBuilder,
+        proto::command::{HttpsListenerConfig, SocketAddress, request::RequestType},
+        state::{ConfigState, StateError},
+    };
+
+    /// A default HTTPS listener config for `address`. When `valid` is false, a
+    /// malformed answer template is injected so the worker's construction
+    /// (`HttpsListener::validate_config` → `HttpAnswers::new`) rejects it. That
+    /// trigger is deterministic AND crypto-provider independent, unlike a
+    /// `BuildRustls` "no usable cipher suites" message which varies across the
+    /// ring / aws-lc-rs / openssl / fips CI cells.
+    fn https_config(address: SocketAddress, valid: bool) -> HttpsListenerConfig {
+        let mut cfg = ListenerBuilder::new_https(address)
+            .to_tls(None)
+            .expect("default HTTPS listener config");
+        if !valid {
+            cfg.answers
+                .insert("404".to_owned(), "not a valid http response".to_owned());
+        }
+        cfg
+    }
+
+    #[test]
+    fn invalid_https_listener_rejected_before_commit_unblocks_corrected_reload() {
+        let address = SocketAddress::new_v4(127, 0, 0, 1, 8443);
+
+        // The pathology this guard defends against: `ConfigState` itself has no
+        // buildability check — it records an unbuildable listener and reserves
+        // its address, after which a corrected reload is refused with
+        // `StateError::Exists`. Prove it at the state layer so the master-side
+        // guard below is demonstrably load-bearing.
+        {
+            let mut state = ConfigState::new();
+            let bad = RequestType::AddHttpsListener(https_config(address, false));
+            state
+                .dispatch(&bad.into())
+                .expect("ConfigState records the bad listener — it has no buildability check");
+            let good = RequestType::AddHttpsListener(https_config(address, true));
+            let err = state
+                .dispatch(&good.into())
+                .expect_err("a reserved address blocks the corrected reload");
+            assert!(
+                matches!(err, StateError::Exists { .. }),
+                "expected StateError::Exists, got {err:?}"
+            );
+        }
+
+        // The fix: the main process validates a listener-add the way the worker
+        // will build it BEFORE dispatch, so the unbuildable config is rejected
+        // and never reaches `ConfigState`.
+        let bad = RequestType::AddHttpsListener(https_config(address, false));
+        assert!(
+            validate_listener_request(&bad).is_err(),
+            "an unbuildable HTTPS listener must be rejected before commit"
+        );
+
+        // With the bad listener correctly never committed, the corrected reload
+        // validates and applies cleanly — no `StateError::Exists` blocker.
+        let mut state = ConfigState::new();
+        let good = RequestType::AddHttpsListener(https_config(address, true));
+        assert!(
+            validate_listener_request(&good).is_ok(),
+            "a valid HTTPS listener must pass validation"
+        );
+        state
+            .dispatch(&good.into())
+            .expect("corrected reload applies when the bad listener never reserved the address");
+    }
+
+    #[test]
+    fn valid_listener_adds_of_every_type_pass_validation() {
+        let http = RequestType::AddHttpListener(
+            ListenerBuilder::new_http(SocketAddress::new_v4(127, 0, 0, 1, 8080))
+                .to_http(None)
+                .expect("default HTTP listener config"),
+        );
+        let https = RequestType::AddHttpsListener(https_config(
+            SocketAddress::new_v4(127, 0, 0, 1, 8081),
+            true,
+        ));
+        let tcp = RequestType::AddTcpListener(
+            ListenerBuilder::new_tcp(SocketAddress::new_v4(127, 0, 0, 1, 8082))
+                .to_tcp(None)
+                .expect("default TCP listener config"),
+        );
+        let udp = RequestType::AddUdpListener(
+            ListenerBuilder::new_udp(SocketAddress::new_v4(127, 0, 0, 1, 8083))
+                .to_udp(None)
+                .expect("default UDP listener config"),
+        );
+        for request in [http, https, tcp, udp] {
+            assert!(
+                validate_listener_request(&request).is_ok(),
+                "a valid listener add must pass validation: {request:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_http_listener_is_rejected_before_commit() {
+        // The HTTP path is fallible through answer-template parsing too.
+        let mut cfg = ListenerBuilder::new_http(SocketAddress::new_v4(127, 0, 0, 1, 8084))
+            .to_http(None)
+            .expect("default HTTP listener config");
+        cfg.answers
+            .insert("404".to_owned(), "not a valid http response".to_owned());
+        let request = RequestType::AddHttpListener(cfg);
+        assert!(
+            validate_listener_request(&request).is_err(),
+            "an unbuildable HTTP listener must be rejected before commit"
         );
     }
 }

--- a/bin/src/command/server.rs
+++ b/bin/src/command/server.rs
@@ -692,7 +692,14 @@ impl CommandHub {
             .job
             .client_token()
             .and_then(|token| self.clients.get_mut(&token));
-        task.job.on_finish(&mut self.server, client, false);
+        // Forward the real `timed_out` the two call sites pass (has_finished →
+        // false, timeout expiry → true). A previous hard-coded `false` made
+        // `timed_out` always false in every `on_finish`: it left the audit
+        // `FanoutStatus::Timeout`/`result` branches unreachable (a timed-out
+        // command reported success) and made `WorkerTask`'s `!timed_out`
+        // rollback guard inert (sozu#1301). Pinned by
+        // `handle_finishing_task_forwards_timed_out_flag`.
+        task.job.on_finish(&mut self.server, client, timed_out);
         self.in_flight
             .retain(|_, in_flight_task_id| *in_flight_task_id != task_id);
         // POST-CONDITION: every in-flight entry pointing at this finished task
@@ -1541,6 +1548,68 @@ mod tests {
         let unix_listener = UnixListener::bind(&socket_path).expect("Could not bind socket");
         Server::new(unix_listener, Config::default(), "sozu".to_owned())
             .expect("Could not create server")
+    }
+
+    fn create_test_hub() -> CommandHub {
+        let dir = tempfile::tempdir().expect("Could not create temp dir");
+        let socket_path = dir.path().join("test.sock");
+        let unix_listener = UnixListener::bind(&socket_path).expect("Could not bind socket");
+        CommandHub::new(unix_listener, Config::default(), "sozu".to_owned())
+            .expect("Could not create command hub")
+    }
+
+    /// Regression (sozu#1301): `handle_finishing_task` must forward its
+    /// `timed_out` argument to `GatheringTask::on_finish`, not a hard-coded
+    /// literal. A previous `false` literal made `timed_out` always false in
+    /// every `on_finish` — disabling `WorkerTask`'s `!timed_out` rollback guard
+    /// and leaving the audit `FanoutStatus::Timeout`/`result` branches
+    /// unreachable (a timed-out command reported success).
+    #[test]
+    fn handle_finishing_task_forwards_timed_out_flag() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        #[derive(Debug)]
+        struct RecordingTask {
+            gatherer: DefaultGatherer,
+            seen: Rc<Cell<Option<bool>>>,
+        }
+        impl GatheringTask for RecordingTask {
+            fn client_token(&self) -> Option<Token> {
+                None
+            }
+            fn get_gatherer(&mut self) -> &mut dyn Gatherer {
+                &mut self.gatherer
+            }
+            fn on_finish(
+                self: Box<Self>,
+                _server: &mut Server,
+                _client: &mut OptionalClient,
+                timed_out: bool,
+            ) {
+                self.seen.set(Some(timed_out));
+            }
+        }
+
+        for expected in [false, true] {
+            let mut hub = create_test_hub();
+            let seen = Rc::new(Cell::new(None));
+            let task = TaskContainer {
+                job: Box::new(RecordingTask {
+                    gatherer: DefaultGatherer::default(),
+                    seen: seen.clone(),
+                }),
+                timeout: None,
+            };
+            // task_id 0 is fine: `handle_finishing_task` takes the task by value
+            // and only uses the id to purge in-flight entries (none exist here).
+            hub.handle_finishing_task(0, task, expected);
+            assert_eq!(
+                seen.get(),
+                Some(expected),
+                "handle_finishing_task must forward timed_out={expected} to on_finish"
+            );
+        }
     }
 
     #[derive(Debug)]

--- a/bin/tests/listener_validate_before_commit_e2e.rs
+++ b/bin/tests/listener_validate_before_commit_e2e.rs
@@ -1,0 +1,131 @@
+//! sozu#1301 end-to-end smoke test.
+//!
+//! An HTTPS listener whose configuration the worker cannot build must NOT
+//! reserve its address in the main process's `ConfigState`, so a corrected
+//! `listener https add` at the same address still succeeds. Before the fix the
+//! invalid listener was committed (and the address reserved) before the worker
+//! rejected it, and the corrected reload was then refused with
+//! `StateError::Exists`.
+//!
+//! Spawns the real `sozu` binary (`CARGO_BIN_EXE_sozu`) as a daemonised master
+//! and drives it over its unix command socket with the `sozu listener https
+//! add` CLI. The unbuildable listener is produced with a malformed `--answer-404`
+//! template file — a deterministic, crypto-provider-independent trigger (it
+//! fails `HttpAnswers::new`, not the rustls build).
+//!
+//! `#[ignore]`d by default because it spawns a master, writes to a temp dir and
+//! binds an ephemeral port. Run manually with:
+//!
+//! ```bash
+//! cargo test -p sozu --test listener_validate_before_commit_e2e -- --ignored
+//! ```
+
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn sozu_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_sozu")
+}
+
+/// Grab a currently-free 127.0.0.1 TCP port by binding to `:0` and releasing
+/// it. Racy in principle, fine for a manual `#[ignore]`d test.
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
+#[test]
+#[ignore = "manual: spawns a real master over a unix socket + binds a port; run with --ignored (see module docs)"]
+fn corrected_https_listener_add_succeeds_after_invalid_one() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let socket_path = temp.path().join("sozu.sock");
+    let config_path = temp.path().join("config.toml");
+    let bad_answer = temp.path().join("bad_404.txt");
+    std::fs::write(&bad_answer, "not a valid http response").expect("write bad answer template");
+
+    // Minimum viable config: command socket only, no listeners, one worker,
+    // automatic-restart disabled so the master exits cleanly on kill.
+    let config = format!(
+        r#"
+command_socket = "{socket}"
+command_buffer_size = 16384
+max_command_buffer_size = 163840
+worker_count = 1
+worker_automatic_restart = false
+log_level = "warn"
+log_target = "stderr"
+max_connections = 100
+buffer_size = 16393
+"#,
+        socket = socket_path.display(),
+    );
+    std::fs::write(&config_path, &config).expect("write config");
+
+    let mut master = Command::new(sozu_bin())
+        .args(["start", "-c", config_path.to_str().unwrap()])
+        .spawn()
+        .expect("spawn sozu start");
+
+    // Wait up to 10 s for the master to create the command socket.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !socket_path.exists() {
+        if Instant::now() > deadline {
+            let _ = master.kill();
+            let _ = master.wait();
+            panic!("sozu master never created {socket_path:?}");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    let address = format!("127.0.0.1:{}", free_port());
+    let cfg = config_path.to_str().unwrap();
+    let bad_answer_path = bad_answer.to_str().unwrap();
+    // A bare `listener https add` leaves the TLS version set empty, which
+    // rustls rejects on its own ("no usable cipher suites"); pass a real
+    // version set so the ONLY invalid thing about the first add is its answer
+    // template, and the corrected add is genuinely buildable.
+    let tls = ["--tls-versions", "TLS_V12", "--tls-versions", "TLS_V13"];
+
+    // 1) An unbuildable HTTPS listener (malformed 404 answer template) is
+    //    rejected. Pre-fix it was rejected too, but only AFTER the main process
+    //    had already committed it and reserved the address.
+    let invalid = Command::new(sozu_bin())
+        .args(["-c", cfg, "listener", "https", "add", "-a", &address])
+        .args(tls)
+        .args(["--answer-404", bad_answer_path])
+        .output()
+        .expect("spawn invalid `listener https add`");
+    let invalid_ok = invalid.status.success();
+
+    // 2) THE #1301 FIX: a corrected add at the SAME address now succeeds,
+    //    because the rejected listener never reserved the address. Before the
+    //    fix this was refused with StateError::Exists.
+    let corrected = Command::new(sozu_bin())
+        .args(["-c", cfg, "listener", "https", "add", "-a", &address])
+        .args(tls)
+        .output()
+        .expect("spawn corrected `listener https add`");
+    let corrected_ok = corrected.status.success();
+
+    // Clean up the master before asserting (a failed assert must not leak it).
+    let _ = master.kill();
+    let _ = master.wait();
+
+    assert!(
+        !invalid_ok,
+        "an unbuildable HTTPS listener add should fail.\nstdout=\n{}\nstderr=\n{}",
+        String::from_utf8_lossy(&invalid.stdout),
+        String::from_utf8_lossy(&invalid.stderr),
+    );
+    assert!(
+        corrected_ok,
+        "corrected HTTPS listener add at the same address must succeed (sozu#1301) — \
+         it was blocked, which means the invalid listener reserved the address.\n\
+         stdout=\n{}\nstderr=\n{}",
+        String::from_utf8_lossy(&corrected.stdout),
+        String::from_utf8_lossy(&corrected.stderr),
+    );
+}

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -47,7 +47,10 @@ pub enum StateError {
     UndispatchableRequest,
     #[error("Did not find {kind:?} with address or id_bytes={}", .id.len())]
     NotFound { kind: ObjectKind, id: String },
-    #[error("{kind:?} with id_bytes={} already exists", .id.len())]
+    #[error(
+        "{kind:?} with id_bytes={} already exists; remove it first, or apply the corresponding update, instead of re-adding it",
+        .id.len()
+    )]
     Exists { kind: ObjectKind, id: String },
     #[error("Wrong field value: {0}")]
     WrongFieldValue(UnknownEnumValue),

--- a/command/src/state.rs
+++ b/command/src/state.rs
@@ -48,7 +48,7 @@ pub enum StateError {
     #[error("Did not find {kind:?} with address or id_bytes={}", .id.len())]
     NotFound { kind: ObjectKind, id: String },
     #[error(
-        "{kind:?} with id_bytes={} already exists; remove it first, or apply the corresponding update, instead of re-adding it",
+        "{kind:?} with id_bytes={} already exists; remove it first, or apply the corresponding update if the object supports one, instead of re-adding it",
         .id.len()
     )]
     Exists { kind: ObjectKind, id: String },

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -1238,27 +1238,43 @@ impl HttpProxy {
 
 impl HttpListener {
     pub fn new(config: HttpListenerConfig, token: Token) -> Result<HttpListener, ListenerError> {
+        let answers = Self::build_answers(&config)?;
         Ok(HttpListener {
             active: false,
             address: config.address.into(),
-            answers: Rc::new(RefCell::new({
-                // Reconcile the legacy `http_answers` per-status fields
-                // with the new template map: the new map wins on
-                // collision, the legacy fields fill in any status the
-                // operator hasn't yet migrated.
-                let mut answers_map = config.answers.clone();
-                if let Some(ref legacy) = config.http_answers {
-                    crate::protocol::http::answers::merge_legacy_into_map(&mut answers_map, legacy);
-                }
-                HttpAnswers::new(&answers_map)
-                    .map_err(|(name, error)| ListenerError::TemplateParse(name, error))?
-            })),
+            answers: Rc::new(RefCell::new(answers)),
             config,
             fronts: Router::new(),
             listener: None,
             tags: BTreeMap::new(),
             token,
         })
+    }
+
+    /// Build the listener's HTTP answer templates from its config, reconciling
+    /// the legacy `http_answers` per-status fields with the new `answers`
+    /// template map (the new map wins on collision; legacy fields fill any
+    /// status not yet migrated). Shared by [`Self::new`] and
+    /// [`Self::validate_config`] so the master-side pre-commit check cannot
+    /// drift from worker construction.
+    fn build_answers(config: &HttpListenerConfig) -> Result<HttpAnswers, ListenerError> {
+        let mut answers_map = config.answers.clone();
+        if let Some(ref legacy) = config.http_answers {
+            crate::protocol::http::answers::merge_legacy_into_map(&mut answers_map, legacy);
+        }
+        HttpAnswers::new(&answers_map)
+            .map_err(|(name, error)| ListenerError::TemplateParse(name, error))
+    }
+
+    /// Validate that a worker can build this HTTP listener configuration (its
+    /// answer templates) WITHOUT constructing the full listener or binding a
+    /// socket. The main process calls this before committing an
+    /// `AddHttpListener` to its `ConfigState` and fanning it out, so an invalid
+    /// listener never reserves its address and blocks a corrected reload
+    /// (sozu#1301).
+    pub fn validate_config(config: &HttpListenerConfig) -> Result<(), ListenerError> {
+        Self::build_answers(config)?;
+        Ok(())
     }
 
     pub fn activate(

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -1351,18 +1351,7 @@ impl HttpsListener {
 
         let server_config = Arc::new(Self::create_rustls_context(&config, resolver.to_owned())?);
 
-        let answers = {
-            // Reconcile the legacy `http_answers` per-status fields with
-            // the new template map: the new map wins on collision, the
-            // legacy fields fill in any status the operator hasn't yet
-            // migrated.
-            let mut answers_map = config.answers.clone();
-            if let Some(ref legacy) = config.http_answers {
-                crate::protocol::http::answers::merge_legacy_into_map(&mut answers_map, legacy);
-            }
-            HttpAnswers::new(&answers_map)
-                .map_err(|(name, error)| ListenerError::TemplateParse(name, error))?
-        };
+        let answers = Self::build_answers(&config)?;
 
         Ok(HttpsListener {
             listener: None,
@@ -1376,6 +1365,41 @@ impl HttpsListener {
             token,
             tags: BTreeMap::new(),
         })
+    }
+
+    /// Build the listener's HTTP answer templates from its config, reconciling
+    /// the legacy `http_answers` per-status fields with the new `answers`
+    /// template map (the new map wins on collision; legacy fields fill any
+    /// status not yet migrated). Shared by [`Self::try_new`] and
+    /// [`Self::validate_config`] so the master-side pre-commit check cannot
+    /// drift from worker construction.
+    fn build_answers(config: &HttpsListenerConfig) -> Result<HttpAnswers, ListenerError> {
+        let mut answers_map = config.answers.clone();
+        if let Some(ref legacy) = config.http_answers {
+            crate::protocol::http::answers::merge_legacy_into_map(&mut answers_map, legacy);
+        }
+        HttpAnswers::new(&answers_map)
+            .map_err(|(name, error)| ListenerError::TemplateParse(name, error))
+    }
+
+    /// Validate that a worker can build this HTTPS listener configuration — the
+    /// rustls context and the answer templates — WITHOUT constructing the full
+    /// listener or binding a socket. Runs the exact fallible steps of
+    /// [`Self::try_new`] (via the shared [`Self::create_rustls_context`] /
+    /// [`Self::build_answers`] helpers), so master-side validation is faithful
+    /// to what the worker will do.
+    ///
+    /// The main process calls this before committing an `AddHttpsListener` to
+    /// its `ConfigState` and fanning it out, so an invalid listener never
+    /// reserves its address and blocks a corrected reload (sozu#1301).
+    pub fn validate_config(config: &HttpsListenerConfig) -> Result<(), ListenerError> {
+        // An empty resolver matches `try_new`: the default certificate is added
+        // later via `AddCertificate`, so only the config-level TLS parameters
+        // (versions, ciphers, groups, ALPN) and the answer templates are
+        // exercised here.
+        Self::create_rustls_context(config, Arc::new(MutexCertificateResolver::default()))?;
+        Self::build_answers(config)?;
+        Ok(())
     }
 
     pub fn activate(

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -2065,6 +2065,18 @@ impl TcpListener {
         })
     }
 
+    /// Validate that a worker can build this TCP listener configuration WITHOUT
+    /// constructing the full listener or binding a socket. TCP listener
+    /// construction has no fallible config today (no rustls context, no answer
+    /// templates; a bad bind surfaces later as an `ActivateListener` failure),
+    /// so this currently always succeeds. It exists for surface parity with the
+    /// HTTP/HTTPS validators the main process calls before committing an
+    /// `Add*Listener` to `ConfigState` and fanning it out (sozu#1301), and is
+    /// the hook for any future TCP-config validation.
+    pub fn validate_config(_config: &TcpListenerConfig) -> Result<(), ListenerError> {
+        Ok(())
+    }
+
     /// Build the [`PrereadConfig`] this listener's `SniPreread` sessions
     /// feed to [`crate::protocol::tcp_preread::SniPrereadCore::handle_input`].
     /// `routes`/`inbound_proxy`/`timeout` come straight from the listener

--- a/lib/src/udp.rs
+++ b/lib/src/udp.rs
@@ -264,6 +264,18 @@ impl UdpListener {
         })
     }
 
+    /// Validate that a worker can build this UDP listener configuration WITHOUT
+    /// constructing the full listener or binding a socket. UDP listener
+    /// construction has no fallible config today (no rustls context, no answer
+    /// templates; a bad bind surfaces later as an `ActivateListener` failure),
+    /// so this currently always succeeds. It exists for surface parity with the
+    /// HTTP/HTTPS validators the main process calls before committing an
+    /// `Add*Listener` to `ConfigState` and fanning it out (sozu#1301), and is
+    /// the hook for any future UDP-config validation.
+    pub fn validate_config(_config: &UdpListenerConfig) -> Result<(), ListenerError> {
+        Ok(())
+    }
+
     /// Bind (or adopt an SCM-passed) socket and register it `READABLE`. The
     /// READABLE registration is what drives `Server::ready` for this listener —
     /// there is no accept path.


### PR DESCRIPTION
## Summary

Fixes #1301. An HTTPS listener whose configuration the worker cannot build (an unusable TLS version/cipher set, or an unparseable answer template) was recorded in the main process's `ConfigState` **before** the worker rejected it, reserving the address. A corrected reload was then refused with `StateError::Exists` and never reached the workers, so the listener stayed down until an explicit `RemoveListener` or a process restart — an operational trap where the natural fix-and-reload loop silently does nothing.

## Approach

Two commits, following the control-plane / data-plane static-stability principle (the control plane must not record what the data plane rejected):

**Part 1 — validate before commit (the fix).** The main process now validates every `Add{Http,Https,Tcp,Udp}Listener` the way the worker builds it, reusing the worker's *own* construction check (`HttpsListener`/`HttpListener::validate_config`, factored out of `try_new` via a shared `build_answers` helper so master and worker cannot drift — same binary, same crypto provider), **before** `ConfigState` is mutated and fanned out. An invalid listener therefore never reserves its address and a corrected reload applies cleanly. Wired into all three master apply paths (`worker_request`, `load_static_config`, `load_state`); invalid listeners in the static config or a loaded state file are skipped without reserving their address (fail-open: one bad listener does not stop the others). This extends an idiom already in `worker_request` (the `SetMetricDetail` master-side pre-validation). `StateError::Exists` now also points at the remedy.

**Part 2 — rollback safety-net (defense-in-depth).** Even after validation, a committed change can be rejected worker-side. When **every** worker rejects it (unanimous, no timeout), the main process reverts its own `ConfigState` with the inverse request, so its authoritative state (replayed into restarted / upgraded workers) never permanently holds an add the whole fleet refused. Covers the non-upsert Add verbs with unambiguous inverses (listeners → `RemoveListener`; HTTP/HTTPS frontends → the same payload under the Remove variant); upsert verbs (`AddCluster` / `AddBackend`) and certificates are deliberately uncovered (they would need prior-value capture, kept best-effort as today). A mixed result is left as-is to avoid diverging the master from workers that accepted.

## Security / protocol impact

Confined to the control-plane command-apply path (`bin/src/command/`, `command/src/state.rs`) and listener construction (`lib/src/{http,https,tcp,udp}.rs`). It makes the main process's authoritative `ConfigState` consistent with what workers actually accepted. Conservative, additive validation; no behavior change on the accepted path, no traffic-path change.

## Tests

- Master-level regression tests (`bin/src/command/requests.rs`): invalid listener rejected before commit, corrected reload succeeds, and `compute_rollback` inverse correctness. **Proven red** (neutering the guard fails the assertions), then green.
- `#[ignore]`d e2e smoke test driving a **real master** over its command socket: confirms a corrected `listener https add` succeeds after an invalid one at the same address.

## Commands run

- `cargo build --all-features --locked` — ok
- `cargo +nightly fmt --all -- --check` — ok
- `cargo clippy --all-targets --locked -- -D warnings` — ok
- `cargo test -p sozu -p sozu-lib -p sozu-command-lib --locked` — ok (771 lib + bin + command)
- `cargo test -p sozu --test listener_validate_before_commit_e2e -- --ignored` — ok

## Docs

- `CHANGELOG.md` updated (Fixed, #1301).

Closes #1301
