### PR TITLE
feat(sim): swarm-test per-seed generator configurations

### DIFF
--- a/bin/src/command/requests.rs
+++ b/bin/src/command/requests.rs
@@ -641,7 +641,7 @@ fn save_state(server: &mut Server, client: &mut ClientSession, path: &str) {
             );
             client.finish_ok(format!(
                 "Saved {count} config messages to {}",
-                &path.display()
+                path.display()
             ));
         }
         Err(error) => {

--- a/bin/src/ctl/top/app.rs
+++ b/bin/src/ctl/top/app.rs
@@ -1035,12 +1035,12 @@ impl App {
             .or_else(|| gauge_value(m.proxying.get(names::buffer::USAGE_PERCENT)))
             .map(|v| v.min(100))
             .unwrap_or(0);
-        self.overview.saturation_pct.push(saturation as u64);
+        self.overview.saturation_pct.push(saturation);
 
         self.overview.active_sessions =
-            gauge_value(m.proxying.get(names::http::ACTIVE_REQUESTS)).unwrap_or(0) as u64;
+            gauge_value(m.proxying.get(names::http::ACTIVE_REQUESTS)).unwrap_or(0);
         self.overview.client_connections =
-            gauge_value(m.proxying.get(names::client::CONNECTIONS)).unwrap_or(0) as u64;
+            gauge_value(m.proxying.get(names::client::CONNECTIONS)).unwrap_or(0);
     }
 
     /// Append a transport-published `TopEvent` into the recent-events ring.

--- a/command/src/proto/display.rs
+++ b/command/src/proto/display.rs
@@ -231,7 +231,7 @@ impl ResponseContent {
 
 impl WorkerResponses {
     fn contain_cluster_infos(&self) -> bool {
-        for (_worker_id, response) in self.map.iter() {
+        for response in self.map.values() {
             if let Some(content_type) = &response.content_type
                 && matches!(content_type, ContentType::Clusters(_))
             {
@@ -242,7 +242,7 @@ impl WorkerResponses {
     }
 
     fn contain_cluster_hashes(&self) -> bool {
-        for (_worker_id, response) in self.map.iter() {
+        for response in self.map.values() {
             if let Some(content_type) = &response.content_type
                 && matches!(content_type, ContentType::ClusterHashes(_))
             {
@@ -631,13 +631,13 @@ fn print_frontends(frontends: &ListedFrontends) -> Result<(), DisplayError> {
 pub fn print_listeners(listeners_list: &ListenersList) -> Result<(), DisplayError> {
     println!("\nHTTP LISTENERS\n================");
 
-    for (_, http_listener) in listeners_list.http_listeners.iter() {
+    for http_listener in listeners_list.http_listeners.values() {
         println!("{http_listener}");
     }
 
     println!("\nHTTPS LISTENERS\n================");
 
-    for (_, https_listener) in listeners_list.https_listeners.iter() {
+    for https_listener in listeners_list.https_listeners.values() {
         println!("{https_listener}");
     }
 
@@ -656,7 +656,7 @@ pub fn print_listeners(listeners_list: &ListenersList) -> Result<(), DisplayErro
             "connect timeout",
             "activated"
         ]);
-        for (_, tcp_listener) in listeners_list.tcp_listeners.iter() {
+        for tcp_listener in listeners_list.tcp_listeners.values() {
             table.add_row(row![
                 format!("{:?}", tcp_listener.address),
                 format!("{:?}", tcp_listener.public_address),
@@ -687,7 +687,7 @@ pub fn print_listeners(listeners_list: &ListenersList) -> Result<(), DisplayErro
             "max flows",
             "activated"
         ]);
-        for (_, udp_listener) in listeners_list.udp_listeners.iter() {
+        for udp_listener in listeners_list.udp_listeners.values() {
             table.add_row(row![
                 format!("{:?}", udp_listener.address),
                 format!("{:?}", udp_listener.public_address),

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -159,6 +159,7 @@ The UDP simulator reads three env knobs (`sim/tests/udp_simulation.rs`,
 | `SOZU_UDP_SIM_SEED` | run that ONE seed verbosely (decimal or `0x`-hex) — the replay path |
 | `SOZU_UDP_SIM_SEEDS` | sweep `0..n` seeds instead of the default `0..256` |
 | `SOZU_UDP_SIM_STEPS` | run `n` steps per seed instead of the default `3000` |
+| `SOZU_SIM_SWARM` | `0` pins every seed to the inclusive all-features configuration; default `1` draws a per-seed swarm subset. Shared by BOTH simulators — see §5 "Swarm configurations" |
 
 ```bash
 # Reproduce a CI failure exactly (the panic prints the failing seed + step):
@@ -309,6 +310,71 @@ The engine needs `--cfg tokio_unstable` (tokio `RngSeed` scheduler determinism),
 so the test is `#![cfg(tokio_unstable)]`-gated and its deps sit under
 `[target.'cfg(tokio_unstable)'.dev-dependencies]` — the flag is scoped to the
 `sozu-sim` build, and `cargo test --workspace` builds it as an empty 0-test binary.
+
+### Swarm configurations (Groce et al., ISSTA 2012)
+
+Both simulators run **swarm testing**
+([Groce et al., ISSTA 2012](https://users.cs.utah.edu/~regehr/papers/swarm12.pdf)):
+instead of every seed exercising the single all-features workload grammar, each
+seed draws a random **configuration** — a subset of the generator features —
+from its own seeded RNG *before the first operation*, so the configuration is a
+pure function of the seed. Feature omission pays twice: omitting a *suppressor*
+lets the workload reach states the full grammar repairs too eagerly, and any
+omission concentrates the seed's step budget on the surviving features (the
+paper's active-suppression and passive-competition mechanisms).
+
+**What a feature is here.**
+
+- `udp_simulation.rs`: an entry of the weighted `Action` grammar
+  (`ACTION_TABLE`). Each buggify arm is tied to its sibling feature (a
+  stale-resolution fault makes no sense in a configuration without
+  `BackendResolved`) and is skipped — never redrawn — when that feature is off.
+- `tcp_preread_sim.rs`: a scenario generator (`GENERATOR_TABLE`), plus the one
+  genuinely orthogonal **fragmentation** axis (off → every delivery is
+  one-shot, and the forced drip generator leaves the pool). The other
+  ClientHello axes (SNI shape, ALPN, GREASE, ECH, multi-record, proxy prefix)
+  are embodied by their carrier generators — toggling one inside a directed
+  generator would invalidate its expected terminal. The 2% buggify byte-flip
+  stays always-on: it is a wire-level fault, not a grammar feature.
+
+**Classification.** A feature is MANDATORY (bootstrap/observation the workload
+cannot run without — always retained), OPTIONAL, or a SUPPRESSOR (it repairs
+the very state another bug needs — the paper's `pop` call to a stack-overflow
+bug):
+
+| Simulator | MANDATORY | SUPPRESSOR | OPTIONAL |
+|---|---|---|---|
+| UDP | `ClientDatagram` — the sole flow creator; without it every shadow-model invariant is vacuously green | `Drain`, `CloseAll`, `AbortFlow`, `SetMaxFlows` — each evicts flows, resets the manager, or sheds future admissions, repairing the very full-table state a capacity bug needs | `BackendResolved`, `BackendDatagram`, `AdvanceClock`, `ReconfigCluster`, `SetMaxRx` |
+| TCP preread | none — `SniPrereadCore` is fresh per connection, and the harness machinery (replay checks, coverage tally) is observation, not a feature | none — no state survives a connection, so nothing can suppress across connections; the swarm benefit here is pure passive competition | all 25 generators, plus the fragmentation axis |
+
+**Per-seed draw and campaign composition.** One seed in four keeps the
+inclusive all-features configuration `C_D` (the paper is explicit that swarm
+subsets complement, never replace, it: a bug needing `k` specific features
+together appears in a coin-toss subset with probability `1/2^k`). The other
+seeds include each optional feature with 50% probability, renormalize the
+remaining weights over the survivors, and collapse an all-off draw back to
+`C_D`. Every sweep — the per-PR job (64 UDP / 512 TCP seeds) and the nightly
+deep swarm — is therefore ≈25% inclusive + ≈75% random subsets of the same
+seed budget.
+
+**Replay contract.** The drawn configuration is printed as one canonical
+`swarm-config sim=... seed=... mode=... features=[...] total_weight=...` line
+before the workload runs, byte-identical across replays of the same seed (the
+`*_swarm_config_is_stable_across_draws` tests assert the stability). A failing
+seed replayed with `SOZU_UDP_SIM_SEED` / `SOZU_TCP_PREREAD_SIM_SEED` therefore
+always shows its configuration. `SOZU_SIM_SWARM=0` (shared by both simulators)
+disables the draw entirely — zero extra RNG consumption, byte-identical to the
+pre-swarm grammar — so a swarm campaign and an all-features campaign of
+identical seed count can be compared directly. The pinned
+`*_replays_known_seed` smoke tests run with swarm off for the same reason.
+
+**Coverage gate placement.** The TCP per-class gate
+(`CoverageTally::assert_full_coverage`) is asserted on the MERGED campaign
+tally, never per seed: a single swarm seed legitimately cannot reach every
+`RejectReason` class, but the sweep still must, and still fails loudly when it
+does not. If a swarm subset trips an invariant, that is the point of the
+exercise: report the failing seed and its printed configuration — never weaken
+the assertion or the gate.
 
 ### Recipe: adding a simulator over another sans-io core
 

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -347,15 +347,17 @@ bug):
 | UDP | `ClientDatagram` — the sole flow creator; without it every shadow-model invariant is vacuously green | `Drain`, `CloseAll`, `AbortFlow`, `SetMaxFlows` — each evicts flows, resets the manager, or sheds future admissions, repairing the very full-table state a capacity bug needs | `BackendResolved`, `BackendDatagram`, `AdvanceClock`, `ReconfigCluster`, `SetMaxRx` |
 | TCP preread | none — `SniPrereadCore` is fresh per connection, and the harness machinery (replay checks, coverage tally) is observation, not a feature | none — no state survives a connection, so nothing can suppress across connections; the swarm benefit here is pure passive competition | all 25 generators, plus the fragmentation axis |
 
-**Per-seed draw and campaign composition.** One seed in four keeps the
-inclusive all-features configuration `C_D` (the paper is explicit that swarm
+**Per-seed draw and campaign composition.** Campaigns run the explicit seed
+range `0..n`, and seeds divisible by four keep the inclusive all-features
+configuration `C_D` (the paper is explicit that swarm
 subsets complement, never replace, it: a bug needing `k` specific features
 together appears in a coin-toss subset with probability `1/2^k`). The other
 seeds include each optional feature with 50% probability, renormalize the
-remaining weights over the survivors, and collapse an all-off draw back to
-`C_D`. Every sweep — the per-PR job (64 UDP / 512 TCP seeds) and the nightly
-deep swarm — is therefore ≈25% inclusive + ≈75% random subsets of the same
-seed budget.
+remaining weights over the survivors, and repair an all-off or all-on draw to
+a non-empty proper subset. Every sweep — the per-PR job (64 UDP / 512 TCP
+seeds) and the nightly deep swarm — therefore reserves exactly one inclusive
+run in each four-seed cohort; shorter final cohorts start with their inclusive
+run.
 
 **Replay contract.** The drawn configuration is printed as one canonical
 `swarm-config sim=... seed=... mode=... features=[...] total_weight=...` line

--- a/doc/udp_simulation.md
+++ b/doc/udp_simulation.md
@@ -66,6 +66,16 @@ folding each `Output` into a shadow model (tracking `FlowCreated` / `FlowEvicted
 for active-flow accounting) and honouring a subset of `SelectBackend` requests
 with `BackendResolved` so flows progress to `Established`.
 
+**Swarm configurations** (Groce et al., ISSTA 2012 — see
+`doc/testing.md` §5 "Swarm configurations" for the full doctrine): each seed
+draws a random subset of this grammar from its own seeded RNG before the first
+step — `ClientDatagram` is MANDATORY and always retained, the others are
+included with 50% probability, and the weights renormalize over the survivors.
+One seed in four keeps the full grammar, and the drawn configuration is
+printed as one `swarm-config` line per seed. `SOZU_SIM_SWARM=0` pins every
+seed to the full grammar (zero extra RNG draws — byte-identical to the
+pre-swarm harness).
+
 `Drain` is special: the core's `draining` flag is a one-way latch (there is no
 "resume"), mirroring the shell draining a listener and then dropping it. The
 simulator therefore treats `Drain` as a self-contained **listener-lifecycle
@@ -77,7 +87,9 @@ manager — so the long run keeps admitting afterwards.
 `buggify_with_prob!(p)` is moonpool's [FoundationDB `buggify`][fdb-buggify]
 primitive: with low per-call probability it injects an *extra* adversarial event
 (stale `BackendResolved`, a reconfig burst, a `max_flows` shrink to a tiny value,
-a giant clock jump). It only ever runs under simulation.
+a giant clock jump). It only ever runs under simulation. Each arm is gated by
+its sibling grammar feature: a swarm configuration that omits a feature omits
+its fault as well (the arm is skipped, never redrawn).
 
 ## Invariants
 
@@ -128,6 +140,7 @@ RUSTFLAGS="--cfg tokio_unstable" SOZU_UDP_SIM_SEEDS=1024 SOZU_UDP_SIM_STEPS=5000
 | `SOZU_UDP_SIM_SEED`   | run that ONE seed with verbose tracing (replay)       |
 | `SOZU_UDP_SIM_SEEDS`  | sweep `n` seeds instead of the default                |
 | `SOZU_UDP_SIM_STEPS`  | run `n` steps per seed instead of the default         |
+| `SOZU_SIM_SWARM`      | `0` pins every seed to the full grammar; default `1` draws per-seed swarm subsets (shared with the TCP preread sim) |
 
 A failing seed is surfaced in moonpool's `SimulationReport` (and the panicking
 invariant prints the seed + step), so the run reproduces via the

--- a/doc/udp_simulation.md
+++ b/doc/udp_simulation.md
@@ -71,10 +71,12 @@ with `BackendResolved` so flows progress to `Established`.
 draws a random subset of this grammar from its own seeded RNG before the first
 step — `ClientDatagram` is MANDATORY and always retained, the others are
 included with 50% probability, and the weights renormalize over the survivors.
-One seed in four keeps the full grammar, and the drawn configuration is
-printed as one `swarm-config` line per seed. `SOZU_SIM_SWARM=0` pins every
-seed to the full grammar (zero extra RNG draws — byte-identical to the
-pre-swarm harness).
+Campaign seeds are the explicit range `0..n`; seeds divisible by four keep the
+full grammar, reserving one inclusive run in every four-seed cohort, while the
+other seeds always use non-empty proper subsets. The drawn configuration is
+printed as one `swarm-config` line per seed. `SOZU_SIM_SWARM=0` pins every seed
+to the full grammar (zero extra RNG draws — byte-identical to the pre-swarm
+harness).
 
 `Drain` is special: the core's `draining` flag is a one-way latch (there is no
 "resume"), mirroring the shell draining a listener and then dropping it. The

--- a/lib/src/backends.rs
+++ b/lib/src/backends.rs
@@ -1061,7 +1061,7 @@ impl BackendList {
         self.backends
             .iter_mut()
             .find(|b| b.borrow().sticky_id.as_deref() == Some(sticky_session))
-            .and_then(|b| if b.borrow().can_open() { Some(b) } else { None })
+            .filter(|b| b.borrow().can_open())
     }
 
     pub fn available_backends(&mut self, backup: bool) -> Vec<Rc<RefCell<Backend>>> {

--- a/lib/src/health_check.rs
+++ b/lib/src/health_check.rs
@@ -510,7 +510,7 @@ impl HealthChecker {
         // Sort indices in descending order so swap_remove doesn't invalidate
         // later indices — it moves the last element to the removed position,
         // which has already been processed or is beyond our range.
-        completed.sort_by(|a, b| b.0.cmp(&a.0));
+        completed.sort_by_key(|entry| std::cmp::Reverse(entry.0));
         // We never schedule the same slot for removal twice, and never more
         // removals than there are in-flight checks.
         debug_assert!(

--- a/lib/src/http.rs
+++ b/lib/src/http.rs
@@ -1026,8 +1026,8 @@ impl HttpProxy {
 
     pub fn give_back_listeners(&mut self) -> Vec<(SocketAddr, MioTcpListener)> {
         self.listeners
-            .iter()
-            .filter_map(|(_, listener)| {
+            .values()
+            .filter_map(|listener| {
                 let mut owned = listener.borrow_mut();
                 if let Some(listener) = owned.listener.take() {
                     // Reset `active` so a subsequent `activate()` re-binds
@@ -1192,7 +1192,7 @@ impl HttpProxy {
     pub fn soft_stop(&mut self) -> Result<(), ProxyError> {
         let listeners: HashMap<_, _> = self.listeners.drain().collect();
         let mut socket_errors = vec![];
-        for (_, l) in listeners.iter() {
+        for l in listeners.values() {
             if let Some(mut sock) = l.borrow_mut().listener.take() {
                 debug!("{} deregistering socket {:?}", log_module_context!(), sock);
                 if let Err(e) = self.registry.deregister(&mut sock) {

--- a/lib/src/https.rs
+++ b/lib/src/https.rs
@@ -1868,7 +1868,7 @@ impl HttpsProxy {
     pub fn soft_stop(&mut self) -> Result<(), ProxyError> {
         let listeners: HashMap<_, _> = self.listeners.drain().collect();
         let mut socket_errors = vec![];
-        for (_, l) in listeners.iter() {
+        for l in listeners.values() {
             if let Some(mut sock) = l.borrow_mut().listener.take() {
                 debug!("{} deregistering socket {:?}", log_module_context!(), sock);
                 if let Err(e) = self.registry.deregister(&mut sock) {

--- a/lib/src/protocol/mux/h2.rs
+++ b/lib/src/protocol/mux/h2.rs
@@ -659,18 +659,18 @@ fn distribute_overhead(
         // Last stream gets all remaining overhead to avoid losing remainder bytes
         // from integer division across earlier streams.
         *overhead_bin
-    } else if total_bytes.0 > 0 {
+    } else if let Some(share) = (*overhead_bin * stream_bytes.0).checked_div(total_bytes.0) {
         // Clamp to remaining overhead — integer division rounding across multiple
         // streams can cause accumulated shares to exceed the total.
-        (*overhead_bin * stream_bytes.0 / total_bytes.0).min(*overhead_bin)
+        share.min(*overhead_bin)
     } else {
         // No stream has transferred any inbound bytes — fall back to even split.
         *overhead_bin / active_streams.max(1)
     };
     let share_out = if is_last_stream {
         *overhead_bout
-    } else if total_bytes.1 > 0 {
-        (*overhead_bout * stream_bytes.1 / total_bytes.1).min(*overhead_bout)
+    } else if let Some(share) = (*overhead_bout * stream_bytes.1).checked_div(total_bytes.1) {
+        share.min(*overhead_bout)
     } else {
         // No stream has transferred any outbound bytes — fall back to even split.
         *overhead_bout / active_streams.max(1)

--- a/lib/src/protocol/mux/mod.rs
+++ b/lib/src/protocol/mux/mod.rs
@@ -1147,7 +1147,7 @@ impl<Front: SocketHandler + std::fmt::Debug, L: ListenerHandler + L7ListenerHand
                     // If any backend resumes, invalidate the stale readiness
                     // flag so the inner loop continues instead of breaking.
                     let context = &mut self.context;
-                    for (_token, backend) in self.router.backends.iter_mut() {
+                    for backend in self.router.backends.values_mut() {
                         if backend.try_resume_reading(context) {
                             all_backends_readiness_are_empty = false;
                         }

--- a/lib/src/protocol/mux/stream.rs
+++ b/lib/src/protocol/mux/stream.rs
@@ -133,15 +133,13 @@ pub struct StreamParts<'a> {
 
 impl Stream {
     pub fn new(pool: Weak<RefCell<Pool>>, context: HttpContext, window: u32) -> Option<Self> {
-        let (front_buffer, back_buffer) = match pool.upgrade() {
-            Some(pool) => {
-                let mut pool = pool.borrow_mut();
-                match (pool.checkout(), pool.checkout()) {
-                    (Some(front_buffer), Some(back_buffer)) => (front_buffer, back_buffer),
-                    _ => return None,
-                }
+        let (front_buffer, back_buffer) = {
+            let pool = pool.upgrade()?;
+            let mut pool = pool.borrow_mut();
+            match (pool.checkout(), pool.checkout()) {
+                (Some(front_buffer), Some(back_buffer)) => (front_buffer, back_buffer),
+                _ => return None,
             }
-            None => return None,
         };
         let stream = Self {
             state: StreamState::Idle,

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -1161,23 +1161,17 @@ impl Server {
 
                 gauge!(names::client::CONNECTIONS, nb_connections);
                 gauge!(names::client::CONNECTIONS_MAX, max_connections);
-                if max_connections > 0 {
-                    gauge!(
-                        "client.connections_percent",
-                        nb_connections * 100 / max_connections
-                    );
+                if let Some(percent) = (nb_connections * 100).checked_div(max_connections) {
+                    gauge!("client.connections_percent", percent);
                 }
 
                 gauge!(names::slab::ENTRIES, slab_len);
                 gauge!(names::slab::CAPACITY, slab_capacity);
-                if slab_capacity > 0 {
-                    gauge!(names::slab::USAGE_PERCENT, slab_len * 100 / slab_capacity);
+                if let Some(percent) = (slab_len * 100).checked_div(slab_capacity) {
+                    gauge!(names::slab::USAGE_PERCENT, percent);
                 }
-                if accept_threshold > 0 {
-                    gauge!(
-                        "slab.accept_threshold_percent",
-                        slab_len * 100 / accept_threshold
-                    );
+                if let Some(percent) = (slab_len * 100).checked_div(accept_threshold) {
+                    gauge!("slab.accept_threshold_percent", percent);
                 }
             }
             // Buffer pool gauges. `buffer.in_use` replaces the older
@@ -1191,8 +1185,8 @@ impl Server {
                 let capacity = pool.inner.capacity();
                 gauge!(names::buffer::IN_USE, used);
                 gauge!(names::buffer::CAPACITY, capacity);
-                if capacity > 0 {
-                    gauge!(names::buffer::USAGE_PERCENT, used * 100 / capacity);
+                if let Some(percent) = (used * 100).checked_div(capacity) {
+                    gauge!(names::buffer::USAGE_PERCENT, percent);
                 }
             }
             // 1Hz tick for `accept_queue.saturated_seconds`. Increments once
@@ -1966,29 +1960,29 @@ impl Server {
                 ));
                 return;
             }
-            Some(RequestType::QueryCertificatesFromWorkers(filters)) => {
-                if filters.fingerprint.is_some() {
-                    let certs = self.config_state.get_certificates(filters.clone());
-                    let response = if !certs.is_empty() {
-                        WorkerResponse::ok_with_content(
-                            message.id.clone(),
-                            ContentType::CertificatesWithFingerprints(
-                                CertificatesWithFingerprints { certs },
-                            )
-                            .into(),
-                        )
-                    } else {
-                        worker_response_error(
-                            message.id.clone(),
-                            "Could not find certificate for this fingerprint",
-                        )
-                    };
-                    push_queue(response);
-                    return;
-                }
-                // if all certificates are queried, or filtered by domain name,
-                // the request will be handled by the https proxy
+            Some(RequestType::QueryCertificatesFromWorkers(filters))
+                if filters.fingerprint.is_some() =>
+            {
+                let certs = self.config_state.get_certificates(filters.clone());
+                let response = if !certs.is_empty() {
+                    WorkerResponse::ok_with_content(
+                        message.id.clone(),
+                        ContentType::CertificatesWithFingerprints(CertificatesWithFingerprints {
+                            certs,
+                        })
+                        .into(),
+                    )
+                } else {
+                    worker_response_error(
+                        message.id.clone(),
+                        "Could not find certificate for this fingerprint",
+                    )
+                };
+                push_queue(response);
+                return;
             }
+            // if all certificates are queried, or filtered by domain name,
+            // the request will be handled by the https proxy
             _other_request => {}
         }
         self.notify_proxys(message);

--- a/lib/src/tcp.rs
+++ b/lib/src/tcp.rs
@@ -2822,7 +2822,7 @@ impl ProxyConfiguration for TcpProxy {
                     message.id
                 );
                 let listeners: HashMap<_, _> = self.listeners.drain().collect();
-                for (_, l) in listeners.iter() {
+                for l in listeners.values() {
                     l.borrow_mut()
                         .listener
                         .take()

--- a/lib/src/udp.rs
+++ b/lib/src/udp.rs
@@ -864,7 +864,7 @@ impl UdpProxy {
                 }
                 self.listener_sessions.clear();
                 let listeners: HashMap<_, _> = self.listeners.drain().collect();
-                for (_, l) in listeners.iter() {
+                for l in listeners.values() {
                     l.borrow_mut()
                         .socket
                         .take()

--- a/lib/src/udp/health.rs
+++ b/lib/src/udp/health.rs
@@ -482,7 +482,7 @@ impl UdpHealthChecker {
             completed.push((idx, success));
         }
 
-        completed.sort_by(|a, b| b.0.cmp(&a.0));
+        completed.sort_by_key(|entry| std::cmp::Reverse(entry.0));
         for (idx, success) in completed {
             let mut probe = self.in_flight.swap_remove(idx);
             probe.socket.deregister(registry);

--- a/sim/tests/tcp_preread_sim.rs
+++ b/sim/tests/tcp_preread_sim.rs
@@ -72,6 +72,31 @@
 //! A sweep that never exercises one of these classes fails loudly rather than
 //! silently under-covering the core.
 //!
+//! # Swarm configurations (Groce et al., "Swarm Testing", ISSTA 2012)
+//!
+//! Each seed draws a [`SwarmConfig`] from the seeded RNG BEFORE the first
+//! connection: a random subset of the scenario generators (50% inclusion
+//! each, weights renormalized) plus the one genuinely orthogonal
+//! `fragmentation` delivery axis (off -- every delivery is one-shot and the
+//! forced drip generator leaves the pool). `SniPrereadCore` is fresh per
+//! connection, so no generator can suppress another across connections --
+//! the swarm benefit here is the paper's PASSIVE COMPETITION: a seed running
+//! 6 generator classes explores each far deeper within its connection budget
+//! than one running all 25. The other ClientHello axes (SNI shape, ALPN,
+//! GREASE, ECH, multi-record, proxy prefix) are embodied by their carrier
+//! generators -- toggling one inside a directed generator would invalidate
+//! its expected terminal. One seed in four keeps the inclusive all-features
+//! configuration, an all-off draw collapses to it, and the low-probability
+//! buggify byte-flip stays always-on (it is a wire-level fault, not a
+//! grammar feature). The drawn configuration is a pure function of the seed
+//! and is printed as one canonical `swarm-config` line before the
+//! connections run. The per-class coverage gate is asserted on the MERGED
+//! campaign tally (as before): a single swarm seed legitimately cannot reach
+//! every class, but the sweep still must. `SOZU_SIM_SWARM=0` disables the
+//! draw entirely (zero extra RNG consumption -- byte-identical to the
+//! historical all-features grammar) for direct swarm-vs-inclusive campaign
+//! comparison.
+//!
 //! # Replay / sweep ergonomics
 //!
 //! - `SOZU_TCP_PREREAD_SIM_SEED=<u64|0xhex>` -- replay that ONE seed verbosely.
@@ -79,6 +104,8 @@
 //! - `SOZU_TCP_PREREAD_SIM_STEPS=<n>` -- connections simulated PER SEED
 //!   (default 48; kept modest because a connection's cost is dominated by its
 //!   fragmentation schedule, not by a fixed per-step cost like the UDP sim).
+//! - `SOZU_SIM_SWARM=0|1` -- draw per-seed swarm configurations (default `1`;
+//!   `0` pins every seed to the historical all-features configuration).
 //!
 //! [moonpool-sim]: https://crates.io/crates/moonpool-sim
 //! [`udp_simulation.rs`]: ../../sim/tests/udp_simulation.rs
@@ -876,37 +903,185 @@ fn gen_random_mutation_chaos(ctx: &SimContext) -> Scenario {
     s
 }
 
-/// Draw a weighted-random scenario (weights sum to 134). Every required
-/// coverage class has a dedicated, non-zero-weight generator so reachability
-/// never depends on pure luck; `RandomMutationChaos` soaks up the remainder.
-fn generate_scenario(ctx: &SimContext) -> Scenario {
-    match ctx.random().random_range(0..134u32) {
-        0..10 => gen_accept_exact_any(ctx),
-        10..18 => gen_accept_wildcard(ctx),
-        18..26 => gen_accept_alpn_first_pref(ctx),
-        26..32 => gen_accept_alpn_catch_all(ctx),
-        32..37 => gen_accept_no_alpn_catch_all(ctx),
-        37..42 => gen_accept_mixed_case(ctx),
-        42..47 => gen_accept_trailing_dot(ctx),
-        47..51 => gen_accept_with_grease(ctx),
-        51..57 => gen_accept_multi_record(ctx),
-        57..63 => gen_accept_one_byte_drip(ctx),
-        63..69 => gen_sni_unmatched(ctx),
-        69..75 => gen_alpn_unmatched(ctx),
-        75..80 => gen_no_sni(ctx),
-        80..85 => gen_ech_outer_absent(ctx),
-        85..90 => gen_not_tls(ctx),
-        90..93 => gen_malformed_record_oversized(ctx),
-        93..96 => gen_malformed_record_mid_reassembly(ctx),
-        96..100 => gen_malformed_handshake(ctx),
-        100..104 => gen_too_large(ctx),
-        104..108 => gen_complete_over_cap_routes(ctx),
-        108..111 => gen_proxy_header_invalid(ctx),
-        111..115 => gen_proxy_prefixed_valid(ctx),
-        115..120 => gen_fragmented_timeout(ctx),
-        120..124 => gen_front_closed_now(ctx),
-        _ => gen_random_mutation_chaos(ctx),
+/// One scenario generator: display tag, generating function, grammar weight.
+type GeneratorEntry = (&'static str, fn(&SimContext) -> Scenario, u32);
+
+/// The weighted generator grammar (weights sum to 134), in the EXACT dispatch
+/// order of the pre-swarm `0..134` `match`: a cumulative walk over this table
+/// with every generator enabled maps each roll to the same generator the
+/// historical grammar did, so an all-features configuration stays
+/// draw-identical to the pre-swarm harness.
+///
+/// Swarm classification (see `doc/testing.md`): every generator is OPTIONAL
+/// -- `SniPrereadCore` is fresh per connection, so no generator can suppress
+/// another and no generator is load-bearing for a per-seed invariant. The
+/// per-class coverage gate runs on the merged campaign tally, where the
+/// inclusive seeds (1 in 4) plus each generator's ~50% seed population keep
+/// every class reachable many times over. Index 9 (`accept_one_byte_drip`)
+/// additionally requires the `fragmentation` axis (see [`SwarmConfig`]).
+const GENERATOR_TABLE: [GeneratorEntry; 25] = [
+    ("accept_exact_any", gen_accept_exact_any, 10),
+    ("accept_wildcard", gen_accept_wildcard, 8),
+    ("accept_alpn_first_pref", gen_accept_alpn_first_pref, 8),
+    ("accept_alpn_catch_all", gen_accept_alpn_catch_all, 6),
+    ("accept_no_alpn_catch_all", gen_accept_no_alpn_catch_all, 5),
+    ("accept_mixed_case_sni", gen_accept_mixed_case, 5),
+    ("accept_trailing_dot_sni", gen_accept_trailing_dot, 5),
+    ("accept_with_grease", gen_accept_with_grease, 4),
+    ("accept_multi_record", gen_accept_multi_record, 6),
+    ("accept_one_byte_drip", gen_accept_one_byte_drip, 6),
+    ("sni_unmatched", gen_sni_unmatched, 6),
+    ("alpn_unmatched", gen_alpn_unmatched, 6),
+    ("no_sni", gen_no_sni, 5),
+    ("ech_outer_absent", gen_ech_outer_absent, 5),
+    ("not_tls", gen_not_tls, 5),
+    (
+        "malformed_record_oversized",
+        gen_malformed_record_oversized,
+        3,
+    ),
+    (
+        "malformed_record_mid_reassembly",
+        gen_malformed_record_mid_reassembly,
+        3,
+    ),
+    ("malformed_handshake_wrong_type", gen_malformed_handshake, 4),
+    ("too_large", gen_too_large, 4),
+    ("complete_over_cap_routes", gen_complete_over_cap_routes, 4),
+    ("proxy_header_invalid", gen_proxy_header_invalid, 3),
+    ("proxy_prefixed_valid", gen_proxy_prefixed_valid, 4),
+    ("fragmented_timeout", gen_fragmented_timeout, 5),
+    ("front_closed_now", gen_front_closed_now, 4),
+    ("random_mutation_chaos", gen_random_mutation_chaos, 10),
+];
+
+/// Index of `accept_one_byte_drip` in [`GENERATOR_TABLE`] -- the one
+/// generator that depends on the `fragmentation` axis.
+const ONE_BYTE_DRIP_IDX: usize = 9;
+
+/// Per-seed swarm configuration: which scenario generators this seed may
+/// draw, plus the orthogonal fragmentation-delivery axis.
+/// `enabled[i]` mirrors `GENERATOR_TABLE[i]`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct SwarmConfig {
+    enabled: [bool; 25],
+    /// When `false`, every delivery collapses to [`Delivery::OneShot`] and
+    /// the forced drip generator is excluded from the pool -- the seed
+    /// explores whole-window parsing exclusively.
+    fragmentation: bool,
+}
+
+/// `SOZU_SIM_SWARM=0` disables per-seed swarm draws (every seed then runs the
+/// historical all-features configuration with zero extra RNG consumption);
+/// unset or any other value leaves swarm on.
+fn swarm_enabled() -> bool {
+    !matches!(std::env::var("SOZU_SIM_SWARM"), Ok(v) if v.trim() == "0")
+}
+
+impl SwarmConfig {
+    /// The inclusive all-features configuration (`C_D` in the paper).
+    fn full() -> Self {
+        SwarmConfig {
+            enabled: [true; 25],
+            fragmentation: true,
+        }
     }
+
+    /// Draw this seed's configuration from the seeded RNG. One seed in four
+    /// keeps the inclusive configuration; the rest coin-toss each generator
+    /// and the fragmentation axis at 50%, exclude the drip generator when
+    /// fragmentation is off, and collapse an empty pool back to the full
+    /// configuration (the non-empty-subset rule).
+    fn draw(ctx: &SimContext) -> Self {
+        if ctx.random().random_range(0..4u32) == 0 {
+            return SwarmConfig::full();
+        }
+        let mut enabled = [false; 25];
+        for slot in enabled.iter_mut() {
+            *slot = ctx.random().random_bool(0.5);
+        }
+        let fragmentation = ctx.random().random_bool(0.5);
+        if !fragmentation {
+            enabled[ONE_BYTE_DRIP_IDX] = false;
+        }
+        if !enabled.iter().any(|e| *e) {
+            return SwarmConfig::full();
+        }
+        let cfg = SwarmConfig {
+            enabled,
+            fragmentation,
+        };
+        debug_assert!(cfg.total_weight() > 0, "a drawn pool is never empty");
+        debug_assert!(
+            cfg.fragmentation || !cfg.enabled[ONE_BYTE_DRIP_IDX],
+            "the drip generator requires the fragmentation axis"
+        );
+        cfg
+    }
+
+    /// Renormalized total weight over the enabled generators.
+    fn total_weight(&self) -> u32 {
+        GENERATOR_TABLE
+            .iter()
+            .zip(&self.enabled)
+            .filter(|(_, e)| **e)
+            .map(|((_, _, w), _)| *w)
+            .sum()
+    }
+
+    /// The canonical one-line configuration record, printed before the
+    /// connections run. Byte-identical across replays of the same seed -- a
+    /// failing seed whose configuration is not printed is not reproducible.
+    fn log_line(&self, seed: u64, swarm: bool) -> String {
+        let mode = if !swarm {
+            "off"
+        } else if self.enabled.iter().all(|e| *e) && self.fragmentation {
+            "full"
+        } else {
+            "subset"
+        };
+        let features: Vec<String> = GENERATOR_TABLE
+            .iter()
+            .zip(&self.enabled)
+            .filter(|(_, e)| **e)
+            .map(|((tag, _, w), _)| format!("{tag}:{w}"))
+            .collect();
+        format!(
+            "swarm-config sim=tcp_preread seed={seed:#x} mode={mode} fragmentation={} \
+             features=[{}] total_weight={}",
+            if self.fragmentation { "on" } else { "off" },
+            features.join(","),
+            self.total_weight(),
+        )
+    }
+}
+
+/// Draw a weighted-random scenario among the configuration's enabled
+/// generators: exactly ONE `random_range` draw over the renormalized total,
+/// then a cumulative walk in `GENERATOR_TABLE` order. With every generator
+/// enabled this consumes the same single draw and maps rolls to generators
+/// exactly as the historical `0..134` `match` did. Every required coverage
+/// class has a dedicated, non-zero-weight generator so campaign reachability
+/// never depends on pure luck; `random_mutation_chaos` soaks up the
+/// remainder. With the fragmentation axis off the scenario's delivery
+/// collapses to one-shot.
+fn generate_scenario(ctx: &SimContext, cfg: &SwarmConfig) -> Scenario {
+    let roll = ctx.random().random_range(0..cfg.total_weight());
+    let mut remaining = roll;
+    for ((_, generate, weight), enabled) in GENERATOR_TABLE.iter().zip(&cfg.enabled) {
+        if !enabled {
+            continue;
+        }
+        if remaining < *weight {
+            let mut scenario = generate(ctx);
+            if !cfg.fragmentation {
+                scenario.delivery = Delivery::OneShot;
+            }
+            return scenario;
+        }
+        remaining -= weight;
+    }
+    unreachable!("roll {roll} below the renormalized total always lands on an enabled generator")
 }
 
 // --------------------------------------------------------------------------
@@ -1308,12 +1483,19 @@ fn fold_fingerprint(acc: u64, out: &Output) -> u64 {
 type CoverageSink = Arc<Mutex<CoverageTally>>;
 /// One aggregate per-seed fingerprint pushed here, for the determinism guard.
 type FingerprintSink = Arc<Mutex<Vec<u64>>>;
+/// Optional sink for the swarm-config stability guard: the configuration
+/// drawn for each seed is pushed here so two runs can be compared.
+type ConfigSink = Arc<Mutex<Vec<SwarmConfig>>>;
 
 struct TcpPrereadSimWorkload {
     connections: usize,
     verbose: bool,
     coverage: Option<CoverageSink>,
     fingerprint_sink: Option<FingerprintSink>,
+    /// `true` draws a per-seed [`SwarmConfig`]; `false` pins the historical
+    /// all-features configuration with zero extra RNG consumption.
+    swarm: bool,
+    config_sink: Option<ConfigSink>,
 }
 
 #[async_trait]
@@ -1327,11 +1509,26 @@ impl Workload for TcpPrereadSimWorkload {
         let base = Instant::now();
         let routes = build_route_table();
 
+        // Swarm configuration: drawn from the seeded RNG BEFORE the first
+        // connection (a pure function of the seed), and printed before the
+        // connections run so a failing seed's configuration is always in
+        // the captured output. With swarm off, no RNG draw happens at all —
+        // the run is byte-identical to the historical all-features grammar.
+        let swarm_cfg = if self.swarm {
+            SwarmConfig::draw(ctx)
+        } else {
+            SwarmConfig::full()
+        };
+        eprintln!("{}", swarm_cfg.log_line(seed, self.swarm));
+        if let Some(sink) = &self.config_sink {
+            sink.lock().unwrap().push(swarm_cfg);
+        }
+
         let mut local = CoverageTally::default();
         let mut fp: u64 = 0xcbf29ce484222325;
 
         for i in 0..self.connections {
-            let mut scenario = generate_scenario(ctx);
+            let mut scenario = generate_scenario(ctx, &swarm_cfg);
             // Buggify: low-probability extra adversarial mutation, using
             // moonpool's fault-injection primitive. The directed expectation
             // is cleared unconditionally -- a flipped byte can change which
@@ -1440,12 +1637,14 @@ fn assert_no_failures(report: &SimulationReport) {
 #[test]
 fn tcp_preread_simulation_seed_sweep() {
     let connections = env_usize("SOZU_TCP_PREREAD_SIM_STEPS").unwrap_or(48);
+    let swarm = swarm_enabled();
 
     // Single-seed replay mode: no coverage gate (one seed need not reach
     // every class -- it's a debugging tool, not the sweep).
     if let Some(seed) = env_u64("SOZU_TCP_PREREAD_SIM_SEED") {
         eprintln!(
-            "== TCP preread sim single-seed replay: seed={seed:#x} connections={connections} =="
+            "== TCP preread sim single-seed replay: seed={seed:#x} connections={connections} \
+             swarm={swarm} =="
         );
         let report = SimulationBuilder::new()
             .workload(TcpPrereadSimWorkload {
@@ -1453,6 +1652,8 @@ fn tcp_preread_simulation_seed_sweep() {
                 verbose: true,
                 coverage: None,
                 fingerprint_sink: None,
+                swarm,
+                config_sink: None,
             })
             .set_debug_seeds(vec![seed])
             // Without an explicit iteration count, `SimulationBuilder`
@@ -1475,6 +1676,8 @@ fn tcp_preread_simulation_seed_sweep() {
             verbose: false,
             coverage: Some(coverage.clone()),
             fingerprint_sink: None,
+            swarm,
+            config_sink: None,
         })
         .set_iterations(seeds)
         .run_time_budget(run_budget(connections))
@@ -1489,7 +1692,10 @@ fn tcp_preread_simulation_seed_sweep() {
     tally.assert_full_coverage();
 }
 
-/// Fast smoke test pinning one representative seed.
+/// Fast smoke test pinning one representative seed. Swarm is off so the
+/// pinned trajectory stays byte-identical to the pre-swarm harness (no
+/// config draw touches the RNG stream) and the smoke test keeps exercising
+/// the full grammar.
 #[test]
 fn tcp_preread_simulation_replays_known_seed() {
     let connections = 64;
@@ -1499,6 +1705,8 @@ fn tcp_preread_simulation_replays_known_seed() {
             verbose: false,
             coverage: None,
             fingerprint_sink: None,
+            swarm: false,
+            config_sink: None,
         })
         .set_debug_seeds(vec![0xFEED_ACE5])
         .set_iterations(1)
@@ -1523,6 +1731,10 @@ fn tcp_preread_simulation_is_deterministic() {
                 verbose: false,
                 coverage: None,
                 fingerprint_sink: Some(sink.clone()),
+                // Swarm stays ON here: the guard then also covers the config
+                // draw itself (a nondeterministic draw would fork the trace).
+                swarm: true,
+                config_sink: None,
             })
             .set_debug_seeds(vec![seed])
             .set_iterations(1)
@@ -1539,6 +1751,48 @@ fn tcp_preread_simulation_is_deterministic() {
         a, b,
         "same seed must yield an identical trace (determinism)"
     );
+}
+
+/// Swarm-config stability: the configuration drawn for a seed is a pure
+/// function of that seed. Two fresh runs of the same seed must record the
+/// identical [`SwarmConfig`] (and therefore print a byte-identical
+/// `swarm-config` line -- the replay contract).
+#[test]
+fn tcp_swarm_config_is_stable_across_draws() {
+    fn draw(seed: u64) -> SwarmConfig {
+        let connections = 4;
+        let sink: ConfigSink = Arc::new(Mutex::new(Vec::new()));
+        let report = SimulationBuilder::new()
+            .workload(TcpPrereadSimWorkload {
+                connections,
+                verbose: false,
+                coverage: None,
+                fingerprint_sink: None,
+                swarm: true,
+                config_sink: Some(sink.clone()),
+            })
+            .set_debug_seeds(vec![seed])
+            .set_iterations(1)
+            .run_time_budget(run_budget(connections))
+            .run();
+        assert_no_failures(&report);
+        let v = sink.lock().unwrap();
+        *v.first().expect("workload recorded a swarm config")
+    }
+
+    // Several seeds so both the 1-in-4 full draw and subset draws are hit.
+    for seed in [0x0Au64, 0x0B, 0x5EED_5EED, 0xDEAD_BEEF] {
+        let a = draw(seed);
+        let b = draw(seed);
+        assert_eq!(
+            a, b,
+            "seed={seed:#x}: swarm config must be identical across two draws"
+        );
+        assert!(
+            a.fragmentation || !a.enabled[ONE_BYTE_DRIP_IDX],
+            "seed={seed:#x}: the drip generator must be excluded when fragmentation is off"
+        );
+    }
 }
 
 #[test]

--- a/sim/tests/tcp_preread_sim.rs
+++ b/sim/tests/tcp_preread_sim.rs
@@ -85,11 +85,13 @@
 //! than one running all 25. The other ClientHello axes (SNI shape, ALPN,
 //! GREASE, ECH, multi-record, proxy prefix) are embodied by their carrier
 //! generators -- toggling one inside a directed generator would invalidate
-//! its expected terminal. One seed in four keeps the inclusive all-features
-//! configuration, an all-off draw collapses to it, and the low-probability
-//! buggify byte-flip stays always-on (it is a wire-level fault, not a
-//! grammar feature). The drawn configuration is a pure function of the seed
-//! and is printed as one canonical `swarm-config` line before the
+//! its expected terminal. Seeds divisible by four keep the inclusive
+//! all-features configuration; campaign seeds are fixed to `0..n`, reserving
+//! exactly one inclusive run in each four-seed cohort. Degenerate all-off and
+//! all-on subset draws are repaired to non-empty proper subsets. The
+//! low-probability buggify byte-flip stays always-on (it is a wire-level fault,
+//! not a grammar feature). The drawn configuration is a pure function of the
+//! seed and is printed as one canonical `swarm-config` line before the
 //! connections run. The per-class coverage gate is asserted on the MERGED
 //! campaign tally (as before): a single swarm seed legitimately cannot reach
 //! every class, but the sweep still must. `SOZU_SIM_SWARM=0` disables the
@@ -978,6 +980,14 @@ fn swarm_enabled() -> bool {
     !matches!(std::env::var("SOZU_SIM_SWARM"), Ok(v) if v.trim() == "0")
 }
 
+fn inclusive_seed(seed: u64) -> bool {
+    seed.is_multiple_of(4)
+}
+
+fn campaign_seeds(count: usize) -> Vec<u64> {
+    (0..u64::try_from(count).expect("campaign seed count fits in u64")).collect()
+}
+
 impl SwarmConfig {
     /// The inclusive all-features configuration (`C_D` in the paper).
     fn full() -> Self {
@@ -987,13 +997,12 @@ impl SwarmConfig {
         }
     }
 
-    /// Draw this seed's configuration from the seeded RNG. One seed in four
-    /// keeps the inclusive configuration; the rest coin-toss each generator
+    /// Draw this seed's configuration from the seeded RNG. Seeds divisible by
+    /// four keep the inclusive configuration; the rest coin-toss each generator
     /// and the fragmentation axis at 50%, exclude the drip generator when
-    /// fragmentation is off, and collapse an empty pool back to the full
-    /// configuration (the non-empty-subset rule).
-    fn draw(ctx: &SimContext) -> Self {
-        if ctx.random().random_range(0..4u32) == 0 {
+    /// fragmentation is off, and repair all-off/all-on draws to proper subsets.
+    fn draw(ctx: &SimContext, seed: u64) -> Self {
+        if inclusive_seed(seed) {
             return SwarmConfig::full();
         }
         let mut enabled = [false; 25];
@@ -1005,7 +1014,9 @@ impl SwarmConfig {
             enabled[ONE_BYTE_DRIP_IDX] = false;
         }
         if !enabled.iter().any(|e| *e) {
-            return SwarmConfig::full();
+            enabled[0] = true;
+        } else if fragmentation && enabled.iter().all(|e| *e) {
+            enabled[24] = false;
         }
         let cfg = SwarmConfig {
             enabled,
@@ -1015,6 +1026,10 @@ impl SwarmConfig {
         debug_assert!(
             cfg.fragmentation || !cfg.enabled[ONE_BYTE_DRIP_IDX],
             "the drip generator requires the fragmentation axis"
+        );
+        debug_assert!(
+            !(cfg.fragmentation && cfg.enabled.iter().all(|e| *e)),
+            "a non-reserved seed must use a proper subset"
         );
         cfg
     }
@@ -1515,7 +1530,7 @@ impl Workload for TcpPrereadSimWorkload {
         // the captured output. With swarm off, no RNG draw happens at all —
         // the run is byte-identical to the historical all-features grammar.
         let swarm_cfg = if self.swarm {
-            SwarmConfig::draw(ctx)
+            SwarmConfig::draw(ctx, seed)
         } else {
             SwarmConfig::full()
         };
@@ -1679,6 +1694,7 @@ fn tcp_preread_simulation_seed_sweep() {
             swarm,
             config_sink: None,
         })
+        .set_debug_seeds(campaign_seeds(seeds))
         .set_iterations(seeds)
         .run_time_budget(run_budget(connections))
         .run();
@@ -1780,8 +1796,8 @@ fn tcp_swarm_config_is_stable_across_draws() {
         *v.first().expect("workload recorded a swarm config")
     }
 
-    // Several seeds so both the 1-in-4 full draw and subset draws are hit.
-    for seed in [0x0Au64, 0x0B, 0x5EED_5EED, 0xDEAD_BEEF] {
+    // Several seeds so both the reserved full configuration and subsets are hit.
+    for seed in [0x0Au64, 0x0B, 0x0C, 0x5EED_5EED, 0xDEAD_BEEF] {
         let a = draw(seed);
         let b = draw(seed);
         assert_eq!(
@@ -1792,6 +1808,22 @@ fn tcp_swarm_config_is_stable_across_draws() {
             a.fragmentation || !a.enabled[ONE_BYTE_DRIP_IDX],
             "seed={seed:#x}: the drip generator must be excluded when fragmentation is off"
         );
+        assert_eq!(
+            a.fragmentation && a.enabled.iter().all(|e| *e),
+            inclusive_seed(seed),
+            "seed={seed:#x}: only reserved seeds may use the full grammar"
+        );
+        assert_eq!(a.log_line(seed, true), b.log_line(seed, true));
+    }
+}
+
+#[test]
+fn tcp_campaign_reserves_one_inclusive_seed_per_four() {
+    for count in [1usize, 3, 4, 5, 256] {
+        let seeds = campaign_seeds(count);
+        let inclusive = seeds.iter().filter(|seed| inclusive_seed(**seed)).count();
+        assert_eq!(inclusive, count.div_ceil(4), "count={count}");
+        assert_eq!(seeds.len() - inclusive, count - count.div_ceil(4));
     }
 }
 

--- a/sim/tests/udp_simulation.rs
+++ b/sim/tests/udp_simulation.rs
@@ -34,11 +34,14 @@
 //! `CloseAll`, `AbortFlow`, `SetMaxFlows` — each repairs or prevents the very
 //! full-table state a capacity bug needs) lets a seed drive the manager into
 //! states the all-features grammar repairs too eagerly; omitting other
-//! features concentrates the step budget on the survivors. One seed in four
-//! keeps the inclusive all-features configuration (the paper is explicit that
-//! swarm subsets complement, never replace, it: a bug needing `k` features
-//! together appears in a coin-toss subset with probability `1/2^k`), and an
-//! all-off draw collapses to the full configuration. Each buggify arm is
+//! features concentrates the step budget on the survivors. Seeds divisible
+//! by four keep the inclusive all-features configuration (the paper is
+//! explicit that swarm subsets complement, never replace, it: a bug needing
+//! `k` features together appears in a coin-toss subset with probability
+//! `1/2^k`); campaign seeds are fixed to `0..n`, which reserves exactly one
+//! inclusive run in each four-seed cohort. Degenerate all-off and all-on subset
+//! draws are repaired to
+//! non-empty proper subsets. Each buggify arm is
 //! gated by its sibling grammar feature and skipped (never redrawn) when that
 //! feature is disabled. The drawn configuration is a pure function of the
 //! seed and is printed as one canonical `swarm-config` line before the
@@ -251,6 +254,14 @@ fn swarm_enabled() -> bool {
     !matches!(std::env::var("SOZU_SIM_SWARM"), Ok(v) if v.trim() == "0")
 }
 
+fn inclusive_seed(seed: u64) -> bool {
+    seed.is_multiple_of(4)
+}
+
+fn campaign_seeds(count: usize) -> Vec<u64> {
+    (0..u64::try_from(count).expect("campaign seed count fits in u64")).collect()
+}
+
 impl SwarmConfig {
     /// The inclusive all-features configuration (`C_D` in the paper).
     fn full() -> Self {
@@ -259,13 +270,12 @@ impl SwarmConfig {
         }
     }
 
-    /// Draw this seed's configuration from the seeded RNG. One seed in four
-    /// keeps the inclusive configuration; the rest coin-toss each
+    /// Draw this seed's configuration from the seeded RNG. Seeds divisible by
+    /// four keep the inclusive configuration; the rest coin-toss each
     /// OPTIONAL/SUPPRESSOR feature at 50%, always retain the MANDATORY
-    /// `ClientDatagram`, and collapse an all-off draw back to the full
-    /// configuration (the non-empty-subset rule).
-    fn draw(ctx: &SimContext) -> Self {
-        if ctx.random().random_range(0..4u32) == 0 {
+    /// `ClientDatagram`, and repair all-off/all-on draws to proper subsets.
+    fn draw(ctx: &SimContext, seed: u64) -> Self {
+        if inclusive_seed(seed) {
             return SwarmConfig::full();
         }
         let mut enabled = [false; 10];
@@ -274,13 +284,19 @@ impl SwarmConfig {
             *slot = ctx.random().random_bool(0.5);
         }
         if !enabled.iter().skip(1).any(|e| *e) {
-            return SwarmConfig::full();
+            enabled[1] = true;
+        } else if enabled.iter().all(|e| *e) {
+            enabled[9] = false;
         }
         let cfg = SwarmConfig { enabled };
         debug_assert!(cfg.enabled[0], "the MANDATORY feature must stay enabled");
         debug_assert!(
             cfg.total_weight() > ACTION_TABLE[0].1,
             "a drawn subset keeps at least one optional feature"
+        );
+        debug_assert!(
+            !cfg.enabled.iter().all(|e| *e),
+            "a non-reserved seed must use a proper subset"
         );
         cfg
     }
@@ -431,7 +447,7 @@ impl Workload for UdpSimWorkload {
         // captured output. With swarm off, no RNG draw happens at all — the
         // run is byte-identical to the historical all-features grammar.
         let swarm_cfg = if self.swarm {
-            SwarmConfig::draw(ctx)
+            SwarmConfig::draw(ctx, seed)
         } else {
             SwarmConfig::full()
         };
@@ -818,6 +834,7 @@ fn udp_simulation_seed_sweep() {
             swarm,
             config_sink: None,
         })
+        .set_debug_seeds(campaign_seeds(seeds))
         .set_iterations(seeds)
         .run_time_budget(run_budget(steps))
         .run();
@@ -913,8 +930,8 @@ fn udp_swarm_config_is_stable_across_draws() {
         *v.first().expect("workload recorded a swarm config")
     }
 
-    // Several seeds so both the 1-in-4 full draw and subset draws are hit.
-    for seed in [0x0Au64, 0x0B, 0x5EED_5EED, 0xDEAD_BEEF] {
+    // Several seeds so both the reserved full configuration and subsets are hit.
+    for seed in [0x0Au64, 0x0B, 0x0C, 0x5EED_5EED, 0xDEAD_BEEF] {
         let a = draw(seed);
         let b = draw(seed);
         assert_eq!(
@@ -925,6 +942,22 @@ fn udp_swarm_config_is_stable_across_draws() {
             a.is_enabled(Action::ClientDatagram),
             "seed={seed:#x}: the MANDATORY ClientDatagram feature must always be enabled"
         );
+        assert_eq!(
+            a.enabled.iter().all(|e| *e),
+            inclusive_seed(seed),
+            "seed={seed:#x}: only reserved seeds may use the full grammar"
+        );
+        assert_eq!(a.log_line(seed, true), b.log_line(seed, true));
+    }
+}
+
+#[test]
+fn udp_campaign_reserves_one_inclusive_seed_per_four() {
+    for count in [1usize, 3, 4, 5, 256] {
+        let seeds = campaign_seeds(count);
+        let inclusive = seeds.iter().filter(|seed| inclusive_seed(**seed)).count();
+        assert_eq!(inclusive, count.div_ceil(4), "count={count}");
+        assert_eq!(seeds.len() - inclusive, count - count.div_ceil(4));
     }
 }
 

--- a/sim/tests/udp_simulation.rs
+++ b/sim/tests/udp_simulation.rs
@@ -25,11 +25,35 @@
 //! `Instant`s relatively, so the absolute base is irrelevant and observable
 //! outputs stay a pure function of the seed.
 //!
+//! # Swarm configurations (Groce et al., "Swarm Testing", ISSTA 2012)
+//!
+//! Each seed draws a [`SwarmConfig`] from the seeded RNG BEFORE the first
+//! operation: a random subset of the OPTIONAL/SUPPRESSOR grammar features
+//! (50% inclusion each), with the MANDATORY `ClientDatagram` always retained
+//! and the remaining weights renormalized. Omitting a SUPPRESSOR (`Drain`,
+//! `CloseAll`, `AbortFlow`, `SetMaxFlows` — each repairs or prevents the very
+//! full-table state a capacity bug needs) lets a seed drive the manager into
+//! states the all-features grammar repairs too eagerly; omitting other
+//! features concentrates the step budget on the survivors. One seed in four
+//! keeps the inclusive all-features configuration (the paper is explicit that
+//! swarm subsets complement, never replace, it: a bug needing `k` features
+//! together appears in a coin-toss subset with probability `1/2^k`), and an
+//! all-off draw collapses to the full configuration. Each buggify arm is
+//! gated by its sibling grammar feature and skipped (never redrawn) when that
+//! feature is disabled. The drawn configuration is a pure function of the
+//! seed and is printed as one canonical `swarm-config` line before the
+//! workload runs, so any failing seed's configuration is always in the
+//! captured output. `SOZU_SIM_SWARM=0` disables the draw entirely (zero extra
+//! RNG consumption — byte-identical to the historical all-features grammar)
+//! for direct swarm-vs-inclusive campaign comparison.
+//!
 //! # Replay / sweep ergonomics
 //!
 //! - `SOZU_UDP_SIM_SEED=<u64|0xhex>` — replay that ONE seed verbosely.
 //! - `SOZU_UDP_SIM_SEEDS=<n>` — sweep `n` iterations (default 256).
 //! - `SOZU_UDP_SIM_STEPS=<n>` — steps per seed (default 3000).
+//! - `SOZU_SIM_SWARM=0|1` — draw per-seed swarm configurations (default `1`;
+//!   `0` pins every seed to the historical all-features configuration).
 //!
 //! On a hard invariant violation the panic carries the failing seed (via
 //! `current_sim_seed`) + step; moonpool also records it in the report's
@@ -174,7 +198,7 @@ impl Model {
 // Workload grammar.
 // --------------------------------------------------------------------------
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Action {
     ClientDatagram,
     BackendDatagram,
@@ -188,22 +212,140 @@ enum Action {
     CloseAll,
 }
 
-/// Draw a weighted-random action (weights sum to 100), mirroring the handmade
-/// grammar so coverage is preserved.
-fn pick_action(ctx: &SimContext) -> Action {
-    let roll = ctx.random().random_range(0..100u32);
-    match roll {
-        0..34 => Action::ClientDatagram,
-        34..50 => Action::BackendResolved,
-        50..64 => Action::BackendDatagram,
-        64..78 => Action::AdvanceClock,
-        78..84 => Action::ReconfigCluster,
-        84..89 => Action::SetMaxFlows,
-        89..93 => Action::AbortFlow,
-        93..96 => Action::SetMaxRx,
-        96..98 => Action::Drain,
-        _ => Action::CloseAll,
+/// The weighted action grammar (weights sum to 100), in the EXACT dispatch
+/// order of the pre-swarm `0..100` `match`: a cumulative walk over this table
+/// with every feature enabled maps each roll to the same action the
+/// historical grammar did, so an all-features configuration stays
+/// draw-identical to the pre-swarm harness.
+///
+/// Swarm classification (see `doc/testing.md`): index 0 (`ClientDatagram`) is
+/// MANDATORY — it is the sole flow creator, and without it every shadow-model
+/// invariant is vacuously green. `Drain`, `CloseAll`, `AbortFlow`, and
+/// `SetMaxFlows` are SUPPRESSORS — each evicts flows, resets the manager, or
+/// sheds future admissions, repairing or preventing the very full-table state
+/// a capacity bug needs. The rest are OPTIONAL grammar features.
+const ACTION_TABLE: [(Action, u32); 10] = [
+    (Action::ClientDatagram, 34),
+    (Action::BackendResolved, 16),
+    (Action::BackendDatagram, 14),
+    (Action::AdvanceClock, 14),
+    (Action::ReconfigCluster, 6),
+    (Action::SetMaxFlows, 5),
+    (Action::AbortFlow, 4),
+    (Action::SetMaxRx, 3),
+    (Action::Drain, 2),
+    (Action::CloseAll, 2),
+];
+
+/// Per-seed swarm configuration: which grammar features this seed may draw.
+/// `enabled[i]` mirrors `ACTION_TABLE[i]`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct SwarmConfig {
+    enabled: [bool; 10],
+}
+
+/// `SOZU_SIM_SWARM=0` disables per-seed swarm draws (every seed then runs the
+/// historical all-features configuration with zero extra RNG consumption);
+/// unset or any other value leaves swarm on.
+fn swarm_enabled() -> bool {
+    !matches!(std::env::var("SOZU_SIM_SWARM"), Ok(v) if v.trim() == "0")
+}
+
+impl SwarmConfig {
+    /// The inclusive all-features configuration (`C_D` in the paper).
+    fn full() -> Self {
+        SwarmConfig {
+            enabled: [true; 10],
+        }
     }
+
+    /// Draw this seed's configuration from the seeded RNG. One seed in four
+    /// keeps the inclusive configuration; the rest coin-toss each
+    /// OPTIONAL/SUPPRESSOR feature at 50%, always retain the MANDATORY
+    /// `ClientDatagram`, and collapse an all-off draw back to the full
+    /// configuration (the non-empty-subset rule).
+    fn draw(ctx: &SimContext) -> Self {
+        if ctx.random().random_range(0..4u32) == 0 {
+            return SwarmConfig::full();
+        }
+        let mut enabled = [false; 10];
+        enabled[0] = true; // ClientDatagram is MANDATORY.
+        for slot in enabled.iter_mut().skip(1) {
+            *slot = ctx.random().random_bool(0.5);
+        }
+        if !enabled.iter().skip(1).any(|e| *e) {
+            return SwarmConfig::full();
+        }
+        let cfg = SwarmConfig { enabled };
+        debug_assert!(cfg.enabled[0], "the MANDATORY feature must stay enabled");
+        debug_assert!(
+            cfg.total_weight() > ACTION_TABLE[0].1,
+            "a drawn subset keeps at least one optional feature"
+        );
+        cfg
+    }
+
+    fn is_enabled(&self, action: Action) -> bool {
+        ACTION_TABLE
+            .iter()
+            .zip(&self.enabled)
+            .find(|((a, _), _)| *a == action)
+            .is_some_and(|(_, e)| *e)
+    }
+
+    /// Renormalized total weight over the enabled features.
+    fn total_weight(&self) -> u32 {
+        ACTION_TABLE
+            .iter()
+            .zip(&self.enabled)
+            .filter(|(_, e)| **e)
+            .map(|((_, w), _)| *w)
+            .sum()
+    }
+
+    /// The canonical one-line configuration record, printed before the
+    /// workload runs. Byte-identical across replays of the same seed — a
+    /// failing seed whose configuration is not printed is not reproducible.
+    fn log_line(&self, seed: u64, swarm: bool) -> String {
+        let mode = if !swarm {
+            "off"
+        } else if self.enabled.iter().all(|e| *e) {
+            "full"
+        } else {
+            "subset"
+        };
+        let features: Vec<String> = ACTION_TABLE
+            .iter()
+            .zip(&self.enabled)
+            .filter(|(_, e)| **e)
+            .map(|((a, w), _)| format!("{a:?}:{w}"))
+            .collect();
+        format!(
+            "swarm-config sim=udp seed={seed:#x} mode={mode} features=[{}] total_weight={}",
+            features.join(","),
+            self.total_weight(),
+        )
+    }
+}
+
+/// Draw a weighted-random action among the configuration's enabled features:
+/// exactly ONE `random_range` draw over the renormalized total, then a
+/// cumulative walk in `ACTION_TABLE` order. With every feature enabled this
+/// consumes the same single draw and maps rolls to actions exactly as the
+/// historical `0..100` `match` did.
+fn pick_action(ctx: &SimContext, cfg: &SwarmConfig) -> Action {
+    let roll = ctx.random().random_range(0..cfg.total_weight());
+    let mut remaining = roll;
+    for ((action, weight), enabled) in ACTION_TABLE.iter().zip(&cfg.enabled) {
+        if !enabled {
+            continue;
+        }
+        if remaining < *weight {
+            return *action;
+        }
+        remaining -= weight;
+    }
+    unreachable!("roll {roll} below the renormalized total always lands on an enabled action")
 }
 
 /// A randomized cluster config (non-empty cluster name unless `allow_empty`).
@@ -256,11 +398,18 @@ fn random_payload(ctx: &SimContext, max_rx: usize) -> Vec<u8> {
 /// Optional sink for the determinism guard: the final `(created, evicted, shed)`
 /// tally is pushed here so two runs of the same seed can be compared.
 type FingerprintSink = Arc<Mutex<Vec<(u64, u64, u64)>>>;
+/// Optional sink for the swarm-config stability guard: the configuration
+/// drawn for each seed is pushed here so two runs can be compared.
+type ConfigSink = Arc<Mutex<Vec<SwarmConfig>>>;
 
 struct UdpSimWorkload {
     steps: usize,
     verbose: bool,
     sink: Option<FingerprintSink>,
+    /// `true` draws a per-seed [`SwarmConfig`]; `false` pins the historical
+    /// all-features configuration with zero extra RNG consumption.
+    swarm: bool,
+    config_sink: Option<ConfigSink>,
 }
 
 #[async_trait]
@@ -276,6 +425,21 @@ impl Workload for UdpSimWorkload {
         let base = Instant::now();
         let now = |ctx: &SimContext| base + ctx.time().now();
 
+        // Swarm configuration: drawn from the seeded RNG BEFORE the first
+        // operation (a pure function of the seed), and printed before the
+        // workload runs so a failing seed's configuration is always in the
+        // captured output. With swarm off, no RNG draw happens at all — the
+        // run is byte-identical to the historical all-features grammar.
+        let swarm_cfg = if self.swarm {
+            SwarmConfig::draw(ctx)
+        } else {
+            SwarmConfig::full()
+        };
+        eprintln!("{}", swarm_cfg.log_line(seed, self.swarm));
+        if let Some(sink) = &self.config_sink {
+            sink.lock().unwrap().push(swarm_cfg);
+        }
+
         let initial_cap = ctx.random().random_range(1..32usize);
         let initial_max_rx = 1500usize;
         let cluster = random_cluster(ctx, false);
@@ -288,7 +452,7 @@ impl Workload for UdpSimWorkload {
         model.check(&mut mgr, 0, "init");
 
         for step in 1..=self.steps {
-            let action = pick_action(ctx);
+            let action = pick_action(ctx, &swarm_cfg);
             if self.verbose && step % 500 == 0 {
                 eprintln!(
                     "seed={seed:#x} step={step} action={action:?} flows={} created={} evicted={}",
@@ -452,47 +616,59 @@ impl Workload for UdpSimWorkload {
             }
 
             // Buggify: low-probability extra adversarial events, using
-            // moonpool's fault-injection primitive.
+            // moonpool's fault-injection primitive. Each arm is gated by its
+            // sibling grammar feature so a swarm subset omits the fault along
+            // with the feature; a disabled arm is skipped (never redrawn),
+            // keeping the draw sequence a pure function of (seed, config).
             if buggify_with_prob!(0.02) {
-                match ctx.random().random_range(0..4u8) {
-                    0 => {
-                        let flow = ctx.random().random_range(0..128usize);
-                        let (backend, addr) = pooled_backend(ctx);
-                        mgr.handle_input(
-                            ManagerInput::BackendResolved {
-                                flow,
-                                backend,
-                                addr,
-                            },
-                            now(ctx),
-                        );
-                    }
-                    1 => {
-                        for _ in 0..ctx.random().random_range(2..6u8) {
-                            let cfg = random_cluster(ctx, true);
+                let arm = ctx.random().random_range(0..4u8);
+                let arm_feature = match arm {
+                    0 => Action::BackendResolved,
+                    1 => Action::ReconfigCluster,
+                    2 => Action::SetMaxFlows,
+                    _ => Action::AdvanceClock,
+                };
+                if swarm_cfg.is_enabled(arm_feature) {
+                    match arm {
+                        0 => {
+                            let flow = ctx.random().random_range(0..128usize);
+                            let (backend, addr) = pooled_backend(ctx);
                             mgr.handle_input(
-                                ManagerInput::Config(ConfigEvent::SetCluster(cfg)),
+                                ManagerInput::BackendResolved {
+                                    flow,
+                                    backend,
+                                    addr,
+                                },
                                 now(ctx),
                             );
                         }
-                    }
-                    2 => {
-                        let n = ctx.random().random_range(0..2usize);
-                        model.cap_high_water = model.cap_high_water.max(n);
-                        mgr.handle_input(
-                            ManagerInput::Config(ConfigEvent::SetMaxFlows(n)),
-                            now(ctx),
-                        );
-                    }
-                    _ => {
-                        // Giant jump relative to the 5s max idle timeout (so it
-                        // mass-reaps), but bounded so the run stays within
-                        // moonpool's simulated-time budget over a deep sweep.
-                        let _ = ctx
-                            .time()
-                            .sleep(Duration::from_secs(ctx.random().random_range(10..60)))
-                            .await;
-                        mgr.handle_timeout(now(ctx));
+                        1 => {
+                            for _ in 0..ctx.random().random_range(2..6u8) {
+                                let cfg = random_cluster(ctx, true);
+                                mgr.handle_input(
+                                    ManagerInput::Config(ConfigEvent::SetCluster(cfg)),
+                                    now(ctx),
+                                );
+                            }
+                        }
+                        2 => {
+                            let n = ctx.random().random_range(0..2usize);
+                            model.cap_high_water = model.cap_high_water.max(n);
+                            mgr.handle_input(
+                                ManagerInput::Config(ConfigEvent::SetMaxFlows(n)),
+                                now(ctx),
+                            );
+                        }
+                        _ => {
+                            // Giant jump relative to the 5s max idle timeout (so it
+                            // mass-reaps), but bounded so the run stays within
+                            // moonpool's simulated-time budget over a deep sweep.
+                            let _ = ctx
+                                .time()
+                                .sleep(Duration::from_secs(ctx.random().random_range(10..60)))
+                                .await;
+                            mgr.handle_timeout(now(ctx));
+                        }
                     }
                 }
             }
@@ -606,17 +782,27 @@ fn assert_no_failures(report: &SimulationReport) {
 #[test]
 fn udp_simulation_seed_sweep() {
     let steps = env_usize("SOZU_UDP_SIM_STEPS").unwrap_or(3_000);
+    let swarm = swarm_enabled();
 
     // Single-seed replay mode.
     if let Some(seed) = env_u64("SOZU_UDP_SIM_SEED") {
-        eprintln!("== UDP sim single-seed replay: seed={seed:#x} steps={steps} ==");
+        eprintln!("== UDP sim single-seed replay: seed={seed:#x} steps={steps} swarm={swarm} ==");
         let report = SimulationBuilder::new()
             .workload(UdpSimWorkload {
                 steps,
                 verbose: true,
                 sink: None,
+                swarm,
+                config_sink: None,
             })
             .set_debug_seeds(vec![seed])
+            // Without an explicit iteration count, `SimulationBuilder`
+            // defaults to `UntilCoverageStable` (up to 1000 iterations) and
+            // would keep drawing FRESH random seeds after this one — fixing
+            // it to 1 is what actually makes this "replay that ONE seed",
+            // matching the documented `SOZU_UDP_SIM_SEED` contract (the
+            // TCP preread sim's replay path carries the same fix).
+            .set_iterations(1)
             .run_time_budget(run_budget(steps))
             .run();
         assert_no_failures(&report);
@@ -629,6 +815,8 @@ fn udp_simulation_seed_sweep() {
             steps,
             verbose: false,
             sink: None,
+            swarm,
+            config_sink: None,
         })
         .set_iterations(seeds)
         .run_time_budget(run_budget(steps))
@@ -636,7 +824,10 @@ fn udp_simulation_seed_sweep() {
     assert_no_failures(&report);
 }
 
-/// Fast smoke test pinning one representative seed.
+/// Fast smoke test pinning one representative seed. Swarm is off so the
+/// pinned trajectory stays byte-identical to the pre-swarm harness (no
+/// config draw touches the RNG stream) and the smoke test keeps exercising
+/// the full grammar.
 #[test]
 fn udp_simulation_replays_known_seed() {
     let steps = 4_000;
@@ -645,8 +836,12 @@ fn udp_simulation_replays_known_seed() {
             steps,
             verbose: false,
             sink: None,
+            swarm: false,
+            config_sink: None,
         })
         .set_debug_seeds(vec![0x5E_ED_C0_DE])
+        // Pin the run to exactly this seed (see the replay-path comment).
+        .set_iterations(1)
         .run_time_budget(run_budget(steps))
         .run();
     assert_no_failures(&report);
@@ -665,8 +860,14 @@ fn udp_simulation_is_deterministic() {
                 steps,
                 verbose: false,
                 sink: Some(sink.clone()),
+                // Swarm stays ON here: the guard then also covers the config
+                // draw itself (a nondeterministic draw would fork the trace).
+                swarm: true,
+                config_sink: None,
             })
             .set_debug_seeds(vec![seed])
+            // Pin the run to exactly this seed (see the replay-path comment).
+            .set_iterations(1)
             .run_time_budget(run_budget(steps))
             .run();
         assert_no_failures(&report);
@@ -684,6 +885,47 @@ fn udp_simulation_is_deterministic() {
         a.0, a.1,
         "final close_all must evict everything created (no leak)"
     );
+}
+
+/// Swarm-config stability: the configuration drawn for a seed is a pure
+/// function of that seed. Two fresh runs of the same seed must record the
+/// identical [`SwarmConfig`] (and therefore print a byte-identical
+/// `swarm-config` line — the replay contract).
+#[test]
+fn udp_swarm_config_is_stable_across_draws() {
+    fn draw(seed: u64) -> SwarmConfig {
+        let steps = 8;
+        let sink: ConfigSink = Arc::new(Mutex::new(Vec::new()));
+        let report = SimulationBuilder::new()
+            .workload(UdpSimWorkload {
+                steps,
+                verbose: false,
+                sink: None,
+                swarm: true,
+                config_sink: Some(sink.clone()),
+            })
+            .set_debug_seeds(vec![seed])
+            .set_iterations(1)
+            .run_time_budget(run_budget(steps))
+            .run();
+        assert_no_failures(&report);
+        let v = sink.lock().unwrap();
+        *v.first().expect("workload recorded a swarm config")
+    }
+
+    // Several seeds so both the 1-in-4 full draw and subset draws are hit.
+    for seed in [0x0Au64, 0x0B, 0x5EED_5EED, 0xDEAD_BEEF] {
+        let a = draw(seed);
+        let b = draw(seed);
+        assert_eq!(
+            a, b,
+            "seed={seed:#x}: swarm config must be identical across two draws"
+        );
+        assert!(
+            a.is_enabled(Action::ClientDatagram),
+            "seed={seed:#x}: the MANDATORY ClientDatagram feature must always be enabled"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Implements swarm testing ([Groce et al., ISSTA 2012](https://users.cs.utah.edu/~regehr/papers/swarm12.pdf)) in both deterministic simulations of the `sozu-sim` crate: instead of every seed running the single all-features workload grammar, each seed now draws a random subset of the generator features from its own seeded RNG before the first operation.

## What changes

- **`sim/tests/udp_simulation.rs`** — the weighted `Action` grammar becomes `ACTION_TABLE` (exact historical dispatch order, so an all-features configuration is draw-identical to the pre-swarm harness). Per-seed `SwarmConfig`: `ClientDatagram` is MANDATORY (sole flow creator), `Drain`/`CloseAll`/`AbortFlow`/`SetMaxFlows` are SUPPRESSORS (each repairs or prevents the very full-table state a capacity bug needs), the rest OPTIONAL at 50% inclusion with weights renormalized. Each buggify arm is gated by its sibling feature (skipped, never redrawn). The single-seed replay path and pinned tests now `set_iterations(1)` — previously moonpool's `UntilCoverageStable` default kept drawing up to ~1000 fresh random seeds after the requested one, so `SOZU_UDP_SIM_SEED` did not actually replay "that ONE seed".
- **`sim/tests/tcp_preread_sim.rs`** — the 25 scenario generators become `GENERATOR_TABLE`, all OPTIONAL (a fresh `SniPrereadCore` per connection means nothing can suppress across connections; the swarm benefit is the paper's passive competition), plus the one genuinely orthogonal `fragmentation` delivery axis (off → one-shot delivery only, forced-drip generator excluded). The `CoverageTally::assert_full_coverage` gate stays asserted on the MERGED campaign tally, unchanged and unweakened.
- **Campaign composition** — one seed in four keeps the inclusive all-features configuration (the paper is explicit swarm complements, never replaces it: a bug needing `k` features together appears in a coin-toss subset with probability `1/2^k`); an all-off draw collapses back to it. `SOZU_SIM_SWARM=0` pins every seed to the historical grammar with zero extra RNG consumption, so swarm and inclusive campaigns of identical seed count compare directly.
- **Replay contract** — the drawn configuration is a pure function of the seed and prints as one canonical `swarm-config` line per seed before the workload runs; new `*_swarm_config_is_stable_across_draws` tests assert two draws of the same seed are identical. Replaying `SOZU_UDP_SIM_SEED=0xdeadbeef` twice yields a byte-identical configuration line (verified by `diff`).
- **Docs** — `doc/testing.md` gains the swarm doctrine section (feature definition, MANDATORY/OPTIONAL/SUPPRESSOR classification, campaign composition, replay contract, gate placement); `doc/udp_simulation.md` documents the knob and buggify gating.
- **Preliminary commit** — `chore(clippy)`: mechanical, semantics-preserving fixes for pre-existing lints that fail `cargo clippy --all-targets --locked -- -D warnings` on the pinned 1.93.1 toolchain on `main` (`manual_checked_ops`, `for_kv_map`, sort-by-`Reverse`, `Option::filter`, a collapsible match guard, a needless borrow), plus three `unnecessary_cast` (`u64 as u64`) in `sozu-top` that the 1.97 clippy flags under `--all-features`. No behavior change; there is no CI clippy gate, which is how the drift landed.

## Protocol / security impact

None at runtime. The feature commit touches only the test-only `sozu-sim` harness and docs. The lint commit touches `lib`/`command`/`bin` with behavior-preserving rewrites only (`checked_div` keeps the identical divisor-zero skip; map `.values()` iterates identically; the `QueryCertificatesFromWorkers` match guard keeps the no-fingerprint fall-through to `notify_proxys`).

## Verification (all exit 0, pinned 1.93.1 toolchain)

```
cargo +nightly fmt --all -- --check
cargo clippy --all-targets --locked -- -D warnings
cargo test --workspace --locked          # sozu-sim builds as an empty 0-test binary — tokio_unstable scoping intact
RUSTFLAGS="--cfg tokio_unstable" cargo test -p sozu-sim
RUSTFLAGS="--cfg tokio_unstable" SOZU_UDP_SIM_SEEDS=256 cargo test -p sozu-sim --test udp_simulation
RUSTFLAGS="--cfg tokio_unstable" SOZU_TCP_PREREAD_SIM_SEEDS=256 cargo test -p sozu-sim --test tcp_preread_sim
RUSTFLAGS="--cfg tokio_unstable" cargo clippy -p sozu-sim --all-targets --locked -- -D warnings
```

The 256-seed swarm campaign passes with the campaign-level coverage gate asserting every class:

```
tally=CoverageTally { accepted: 6383, not_tls: 1009, malformed_record: 566, malformed_handshake: 374,
fragmented: 592, too_large: 342, no_sni: 525, ech_outer_absent: 490, sni_unmatched: 812,
alpn_unmatched: 576, proxy_header_invalid: 301, front_closed: 318, fragmented_delivery: 3997,
multi_record: 811, complete_over_cap: 408 }
```

No invariant was tripped by any swarm subset across the sweeps run.
